### PR TITLE
Handle opening files directly from native OS

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,6 +26,11 @@ app.on('window-all-closed', () => {
   }
 });
 
+app.on('open-file', (event, path) => {
+  event.preventDefault();
+  launchFilename(resolve(path));
+});
+
 app.on('ready', () => {
   // Get the default menu first
   Menu.setApplicationMenu(defaultMenu);


### PR DESCRIPTION
Relying on `open-file` event. Couldn't be any simpler.

You'll need a built copy of nteract to use this (with our new dist hooks).
