### PR TITLE
Always on completions

### DIFF
--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -63,7 +63,16 @@ export default class Editor extends React.Component {
     //       is deleted
     inputEvents
       .debounceTime(20)
-      .subscribe(event => event.cm.execCommand('autocomplete'));
+      // Filter out whitespace changes, only propagate when a partial token
+      .filter(event => {
+        const editor = event.cm;
+        const tokenRange = editor.findWordAt(editor.getCursor());
+        const token = editor.getRange(tokenRange.anchor, tokenRange.head);
+        return /\S/.test(token);
+      })
+      .subscribe(event => {
+        event.cm.execCommand('autocomplete');
+      });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -47,6 +47,11 @@ export default class Editor extends React.Component {
     if (this.props.focused) {
       this.refs.codemirror.focus();
     }
+    this.refs.codemirror.getCodeMirror().on('change', (cm, change) => {
+      if (change.origin === '+input') {
+        cm.execCommand('autocomplete');
+      }
+    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -100,7 +105,6 @@ export default class Editor extends React.Component {
         hint: this.hint,
       },
       extraKeys: {
-        'Ctrl-Space': 'autocomplete',
       },
     };
     return (

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -356,8 +356,10 @@ code {
   max-width: 19em;
   white-space: pre;
   cursor: pointer;
+  color: var(--cm-hint-color);
 }
 
 li.CodeMirror-hint-active {
   background: var(--cm-hint-bg-active);
+  color: var(--cm-hint-color-active);
 }

--- a/static/styles/theme-dark.css
+++ b/static/styles/theme-dark.css
@@ -34,6 +34,8 @@
   --cm-matchingbracket-outline: grey;
   --cm-matchingbracket-color: white;
 
-  --cm-hint-bg: white;
-  --cm-hint-bg-active: #ABD1FF;
+  --cm-hint-color: var(--main-fg-color);
+  --cm-hint-color-active: var(--cm-color);
+  --cm-hint-bg: var(--main-bg-color);
+  --cm-hint-bg-active: var(--pager-bg);
 }

--- a/static/styles/theme-light.css
+++ b/static/styles/theme-light.css
@@ -34,6 +34,8 @@
   --cm-matchingbracket-outline: grey;
   --cm-matchingbracket-color: black;
 
-  --cm-hint-bg: white;
+  --cm-hint-color: var(--cm-color);
+  --cm-hint-color-active: var(--cm-color);
+  --cm-hint-bg: var(--main-bg-color);
   --cm-hint-bg-active: #ABD1FF;
 }


### PR DESCRIPTION
This switches us over to hints all the time, without the users hitting a hot key (though they can still invoke it manually with ctrl-space).

In order to do completions all the time, without tab, we have to set completeSingle to false. Otherwise users will "overtype" the completions with their own text.

For example, let's say a user is typing "import" in Python:

Type `i` (list of completions)

Type `m` ("import" matches, gets filled out)

Type p and now the text reads:

```
importp
```

Switching to this mode makes us behave more like Visual Studio and Atom. The user
must confirm the match in order to accept it. For previous Jupyter users, this
may cause a rift because muscle memory tells them to use tab. This _is_ a different environment
so maybe that's alright.

My personal preference is to have this mode on by default. Thoughts?

Please try it out. It's kind of awesome.
