### PR TITLE
Adapt the injected kernelspec to nbformat

### DIFF
--- a/main/launch.js
+++ b/main/launch.js
@@ -30,13 +30,25 @@ export function launch(notebook, filename) {
 }
 
 export function launchNewNotebook(kernelspec) {
-  return Promise.resolve(launch(
-    appendCell(emptyNotebook, emptyCodeCell)
-      .set('kernelspec', immutable.fromJS(kernelspec))));
+  const starterNotebook = appendCell(emptyNotebook, emptyCodeCell);
+
+  let nb = starterNotebook;
+
+  if (kernelspec && kernelspec.name && kernelspec.spec
+                 && kernelspec.spec.language && kernelspec.spec.display_name) {
+    nb = starterNotebook.setIn(['metadata', 'kernelspec'], immutable.fromJS({
+      name: kernelspec.name,
+      language: kernelspec.spec.language,
+      display_name: kernelspec.spec.display_name,
+    }));
+  }
+
+  return Promise.resolve(launch(nb));
 }
 
 export function launchFilename(filename) {
   if (!filename) {
+    console.warn('WARNING: launching a notebook with no filename and no kernelspec');
     return Promise.resolve(launchNewNotebook());
   }
 

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -34,7 +34,7 @@ class Notebook extends React.Component {
   componentWillMount() {
     require('codemirror/mode/markdown/markdown');
 
-    const lang = this.props.notebook.getIn(['metadata', 'language_info', 'name']);
+    const lang = this.props.notebook.getIn(['metadata', 'kernelspec', 'language']);
     if (!lang) {
       return;
     }


### PR DESCRIPTION
This slightly fixes #200, for the case of `File -> New Notebook -> Lang`, when it matches the CodeMirror mode. The follow up to this is using the `kernel_info_request` which gives us all the metadata that belongs in the notebook document on launch. It's too bad it's not in the kernelspec itself (to raise up on Jupyter somewhere?).
