### PR TITLE
Hide display area if empty.

### DIFF
--- a/src/notebook/styles/main.css
+++ b/src/notebook/styles/main.css
@@ -167,6 +167,11 @@ img
     padding: 10px 10px 10px 60px;
 }
 
+.cell_display:empty
+{
+    display:none;
+}
+
 .code_cell .input_area
 {
     display: flex;


### PR DESCRIPTION
Because there is no reason to show anything, and that's make the
notebook a bit more compact.
