### PR TITLE
Don't Merge: Proposed dep injected subject tests.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     ],
     "plugins": [
       "transform-class-properties",
-      "transform-object-rest-spread"
+      "transform-object-rest-spread",
+      "rewire"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
     "babel-eslint": "^6.0.2",
+    "babel-plugin-rewire": "^1.0.0-rc-2",
     "babel-plugin-transform-class-properties": "^6.3.13",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.1.18",
@@ -99,6 +100,7 @@
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",
     "rimraf": "^2.5.2",
+    "sinon": "^1.17.3",
     "watch": "^0.17.1"
   }
 }


### PR DESCRIPTION
This is a proposed approach for testing our async flows within actions/agendas that uses `babel-plugin-rewire` to inject mocks into the tested module on the fly.

cc @rgbkrk 
