### PR TITLE
Pass the mimebundle transforms and displayOrder through

### DIFF
--- a/src/components/cell/code-cell.js
+++ b/src/components/cell/code-cell.js
@@ -5,6 +5,8 @@ import Inputs from './inputs';
 import Editor from './editor';
 import Display from 'react-jupyter-display-area';
 
+import Immutable from 'immutable';
+
 import {
   executeCell,
 } from '../../actions';
@@ -14,9 +16,11 @@ export default class CodeCell extends React.Component {
 
   static propTypes = {
     cell: React.PropTypes.any,
+    displayOrder: React.PropTypes.instanceOf(Immutable.List),
     id: React.PropTypes.string,
     language: React.PropTypes.string,
     theme: React.PropTypes.string,
+    transforms: React.PropTypes.instanceOf(Immutable.Map),
   };
 
   static contextTypes = {
@@ -59,6 +63,8 @@ export default class CodeCell extends React.Component {
         </div>
         <Display className='cell_display'
                  outputs={this.props.cell.get('outputs')}
+                 displayOrder={this.props.displayOrder}
+                 transforms={this.props.transforms}
         />
       </div>
     );

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -5,14 +5,18 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import DraggableCell from './cell';
 import { moveCell } from '../actions';
 
+import Immutable from 'immutable';
+
 class Notebook extends React.Component {
   static displayName = 'Notebook';
 
   static propTypes = {
     channels: React.PropTypes.any,
+    displayOrder: React.PropTypes.instanceOf(Immutable.List),
     notebook: React.PropTypes.any,
     onCellChange: React.PropTypes.func,
     selected: React.PropTypes.array,
+    transforms: React.PropTypes.instanceOf(Immutable.Map),
   };
 
   static contextTypes = {
@@ -68,6 +72,8 @@ class Notebook extends React.Component {
                        id={id}
                        key={id}
                        isSelected={selected}
+                       displayOrder={this.props.displayOrder}
+                       transforms={this.props.transforms}
                        onTextChange={text => {
                          const newCell = cellMap.get(id).set('source', text);
                          this.props.onCellChange(id, newCell);


### PR DESCRIPTION
This sets us up for being able to configure what our default transforms are, motivated by @andrewosh's remote kernel use case and security concerns.

Example sanitized notebook (only allows `text/plain` mimetype):

<img width="771" alt="screenshot 2016-03-02 21 19 46" src="https://cloud.githubusercontent.com/assets/836375/13483741/d7ccf6ee-e0bc-11e5-88c4-4a247bf3f5db.png">

To do this, I created a new `displayOrder` and passed it through to the notebook:

``` diff
diff --git a/src/index.js b/src/index.js
index 953760e..177c642 100644
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,9 @@ const { store, dispatch } = createStore({
 }, reducers);
 initKeymap(window, dispatch);

+import Immutable from 'immutable';
+const displayOrder = new Immutable.List(['text/plain']);
+
 import { ipcRenderer as ipc } from 'electron';
 ipc.on('menu:new-kernel', (e, name) => dispatch(newKernel(name)));
 ipc.on('menu:save', () => dispatch(save()));
@@ -56,7 +59,9 @@ class App extends React.Component {
             <Notebook
               selected={this.state.selected}
               notebook={this.state.notebook}
-              channels={this.state.channels} />
+              channels={this.state.channels}
+              displayOrder={displayOrder}
+              />
           }
         </div>
       </Provider>
```

This is merely putting it in place so that Andrew can do some more hacking on top.
