### PR TITLE
Open URLs within the user's default browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": ":notebook: the nteract notebook",
   "main": "index.js",
   "scripts": {
+    "prestart": "npm run build",
     "start": "electron .",
     "prepublish": "npm run build",
     "clean": "rimraf build dist",

--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -1,9 +1,16 @@
 import BrowserWindow from 'browser-window';
 import path from 'path';
 
+import { shell } from 'electron';
+
 import { emptyNotebook, emptyCodeCell, appendCell, fromJS } from 'commutable';
 import * as immutable from 'immutable';
 import fs from 'fs';
+
+export function deferURL(event, url) {
+  event.preventDefault();
+  shell.openExternal(url);
+}
 
 export function launch(notebook, filename) {
   let win = new BrowserWindow({
@@ -19,6 +26,8 @@ export function launch(notebook, filename) {
   win.webContents.on('did-finish-load', () => {
     win.webContents.send('main:load', { notebook: notebook.toJS(), filename });
   });
+
+  win.webContents.on('will-navigate', deferURL);
 
   win.on('close', () => {
     win.webContents.send('menu:kill-kernel');


### PR DESCRIPTION
Closes #125. All links get opened externally within the browser. Before, if you load a URL within nteract, that page would get access to node. This has parallels to the origin story of how I met @kenwheeler.
