### PR TITLE
Problem: We only need the first execute_input resp

### DIFF
--- a/src/components/Cell/CodeCell.jsx
+++ b/src/components/Cell/CodeCell.jsx
@@ -58,6 +58,7 @@ export default class CodeCell extends React.Component {
 
     childMessages.ofMessageType(['execute_input'])
                  .pluck('content', 'execution_count')
+                 .first()
                  .subscribe((ct) => {
                    this.context.dispatch(updateCellExecutionCount(this.props.id, ct));
                  });
@@ -77,7 +78,7 @@ export default class CodeCell extends React.Component {
 
     shell.next(executeRequest);
 
-    // TODO: Manage subscriptions, trigger executionCount changes, more...
+    // TODO: Manage subscriptions
   }
 
   render() {


### PR DESCRIPTION
Solution: .first() operator

This will auto-dispose for us, which is awesome.
