### PR TITLE
Bump electron compile, make babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+  {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "transform-class-properties",
+      "transform-export-extensions"
+    ]
+  }

--- a/app.js
+++ b/app.js
@@ -25,7 +25,10 @@ app.on('ready', () => {
     title: 'Composition',
   });
 
-  mainWindow.loadURL('file://' + path.join(__dirname, '/index.html'));
+  const index = path.join(__dirname, '/index.html');
+  console.log(index);
+
+  mainWindow.loadURL(`file://${index}`);
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/main.js
+++ b/main.js
@@ -1,5 +1,7 @@
 // Bootstrap main that lets us use ES6, JSX, etc.
 // Through the rest of our app code.
 // NOTE: This must remain ES5 code.
-require('electron-compile').init();
-require('./app.js');
+var path = require('path');
+
+var appRoot = path.join(__dirname);
+require('electron-compile').init(appRoot, './app');

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "babel-preset-react": "^6.3.13",
     "chai": "^3.4.1",
     "chai-immutable": "^1.5.3",
-    "electron-compile": "^1.0.1",
-    "electron-compilers": "^1.0.1",
+    "electron-compile": "^2.0.4",
+    "electron-compilers": "^2.0.4",
     "electron-mocha": "^0.7.0",
     "electron-packager": "^5.1.1",
     "electron-prebuilt": "^0.35.1",
@@ -65,15 +65,5 @@
     "eslint-plugin-babel": "^3.0.0",
     "eslint-plugin-react": "^3.11.3",
     "react-addons-test-utils": "^0.14.5"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "react"
-    ],
-    "plugins": [
-      "transform-class-properties",
-      "transform-export-extensions"
-    ]
   }
 }


### PR DESCRIPTION
Ran into issues, as noted in https://github.com/jupyter/atom-notebook/issues/26#issuecomment-169490529. Ended up moving the `babelrc` out and upgrading to the recent release of electron-compile.
