### PR TITLE
Tweaks to make the spawn cell toolbar look like the cell toolbar

### DIFF
--- a/src/components/cell/spawn-tool.js
+++ b/src/components/cell/spawn-tool.js
@@ -16,9 +16,16 @@ export default class SpawnTool extends React.Component {
 
   render() {
     return (
-      <div className={'spawn-tool ' + (this.props.spawnBefore ? 'above' : 'below')}>
-        <span className='spawn-text' onClick={() => this._spawnTextCell()}>+text</span>
-        <span className='spawn-code' onClick={() => this._spawnCodeCell()}>+code</span>
+      <div className={'spawn-positioner ' + (this.props.spawnBefore ? 'above' : 'below')}>
+        <div className='spawn-tool'>
+          <span className='spawn-label'>Add cell</span>
+          <button onClick={this._spawnTextCell.bind(this)}>
+            <i className='material-icons'>art_track</i>
+          </button>
+          <button onClick={this._spawnCodeCell.bind(this)}>
+            <i className='material-icons'>code</i>
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/components/cell/spawning-cell.js
+++ b/src/components/cell/spawning-cell.js
@@ -45,7 +45,7 @@ export default class SpawningCell extends React.Component {
 
   _handleMouseMove(mouseEvent) {
     const mouseOffset = this._getMouseOffset(mouseEvent);
-    this.setState({ mouseOffset, showTool: true });
+    this.setState({ mouseOffset, showTool: mouseOffset < 0.3 || mouseOffset > 0.7 });
   }
 
   _getMouseOffset(mouseEvent) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -194,35 +194,62 @@ img
     flex: 1 1 auto;
 }
 
-.spawn-tool {
+.spawn-positioner {
   text-align: center;
   height: 0px;
   overflow: visible;
   position: relative;
   z-index: 99;
   width: 100%;
-  cursor: pointer;
 }
 
-.spawn-tool.above {
-  top: -5px;
+.spawn-positioner.above {
+  top: -19px;
 }
-.spawn-tool.below {
-  top: -30px;
+.spawn-positioner.below {
+  top: -6px;
 }
 
-.spawn-text, .spawn-code {
-  background-color: #f6f6f6;
-  height: 20px;
-  margin: 5px;
-  border-radius: 4px;
-  border: 1px solid #ccc;
-  color: #aaa;
-  width: 50px;
+.spawn-tool {
   display: inline-block;
+  background: white;
+  box-shadow: 0 1px 2px 0 rgba(0,0,0,.50);
 }
 
-.spawn-text:hover, .spawn-code:hover {
-  border: 1px solid #aaa;
-  color: #777;
+.spawn-tool button
+{
+  display: inline-block;
+
+  width: 22px;
+  height: 20px;
+  padding: 2px 4px;
+
+  text-align: center;
+
+  border: none;
+  outline: none;
+  background: none;
+}
+
+.spawn-tool button i
+{
+  /* These icons are thin, use a larger font than the cell toolbar */
+  font-size: 17px;
+  line-height: 1;
+
+  color: #aaa;
+}
+
+.spawn-tool button i:hover
+{
+  color: #555;
+}
+
+.spawn-tool .spawn-label {
+  color: #aaa;
+  font-size: 12px;
+  text-transform: uppercase;
+  padding: 5px;
+  vertical-align: text-bottom;
+  font-weight: bold;
 }


### PR DESCRIPTION
Also, only show the toolbar when the mouse is 30% away from the border, opposed to the current 50%.
