### PR TITLE
Provide some helpers for always getting the status

### DIFF
--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -12,6 +12,13 @@ export function exit() {
   };
 }
 
+export function setExecutionState(executionState) {
+  return {
+    type: constants.SET_EXECUTION_STATE,
+    executionState,
+  };
+}
+
 export function killKernel() {
   return {
     type: constants.KILL_KERNEL,

--- a/src/notebook/constants/index.js
+++ b/src/notebook/constants/index.js
@@ -27,3 +27,5 @@ export const UPDATE_CELL_OUTPUTS = Symbol('UPDATE_CELL_OUTPUTS');
 export const UPDATE_CELL_SOURCE = Symbol('UPDATE_CELL_SOURCE');
 
 export const SET_LANGUAGE_INFO = Symbol('SET_LANGUAGE_INFO');
+
+export const SET_EXECUTION_STATE = Symbol('SET_EXECUTION_STATE');

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -43,6 +43,7 @@ ipc.on('main:load', (e, launchData) => {
 
   store
     .pluck('executionState')
+    .distinctUntilChanged()
     .subscribe(executionState => {
       console.warn(`kernel status: ${executionState}`);
       // TODO: Update the app title with the execution state.

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -22,7 +22,7 @@ ipc.on('main:load', (e, launchData) => {
   const { store, dispatch } = createStore({
     notebook: null,
     filename: launchData.filename,
-    executionState: 'prestart',
+    executionState: 'not connected',
   }, reducers);
 
   store

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -46,6 +46,10 @@ export default {
   [constants.ERROR_KERNEL_NOT_CONNECTED]: function alertKernelNotConnected(state) {
     return { ...state, error: 'Error: We\'re not connected to a runtime!' };
   },
+  [constants.SET_EXECUTION_STATE]: function setExecutionState(state, action) {
+    const { executionState } = action;
+    return { ...state, executionState };
+  },
   [constants.DONE_SAVING]: function doneSaving(state) {
     return { ...state, isSaving: false };
   },


### PR DESCRIPTION
## Overview
- Listen for new `status` updates
- When a new set of `channels` come in, toss the old status subscription and set up a new one
## Implementation
- Configure reducer, action creator, and constant for execution state
- Rely on RxJS's `switchMap` to subscribe to new statuses on a new `channels`, disposing the old subscription

This assumes that the kernel status would be used somewhere native.

/cc @betatim This takes it part way towards what you're looking for. At the very least, the actions and reducers are in place for you here.
