### PR TITLE
Problem: newly created text cells are invisible

### DIFF
--- a/src/components/cell/markdown-cell.js
+++ b/src/components/cell/markdown-cell.js
@@ -22,14 +22,18 @@ export default class MarkdownCell extends React.Component {
     this.state = {
       view: true,
       // HACK: We'll need to handle props and state change better here
-      source: this.props.cell.get('source'),
+      source: 'Edit me by double clicking',
     };
   }
 
+
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      source: nextProps.cell.get('source'),
-    });
+    var source = nextProps.cell.get('source');
+    if (source) {
+      this.setState({
+        source: source,
+      });
+    }
   }
 
   keyDown(e) {


### PR DESCRIPTION
Solution fill new markdown cells with some text.

(I'd like some tutoring about `componentWillReceiveProps`: why is called extremely often? In particular who 'triggers' this when the notebook is loaded from a file?)
