### PR TITLE
Filter out undefined and null from notebook list

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -25,5 +25,5 @@ app.on('ready', () => {
   Menu.setApplicationMenu(defaultMenu);
   // Let the kernels/languages come in after
   loadFullMenu().then(menu => Menu.setApplicationMenu(menu));
-  notebooks.map(f=>resolve(f)).forEach(launchFilename);
+  notebooks.filter(Boolean).map(f => resolve(f)).forEach(launchFilename);
 });


### PR DESCRIPTION
With no arguments to this app, `f` ends up being null. This affected the "empty notebook" startup case:

```
npm run start
```

That creates a `null` entry in notebooks, ended up just filtering it out here. It also means there is no dummy notebook on launch... I'll investigate that next.
