### PR TITLE
Extract menu bits

### DIFF
--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -9,6 +9,7 @@ import Notebook from './components/notebook';
 import {
   setNotebook,
 } from './actions';
+
 import { initKeymap } from './keys/keymap';
 import { ipcRenderer as ipc } from 'electron';
 

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -7,55 +7,21 @@ import Provider from './components/util/provider';
 import Notebook from './components/notebook';
 
 import {
-  showSaveAsDialog,
-} from './api/save';
-
-import {
   setNotebook,
-  newKernel,
-  save,
-  saveAs,
-  killKernel,
 } from './actions';
 import { initKeymap } from './keys/keymap';
 import { ipcRenderer as ipc } from 'electron';
+
+import { initMenuHandlers } from './menu';
 
 ipc.on('main:load', (e, launchData) => {
   const { store, dispatch } = createStore({
     notebook: null,
     filename: launchData.filename,
   }, reducers);
+
   initKeymap(window, dispatch);
-
-
-  function triggerSaveAs() {
-    showSaveAsDialog()
-      .then(filename => {
-        if (!filename) {
-          return;
-        }
-        const { notebook } = store.getState();
-        dispatch(saveAs(filename, notebook));
-      }
-    );
-  }
-
-  ipc.on('menu:new-kernel', (evt, name) => dispatch(newKernel(name)));
-  ipc.on('menu:save', () => {
-    const state = store.getState();
-    const { notebook, filename } = state;
-    if (!filename) {
-      triggerSaveAs();
-    } else {
-      dispatch(save(filename, notebook));
-    }
-  });
-  ipc.on('menu:save-as', (evt, filename) => {
-    const state = store.getState();
-    const { notebook } = state;
-    dispatch(saveAs(filename, notebook));
-  });
-  ipc.on('menu:kill-kernel', () => dispatch(killKernel()));
+  initMenuHandlers(store, dispatch);
 
   class App extends React.Component {
     constructor(props) {

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -39,9 +39,17 @@ export function dispatchSave(store, dispatch) {
   }
 }
 
+export function dispatchNewkernel(store, dispatch, evt, name) {
+  dispatch(newKernel(name));
+}
+
+export function dispatchKillKernel(store, dispatch) {
+  dispatch(killKernel());
+}
+
 export function initMenuHandlers(store, dispatch) {
-  ipc.on('menu:new-kernel', (evt, name) => dispatch(newKernel(name)));
+  ipc.on('menu:new-kernel', dispatchNewkernel.bind(null, store, dispatch));
   ipc.on('menu:save', dispatchSave.bind(null, store, dispatch));
   ipc.on('menu:save-as', dispatchSaveAs.bind(null, store, dispatch));
-  ipc.on('menu:kill-kernel', () => dispatch(killKernel()));
+  ipc.on('menu:kill-kernel', dispatchKillKernel.bind(null, store, dispatch));
 }

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -1,0 +1,43 @@
+
+import {
+  showSaveAsDialog,
+} from '../api/save';
+
+import {
+  newKernel,
+  save,
+  saveAs,
+  killKernel,
+} from '../actions';
+import { ipcRenderer as ipc } from 'electron';
+
+export function initMenuHandlers(store, dispatch) {
+  function triggerSaveAs() {
+    showSaveAsDialog()
+      .then(filename => {
+        if (!filename) {
+          return;
+        }
+        const { notebook } = store.getState();
+        dispatch(saveAs(filename, notebook));
+      }
+    );
+  }
+
+  ipc.on('menu:new-kernel', (evt, name) => dispatch(newKernel(name)));
+  ipc.on('menu:save', () => {
+    const state = store.getState();
+    const { notebook, filename } = state;
+    if (!filename) {
+      triggerSaveAs();
+    } else {
+      dispatch(save(filename, notebook));
+    }
+  });
+  ipc.on('menu:save-as', (evt, filename) => {
+    const state = store.getState();
+    const { notebook } = state;
+    dispatch(saveAs(filename, notebook));
+  });
+  ipc.on('menu:kill-kernel', () => dispatch(killKernel()));
+}


### PR DESCRIPTION
Put menu setup in another file where we handle the init. This makes it a bit easier to test. Native menu actions only emit their event as well as some attached data (it originates in the Electron main thread).

In order for everything to flow through our Flux store here, we need to make `dispatch` and `store` available to the event callback. This can be done in two ways. I went for the explicit bind to create a function that has `store` and `dispatch`.
