### PR TITLE
Bump latest transformime, react, react-dom.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "history": "^1.17.0",
     "immutable": "^3.7.6",
     "normalize.css": "^3.0.3",
-    "react": "^0.14.3",
+    "react": "^0.14.5",
     "react-code-mirror": "^3.0.6",
-    "react-dom": "^0.14.3",
+    "react-dom": "^0.14.5",
     "react-markdown": "^1.2.1",
     "react-router": "^1.0.3",
     "rx": "^4.0.7",
-    "transformime-react": "0.1.0"
+    "transformime-react": "0.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",


### PR DESCRIPTION
With the latest in transformime-react, we now have HTML and Markdown rendering in display areas. Bumped the `react` versions to match `transformime-react` as well.
