### PR TITLE
Set app name to 'nteract'

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -206,7 +206,9 @@ export const help = {
   ],
 };
 
-const name = app.getName();
+const name = 'nteract';
+app.setName(name);
+
 export const named = {
   label: name,
   submenu: [


### PR DESCRIPTION
The application name under the menubar listed "Electron" as the app, this sets it to nteract.

Note that this does not change the parent menu item (the thing displayed in the OS X menubar) as that must be configured in `electron-packager`.
