### PR TITLE
[WIP] The Focused Cell

### DIFF
--- a/src/actions/constants.js
+++ b/src/actions/constants.js
@@ -17,6 +17,7 @@ export const READ_NOTEBOOK = Symbol('READ_NOTEBOOK');
 
 export const MOVE_CELL = Symbol('MOVE_CELL');
 export const NEW_CELL_AFTER = Symbol('NEW_CELL_AFTER');
+export const NEXT_CELL = Symbol('NEXT_CELL');
 export const UPDATE_CELL_EXECUTION_COUNT = Symbol('UPDATE_CELL_EXECUTION_COUNT');
 export const UPDATE_CELL_OUTPUTS = Symbol('UPDATE_CELL_OUTPUTS');
 export const UPDATE_CELL_SOURCE = Symbol('UPDATE_CELL_SOURCE');

--- a/src/actions/constants.js
+++ b/src/actions/constants.js
@@ -11,6 +11,7 @@ export const KILL_KERNEL = Symbol('KILL_KERNEL');
 export const EXIT = Symbol('EXIT');
 
 export const SET_SELECTED = Symbol('SET_SELECTED');
+export const SET_FOCUSED = Symbol('SET_FOCUSED');
 
 export const READ_NOTEBOOK = Symbol('READ_NOTEBOOK');
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -21,6 +21,7 @@ import {
   UPDATE_CELL_EXECUTION_COUNT,
   READ_NOTEBOOK,
   ERROR_KERNEL_NOT_CONNECTED,
+  SET_FOCUSED,
 } from './constants';
 
 import {
@@ -121,6 +122,13 @@ export function updateCellOutputs(id, outputs) {
     type: UPDATE_CELL_OUTPUTS,
     id,
     outputs,
+  };
+}
+
+export function focusCell(id) {
+  return {
+    type: SET_FOCUSED,
+    id,
   };
 }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -18,6 +18,7 @@ import {
   UPDATE_CELL_OUTPUTS,
   MOVE_CELL,
   NEW_CELL_AFTER,
+  NEXT_CELL,
   UPDATE_CELL_EXECUTION_COUNT,
   READ_NOTEBOOK,
   ERROR_KERNEL_NOT_CONNECTED,
@@ -154,6 +155,13 @@ export function updateCellExecutionCount(id, count) {
     type: UPDATE_CELL_EXECUTION_COUNT,
     id,
     count,
+  };
+}
+
+export function nextCell(id) {
+  return {
+    type: NEXT_CELL,
+    id,
   };
 }
 

--- a/src/components/cell/cell.js
+++ b/src/components/cell/cell.js
@@ -25,6 +25,10 @@ class Cell extends React.Component {
     this.setSelected = this.setSelected.bind(this);
   }
 
