### PR TITLE
CloudFlare+WebSockets+SSL dont work with free plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # composition
 
-[![Build Status](https://travis-ci.org/nteract/composition.svg)](https://travis-ci.org/nteract/composition) [![slack in](https://slack.nteract.in/badge.svg)](https://slack.nteract.in)
+[![Build Status](https://travis-ci.org/nteract/composition.svg)](https://travis-ci.org/nteract/composition) [![slack in](https://slack.nteract.in/badge.svg)](http://slack.nteract.in)
 
 :notebook: Electron app of the Jupyter Notebook
 


### PR DESCRIPTION
After getting reports of not being able to login, I noticed that socket.io wasn't able to establish it's normal connection for our slackin instance. I turned off the "terminate" at CloudFlare option and this now works over HTTP.
