### PR TITLE
Remove unused onCellChange prop in notebook

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -13,7 +13,6 @@ class Notebook extends React.Component {
     channels: React.PropTypes.any,
     displayOrder: React.PropTypes.instanceOf(Immutable.List),
     notebook: React.PropTypes.any,
-    onCellChange: React.PropTypes.func,
     transforms: React.PropTypes.instanceOf(Immutable.Map),
   };
 


### PR DESCRIPTION
Was demoing and talking through the architecture with @andrewosh, noticed this unused prop.

The other props here that we're not using `displayOrder` and `transforms` are intended to be used later as well, so I left them as is. `onCellChange` had no other purpose really, began life elsewhere.
