### PR TITLE
Set title via native windowing API

### DIFF
--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -15,6 +15,7 @@ import { initKeymap } from './keys/keymap';
 import { ipcRenderer as ipc } from 'electron';
 
 import { initMenuHandlers } from './menu';
+import { initNativeHandlers } from './native-window';
 
 const Rx = require('@reactivex/rxjs');
 
@@ -41,14 +42,7 @@ ipc.on('main:load', (e, launchData) => {
       dispatch(setExecutionState(st));
     });
 
-  store
-    .pluck('executionState')
-    .distinctUntilChanged()
-    .subscribe(executionState => {
-      console.warn(`kernel status: ${executionState}`);
-      // TODO: Update the app title with the execution state.
-    });
-
+  initNativeHandlers(store);
   initKeymap(window, dispatch);
   initMenuHandlers(store, dispatch);
 

--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -1,0 +1,14 @@
+import { getCurrentWindow } from 'remote';
+
+export function initNativeHandlers(store) {
+  store
+    .map(state => {
+      const { executionState, filename } = state;
+      return `${filename || 'Untitled'} - ${executionState}`;
+    })
+    .distinctUntilChanged()
+    .subscribe(title => {
+      const win = getCurrentWindow();
+      win.setTitle(title);
+    });
+}


### PR DESCRIPTION
- Use the remote module to [get the current `BrowserWindow`](https://github.com/atom/electron/blob/master/docs/api/remote.md#remotegetcurrentwindow)
- Subscribe to the Flux store for updates to the filename and execution state

This looks a little funny when hopping between `idle <---> busy`, I look forward to someone making a better representation.
