### PR TITLE
Trim unused deps and bump babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,8 @@
   "homepage": "https://github.com/nteract/nteract",
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.2",
-    "ansi-to-html": "^0.3.0",
     "atom-keymap": "^6.3.1",
     "codemirror": "^5.12.0",
-    "color": "^0.10.1",
     "commander": "^2.9.0",
     "commutable": "^0.6.0",
     "enchannel-zmq-backend": "^1.0.1",
@@ -49,7 +47,6 @@
     "react-dom": "^0.14.7",
     "react-jupyter-display-area": "0.2.1",
     "react-markdown": "^1.2.4",
-    "react-router": "^1.0.3",
     "source-code-pro": "git://github.com/adobe-fonts/source-code-pro.git#release",
     "source-sans-pro": "git://github.com/adobe-fonts/source-sans-pro.git#release",
     "spawnteract": "^2.0.0",
@@ -59,13 +56,12 @@
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.17",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.2",
     "babel-plugin-transform-class-properties": "^6.3.13",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.3.13",
     "chai": "^3.4.1",
-    "chai-immutable": "^1.5.3",
     "electron-compile": "^2.0.4",
     "electron-compilers": "^2.0.4",
     "electron-mocha": "^0.7.0",
@@ -75,7 +71,6 @@
     "eslint-plugin-react": "^4.1.0",
     "estraverse-fb": "^1.3.1",
     "react-addons-test-utils": "^0.14.5",
-    "sinon": "^1.17.3",
     "watch": "^0.17.1"
   }
 }


### PR DESCRIPTION
Closes #291 (the eslint portion). Trimmed some unused deps using [`npm-check`](https://github.com/dylang/npm-check) as well. There were some other major bumps we may want to check out soon too. I kept this PR conservative.
