### PR TITLE
[WIP] Boilerplate in/out test of newKernel

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",
     "rimraf": "^2.5.2",
+    "sinon": "^1.17.3",
     "watch": "^0.17.1"
   }
 }

--- a/test/renderer/reducers/app_spec.js
+++ b/test/renderer/reducers/app_spec.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import reducers from '../../../src/notebook/reducers/app';
+
+import * as constants from '../../../src/notebook/constants';
+
+const sinon = require('sinon');
+
+describe('reducers', () => {
+  it('reduces NEW_KERNEL actions', () => {
+    const reducer = reducers[constants.NEW_KERNEL];
+
+    const shellComplete = sinon.spy();
+    const iopubComplete = sinon.spy();
+    const stdinComplete = sinon.spy();
+    const spawnKill = sinon.spy();
+
+    const state = {
+      channels: {
+        shell: {
+          complete: shellComplete,
+        },
+        iopub: {
+          complete: iopubComplete,
+        },
+        stdin: {
+          complete: stdinComplete,
+        }
+      },
+      spawn: {
+        kill: spawnKill,
+      }
+    }
+
+    const action = {
+      channels: 'channels',
+      connectionFile: 'connection',
+      spawn: 'spawn',
+    }
+
+    const newState = reducer(state, action);
+
+    expect(newState.channels).to.equal(action.channels);
+    expect(newState.connnectionFile).to.equal(action.connectionFile);
+    expect(newState.spawn).to.equal(action.spawn);
+
+    expect(shellComplete.called).to.be.true;
+    expect(iopubComplete.called).to.be.true;
+    expect(stdinComplete.called).to.be.true;
+    expect(spawnKill.called).to.be.true;
+  })
+})


### PR DESCRIPTION
Complete with failure!

Is Babel handling the spread operator differently in the test and in electron?
