### PR TITLE
Use commutable for creating the immutable notebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ansi-to-html": "^0.3.0",
     "codemirror": "^5.10.0",
     "color": "^0.10.1",
+    "commutable": "^0.1.2",
     "history": "^1.17.0",
     "immutable": "^3.7.6",
     "normalize.css": "^3.0.3",

--- a/src/components/Cell/CodeCell.jsx
+++ b/src/components/Cell/CodeCell.jsx
@@ -17,7 +17,7 @@ export default class CodeCell extends React.Component {
     return (
       <div>
         <Editor language={this.props.language}
-                text={this.props.input.join('')} />
+                text={this.props.input} />
         <Display outputs={this.props.outputs} />
       </div>
     );

--- a/src/components/Cell/MarkdownCell.jsx
+++ b/src/components/Cell/MarkdownCell.jsx
@@ -19,7 +19,7 @@ export default class MarkdownCell extends React.Component {
     this.state = {
       view: true,
       // HACK: We'll need to handle props and state change better here
-      source: this.props.input.join(''),
+      source: this.props.input,
     };
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,29 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Immutable from 'immutable';
+
+import * as commutable from 'commutable';
 
 import Notebook from './components/Notebook';
 
 require.extensions['.ipynb'] = require.extensions['.json'];
 const notebook = require('../test-notebooks/multiples.ipynb');
-
-// Convert the multiline strings from a raw notebook so we have a nice
-// consistent structure for Immutable.JS
-for(const cell of notebook.cells) {
-  if(cell.outputs) {
-    for(const output of cell.outputs) {
-      if (output.data) {
-        for (const mimetype in output.data) {
-          if (Array.isArray(output.data[mimetype])) {
-            output.data[mimetype] = output.data[mimetype].join('');
-          }
-        }
-      }
-    }
-  }
-}
-
-const immutableNotebook = Immutable.fromJS(notebook);
+const immutableNotebook = commutable.fromJS(notebook);
 
 ReactDOM.render(
   <Notebook cells={immutableNotebook.get('cells')}

--- a/test/dummyNotebook_helper.js
+++ b/test/dummyNotebook_helper.js
@@ -1,24 +1,8 @@
-import Immutable from 'immutable';
+import { fromJS } from 'commutable';
 
 // This is only here as a stop gap until we test innards directly.
 
 require.extensions['.ipynb'] = require.extensions['.json'];
 const notebook = require('../test-notebooks/multiples.ipynb');
 
-// Convert the multiline strings from a raw notebook so we have a nice
-// consistent structure for Immutable.JS
-for(const cell of notebook.cells) {
-  if(cell.outputs) {
-    for(const output of cell.outputs) {
-      if (output.data) {
-        for (const mimetype in output.data) {
-          if (Array.isArray(output.data[mimetype])) {
-            output.data[mimetype] = output.data[mimetype].join('');
-          }
-        }
-      }
-    }
-  }
-}
-
-export default Immutable.fromJS(notebook);
+export default fromJS(notebook);


### PR DESCRIPTION
I've created a package to help with operations on the notebook, called `commutable`. It creates an Immutable.js structure out of a raw notebook object. It also turns all the "multi-line" strings into just strings for use in-memory. That's standard practice amongst Jupyter as on disk they're arrays of strings for source, outputs, etc. to make git and the notebook easier to work with.
