### PR TITLE
Bump spawnteract.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-router": "^1.0.3",
     "source-code-pro": "git://github.com/adobe-fonts/source-code-pro.git#release",
     "source-sans-pro": "git://github.com/adobe-fonts/source-sans-pro.git#release",
-    "spawnteract": "^1.0.2",
+    "spawnteract": "^2.0.0",
     "transformime-react": "0.4.0",
     "uuid": "^2.0.1"
   },


### PR DESCRIPTION
At the very least, bump us to the version of spawnteract that accepts [options for `child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) so that we can handle #261.
