### PR TITLE
Update import in response to deprecation warning

### DIFF
--- a/test/main/launch.js
+++ b/test/main/launch.js
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 
 import { launchNewNotebook } from '../../build/main/launch';
-
-var ipc = require('ipc');
+import {ipcMain as ipc} from 'electron';
 
 describe('launch', () => {
   describe('launchNewNotebook', () => {


### PR DESCRIPTION
The `ipc` module is being split and deprecated.

LET US STAY ON THE CUTTING EDGE. 
