### PR TITLE
Problem: No mechanism for listening to keyboard events on elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.2",
     "ansi-to-html": "^0.3.0",
+    "atom-keymap": "^6.3.1",
     "codemirror": "^5.12.0",
     "color": "^0.10.1",
     "commutable": "^0.4.0",

--- a/src/actions/default-map.json
+++ b/src/actions/default-map.json
@@ -1,0 +1,5 @@
+{
+  "body": {
+    "f1": "action:exit"
+  }
+}

--- a/src/actions/keymap.js
+++ b/src/actions/keymap.js
@@ -1,0 +1,31 @@
+import * as actions from './index';
+import KeymapManager from 'atom-keymap';
+
+function registerListeners(window, dispatch) {
+  if (!window) throw new Error('window not defined');
+  if (!dispatch) throw new Error('dispatch not defined');
+
+  // Register action event listeners on the window for every know action.
+  Object.keys(actions).forEach(actionName => {
+    window.addEventListener('action:' + actionName, () => {
+      try {
+        dispatch(actions[actionName]());
+      } catch (err) {
+        console.error('key bound action ivoke failure', actionName, err);
+      }
+    });
+  });
+}
+
+export function initKeymap(window, dispatch) {
+  registerListeners(window, dispatch);
+
+  const document = window.document;
+  const keymaps = new KeymapManager();
+  keymaps.defaultTarget = document.body;
+  document.addEventListener('keydown', event => keymaps.handleKeyboardEvent(event));
+
+  // Add the keymap files, can also be specified as directories
+  keymaps.add('/default-keymap', require('./default-map.json'));
+  // keymaps.loadKeymap('/path/to/keymap-file.json');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,11 @@ import {
   saveAs,
   killKernel,
 } from './actions';
+import { initKeymap } from './actions/keymap';
 
 const filename = decodeURIComponent(window.location.hash.slice(1));
 const { store, dispatch } = createStore({ notebook: null, selected: [], filename }, reducers);
+initKeymap(window, dispatch);
 
 import { ipcRenderer as ipc } from 'electron';
 ipc.on('menu:new-kernel', (e, name) => dispatch(newKernel(name)));


### PR DESCRIPTION
Solution: Add atom's atom-keymap package.  Add basic code to get it to work. 

Still required, the ability to load user keymaps and some useful actions for key bound events.
