### PR TITLE
Commutable bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "atom-keymap": "^6.3.1",
     "codemirror": "^5.12.0",
     "color": "^0.10.1",
-    "commutable": "^0.4.0",
+    "commutable": "0.5.0",
     "enchannel-zmq-backend": "^1.0.1",
     "history": "^1.17.0",
     "immutable": "^3.7.6",

--- a/src/reducers/document.js
+++ b/src/reducers/document.js
@@ -1,4 +1,5 @@
 import * as commutable from 'commutable';
+import * as uuid from 'uuid';
 
 export function loadNotebook(state, action) {
   const { data } = action;
@@ -11,9 +12,8 @@ export function loadNotebook(state, action) {
 export function updateExecutionCount(state, action) {
   const { id, count } = action;
   const { notebook } = state;
-  const updatedNotebook = notebook.setIn(['cellMap', id, 'execution_count'], count);
   return Object.assign({}, state, {
-    notebook: updatedNotebook,
+    notebook: commutable.updateExecutionCount(notebook, id, count),
   });
 }
 
@@ -35,12 +35,9 @@ export function moveCell(state, action) {
 
 export function removeCell(state, action) {
   const { notebook } = state;
-  const { id: cellId } = action;
-  const updatedNotebook = notebook
-    .removeIn(['cellMap', cellId])
-    .update('cellOrder', cellOrder => cellOrder.filterNot(id => id === cellId));
+  const { id } = action;
   return Object.assign({}, state, {
-    notebook: updatedNotebook,
+    notebook: commutable.removeCell(notebook, id),
   });
 }
 
@@ -51,25 +48,24 @@ export function newCellAfter(state, action) {
   const cell = cellType === 'markdown' ? commutable.emptyMarkdownCell :
                                          commutable.emptyCodeCell;
   const index = notebook.get('cellOrder').indexOf(id) + 1;
+  const cellID = uuid.v4();
   return Object.assign({}, state, {
-    notebook: commutable.insertCellAt(notebook, cell, index),
+    notebook: commutable.insertCellAt(notebook, cell, cellID, index),
   });
 }
 
 export function updateSource(state, action) {
   const { id, source } = action;
   const { notebook } = state;
-  const updatedNotebook = notebook.setIn(['cellMap', id, 'source'], source);
   return Object.assign({}, state, {
-    notebook: updatedNotebook,
+    notebook: commutable.updateSource(notebook, id, source),
   });
 }
 
 export function updateOutputs(state, action) {
   const { id, outputs } = action;
   const { notebook } = state;
-  const updatedNotebook = notebook.setIn(['cellMap', id, 'outputs'], outputs);
   return Object.assign({}, state, {
-    notebook: updatedNotebook,
+    notebook: commutable.updateOutputs(notebook, id, outputs),
   });
 }


### PR DESCRIPTION
Commutable `v0.5.0` brings in more helpers for common operations :tada:. It now requires you to pass the cell ID in for a new cell as well. Adaptation here, should help with #176.
