### PR TITLE
Create a way to get kernel-info

### DIFF
--- a/src/notebook/api/kernel-info.js
+++ b/src/notebook/api/kernel-info.js
@@ -1,0 +1,20 @@
+import {
+  createMessage,
+} from '../api/messaging';
+
+// Usage, assuming using Fluorine
+// dispatch(executeCell(id,source)(channels))
+
+export default function kernelInfo(channels) {
+  if (!channels || !channels.shell) {
+    throw new Error('shell channel not available for sending kernel info request');
+  }
+  const { shell } = channels;
+
+  const message = createMessage('kernel_info_request');
+  return shell
+    .childOf(message)
+    .map(msg => msg.content)
+    .first()
+    .toPromse();
+}


### PR DESCRIPTION
This will get used later to populate:
- Notebook level metadata
- Codemirror mode
- Help links

I didn't wrap this up as an action yet, it's simply a function that returns a promise that resolves to:

``` js
{ implementation_version: '4.1.2',
  protocol_version: '5.0',
  help_links:
   [ { url: 'http://docs.python.org/3.5', text: 'Python' },
     { url: 'http://ipython.org/documentation.html',
       text: 'IPython' },
     { url: 'http://docs.scipy.org/doc/numpy/reference/',
       text: 'NumPy' },
     { url: 'http://docs.scipy.org/doc/scipy/reference/',
       text: 'SciPy' },
     { url: 'http://matplotlib.org/contents.html',
       text: 'Matplotlib' },
     { url: 'http://docs.sympy.org/latest/index.html',
       text: 'SymPy' },
     { url: 'http://pandas.pydata.org/pandas-docs/stable/',
       text: 'pandas' } ],
  implementation: 'ipython',
  language_info:
   { version: '3.5.1',
     file_extension: '.py',
     name: 'python',
     nbconvert_exporter: 'python',
     mimetype: 'text/x-python',
     codemirror_mode: { version: 3, name: 'ipython' },
     pygments_lexer: 'ipython3' },
  banner: 'Python 3.5.1 (default, Dec  7 2015, 21:59:08) \nType "copyright", "credits" or "license" for more information.\n\nIPython 4.1.2 -- An enhanced Interactive Python.\n?         -> Introduction and overview of IPython\'s features.\n%quickref -> Quick reference.\nhelp      -> Python\'s own help system.\nobject?   -> Details about \'object\', use \'object??\' for extra details.\n%guiref   -> A brief reference about the graphical user interface.\n' }
```
