### PR TITLE
Kernel does not shutdown when quitting app

### DIFF
--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -20,6 +20,10 @@ export function launch(notebook, filename) {
     win.webContents.send('main:load', { notebook: notebook.toJS(), filename });
   });
 
+  win.on('close', () => {
+    win.webContents.send('menu:kill-kernel');
+  });
+
   // Emitted when the window is closed.
   win.on('closed', () => {
     win = null;


### PR DESCRIPTION
Send `menu:kill-kernel` IPC just before the window is closed (`close`).

If others listen for the `close` event and decide closing isn't the right
thing to do we need to revisit this. Sending it on `closed` is too late :(
