### PR TITLE
Lock to 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4.2"
   - "5.1"
 before_script:
   - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is a work in progress. Check out the issues for more detail.
 
 ### Development
 
+Requires node 5.x and npm 3.
+
 1. Fork this repo
 2. Clone it `git clone https://github.com/nteract/composition`
 3. `cd` to where you `clone`d it


### PR DESCRIPTION
For the time being, let's stick to one version of node + Electron that matches. 
