### PR TITLE
Problem: launch kernel error not displayed to user

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -14,7 +14,7 @@ export function newKernel(kernelSpecName) {
           spawn,
         });
       })
-      .catch((err) => console.log("err"));
+      .catch((err) => console.error(err));
   };
 }
 


### PR DESCRIPTION
Solution: Log the error itself

We need to think on what streams our errors end up in. Is this a userland popup? How does it get represented? At the very least, I just didn't want to see the error get squashed.
