### PR TITLE
Tough love

### DIFF
--- a/src/notebook/api/kernel.js
+++ b/src/notebook/api/kernel.js
@@ -37,9 +37,12 @@ export function shutdownKernel(channels, spawn, connectionFile) {
     channels.stdin.complete();
   }
   if (spawn) {
-    spawn.kill();
+    spawn.stdin.destroy();
+    spawn.stdout.destroy();
+    spawn.stderr.destroy();
+    spawn.kill('SIGKILL');
   }
   if (connectionFile) {
-    fs.unlink(connectionFile);
+    fs.unlinkSync(connectionFile);
   }
 }

--- a/src/notebook/api/kernel.js
+++ b/src/notebook/api/kernel.js
@@ -35,6 +35,7 @@ export function shutdownKernel(channels, spawn, connectionFile) {
     channels.shell.complete();
     channels.iopub.complete();
     channels.stdin.complete();
+    channels.control.complete();
   }
   if (spawn) {
     spawn.stdin.destroy();


### PR DESCRIPTION
- Switch from `SIGINT` to `SIGKILL` to force close a kernel
- Close the `control` socket
- Destroy streams on the spawned kernel process
