### PR TITLE
Rely on channels via context.

### DIFF
--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -148,9 +148,9 @@ export function updateCellExecutionCount(id, count) {
   };
 }
 
-export function executeCell(id, source) {
-  return (subject, dispatch, state) => {
-    const obs = agendas.executeCell(id, source)(state.channels);
+export function executeCell(channels, id, source) {
+  return (subject) => {
+    const obs = agendas.executeCell(channels, id, source);
     obs.subscribe(action => {
       subject.next(action);
     }, (error) => {

--- a/src/notebook/agendas/index.js
+++ b/src/notebook/agendas/index.js
@@ -11,66 +11,61 @@ import {
   updateCellOutputs,
 } from '../actions';
 
-// Usage, assuming using Fluorine
-// dispatch(executeCell(id,source)(channels))
+export function executeCell(channels, id, source) {
+  return Rx.Observable.create((subscriber) => {
+    if (!channels || !channels.iopub || !channels.shell) {
+      subscriber.error('kernel not connected');
+      subscriber.complete();
+      return () => {};
+    }
 
-export function executeCell(id, source) {
-  return function executeCellOnChannels(channels) {
-    return Rx.Observable.create((subscriber) => {
-      if (!channels || !channels.iopub || !channels.shell) {
-        subscriber.error('kernel not connected');
-        subscriber.complete();
-        return () => {};
-      }
+    const { iopub, shell } = channels;
 
-      const { iopub, shell } = channels;
+    // Track all of our subscriptions for full disposal
+    const subscriptions = [];
 
-      // Track all of our subscriptions for full disposal
-      const subscriptions = [];
+    const executeRequest = createExecuteRequest(source);
 
-      const executeRequest = createExecuteRequest(source);
+    // Limitation of the Subject implementation in enchannel
+    // we must shell.subscribe in order to shell.next
+    subscriptions.push(shell.subscribe(() => {}));
 
-      // Limitation of the Subject implementation in enchannel
-      // we must shell.subscribe in order to shell.next
-      subscriptions.push(shell.subscribe(() => {}));
+    // Set the current outputs to an empty list
+    subscriber.next(updateCellOutputs(id, new Immutable.List()));
 
-      // Set the current outputs to an empty list
-      subscriber.next(updateCellOutputs(id, new Immutable.List()));
+    const childMessages = iopub.childOf(executeRequest)
+                               .share();
 
-      const childMessages = iopub.childOf(executeRequest)
-                                 .share();
+    subscriptions.push(
+      childMessages.ofMessageType(['execute_input'])
+                 .pluck('content', 'execution_count')
+                 .first()
+                 .subscribe((ct) => {
+                   subscriber.next(updateCellExecutionCount(id, ct));
+                 })
+    );
 
-      subscriptions.push(
-        childMessages.ofMessageType(['execute_input'])
-                   .pluck('content', 'execution_count')
-                   .first()
-                   .subscribe((ct) => {
-                     subscriber.next(updateCellExecutionCount(id, ct));
-                   })
-      );
+    // Handle all the nbformattable messages
+    subscriptions.push(childMessages
+         .ofMessageType(['execute_result', 'display_data', 'stream', 'error', 'clear_output'])
+         .map(msgSpecToNotebookFormat)
+         // Iteratively reduce on the outputs
+         .scan((outputs, output) => {
+           if (output.output_type === 'clear_output') {
+             return new Immutable.List();
+           }
+           return outputs.push(Immutable.fromJS(output));
+         }, new Immutable.List())
+         // Update the outputs with each change
+         .subscribe(outputs => {
+           subscriber.next(updateCellOutputs(id, outputs));
+         })
+    );
 
-      // Handle all the nbformattable messages
-      subscriptions.push(childMessages
-           .ofMessageType(['execute_result', 'display_data', 'stream', 'error', 'clear_output'])
-           .map(msgSpecToNotebookFormat)
-           // Iteratively reduce on the outputs
-           .scan((outputs, output) => {
-             if (output.output_type === 'clear_output') {
-               return new Immutable.List();
-             }
-             return outputs.push(Immutable.fromJS(output));
-           }, new Immutable.List())
-           // Update the outputs with each change
-           .subscribe(outputs => {
-             subscriber.next(updateCellOutputs(id, outputs));
-           })
-      );
+    shell.next(executeRequest);
 
-      shell.next(executeRequest);
-
-      return function executionDisposed() {
-        subscriptions.forEach((sub) => sub.unsubscribe());
-      };
-    });
-  };
+    return function executionDisposed() {
+      subscriptions.forEach((sub) => sub.unsubscribe());
+    };
+  });
 }

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -30,8 +30,9 @@ const CodeCell = (props, context) => {
       // this.context.dispatch(nextCell(props.id));
     }
 
-    context.dispatch(executeCell(props.id,
-                                      props.cell.get('source')));
+    context.dispatch(executeCell(context.channels,
+                                 props.id,
+                                 props.cell.get('source')));
   }
 
   return (

--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -9,6 +9,7 @@ class Toolbar extends React.Component {
   };
 
   static contextTypes = {
+    channels: React.PropTypes.object,
     dispatch: React.PropTypes.func,
   };
 
@@ -27,7 +28,8 @@ class Toolbar extends React.Component {
   }
 
   executeCell() {
-    this.context.dispatch(executeCell(this.props.id,
+    this.context.dispatch(executeCell(this.context.channels,
+                                      this.props.id,
                                       this.props.cell.get('source')));
   }
 

--- a/src/notebook/store/index.js
+++ b/src/notebook/store/index.js
@@ -17,8 +17,6 @@ export default function createStore(initialState, reducers) {
     initialState || {}
   ).share();
 
-  // Debugging time
-
   const stateSymbol = Symbol('state');
   store.subscribe(state => {
     store[stateSymbol] = state;
@@ -28,9 +26,8 @@ export default function createStore(initialState, reducers) {
   store.getState = () => store[stateSymbol];
 
   function dispatch(action) {
-    // We need the current state at this time
     return typeof action === 'function'
-      ? action.call(null, subject, dispatch, store.getState())
+      ? action.call(null, subject, dispatch)
       : subject.next(action);
   }
 


### PR DESCRIPTION
This cleans up the `executeCell` action as well as the store itself (no more passing in the state).
