### PR TITLE
Fix white at bottom of cell.

### DIFF
--- a/src/notebook/styles/main.css
+++ b/src/notebook/styles/main.css
@@ -189,7 +189,7 @@ img
     font-size: 12px;
 
     width: 50px;
-    padding: 10px 0;
+    padding: 9px 0;
 
     text-align: center;
 


### PR DESCRIPTION
body -line height is 22px, with a padding of 10px (tom & bottom) adds up
to 42, which is bigger than 40, the minimum of a 1line codemirror.

Closes #264
