### PR TITLE
Problem: inactive cell not flat and flushed

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -88,6 +88,12 @@ img
     box-shadow: 0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.24);
 }
 
+.cell:hover .input_area .cell_inputs,
+.cell:active .input_area .cell_inputs,
+.cell:focus .input_area .cell_inputs {
+  background-color: #e2dfe3;
+}
+
 .cell_markdown
 {
     padding: 10px;
@@ -115,7 +121,7 @@ img
     text-align: center;
 
     color: #8c8a8e;
-    background-color: #e2dfe3;
+    background-color: #fafafa;
 
     flex: 0 0 auto;
 }


### PR DESCRIPTION
Solution: Only darken the execution count section on hover, active, focus

We really need the concept of an active cell, which we're still aiming for.
Wanted to get closer to the mock for people to see.

Problems:
- cell is only "active" according to the mouse (since we can't style
  relatively with the current hierarchy)
- style of the inactive cell is hardcoded to match our current codemirror theme

Those two need to be solved separately: active cells (#44) and theming (#22).
