### PR TITLE
Problem: we don't have simple ways of creating messages

### DIFF
--- a/src/api/messaging.js
+++ b/src/api/messaging.js
@@ -1,0 +1,36 @@
+/* eslint camelcase: 0 */ // <-- Per Jupyter message spec
+
+import * as uuid from 'uuid';
+
+const session = uuid.v4();
+
+export function createMessage(msg_type) {
+  const username = process.env.LOGNAME || process.env.USER ||
+                   process.env.LNAME || process.env.USERNAME;
+  return {
+    header: {
+      username,
+      session,
+      msg_type,
+      msg_id: uuid.v4(),
+      date: new Date(),
+      version: '5.0',
+    },
+    metadata: {},
+    parent_header: {},
+    content: {},
+  };
+}
+
+export function createExecuteRequest(code) {
+  const executeRequest = createMessage('execute_request');
+  executeRequest.content = {
+    code,
+    silent: false,
+    store_history: true,
+    user_expressions: {},
+    allow_stdin: false,
+    stop_on_error: false,
+  };
+  return executeRequest;
+}


### PR DESCRIPTION
Solution: Write a simple `createMessage` and `createExecuteRequest`

Note: this treats the session id as a module level closure. I honestly don't know if we need to track on sessions.
