### PR TITLE
Editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>nteract notebook</title>
+    <title>composition</title>
     <link rel="stylesheet" href="./node_modules/normalize.css/normalize.css"/>
     <link rel="stylesheet" href="./node_modules/codemirror/lib/codemirror.css"/>
     <link rel="stylesheet" href="./node_modules/codemirror/theme/solarized.css"/>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <title>nteract notebook</title>
     <link rel="stylesheet" href="./node_modules/normalize.css/normalize.css"/>
+    <link rel="stylesheet" href="./node_modules/codemirror/lib/codemirror.css"/>
+    <link rel="stylesheet" href="./node_modules/codemirror/theme/solarized.css"/>
+    <link rel="stylesheet" href="./node_modules/codemirror/theme/base16-light.css"/>
+    <link rel="stylesheet" href="./node_modules/codemirror/theme/base16-dark.css"/>
+    <link rel="stylesheet" href="./node_modules/codemirror/theme/neo.css"/>
+    <link rel="stylesheet" href="./node_modules/codemirror/theme/neat.css"/>
+    <link rel="stylesheet" href="./main.css"/>
   </head>
   <body>
     <div id="app">

--- a/main.css
+++ b/main.css
@@ -1,0 +1,36 @@
+pre {
+  word-wrap: break-word;
+  line-height: 1.21429em;
+  font-size: 14px;
+}
+
+.CodeMirror {
+    line-height: 1.21429em;
+    font-size: 14px;
+    height: auto;
+    background: none;
+}
+
+.CodeMirror-scroll {
+    overflow-y: hidden;
+    overflow-x: auto;
+}
+
+.CodeMirror-lines {
+    padding: 0.4em;
+}
+
+.CodeMirror-linenumber {
+    padding: 0 8px 0 4px;
+}
+
+.CodeMirror-gutters {
+    border-bottom-left-radius: 2px;
+    border-top-left-radius: 2px;
+}
+
+.CodeMirror pre {
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/nteract/composition",
   "dependencies": {
+    "codemirror": "^5.10.0",
     "color": "^0.10.1",
     "history": "^1.17.0",
     "immutable": "^3.7.6",
@@ -38,6 +39,7 @@
     "jupyter-paths": "^0.1.0",
     "normalize.css": "^3.0.3",
     "react": "^0.14.3",
+    "react-code-mirror": "^3.0.6",
     "react-dom": "^0.14.3",
     "react-router": "^1.0.3",
     "rx": "^4.0.7"

--- a/src/components/Cell.jsx
+++ b/src/components/Cell.jsx
@@ -14,7 +14,7 @@ export default class Cell extends React.Component {
 
   render() {
     return (
-      <div>
+      <div style={{paddingLeft: '10px', paddingRight: '10px'}}>
         <Editor text={this.props.input} language={this.props.language} ref='editor' />
         <OutputArea ref='output-area' outputs={this.props.outputs} />
       </div>

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,18 +1,48 @@
 import React from 'react';
 
+import CodeMirror from 'react-code-mirror';
+
 export default class Editor extends React.Component {
   static displayName = 'Editor';
 
   static propTypes = {
     language: React.PropTypes.string,
+    lineNumbers: React.PropTypes.bool,
     text: React.PropTypes.any,
+    theme: React.PropTypes.string,
   };
+
+  static defaultProps = {
+    language: 'python',
+    lineNumbers: false,
+    text: '',
+    theme: 'neat',
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      source: this.props.text.join('\n'),
+    };
+  }
 
   render() {
     return (
-      <pre>
-        {this.props.text}
-      </pre>
+      <CodeMirror value={this.state.source}
+                  mode={this.props.language}
+                  style={{
+                    border: '1px solid #cfcfcf',
+                    borderRadius: '2px',
+                    background: '#f7f7f7',
+                  }}
+                  textAreaClassName={['editor']}
+                  textAreaStyle={{ minHeight: '10em' }}
+                  lineNumbers={this.props.lineNumbers}
+                  theme={this.props.theme}
+                  onChange={(e) => {
+                    this.setState({ source: e.target.value });
+                  }}
+                  />
     );
   }
 }

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -10,9 +10,19 @@ export default class Notebook extends React.Component {
     language: React.PropTypes.string,
   };
 
+  componentWillMount() {
+    const lang = this.props.language;
+    // HACK: This should give you the heeby-jeebies
+    // Mostly because lang could be ../../../../whatever
+    // This is the notebook though, so hands off
+    // We'll want to check for this existing later
+    // and any other validation
+    require('codemirror/mode/' + lang + '/' + lang);
+  }
+
   render() {
     return (
-      <div ref='cells'>
+      <div style={{ paddingTop: '10px' }} ref='cells'>
       {
         this.props.cells.map((cell, index) => {
           return <Cell input={cell.get('source')}

--- a/src/components/OutputArea.jsx
+++ b/src/components/OutputArea.jsx
@@ -7,14 +7,22 @@ export default class OutputArea extends React.Component {
     outputs: React.PropTypes.any,
   };
 
+  // Temporary until I bring in all the transformime and JDA handling
+  cleanOutput(output, index) {
+    const outputType = output.get('output_type');
+    if(outputType === 'execute_result') {
+      return <pre key={index}>{ output.getIn(['data', 'text/plain']) }</pre>;
+    }
+    else if (outputType === 'stream') {
+      return <pre key={index}>{ output.get('text').join('') }</pre>;
+    }
+  }
+
   render() {
     return (
       <div>
       {
-        this.props.outputs
-                  .map((output, index) =>
-                    <pre key={index}> {JSON.stringify(output)}</pre>
-                  )
+        this.props.outputs.map(this.cleanOutput)
       }
       </div>
     );


### PR DESCRIPTION
![screenshot 2016-01-01 23 05 41](https://cloud.githubusercontent.com/assets/836375/12073302/8ab4ecea-b0dd-11e5-9ce1-b9c378fe6343.png)

Just a start here. CodeMirror and React is a bit of a strange beast. The codemirror mode needs to be `require`d before the component using CodeMirror is mounted. For this, I relied on `componentWillMount` to set up the language mode.

The CSS here is quite boilerplate, just to get going. For some reason, electron compile was handling less properly so I used regular CSS computed from the jupyter notebook less files as well as a few tweaks. No strong opinions here.

It would be nice if we could import the css for the codemirror theme on demand. Not touching that in this PR.
