### PR TITLE
Problem: Can't tell which cell is focused

### DIFF
--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -168,6 +168,13 @@ export function updateCellExecutionCount(id, count) {
   };
 }
 
+export function focusNextCell(id) {
+  return {
+    type: constants.FOCUS_NEXT_CELL,
+    id,
+  };
+}
+
 export function executeCell(channels, id, source) {
   return (subject) => {
     const obs = agendas.executeCell(channels, id, source);

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -8,6 +8,7 @@ class Cell extends React.Component {
   static propTypes = {
     cell: React.PropTypes.any,
     id: React.PropTypes.string,
+    focusedCell: React.PropTypes.string,
     onCellChange: React.PropTypes.func,
   };
 

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -9,6 +9,7 @@ import Immutable from 'immutable';
 
 import {
   executeCell,
+  focusNextCell,
 } from '../../actions';
 
 const CodeCell = (props, context) => {
@@ -26,8 +27,7 @@ const CodeCell = (props, context) => {
       // TODO: Remove this, as it should be created if at the end of document only
       // this.context.dispatch(createCellAfter('code', props.id));
 
-      // should instead be
-      // this.context.dispatch(nextCell(props.id));
+      context.dispatch(focusNextCell(props.id));
     }
 
     context.dispatch(executeCell(context.channels,
@@ -43,6 +43,7 @@ const CodeCell = (props, context) => {
           id={props.id}
           input={props.cell.get('source')}
           language={props.language}
+          focused={props.id === props.focusedCell}
         />
       </div>
       <Display
@@ -62,6 +63,7 @@ CodeCell.propTypes = {
   language: React.PropTypes.string,
   theme: React.PropTypes.string,
   transforms: React.PropTypes.instanceOf(Immutable.Map),
+  focusedCell: React.PropTypes.string,
 };
 
 CodeCell.contextTypes = {

--- a/src/notebook/components/cell/draggable-cell.js
+++ b/src/notebook/components/cell/draggable-cell.js
@@ -57,6 +57,7 @@ class DraggableCell extends React.Component {
     id: React.PropTypes.string,
     isDragging: React.PropTypes.bool.isRequired,
     isOver: React.PropTypes.bool.isRequired,
+    focusedCell: React.PropTypes.string,
   };
 
   static contextTypes = {

--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -13,6 +13,7 @@ export default class Editor extends React.Component {
     lineNumbers: React.PropTypes.bool,
     onChange: React.PropTypes.func,
     theme: React.PropTypes.string,
+    focused: React.PropTypes.bool,
   };
 
   static contextTypes = {

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -14,6 +14,7 @@ class Notebook extends React.Component {
     displayOrder: React.PropTypes.instanceOf(Immutable.List),
     notebook: React.PropTypes.any,
     transforms: React.PropTypes.instanceOf(Immutable.Map),
+    focusedCell: React.PropTypes.string,
   };
 
   static contextTypes = {
@@ -68,6 +69,7 @@ class Notebook extends React.Component {
           displayOrder={this.props.displayOrder}
           transforms={this.props.transforms}
           moveCell={this.moveCell}
+          focusedCell={this.props.focusedCell}
         />
         <CellCreator key={`creator-${id}`} id={id} above={false} />
       </div>);

--- a/src/notebook/constants/index.js
+++ b/src/notebook/constants/index.js
@@ -29,3 +29,4 @@ export const UPDATE_CELL_SOURCE = Symbol('UPDATE_CELL_SOURCE');
 export const SET_LANGUAGE_INFO = Symbol('SET_LANGUAGE_INFO');
 
 export const SET_EXECUTION_STATE = Symbol('SET_EXECUTION_STATE');
+export const FOCUS_NEXT_CELL = Symbol('FOCUS_NEXT_CELL');

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -68,6 +68,7 @@ ipc.on('main:load', (e, launchData) => {
               <Notebook
                 notebook={this.state.notebook}
                 channels={this.state.channels}
+                focusedCell={this.state.focusedCell}
               />
             }
           </div>

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -10,6 +10,15 @@ export default {
       notebook: action.data,
     };
   },
+  [constants.FOCUS_NEXT_CELL]: function focusNextCell(state, action) {
+    const { notebook } = state;
+    const cellOrder = notebook.get('cellOrder');
+    const curIndex = cellOrder.findIndex(id => id === action.id);
+    return {
+      ...state,
+      focusedCell: cellOrder.get(curIndex + 1),
+    };
+  },
   [constants.UPDATE_CELL_EXECUTION_COUNT]: function updateExecutionCount(state, action) {
     const { id, count } = action;
     const { notebook } = state;


### PR DESCRIPTION
Add ID of the next cell to the state when pressing shift+return

I can't work out how to actually focus a cell once it knows that
it is the currently focused cell. CM has a `autofocus` option
but I don't think this is exposed in `react-code-mirror`. Ideas?
