### PR TITLE
notebooks with titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>nteract</title>
     <link rel="stylesheet" href="./node_modules/normalize.css/normalize.css"/>
     <link rel="stylesheet" href="./node_modules/codemirror/lib/codemirror.css"/>
     <link rel="stylesheet" href="./node_modules/source-sans-pro/source-sans-pro.css"/>

--- a/main/launch.js
+++ b/main/launch.js
@@ -8,7 +8,7 @@ export default function launch(notebook) {
     height: 1000,
     // frame: false,
     darkTheme: true,
-    title: 'nteract',
+    title: path.relative('.', notebook.replace(/.ipynb$/,''))
   });
 
   const index = path.join(__dirname, '..', 'index.html');

--- a/main/menu.js
+++ b/main/menu.js
@@ -32,8 +32,8 @@ export const file = {
         };
         dialog.showOpenDialog(opts, (fname) => {
           if(fname) {
-            launch(fname);
-	  }
+            launch(fname[0]);
+          }
         });
       },
       accelerator: 'CmdOrCtrl+O',


### PR DESCRIPTION
So it's hard to keep track of what's what once you start opening multiple notebooks. Here's a set of changes that makes the title of each window be the path of the notebook relative to the current working directory, without the `.ipynb` extension at the end. As a bonus, the Window menu on OS X is now usable.

They look like this:

<img width="837" alt="screen shot 2016-02-15 at 11 22 25 am" src="https://cloud.githubusercontent.com/assets/118211/13058267/f2c5c2de-d3d6-11e5-9ac3-495933fd16a3.png">
