### PR TITLE
Registering documents on OS X

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "dist": "electron-packager . nteract --prune --out dist",
     "dist:linux64": "npm run dist -- --platform=linux --arch=x64",
     "dist:linux32": "npm run dist -- --platform=linux --arch=ia32",
-    "dist:osx64": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
-    "dist:osx32": "npm run dist -- --platform=darwin --arch=ia32 --icon ./static/icon.icns --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract"
+    "dist:osx64": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
+    "dist:osx32": "npm run dist -- --platform=darwin --arch=ia32 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "dist": "electron-packager . nteract --prune --out dist",
     "dist:linux64": "npm run dist -- --platform=linux --arch=x64",
     "dist:linux32": "npm run dist -- --platform=linux --arch=ia32",
-    "dist:osx64": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --app-category-type=public.app-category.developer-tools --app-bundle-id=nteract.nteract",
-    "dist:osx32": "npm run dist -- --platform=darwin --arch=ia32 --icon ./static/icon.icns --app-category-type=public.app-category.developer-tools --app-bundle-id=nteract.nteract"
+    "dist:osx64": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
+    "dist:osx32": "npm run dist -- --platform=darwin --arch=ia32 --icon ./static/icon.icns --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract"
   },
   "repository": {
     "type": "git",

--- a/static/extend.plist
+++ b/static/extend.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBbundleDocumentTypes</key>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>ipynb</string>
+      </array>
+      <key>CFBundleTypeName</key>
+      <string>public.ipynb</string>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>LSHandlerRank</key>
+      <string>Owner</string>
+      <key>LSItemContentTypes</key>
+      <array>
+        <string>public.ipynb</string>
+      </array>
+    </dict>
+    <key>UTImportedTypeDeclarations</key>
+    <dict>
+      <key>UTTypeConformsTo</key>
+      <array>
+        <string>public.data</string>
+      </array>
+      <key>UTTypeIdentifier</key>
+      <string>public.ipynb</string>
+      <key>UTTypeTagSpecification</key>
+      <dict>
+        <key>com.apple.ostype</key>
+        <string>IPYNB</string>
+        <key>public.filename-extension</key>
+        <array>
+          <string>ipynb</string>
+        </array>
+        <key>public.mime-type</key>
+        <string>application/x-ipynb+json</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/static/extend.plist
+++ b/static/extend.plist
@@ -10,36 +10,38 @@
           <string>ipynb</string>
         </array>
         <key>CFBundleTypeName</key>
-        <string>public.ipynb</string>
+        <string>io.nteract.notebook</string>
         <key>CFBundleTypeRole</key>
         <string>Editor</string>
         <key>LSHandlerRank</key>
         <string>Owner</string>
         <key>LSItemContentTypes</key>
         <array>
-          <string>public.ipynb</string>
+          <string>io.nteract.notebook</string>
         </array>
       </dict>
     </array>
-    <key>UTImportedTypeDeclarations</key>
-    <dict>
-      <key>UTTypeConformsTo</key>
-      <array>
-        <string>public.data</string>
-      </array>
-      <key>UTTypeIdentifier</key>
-      <string>public.ipynb</string>
-      <key>UTTypeTagSpecification</key>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
       <dict>
-        <key>com.apple.ostype</key>
-        <string>IPYNB</string>
-        <key>public.filename-extension</key>
+        <key>UTTypeConformsTo</key>
         <array>
-          <string>ipynb</string>
+          <string>public.composite-content</string>
         </array>
-        <key>public.mime-type</key>
-        <string>application/x-ipynb+json</string>
+        <key>UTTypeDescription</key>
+        <string>nteract notebook</string>
+        <key>UTTypeIdentifier</key>
+        <string>io.nteract.notebook</string>
+        <key>UTTypeTagSpecification</key>
+        <dict>
+          <key>public.filename-extension</key>
+          <array>
+            <string>ipynb</string>
+          </array>
+          <key>public.mime-type</key>
+          <string>application/x-ipynb+json</string>
+        </dict>
       </dict>
-    </dict>
+    </array>
   </dict>
 </plist>

--- a/static/extend.plist
+++ b/static/extend.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>CFBbundleDocumentTypes</key>
+    <key>CFBundleDocumentTypes</key>
     <dict>
       <key>CFBundleTypeExtensions</key>
       <array>

--- a/static/extend.plist
+++ b/static/extend.plist
@@ -3,22 +3,24 @@
 <plist version="1.0">
   <dict>
     <key>CFBundleDocumentTypes</key>
-    <dict>
-      <key>CFBundleTypeExtensions</key>
-      <array>
-        <string>ipynb</string>
-      </array>
-      <key>CFBundleTypeName</key>
-      <string>public.ipynb</string>
-      <key>CFBundleTypeRole</key>
-      <string>Editor</string>
-      <key>LSHandlerRank</key>
-      <string>Owner</string>
-      <key>LSItemContentTypes</key>
-      <array>
+    <array>
+      <dict>
+        <key>CFBundleTypeExtensions</key>
+        <array>
+          <string>ipynb</string>
+        </array>
+        <key>CFBundleTypeName</key>
         <string>public.ipynb</string>
-      </array>
-    </dict>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+        <key>LSHandlerRank</key>
+        <string>Owner</string>
+        <key>LSItemContentTypes</key>
+        <array>
+          <string>public.ipynb</string>
+        </array>
+      </dict>
+    </array>
     <key>UTImportedTypeDeclarations</key>
     <dict>
       <key>UTTypeConformsTo</key>


### PR DESCRIPTION
Thus begins registering nteract as a handler for `*.ipynb`. Haven't gotten this to actually do the registration, though I think these are the values. Since I didn't open XCode to help me make this, I wrote this snippet of node:

``` javascript
const plist = require('plist');

const fs = require('fs');

const data = {
  CFBundleDocumentTypes: [
    {
      CFBundleTypeExtensions: ['ipynb'],
      // CFBundleTypeIconFile ?
      CFBundleTypeName: 'io.nteract.notebook',
      CFBundleTypeRole: 'Editor',
      LSHandlerRank: 'Owner',
      LSItemContentTypes: ['io.nteract.notebook'],
    },
  ],
  UTExportedTypeDeclarations: [
    {
      UTTypeConformsTo: ['public.composite-content'],
      UTTypeDescription: 'nteract notebook',
      UTTypeIdentifier: 'io.nteract.notebook',
      UTTypeTagSpecification: {
        'public.filename-extension': ['ipynb'],
        'public.mime-type': 'application/x-ipynb+json',
      },
    },
  ],
};

fs.writeFileSync('./static/extend.plist', plist.build(data));
```
