### PR TITLE
Problem: Markdown cell padding didn't match code

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -100,7 +100,7 @@ img
 
 .cell_markdown
 {
-    padding: 10px;
+    padding: 10px 50px 10px 50px;
 }
 
 .cell_display


### PR DESCRIPTION
Solution: Make the left padding be the same as the code cell input area.

Most of the motivation here is that I want the draggable section to be the same margin/handle on the left hand side (or right hand side if we're flipped for a rtl written language). This strikes a good balance in the appearance for now.
