### PR TITLE
Make sure we break-word on .cell_display

### DIFF
--- a/src/notebook/styles/main.css
+++ b/src/notebook/styles/main.css
@@ -180,6 +180,7 @@ td {
 
 .cell_display
 {
+    word-wrap: break-word;
     padding: 10px 10px 10px 60px;
 }
 


### PR DESCRIPTION
Noticed some long flowing sections that needed some wrapping to not escape the cell area.
