### PR TITLE
Constants Helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "electron-mocha --renderer --compilers js:babel-core/register 'test/**/*.js'",
+    "test:watch": "watch 'npm run test' test/",
     "start": "electron main.js"
   },
   "repository": {
@@ -70,6 +71,7 @@
     "eslint-plugin-babel": "^3.0.0",
     "eslint-plugin-react": "^3.11.3",
     "react-addons-test-utils": "^0.14.5",
-    "sinon": "^1.17.3"
+    "sinon": "^1.17.3",
+    "watch": "^0.17.1"
   }
 }

--- a/src/actions/constants.js
+++ b/src/actions/constants.js
@@ -1,24 +1,16 @@
-export const CHANGE_FILENAME = Symbol('CHANGE_FILENAME');
+import createConstants from './createConstants';
 
-export const START_SAVING = Symbol('START_SAVING');
-export const DONE_SAVING = Symbol('DONE_SAVING');
-
-export const ERROR_KERNEL_NOT_CONNECTED = Symbol('ERROR_KERNEL_NOT_CONNECTED');
-
-export const NEW_KERNEL = Symbol('NEW_KERNEL');
-export const KILL_KERNEL = Symbol('KILL_KERNEL');
-
-export const EXIT = Symbol('EXIT');
-
-export const SET_SELECTED = Symbol('SET_SELECTED');
-
-export const NEW_NOTEBOOK = Symbol('NEW_NOTEBOOK');
-export const READ_NOTEBOOK = Symbol('READ_NOTEBOOK');
-
-export const MOVE_CELL = Symbol('MOVE_CELL');
-export const REMOVE_CELL = Symbol('REMOVE_CELL');
-
-export const NEW_CELL_AFTER = Symbol('NEW_CELL_AFTER');
-export const UPDATE_CELL_EXECUTION_COUNT = Symbol('UPDATE_CELL_EXECUTION_COUNT');
-export const UPDATE_CELL_OUTPUTS = Symbol('UPDATE_CELL_OUTPUTS');
-export const UPDATE_CELL_SOURCE = Symbol('UPDATE_CELL_SOURCE');
+export default createConstants(
+  'CHANGE_FILENAME',
+  'START_SAVING', 'DONE_SAVING',
+  'ERROR_KERNEL_NOT_CONNECTED',
+  'NEW_KERNEL', 'KILL_KERNEL',
+  'EXIT',
+  'SET_SELECTED',
+  'NEW_NOTEBOOK', 'READ_NOTEBOOK',
+  'MOVE_CELL', 'REMOVE_CELL',
+  'NEW_CELL_AFTER',
+  'UPDATE_CELL_EXECUTION_COUNT',
+  'UPDATE_CELL_OUTPUTS',
+  'UPDATE_CELL_SOURCE'
+);

--- a/src/actions/createConstants.js
+++ b/src/actions/createConstants.js
@@ -1,0 +1,10 @@
+/**
+ * Small utility function to ease the creation of constants. Variadic,
+ * so no need to pass in array.
+ * @param  {Array-Like Object}  constants Strings to create constants based on.
+ * @return {Object}             Object with constant keys, Symbol values.
+ */
+export default (...constants) => constants.reduce((acc, constant) => Object.assign(
+  acc,
+  { [constant]: Symbol(constant) }
+), {});

--- a/test/createConstants_spec.js
+++ b/test/createConstants_spec.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+
+import createConstants from '../src/actions/createConstants';
+
+describe('createConstants', () => {
+  it('creates an object', () => {
+    const subject = createConstants('ONE', 'TWO');
+
+    expect(subject).to.be.a('object');
+  });
+
+  it('has the arguments that were passed in as keys', () => {
+    const subject = createConstants('ONE', 'TWO');
+
+    expect(subject).to.have.all.keys('ONE', 'TWO');
+  });
+
+  it('creates symbols for each key', () => {
+    const subject = createConstants('ONE', 'TWO');
+
+    Object.keys(subject).forEach(key => {
+      expect(subject[key]).to.be.a('symbol');
+    });
+  });
+});


### PR DESCRIPTION
This utility makes creating constants a little less verbose and error-prone. When writing tests for it, I noticed `electron-mocha` doesn't support (and probably never will support) `--watch`, see [#18](https://github.com/jprichardson/electron-mocha/pull/18), so I added `watch` as `devDependency` and a new task for running tests on file changes.
- Add watch as dependency for TDD, plus 'test:watch' task
- Add createConstants utility + specs
