### PR TITLE
Rely on unload for shutdown of kernels.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ cache:
 
 before_install:
   - source travis_before_install
+  - pip install jupyter_console --user
+  - jupyter kernelspec install-self --user
 
 install: env LD_LIBRARY_PATH=$LDHACK/lib LD_RUN_PATH=$LDHACK/lib PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig LDFLAGS=-L$LDHACK/lib CFLAGS=-I$LDHACK/lib/include npm install
 

--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -29,10 +29,6 @@ export function launch(notebook, filename) {
 
   win.webContents.on('will-navigate', deferURL);
 
-  win.on('close', () => {
-    win.webContents.send('menu:kill-kernel');
-  });
-
   // Emitted when the window is closed.
   win.on('closed', () => {
     win = null;

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -270,7 +270,7 @@ export const named = {
     {
       label: 'Quit',
       accelerator: 'Command+Q',
-      click: () => { app.quit(); },
+      click: () => app.quit(),
     },
   ],
 };

--- a/src/notebook/api/kernel.js
+++ b/src/notebook/api/kernel.js
@@ -5,6 +5,7 @@ import {
   createShellSubject,
 } from 'enchannel-zmq-backend';
 
+import * as fs from 'fs';
 import * as uuid from 'uuid';
 import { launch } from 'spawnteract';
 
@@ -27,4 +28,18 @@ export function launchKernel(kernelSpecName, spawnOptions) {
           spawn,
         };
       });
+}
+
+export function shutdownKernel(channels, spawn, connectionFile) {
+  if (channels) {
+    channels.shell.complete();
+    channels.iopub.complete();
+    channels.stdin.complete();
+  }
+  if (spawn) {
+    spawn.kill();
+  }
+  if (connectionFile) {
+    fs.unlink(connectionFile);
+  }
 }

--- a/src/notebook/global-events/index.js
+++ b/src/notebook/global-events/index.js
@@ -1,0 +1,20 @@
+import {
+  shutdownKernel,
+} from '../reducers/app';
+
+/**
+export function beforeUnload(store, dispatch, e) {
+}
+*/
+
+export function unload(store, dispatch, e) {
+  console.warn(e);
+  const state = store.getState();
+  shutdownKernel(state.channels, state.spawn, state.connectionFile);
+}
+
+export function initGlobalHandlers(store, dispatch) {
+  // TODO: use beforeunload to ask user to save
+  // global.window.onbeforeunload = beforeUnload.bind(null, store, dispatch);
+  global.window.onunload = unload.bind(null, store, dispatch);
+}

--- a/src/notebook/global-events/index.js
+++ b/src/notebook/global-events/index.js
@@ -7,8 +7,9 @@ export function beforeUnload(store, dispatch, e) {
 }
 */
 
-export function unload(store, dispatch, e) {
-  console.warn(e);
+export function unload(store) {
+  // Note that the full signature is (store, dispatch, e)
+  // though we only use store here as shutdown is required to be an immediate action
   const state = store.getState();
   shutdownKernel(state.channels, state.spawn, state.connectionFile);
 }

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -22,6 +22,7 @@ import storage from 'electron-json-storage';
 
 import { initMenuHandlers } from './menu';
 import { initNativeHandlers } from './native-window';
+import { initGlobalHandlers } from './global-events';
 
 const Github = require('github4');
 
@@ -64,6 +65,7 @@ ipc.on('main:load', (e, launchData) => {
   initNativeHandlers(store);
   initKeymap(window, dispatch);
   initMenuHandlers(store, dispatch);
+  initGlobalHandlers(store, dispatch);
 
   class App extends React.Component {
     constructor(props) {

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -1,20 +1,8 @@
-import * as fs from 'fs';
-
 import * as constants from '../constants';
 
-export function shutdownKernel(channels, spawn, connectionFile) {
-  if (channels) {
-    channels.shell.complete();
-    channels.iopub.complete();
-    channels.stdin.complete();
-  }
-  if (spawn) {
-    spawn.kill();
-  }
-  if (connectionFile) {
-    fs.unlink(connectionFile);
-  }
-}
+import {
+  shutdownKernel,
+} from '../api/kernel';
 
 export function cleanupKernel(state) {
   shutdownKernel(state.channels, state.spawn, state.connectionFile);

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -2,18 +2,22 @@ import * as fs from 'fs';
 
 import * as constants from '../constants';
 
-function cleanupKernel(state) {
-  if (state.channels) {
-    state.channels.shell.complete();
-    state.channels.iopub.complete();
-    state.channels.stdin.complete();
+export function shutdownKernel(channels, spawn, connectionFile) {
+  if (channels) {
+    channels.shell.complete();
+    channels.iopub.complete();
+    channels.stdin.complete();
   }
-  if (state.spawn) {
-    state.spawn.kill();
+  if (spawn) {
+    spawn.kill();
   }
-  if (state.connectionFile) {
-    fs.unlink(state.connectionFile);
+  if (connectionFile) {
+    fs.unlink(connectionFile);
   }
+}
+
+export function cleanupKernel(state) {
+  shutdownKernel(state.channels, state.spawn, state.connectionFile);
 
   const cleanState = {
     ...state,

--- a/test/renderer/api/kernel-spec.js
+++ b/test/renderer/api/kernel-spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+
+import {
+  launchKernel,
+  shutdownKernel,
+} from '../../../src/notebook/api/kernel';
+
+describe('the circle of life', () => {
+  it('is available for creating and destroying kernels', () => {
+    const kernel = launchKernel('python');
+    shutdownKernel(kernel.channels, kernel.connectionFile, kernel.spawn);
+  });
+});


### PR DESCRIPTION
Fixes #245.

We'll want to move out the kernel cleanup function to somewhere within `notebook/api` (which still seems like a misnomer) or a separate library.
