### PR TITLE
LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.otf filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+*.woff filter=lfs diff=lfs merge=lfs -text
+*.eot filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For RedHat/CentOS/Fedora based variants, you'll need `zeromq` and `zeromq-devel`
 
 #### Install
 
-Requires node 5.x and npm 3. Join us in the future.
+Requires node 5.x, npm 3, and [git-lfs](https://git-lfs.github.com/).
 
 1. Fork this repo
 2. Clone it `git clone https://github.com/nteract/nteract`


### PR DESCRIPTION
Start introducing LFS usage in this repository so that when developers run `npm install` (after nuking `node_modules` for instance) they don't have to re-download fonts over npm.
