### PR TITLE
Pass spawn options on through.

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -36,6 +36,7 @@ export const fileSubMenus = {
         properties: [
           'openFile',
         ],
+        // TODO: This should be based on the currently opened notebook
         defaultPath: process.cwd(),
       };
       dialog.showOpenDialog(opts, (fname) => {

--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -32,9 +32,9 @@ export function setLanguageInfo(langInfo) {
   };
 }
 
-export function newKernel(kernelSpecName) {
+export function newKernel(kernelSpecName, spawnOptions) {
   return (subject) => {
-    launchKernel(kernelSpecName)
+    launchKernel(kernelSpecName, spawnOptions)
       .then(kc => {
         const { channels, connectionFile, spawn } = kc;
 
@@ -86,7 +86,7 @@ export function saveAs(filename, notebook) {
   };
 }
 
-export function setNotebook(nbData) {
+export function setNotebook(nbData, spawnOptions) {
   return (subject, dispatch) => {
     const data = Immutable.fromJS(nbData);
     subject.next({
@@ -101,7 +101,7 @@ export function setNotebook(nbData) {
     ], data.getIn([
       'metadata', 'language_info', 'name',
     ], 'python3'));
-    dispatch(newKernel(kernelName));
+    dispatch(newKernel(kernelName, spawnOptions));
   };
 }
 

--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -89,7 +89,7 @@ export function saveAs(filename, notebook) {
 }
 
 export function setNotebook(nbData, filename) {
-  const cwd = path.dirname(path.resolve(filename));
+  const cwd = (filename && path.dirname(path.resolve(filename))) || process.cwd;
   return (subject, dispatch) => {
     const data = Immutable.fromJS(nbData);
     subject.next({

--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 import Immutable from 'immutable';
 import * as commutable from 'commutable';
 import { writeFile } from 'fs';
@@ -32,9 +34,9 @@ export function setLanguageInfo(langInfo) {
   };
 }
 
-export function newKernel(kernelSpecName, spawnOptions) {
+export function newKernel(kernelSpecName, cwd) {
   return (subject) => {
-    launchKernel(kernelSpecName, spawnOptions)
+    launchKernel(kernelSpecName, { cwd })
       .then(kc => {
         const { channels, connectionFile, spawn } = kc;
 
@@ -86,7 +88,8 @@ export function saveAs(filename, notebook) {
   };
 }
 
-export function setNotebook(nbData, spawnOptions) {
+export function setNotebook(nbData, filename) {
+  const cwd = path.dirname(path.resolve(filename));
   return (subject, dispatch) => {
     const data = Immutable.fromJS(nbData);
     subject.next({
@@ -101,7 +104,7 @@ export function setNotebook(nbData, spawnOptions) {
     ], data.getIn([
       'metadata', 'language_info', 'name',
     ], 'python3'));
-    dispatch(newKernel(kernelName, spawnOptions));
+    dispatch(newKernel(kernelName, cwd));
   };
 }
 

--- a/src/notebook/api/kernel.js
+++ b/src/notebook/api/kernel.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 import {
   createControlSubject,
   createStdinSubject,
@@ -29,12 +27,4 @@ export function launchKernel(kernelSpecName, spawnOptions) {
           spawn,
         };
       });
-}
-
-export function createSpawnOptions(filename) {
-  const spawnOptions = {};
-  if (filename) {
-    spawnOptions.cwd = path.dirname(path.resolve(filename));
-  }
-  return spawnOptions;
 }

--- a/src/notebook/api/kernel.js
+++ b/src/notebook/api/kernel.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 import {
   createControlSubject,
   createStdinSubject,
@@ -8,8 +10,8 @@ import {
 import * as uuid from 'uuid';
 import { launch } from 'spawnteract';
 
-export function launchKernel(kernelSpecName) {
-  return launch(kernelSpecName)
+export function launchKernel(kernelSpecName, spawnOptions) {
+  return launch(kernelSpecName, spawnOptions)
       .then(c => {
         const kernelConfig = c.config;
         const spawn = c.spawn;
@@ -27,4 +29,12 @@ export function launchKernel(kernelSpecName) {
           spawn,
         };
       });
+}
+
+export function createSpawnOptions(filename) {
+  const spawnOptions = {};
+  if (filename) {
+    spawnOptions.cwd = path.dirname(path.resolve(filename));
+  }
+  return spawnOptions;
 }

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -11,6 +11,10 @@ import {
   setExecutionState,
 } from './actions';
 
+import {
+  createSpawnOptions,
+} from './api/kernel';
+
 import { initKeymap } from './keys/keymap';
 import { ipcRenderer as ipc } from 'electron';
 
@@ -53,7 +57,10 @@ ipc.on('main:load', (e, launchData) => {
       store.subscribe(state => this.setState(state));
     }
     componentDidMount() {
-      dispatch(setNotebook(launchData.notebook));
+      const state = store.getState();
+      const filename = (state && state.filename) || launchData.filename;
+      const spawnOptions = createSpawnOptions(filename);
+      dispatch(setNotebook(launchData.notebook, spawnOptions));
     }
     render() {
       return (

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -11,10 +11,6 @@ import {
   setExecutionState,
 } from './actions';
 
-import {
-  createSpawnOptions,
-} from './api/kernel';
-
 import { initKeymap } from './keys/keymap';
 import { ipcRenderer as ipc } from 'electron';
 
@@ -59,8 +55,7 @@ ipc.on('main:load', (e, launchData) => {
     componentDidMount() {
       const state = store.getState();
       const filename = (state && state.filename) || launchData.filename;
-      const spawnOptions = createSpawnOptions(filename);
-      dispatch(setNotebook(launchData.notebook, spawnOptions));
+      dispatch(setNotebook(launchData.notebook, filename));
     }
     render() {
       return (

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -1,7 +1,10 @@
-
 import {
   showSaveAsDialog,
 } from '../api/save';
+
+import {
+  createSpawnOptions,
+} from '../api/kernel';
 
 import {
   newKernel,
@@ -40,7 +43,9 @@ export function dispatchSave(store, dispatch) {
 }
 
 export function dispatchNewkernel(store, dispatch, evt, name) {
-  dispatch(newKernel(name));
+  const { filename } = store.getState();
+  const spawnOptions = createSpawnOptions(filename);
+  dispatch(newKernel(name, spawnOptions));
 }
 
 export function dispatchKillKernel(store, dispatch) {

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -1,10 +1,8 @@
+const path = require('path');
+
 import {
   showSaveAsDialog,
 } from '../api/save';
-
-import {
-  createSpawnOptions,
-} from '../api/kernel';
 
 import {
   newKernel,
@@ -43,8 +41,11 @@ export function dispatchSave(store, dispatch) {
 }
 
 export function dispatchNewkernel(store, dispatch, evt, name) {
-  const { filename } = store.getState();
-  const spawnOptions = createSpawnOptions(filename);
+  const state = store.getState();
+  const spawnOptions = {};
+  if (state && state.filename) {
+    spawnOptions.cwd = path.dirname(path.resolve(state.filename));
+  }
   dispatch(newKernel(name, spawnOptions));
 }
 


### PR DESCRIPTION
Closes #261.

This was a bit awkward to handle because of how actions need the filename that is in the store. For `menu`, this works out fine because it can call `store.getState()`. On load of a notebook though, that's not the case. Certainly open to cleanup after this.
