### PR TITLE
provide getState()

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -18,19 +18,19 @@ export default function createStore(initialState, reducers) {
   ).share();
 
   // Debugging time
-  store.subscribe(null, (err) => {
+
+  const stateSymbol = Symbol('state');
+  store.subscribe(state => {
+    store[stateSymbol] = state;
+  }, (err) => {
     console.error('Error in the store', err);
   });
-
-  let lastState = {};
-  store.subscribe(st => {
-    lastState = st;
-  });
+  store.getState = () => store[stateSymbol];
 
   function dispatch(action) {
     // We need the current state at this time
     return typeof action === 'function'
-      ? action.call(null, subject, dispatch, lastState)
+      ? action.call(null, subject, dispatch, store.getState())
       : subject.next(action);
   }
 


### PR DESCRIPTION
This is a stop gap to start moving some of our native Electron actions and dispatch to rely on less of an awkward API, moving us closer to Redux. I'm going to clean up `save` and `saveAs` after this.
