### PR TITLE
Don't do autocomplete when the change is a newline

### DIFF
--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -66,6 +66,11 @@ export default class Editor extends React.Component {
     //       is deleted
     inputEvents
       .debounceTime(20)
+      // Pass through changes that aren't newlines
+      .filter(event => event.change.text.length === 1 ||
+                       event.change.text.length === 2 &&
+                       !(event.change.text[0] === '' && event.change.text[1] === '')
+      )
       // Pass through only partial tokens that are composed of words
       .filter(event => {
         const editor = event.cm;


### PR DESCRIPTION
When a newline is inserted before existing code like in #409, the change event's
text field is exactly `["", ""]`. This patch filters that out.

While this "solves" the problem for new lines, inserting a space before an existing
also has this problem (of showing IPython globals). We'll need to visit this again
and see if there's a way to simplify for the "natural" thing to do for automatic
hinting like we're doing here.