+  componentDidMount() {
+    this.focus();
+  }
+
   componentWillUpdate() {
     const node = ReactDOM.findDOMNode(this);
     this.scrollHeight = node.scrollHeight;
@@ -34,8 +38,13 @@ class Cell extends React.Component {
   componentDidUpdate() {
     const node = ReactDOM.findDOMNode(this);
     node.scrollTop = this.scrollTop + (node.scrollHeight - this.scrollHeight);
+    this.focus();
+  }
+
+  focus() {
+    console.log(this.props.id, this.props.isFocused);
     if(this.props.isFocused) {
-      node.scrollIntoView();
+      ReactDOM.findDOMNode(this).scrollIntoView();
     }
   }
 

--- a/src/components/cell/cell.js
+++ b/src/components/cell/cell.js
@@ -25,17 +25,16 @@ class Cell extends React.Component {
   }
 
   componentWillUpdate() {
-    if(this.props.isFocused) {
-      const node = this.getDOMNode();
-      this.scrollHeight = node.scrollHeight;
-      this.scrollTop = node.scrollTop;
-    }
+    const node = this.getDOMNode();
+    this.scrollHeight = node.scrollHeight;
+    this.scrollTop = node.scrollTop;
   }
 
   componentDidUpdate() {
+    const node = this.getDOMNode();
+    node.scrollTop = this.scrollTop + (node.scrollHeight - this.scrollHeight);
     if(this.props.isFocused) {
-      const node = this.getDOMNode();
-      node.scrollTop = this.scrollTop + (node.scrollHeight - this.scrollHeight);
+      node.scrollIntoView();
     }
   }
 

--- a/src/components/cell/cell.js
+++ b/src/components/cell/cell.js
@@ -42,7 +42,6 @@ class Cell extends React.Component {
   }
 
   focus() {
-    console.log(this.props.id, this.props.isFocused);
     if(this.props.isFocused) {
       ReactDOM.findDOMNode(this).scrollIntoView();
     }

--- a/src/components/cell/cell.js
+++ b/src/components/cell/cell.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import CodeCell from './code-cell';
 import MarkdownCell from './markdown-cell';
@@ -25,13 +26,13 @@ class Cell extends React.Component {
   }
 
   componentWillUpdate() {
-    const node = this.getDOMNode();
+    const node = ReactDOM.findDOMNode(this);
     this.scrollHeight = node.scrollHeight;
     this.scrollTop = node.scrollTop;
   }
 
   componentDidUpdate() {
-    const node = this.getDOMNode();
+    const node = ReactDOM.findDOMNode(this);
     node.scrollTop = this.scrollTop + (node.scrollHeight - this.scrollHeight);
     if(this.props.isFocused) {
       node.scrollIntoView();

--- a/src/components/cell/cell.js
+++ b/src/components/cell/cell.js
@@ -11,6 +11,7 @@ class Cell extends React.Component {
   static propTypes = {
     cell: React.PropTypes.any,
     id: React.PropTypes.string,
+    isFocused: React.PropTypes.bool,
     isSelected: React.PropTypes.bool,
   };
 
@@ -21,6 +22,21 @@ class Cell extends React.Component {
   constructor(props) {
     super(props);
     this.setSelected = this.setSelected.bind(this);
+  }
+
+  componentWillUpdate() {
+    if(this.props.isFocused) {
+      const node = this.getDOMNode();
+      this.scrollHeight = node.scrollHeight;
+      this.scrollTop = node.scrollTop;
+    }
+  }
+
+  componentDidUpdate() {
+    if(this.props.isFocused) {
+      const node = this.getDOMNode();
+      node.scrollTop = this.scrollTop + (node.scrollHeight - this.scrollHeight);
+    }
   }
 
   setSelected(e) {

--- a/src/components/cell/code-cell.js
+++ b/src/components/cell/code-cell.js
@@ -7,6 +7,7 @@ import Display from 'react-jupyter-display-area';
 
 import {
   executeCell,
+  nextCell,
 } from '../../actions';
 
 export default class CodeCell extends React.Component {
@@ -35,11 +36,7 @@ export default class CodeCell extends React.Component {
     }
 
     if (e.shiftKey) {
-      // TODO: Remove this, as it should be created if at the end of document only
-      // this.context.dispatch(createCellAfter('code', this.props.id));
-
-      // should instead be
-      // this.context.dispatch(nextCell(this.props.id));
+      this.context.dispatch(nextCell(this.props.id));
     }
 
     this.context.dispatch(executeCell(this.props.id,

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -69,7 +69,7 @@ class Notebook extends React.Component {
                        id={id}
                        key={id}
                        isSelected={selected}
-                       focused={this.props.focused === id}
+                       isFocused={this.props.focused === id}
                        onTextChange={text => {
                          const newCell = cellMap.get(id).set('source', text);
                          this.props.onCellChange(id, newCell);

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -10,6 +10,7 @@ class Notebook extends React.Component {
 
   static propTypes = {
     channels: React.PropTypes.any,
+    focused: React.PropTypes.string,
     notebook: React.PropTypes.any,
     onCellChange: React.PropTypes.func,
     selected: React.PropTypes.array,
@@ -68,6 +69,7 @@ class Notebook extends React.Component {
                        id={id}
                        key={id}
                        isSelected={selected}
+                       focused={this.props.focused === id}
                        onTextChange={text => {
                          const newCell = cellMap.get(id).set('source', text);
                          this.props.onCellChange(id, newCell);

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,8 @@ class App extends React.Component {
             <Notebook
               selected={this.state.selected}
               notebook={this.state.notebook}
-              channels={this.state.channels} />
+              channels={this.state.channels}
+              focused={this.state.focused} />
           }
         </div>
       </Provider>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -15,6 +15,7 @@ import {
   UPDATE_CELL_OUTPUTS,
   UPDATE_CELL_SOURCE,
   ERROR_KERNEL_NOT_CONNECTED,
+  SET_FOCUSED,
 } from '../actions/constants';
 
 import {
@@ -41,6 +42,13 @@ reducers[SET_SELECTED] = function setSelected(state, action) {
       action.ids;
   return Object.assign({}, state, {
     selected,
+  });
+};
+
+reducers[SET_FOCUSED] = function setFocused(state, action) {
+  const focused = action.id;
+  return Object.assign({}, state, {
+    focused,
   });
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -62,6 +62,8 @@ reducers[NEXT_CELL] = function nextCell(state, action) {
     // what cellID I want or for it to return one to me
     // notebook = commutable.appendCell(notebook, cell);
     // doing it here, then writing the idiomatic clean interface later
+    // When writing tests, I ran into this too as the cell ID was wrapped
+    // in a closure and had to be extracted by "knowing" where the next cell was
     const cellID = uuid();
     notebook = notebook.setIn(['cellMap', cellID], cell)
                        .set('cellOrder',

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,9 @@
 import * as fs from 'fs';
 
+import * as commutable from 'commutable';
+
+import { v4 as uuid } from 'node-uuid';
+
 import {
   CHANGE_FILENAME,
   DONE_SAVING,
@@ -16,6 +20,7 @@ import {
   UPDATE_CELL_SOURCE,
   ERROR_KERNEL_NOT_CONNECTED,
   SET_FOCUSED,
+  NEXT_CELL,
 } from '../actions/constants';
 
 import {
@@ -35,6 +40,41 @@ reducers[NEW_CELL_AFTER] = newCellAfter;
 reducers[UPDATE_CELL_SOURCE] = updateSource;
 reducers[UPDATE_CELL_OUTPUTS] = updateOutputs;
 reducers[MOVE_CELL] = moveCell;
+
+reducers[NEXT_CELL] = function nextCell(state, action) {
+  // If the next cell doesn't exist, create a new one
+  let { notebook } = state;
+  const { id } = action;
+
+  const cellOrder = notebook.get('cellOrder');
+
+  const priorIndex = cellOrder.indexOf(id);
+
+  let focused = cellOrder[priorIndex + 1];
+
+  if(priorIndex === -1 || // What does this behavior mean?
+     priorIndex === cellOrder.size - 1) {
+    // Here we'll create a new cell at the end of the document
+    // create a new cell
+    const cell = commutable.emptyCodeCell; // Until configurable
+
+    // This is another time where I wish I could either tell appendCell
+    // what cellID I want or for it to return one to me
+    // notebook = commutable.appendCell(notebook, cell);
+    // doing it here, then writing the idiomatic clean interface later
+    const cellID = uuid();
+    notebook = notebook.setIn(['cellMap', cellID], cell)
+                       .set('cellOrder',
+                            notebook.get('cellOrder').push(cellID));
+    focused = cellID;
+  }
+
+  // Now switch focus to that one
+  return Object.assign({}, state, {
+    notebook,
+    focused,
+  });
+};
 
 reducers[SET_SELECTED] = function setSelected(state, action) {
   const selected = action.additive ?

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -50,7 +50,7 @@ reducers[NEXT_CELL] = function nextCell(state, action) {
 
   const priorIndex = cellOrder.indexOf(id);
 
-  let focused = cellOrder[priorIndex + 1];
+  let focused = cellOrder.get(priorIndex + 1);
 
   if(priorIndex === -1 || // What does this behavior mean?
      priorIndex === cellOrder.size - 1) {


### PR DESCRIPTION
DON'T MERGE, this is semi-functional with some bad breaking things.

I may break this up into only providing the code for the actions and reducers, leave the UI bits for later.

This begins adding a way to focus a cell, primarily for the `run-and-move-to-next` action.
- [x] Create the actions and reducers for setting the focused cell
- [ ] On code cells, setting focus will result in honing in on the codemirror ref
- [ ] On Markdown cells, if not in "view rendered" mode, should do... something?
- [ ] Figure out how to reason about that fact that this is always going to have to update based on the user's "active position" on the page

/cc @kenwheeler 
