### PR TITLE
Remove unused babel plugin for transforming export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,6 @@
     ],
     "plugins": [
       "transform-class-properties",
-      "transform-export-extensions",
       "transform-object-rest-spread"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "babel-core": "^6.3.17",
     "babel-eslint": "^5.0.0",
     "babel-plugin-transform-class-properties": "^6.3.13",
-    "babel-plugin-transform-export-extensions": "^6.3.13",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.3.13",


### PR DESCRIPTION
We're not using this anywhere as far as I can tell. All the notebook ops I did seemed to be working well.
