### PR TITLE
ctrl-enter runs cell without focus

### DIFF
--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -23,6 +23,8 @@ const CodeCell = (props, context) => {
       return;
     }
 
+    e.preventDefault();
+
     if (e.shiftKey) {
       // TODO: Remove this, as it should be created if at the end of document only
       // this.context.dispatch(createCellAfter('code', props.id));

--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -36,15 +36,6 @@ export default class Editor extends React.Component {
     this.onChange = this.onChange.bind(this);
   }
 
-  componentDidMount() {
-    const editor = ReactDOM.findDOMNode(this.refs.codemirror);
-    editor.addEventListener('keypress', (e) => {
-      if (e.keyCode === 13 && e.shiftKey) {
-        e.preventDefault();
-      }
-    });
-  }
-
   componentWillReceiveProps(nextProps) {
     this.setState({
       source: nextProps.input,


### PR DESCRIPTION
This also removes an extra listener we didn't need (can `e.preventDefault` on the code cell).
