### PR TITLE
Prevent the completer from flickering.

### DIFF
--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -71,7 +71,10 @@ export default class Editor extends React.Component {
         return /(\w|\.)/.test(token);
       })
       .subscribe(event => {
-        event.cm.execCommand('autocomplete');
+        if(!event.cm.state.completionActive){
+          event.cm.execCommand('autocomplete');
+        }
+
       });
   }
 


### PR DESCRIPTION
Actually trigger an "autocomplete" IIF the completion is not already
shown. Otherwise let codemirror deal with the **update** of the popup,
instead of removing the dom element and reinserting.

Prevent "flicker" of the tooltip.
