### PR TITLE
Keep the kernel fields together.

### DIFF
--- a/src/notebook/api/kernel.js
+++ b/src/notebook/api/kernel.js
@@ -30,20 +30,20 @@ export function launchKernel(kernelSpecName, spawnOptions) {
       });
 }
 
-export function shutdownKernel(channels, spawn, connectionFile) {
-  if (channels) {
-    channels.shell.complete();
-    channels.iopub.complete();
-    channels.stdin.complete();
-    channels.control.complete();
+export function shutdownKernel(kernel) {
+  if (kernel.channels) {
+    kernel.channels.shell.complete();
+    kernel.channels.iopub.complete();
+    kernel.channels.stdin.complete();
+    kernel.channels.control.complete();
   }
-  if (spawn) {
-    spawn.stdin.destroy();
-    spawn.stdout.destroy();
-    spawn.stderr.destroy();
-    spawn.kill('SIGKILL');
+  if (kernel.spawn) {
+    kernel.spawn.stdin.destroy();
+    kernel.spawn.stdout.destroy();
+    kernel.spawn.stderr.destroy();
+    kernel.spawn.kill('SIGKILL');
   }
-  if (connectionFile) {
-    fs.unlinkSync(connectionFile);
+  if (kernel.connectionFile) {
+    fs.unlinkSync(kernel.connectionFile);
   }
 }

--- a/src/notebook/global-events/index.js
+++ b/src/notebook/global-events/index.js
@@ -11,7 +11,12 @@ export function unload(store) {
   // Note that the full signature is (store, dispatch, e)
   // though we only use store here as shutdown is required to be an immediate action
   const state = store.getState();
-  shutdownKernel(state.channels, state.spawn, state.connectionFile);
+  const kernel = {
+    channels: state.channels,
+    spawn: state.spawn,
+    connectionFile: state.connectionFile,
+  };
+  shutdownKernel(kernel);
 }
 
 export function initGlobalHandlers(store, dispatch) {

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -4,7 +4,7 @@ import {
   shutdownKernel,
 } from '../api/kernel';
 
-export function cleanupKernel(state) {
+function cleanupKernel(state) {
   const kernel = {
     channels: state.channels,
     spawn: state.spawn,

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -5,7 +5,12 @@ import {
 } from '../api/kernel';
 
 export function cleanupKernel(state) {
-  shutdownKernel(state.channels, state.spawn, state.connectionFile);
+  const kernel = {
+    channels: state.channels,
+    spawn: state.spawn,
+    connectionFile: state.connectionFile,
+  };
+  shutdownKernel(kernel);
 
   const cleanState = {
     ...state,

--- a/test/renderer/api/kernel-spec.js
+++ b/test/renderer/api/kernel-spec.js
@@ -7,7 +7,12 @@ import {
 
 describe('the circle of life', () => {
   it('is available for creating and destroying kernels', () => {
-    const kernel = launchKernel('python');
-    shutdownKernel(kernel.channels, kernel.connectionFile, kernel.spawn);
+    const kernelPromise = launchKernel('python3');
+
+    return kernelPromise.then(kernel => {
+      expect(kernel.spawn.killed).to.not.be.true;
+      shutdownKernel(kernel);
+      expect(kernel.spawn.killed).to.be.true;
+    })
   });
 });

--- a/test/renderer/api/kernel-spec.js
+++ b/test/renderer/api/kernel-spec.js
@@ -7,7 +7,7 @@ import {
 
 describe('the circle of life', () => {
   it('is available for creating and destroying kernels', () => {
-    const kernelPromise = launchKernel('python3');
+    const kernelPromise = launchKernel('python2');
 
     return kernelPromise.then(kernel => {
       expect(kernel.spawn.killed).to.not.be.true;

--- a/test/renderer/reducers/app_spec.js
+++ b/test/renderer/reducers/app_spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import * as constants from '../../../src/notebook/constants';
+
+import { reducers } from '../../../src/notebook/reducers';
+
+const setNotebook = reducers[constants.SET_NOTEBOOK];
+const updateExecutionCount = reducers[constants.UPDATE_CELL_EXECUTION_COUNT];
+const newCellAfter = reducers[constants.NEW_CELL_AFTER];
+
+describe('cleanupKernel', () => {
+  it('nullifies entries for the kernel in state', () => {
+    const state = {
+      channels: false,
+      spawn: false,
+      connectionFile: false,
+    };
+    const newState = reducers[constants.KILL_KERNEL](state);
+    expect(newState.channels).to.be.null;
+    expect(newState.spawn).to.be.null;
+    expect(newState.connectionFile).to.be.null;
+  });
+});


### PR DESCRIPTION
This puts the kernel fields together so the call is symmetric (and so I don't use the wrong args).
