### PR TITLE
Depend directly on fonts from material icons

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.woff filter=lfs diff=lfs merge=lfs -text
 *.eot filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
+*.ijmap filter=lfs diff=lfs merge=lfs -text

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "enchannel-zmq-backend": "^1.0.1",
     "immutable": "^3.7.6",
     "kernelspecs": "^1.0.1",
-    "material-design-icons": "^2.2.0",
     "normalize.css": "^4.0.0",
     "react": "^15.0.1",
     "react-code-mirror": "^3.0.6",

--- a/src/notebook/fonts/material-design-icons/MaterialIcons-Regular.ttf
+++ b/src/notebook/fonts/material-design-icons/MaterialIcons-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7f4a3ab562048f28dd1fa691601bc43363a61d0f876d16d8316c52e4f32d696
+size 128180

--- a/src/notebook/fonts/material-design-icons/MaterialIcons-Regular.woff
+++ b/src/notebook/fonts/material-design-icons/MaterialIcons-Regular.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4a1baec300d09e03a8380b85918267ee80faae8e00c6c56b48e2e74b1d9b38d
+size 57620

--- a/src/notebook/fonts/material-design-icons/MaterialIcons-Regular.woff2
+++ b/src/notebook/fonts/material-design-icons/MaterialIcons-Regular.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a87d66c91b2e7dc5530aef76c03bd6a3d25ea5826110bf4803b561b811cc8726
+size 44300

--- a/src/notebook/fonts/material-design-icons/README.md
+++ b/src/notebook/fonts/material-design-icons/README.md
@@ -1,0 +1,9 @@
+The recommended way to use the Material Icons font is by linking to the web font hosted on Google Fonts:
+
+```html
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">
+```
+
+Read more in our full usage guide:
+http://google.github.io/material-design-icons/#icon-font-for-the-web

--- a/src/notebook/fonts/material-design-icons/README.md
+++ b/src/notebook/fonts/material-design-icons/README.md
@@ -1,3 +1,16 @@
+# Material Design Icons from Google
+
+Since material-design-icons is more than 350 MB, we've included only the bits we need from the `iconfonts` directory from the `material-design-icons` module.
+
+A few other files that aren't included here, because they aren't in the CSS file we use:
+
+* codepoints
+* MaterialIcons-Regular.ijmap
+* MaterialIcons-Regular.svg 
+* MaterialIcons-Regular.eot - we don't support IE6-8; this was removed from the CSS file too
+
+## Original README
+
 The recommended way to use the Material Icons font is by linking to the web font hosted on Google Fonts:
 
 ```html

--- a/src/notebook/fonts/material-design-icons/material-icons.css
+++ b/src/notebook/fonts/material-design-icons/material-icons.css
@@ -1,0 +1,38 @@
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: local('Material Icons'),
+       local('MaterialIcons-Regular'),
+       url(MaterialIcons-Regular.woff2) format('woff2'),
+       url(MaterialIcons-Regular.woff) format('woff'),
+       url(MaterialIcons-Regular.ttf) format('truetype');
+}
+
+.material-icons {
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;  /* Preferred icon size */
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
+}

--- a/src/notebook/fonts/material-design-icons/material-icons.css
+++ b/src/notebook/fonts/material-design-icons/material-icons.css
@@ -2,7 +2,6 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
        url(MaterialIcons-Regular.woff2) format('woff2'),
@@ -32,7 +31,4 @@
 
   /* Support for Firefox. */
   -moz-osx-font-smoothing: grayscale;
-
-  /* Support for IE. */
-  font-feature-settings: 'liga';
 }

--- a/src/notebook/index.html
+++ b/src/notebook/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../../node_modules/codemirror/addon/hint/show-hint.css"/>
     <link rel="stylesheet" href="../../node_modules/source-sans-pro/source-sans-pro.css"/>
     <link rel="stylesheet" href="../../node_modules/source-code-pro/source-code-pro.css"/>
-    <link rel="stylesheet" href="../../node_modules/material-design-icons/iconfont/material-icons.css"/>
+    <link rel="stylesheet" href="./fonts/material-design-icons/material-icons.css"/>
     <link rel="stylesheet" href="./styles/cm-composition.css"/>
     <link rel="stylesheet" href="./styles/main.css"/>
   </head>


### PR DESCRIPTION
Check in a subset of Material Icons we care about, removing the need for
the dependency on Material Icons from npm (which was > 350 MB).

Before:

```
$ du -d 1 -h node_modules | grep M
 28M    node_modules/@reactivex
2.2M    node_modules/babel-cli
2.2M    node_modules/babel-core
2.2M    node_modules/babel-generator
2.1M    node_modules/babel-helper-builder-react-jsx
2.1M    node_modules/babel-helper-define-map
2.1M    node_modules/babel-helper-regex
2.1M    node_modules/babel-plugin-transform-es2015-block-scoping
6.9M    node_modules/babel-polyfill
8.7M    node_modules/babel-register
1.0M    node_modules/babel-runtime
2.1M    node_modules/babel-template
2.3M    node_modules/babel-traverse
2.2M    node_modules/babel-types
2.4M    node_modules/cheerio
2.6M    node_modules/codemirror
4.2M    node_modules/core-js
2.9M    node_modules/electron-compile
2.8M    node_modules/electron-compilers
109M    node_modules/electron-prebuilt
3.3M    node_modules/es5-ext
1.1M    node_modules/escope
2.2M    node_modules/eslint
7.2M    node_modules/fsevents
4.3M    node_modules/less
4.4M    node_modules/lodash
2.3M    node_modules/lodash-es
356M    node_modules/material-design-icons
1.6M    node_modules/mocha
2.7M    node_modules/react
9.3M    node_modules/source-code-pro
8.6M    node_modules/source-sans-pro
 10M    node_modules/typescript
2.5M    node_modules/zmq
648M    node_modules
```

After:

```
$ du -d 1 -h node_modules | grep M
 28M    node_modules/@reactivex
2.2M    node_modules/babel-cli
2.2M    node_modules/babel-core
2.2M    node_modules/babel-generator
2.1M    node_modules/babel-helper-builder-react-jsx
2.1M    node_modules/babel-helper-define-map
2.1M    node_modules/babel-helper-regex
2.1M    node_modules/babel-plugin-transform-es2015-block-scoping
6.9M    node_modules/babel-polyfill
8.7M    node_modules/babel-register
1.0M    node_modules/babel-runtime
2.1M    node_modules/babel-template
2.3M    node_modules/babel-traverse
2.2M    node_modules/babel-types
2.4M    node_modules/cheerio
2.6M    node_modules/codemirror
4.2M    node_modules/core-js
2.9M    node_modules/electron-compile
2.8M    node_modules/electron-compilers
109M    node_modules/electron-prebuilt
3.3M    node_modules/es5-ext
1.1M    node_modules/escope
2.2M    node_modules/eslint
7.2M    node_modules/fsevents
4.3M    node_modules/less
4.4M    node_modules/lodash
2.3M    node_modules/lodash-es
1.6M    node_modules/mocha
2.7M    node_modules/react
9.3M    node_modules/source-code-pro
8.6M    node_modules/source-sans-pro
 10M    node_modules/typescript
2.5M    node_modules/zmq
292M    node_modules
```
