### PR TITLE
Check for empty object response from storage

### DIFF
--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -71,7 +71,7 @@ ipc.on('main:load', (e, launchData) => {
       store.subscribe(state => this.setState(state));
       storage.get('theme', (error, data) => {
         if (error) throw error;
-        if (data.length > 0) return;
+        if (Object.keys(data).length === 0) return;
         this.setState({
           theme: data.theme,
         });


### PR DESCRIPTION
With [`electron-json-storage`](https://github.com/jviotti/electron-json-storage), if the key doesn't exist in the user data, an empty object is returned.

If you ever want to clear your storage on OS X, it's located at:
 `~/Library/Application\ Support/nteract/`.

Follow up to #306.
