### PR TITLE
Problem: Cell should have access to all its props

### DIFF
--- a/src/components/Cell/Cell.jsx
+++ b/src/components/Cell/Cell.jsx
@@ -7,15 +7,14 @@ export default class Cell extends React.Component {
   static displayName = 'Cell';
 
   static propTypes = {
-    input: React.PropTypes.any,
-    language: React.PropTypes.string,
-    outputs: React.PropTypes.any,
+    cell: React.PropTypes.any,
+    notebook: React.PropTypes.any,
     type: React.PropTypes.string,
   };
 
   render() {
     return (
-      <div className="cell">
+      <div className='cell'>
         {
         this.props.type === 'markdown' ?
           <MarkdownCell {...this.props}/> :

--- a/src/components/Cell/Cell.jsx
+++ b/src/components/Cell/Cell.jsx
@@ -9,14 +9,15 @@ export default class Cell extends React.Component {
   static propTypes = {
     cell: React.PropTypes.any,
     notebook: React.PropTypes.any,
-    type: React.PropTypes.string,
   };
 
   render() {
+    const cell = this.props.cell;
+    const type = cell.get('cell_type');
     return (
       <div className='cell'>
         {
-        this.props.type === 'markdown' ?
+        type === 'markdown' ?
           <MarkdownCell {...this.props}/> :
           <CodeCell {...this.props}/>
         }

--- a/src/components/Cell/CodeCell.jsx
+++ b/src/components/Cell/CodeCell.jsx
@@ -7,17 +7,23 @@ export default class CodeCell extends React.Component {
   static displayName = 'CodeCell';
 
   static propTypes = {
-    input: React.PropTypes.any,
+    cell: React.PropTypes.any,
     language: React.PropTypes.string,
-    outputs: React.PropTypes.any,
     theme: React.PropTypes.string,
   };
 
   render() {
     return (
       <div>
-        <Editor {...this.props} />
-        <Display className="cell_display" {...this.props} />
+        <Editor
+          index={this.props.index}
+          input={this.props.cell.get('source')}
+          language={this.props.language}
+          notebook={this.props.notebook}
+        />
+        <Display className='cell_display'
+                 outputs={this.props.cell.get('outputs')}
+        />
       </div>
     );
   }

--- a/src/components/Cell/Editor.jsx
+++ b/src/components/Cell/Editor.jsx
@@ -45,15 +45,15 @@ export default class Editor extends React.Component {
 
   render() {
     return (
-      <div className="cell_editor">
+      <div className='cell_editor'>
         <Inputs {...this.props}/>
         <CodeMirror value={this.state.source}
-                    className="cell_cm"
+                    className='cell_cm'
                     mode={this.props.language}
                     textAreaClassName={['editor']}
                     textAreaStyle={{
                       minHeight: '10em',
-                      backgroundColor: 'red'
+                      backgroundColor: 'red',
                     }}
                     lineNumbers={this.props.lineNumbers}
                     theme={this.props.theme}

--- a/src/components/Cell/MarkdownCell.jsx
+++ b/src/components/Cell/MarkdownCell.jsx
@@ -9,10 +9,8 @@ export default class MarkdownCell extends React.Component {
   static displayName = 'MarkdownCell';
 
   static propTypes = {
-    // Unlike the code cell, we default to language of markdown
-    // and don't have outputs
+    cell: React.PropTypes.any,
     index: React.PropTypes.number,
-    input: React.PropTypes.any,
     notebook: React.PropTypes.object,
   };
 
@@ -25,7 +23,7 @@ export default class MarkdownCell extends React.Component {
     this.state = {
       view: true,
       // HACK: We'll need to handle props and state change better here
-      source: this.props.input,
+      source: this.props.cell.get('source'),
     };
   }
 
@@ -46,7 +44,7 @@ export default class MarkdownCell extends React.Component {
     return (
         (this.state && this.state.view) ?
           <div
-            className="cell_markdown"
+            className='cell_markdown'
             onDoubleClick={() => this.setState({ view: false }) }>
             <ReactMarkdown source={this.state.source} />
           </div> :

--- a/src/components/Cell/MarkdownCell.jsx
+++ b/src/components/Cell/MarkdownCell.jsx
@@ -29,7 +29,7 @@ export default class MarkdownCell extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      source: nextProps.input,
+      source: nextProps.cell.get('source'),
     });
   }
 

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -38,6 +38,7 @@ export default class Notebook extends React.Component {
       {
         cells.map((cell, index) => {
           return <Cell input={cell.get('source')}
+                       cell={cell}
                        language={this.props.notebook.getIn(['metadata', 'language_info', 'name'])}
                        outputs={cell.get('outputs')}
                        notebook={this.props.notebook}

--- a/src/components/Notebook.jsx
+++ b/src/components/Notebook.jsx
@@ -37,13 +37,10 @@ export default class Notebook extends React.Component {
 
       {
         cells.map((cell, index) => {
-          return <Cell input={cell.get('source')}
-                       cell={cell}
+          return <Cell cell={cell}
                        language={this.props.notebook.getIn(['metadata', 'language_info', 'name'])}
-                       outputs={cell.get('outputs')}
                        notebook={this.props.notebook}
                        index={index}
-                       type={cell.get('cell_type')}
                        key={index}
                        onTextChange={text => {
                          const newCell = cell.set('source', text);


### PR DESCRIPTION
Solution: Pass the cell down

We can use this to pass on `cell.get('execution_count')` the input numbering in a follow on PR. I'll probably end up cleaning up `UPDATE_CELL` as well afterward.
