### PR TITLE
Shift button position and add titles.

### DIFF
--- a/src/components/cell/cell-creator-buttons.js
+++ b/src/components/cell/cell-creator-buttons.js
@@ -15,11 +15,11 @@ export default class CellCreatorButtons extends React.Component {
   render() {
     return (
       <div className='creator-tool'>
-        <span className='creator-label'>Add cell</span>
-        <button onClick={this._createTextCell.bind(this)}>
+        <button onClick={this._createTextCell.bind(this)} title="create text cell">
           <i className='material-icons'>art_track</i>
         </button>
-        <button onClick={this._createCodeCell.bind(this)}>
+        <span className='creator-label'>Add cell</span>
+        <button onClick={this._createCodeCell.bind(this)} title="create code cell">
           <i className='material-icons'>code</i>
         </button>
       </div>


### PR DESCRIPTION
Moved the buttons so that they're on either side of "add cell". While I was at it I added titles to the buttons so that hovering over them provides helper text.

Screenshot:

<img width="248" alt="screenshot 2016-03-06 20 33 59" src="https://cloud.githubusercontent.com/assets/836375/13559537/b8583dd4-e3da-11e5-83bc-4b6d52ab7f16.png">

Cursor doesn't show above. May be worth giving [react-a11y](https://github.com/reactjs/react-a11y) a spin after this to highlight other spots we're not providing cues on.
