### PR TITLE
remove osx32 dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "dist": "electron-packager . nteract --prune --out dist",
     "dist:linux64": "npm run dist -- --platform=linux --arch=x64",
     "dist:linux32": "npm run dist -- --platform=linux --arch=ia32",
-    "dist:osx64": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
-    "dist:osx32": "npm run dist -- --platform=darwin --arch=ia32 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract"
+    "dist:osx64": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The last 32b-only Mac shipped in 2006, so wait until someone asks for a 32b OS X app before committing to supporting one.
