### PR TITLE
Take out the gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,0 @@
-*.otf filter=lfs diff=lfs merge=lfs -text
-*.ttf filter=lfs diff=lfs merge=lfs -text
-*.woff2 filter=lfs diff=lfs merge=lfs -text
-*.woff filter=lfs diff=lfs merge=lfs -text
-*.eot filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-*.ijmap filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
The last remaining bit of Git LFS that was here.

This seemed to cause issues locally for me with the PNGs that are in the repo now.
