### PR TITLE
Problem: Cancelling the file open dialog should do nothing

### DIFF
--- a/main/menu.js
+++ b/main/menu.js
@@ -31,7 +31,9 @@ export const file = {
           defaultPath: process.cwd(),
         };
         dialog.showOpenDialog(opts, (fname) => {
-          launch(fname);
+          if(fname) {
+            launch(fname);
+	  }
         });
       },
       accelerator: 'CmdOrCtrl+O',


### PR DESCRIPTION
Solution: only open a new window if a file name was selected.

Fixes #156 
