### PR TITLE
eslint touchups

### DIFF
--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -26,9 +26,6 @@ const CodeCell = (props, context) => {
     e.preventDefault();
 
     if (e.shiftKey) {
-      // TODO: Remove this, as it should be created if at the end of document only
-      // this.context.dispatch(createCellAfter('code', props.id));
-
       context.dispatch(focusNextCell(props.id));
     }
 

--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 import CodeMirror from 'react-code-mirror';
 

--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -4,15 +4,18 @@ export function initNativeHandlers(store) {
   store
     .map(state => {
       const { executionState, filename } = state;
-      return {title:`${filename || 'Untitled'} - ${executionState}`, path:filename};
+      return {
+        title: `${filename || 'Untitled'} - ${executionState}`,
+        path: filename,
+      };
     })
     .distinctUntilChanged()
     .debounceTime(200)
     .subscribe(res => {
       const win = getCurrentWindow();
-      // no indication of this does not exists or is no-op on Non OSX.
-      if(res.path){
-          (win.setRepresentedFilename||function(){})(res.path);
+      // TODO: Investigate if setRepresentedFilename() is a no-op on non-OS X
+      if (res.path && win.setRepresentedFilename) {
+        win.setRepresentedFilename(res.path);
       }
       win.setTitle(res.title);
     });

--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -15,6 +15,7 @@ export function initNativeHandlers(store) {
       const win = getCurrentWindow();
       // TODO: Investigate if setRepresentedFilename() is a no-op on non-OS X
       if (res.path && win.setRepresentedFilename) {
+        // TODO: this needs to be the full path to the file
         win.setRepresentedFilename(res.path);
       }
       win.setTitle(res.title);

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -10,7 +10,7 @@ export default {
       notebook: action.data,
     };
   },
-  [constants.FOCUS_CELL]: function focusCell(state, action){
+  [constants.FOCUS_CELL]: function focusCell(state, action) {
     const { id } = action;
     return {
       ...state,


### PR DESCRIPTION
Lint rolling.

We need to investigate `.setRepresentedFilename()` and other OS specific functions to know whether we have to check on them on other OSes, as suggested by @Carreau.

@jdfreder - when you are able to get to your Linux box later, can you pop open an Electron window, open the dev console and run:

```
require('remote').getCurrentWindow().setRepresentedFilename
```
