### PR TITLE
Autocomplete only when current token has \w

### DIFF
--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -68,7 +68,7 @@ export default class Editor extends React.Component {
         const editor = event.cm;
         const tokenRange = editor.findWordAt(editor.getCursor());
         const token = editor.getRange(tokenRange.anchor, tokenRange.head);
-        return /\w/.test(token);
+        return /(\w|\.)/.test(token);
       })
       .subscribe(event => {
         event.cm.execCommand('autocomplete');

--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -63,12 +63,12 @@ export default class Editor extends React.Component {
     //       is deleted
     inputEvents
       .debounceTime(20)
-      // Filter out whitespace changes, only propagate when a partial token
+      // Pass through only partial tokens that are composed of words
       .filter(event => {
         const editor = event.cm;
         const tokenRange = editor.findWordAt(editor.getCursor());
         const token = editor.getRange(tokenRange.anchor, tokenRange.head);
-        return /\S/.test(token);
+        return /\w/.test(token);
       })
       .subscribe(event => {
         event.cm.execCommand('autocomplete');


### PR DESCRIPTION
This is quite a bit better than the previous token check.

![wordy](https://cloud.githubusercontent.com/assets/836375/14763045/ed0c3efa-094f-11e6-974f-00effff23a72.gif)
