### PR TITLE
Use representative filename  on os X

### DIFF
--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -4,12 +4,17 @@ export function initNativeHandlers(store) {
   store
     .map(state => {
       const { executionState, filename } = state;
-      return `${filename || 'Untitled'} - ${executionState}`;
+      return {title:`${filename || 'Untitled'} - ${executionState}`, path:filename};
     })
     .distinctUntilChanged()
     .debounceTime(200)
-    .subscribe(title => {
+    .subscribe(res => {
       const win = getCurrentWindow();
-      win.setTitle(title);
+      // no indication of this does not exists or is no-op on Non OSX.
+      debugger;
+      if(res.path){
+          (win.setRepresentedFilename||function(){})(res.path);
+      }
+      win.setTitle(res.title);
     });
 }


### PR DESCRIPTION
![rf](https://cloud.githubusercontent.com/assets/335567/14003063/3c112ee4-f10d-11e5-9ff3-65a859de8bc7.gif)

Should later : 

1) compress `$HOME` to `~`
2) quote filename if space in it,or it looks weird.
