### PR TITLE
problem: hovering and selecting can be hard to see

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -80,16 +80,16 @@ img
 {
     margin: 10px;
 
-    transition: all .2s ease-in-out;
+    transition: all .1s ease-in-out;
 }
 
 .cell:hover
 {
-    box-shadow: 0 1px 3px rgba(0,0,0,.12), 0 1px 2px rgba(0,0,0,.24);
+    box-shadow: 1px 1px 3px rgba(0,0,0,.12), -1px -1px 3px rgba(0,0,0,.12);
 }
 
 .cell.selected {
-    box-shadow: 0 1px 8px rgba(0,0,0,.12), 0 1px 8px rgba(0,0,0,.24);
+    box-shadow: 3px 3px 9px rgba(0,0,0,.12), -3px -3px 9px rgba(0,0,0,.12);
 }
 
 .cell:hover .input_area .cell_inputs,


### PR DESCRIPTION
solution: use symmetric shadow and speed up transitions

welcome disagreement on this one =) but I find that when I hover over a cell that extends off the bottom, I'm confused as to whether it's actually highlighted because I can't see the bottom, where the shadow is. making the shadows symmetric helps you know what you're hovering. and I found speeding up the transitions helps a bit as well.
