### PR TITLE
Wrap code (text/plain) so it fits within a cell

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -263,7 +263,7 @@ td {
 
 code {
   font-family: 'Source Code Pro';
-  white-space: pre;
+  white-space: pre-wrap;
   font-size: 14px;
 }
 


### PR DESCRIPTION
Before:

<img width="767" alt="screenshot 2016-04-27 01 37 17" src="https://cloud.githubusercontent.com/assets/836375/14843748/5e2a1182-0c18-11e6-9051-deed40c8fb74.png">

After:

<img width="754" alt="screenshot 2016-04-27 01 37 42" src="https://cloud.githubusercontent.com/assets/836375/14843755/665837a8-0c18-11e6-9fb3-981bb5df2c68.png">

/cc @betatim who asked about this
