### PR TITLE
Clarify the difference between main and renderer

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,3 @@
+For those getting started with Electron based development, it's good to know about the main thread and the rendering thread.
+
+With nteract, our main thread components are in `main/` while the notebook app is in `notebook/`.


### PR DESCRIPTION
Adds a simple README for when people navigate into `src`.
