### PR TITLE
Problem: Stroustrup brace style uncommon

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -147,7 +147,7 @@
 
     /* Stylistic Issues */
     "array-bracket-spacing": [1, "never"],
-    "brace-style": [1, "stroustrup", { "allowSingleLine": true }],
+    "brace-style": [1, "1tbs", { "allowSingleLine": true }],
     "camelcase": [1, { "properties": "always" }],
     "comma-spacing": [1, { "before": false, "after": true }],
     "comma-style": [1, "last"],

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,8 +11,7 @@ export const getJSON = filepath =>
         const nb = JSON.parse(data);
         resolve(nb);
         return;
-      }
-      catch (e) {
+      } catch (e) {
         reject(e);
       }
     });


### PR DESCRIPTION
Solution:  Switch to the one true brace style.  See the styles here: http://eslint.org/docs/rules/brace-style.html
