### PR TITLE
Switch to commonJS import of rxjs 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
   },
   "homepage": "https://github.com/nteract/nteract",
   "dependencies": {
-    "@reactivex/rxjs": "5.0.0-beta.2",
+    "rxjs": "^5.0.0-beta.6",
     "codemirror": "^5.13.4",
     "commander": "^2.9.0",
     "commutable": "^0.9.0",
     "electron-json-storage": "^2.0.0",
     "electron-packager": "^7.0.0",
-    "enchannel": "^1.1.2",
-    "enchannel-zmq-backend": "^1.0.1",
+    "enchannel": "^1.1.3",
+    "enchannel-zmq-backend": "^2.0.1",
     "github-api": "^1.1.0",
     "github4": "^1.0.0",
     "home-dir": "^1.0.0",
@@ -74,7 +74,7 @@
     "remark-react": "^2.1.0",
     "spawnteract": "^2.0.0",
     "transformime-react": "^1.0.0",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/notebook/agendas/index.js
+++ b/src/notebook/agendas/index.js
@@ -1,4 +1,4 @@
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 const Immutable = require('immutable');
 
 import {

--- a/src/notebook/api/messaging/index.js
+++ b/src/notebook/api/messaging/index.js
@@ -2,7 +2,7 @@
 
 import * as uuid from 'uuid';
 
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 const Observable = Rx.Observable;
 
 export const session = uuid.v4();

--- a/src/notebook/components/cell/editor.js
+++ b/src/notebook/components/cell/editor.js
@@ -3,7 +3,7 @@ import React from 'react';
 import CodeMirror from 'react-codemirror';
 import CM from 'codemirror';
 
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 
 import { updateCellSource } from '../../actions';
 

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -25,7 +25,7 @@ import { initGlobalHandlers } from './global-events';
 
 const Github = require('github4');
 
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 
 const github = new Github();
 

--- a/src/notebook/publication/github.js
+++ b/src/notebook/publication/github.js
@@ -1,4 +1,4 @@
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 const commutable = require('commutable');
 const path = require('path');
 

--- a/src/notebook/store/index.js
+++ b/src/notebook/store/index.js
@@ -1,4 +1,4 @@
-import * as Rx from '@reactivex/rxjs';
+import * as Rx from 'rxjs/Rx';
 import { mark, measure } from '../performance';
 
 export default function createStore(initialState, reducers) {

--- a/test/renderer/actions/index_spec.js
+++ b/test/renderer/actions/index_spec.js
@@ -6,7 +6,7 @@ import * as constants from '../../../src/notebook/constants';
 
 import createStore from '../../../src/notebook/store';
 
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 
 describe('setExecutionState', () => {
   it('creates a SET_EXECUTION_STATE action', () => {

--- a/test/renderer/api/messaging/index_spec.js
+++ b/test/renderer/api/messaging/index_spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { childOf } from '../../../../src/notebook/api/messaging';
 
-const Rx = require('@reactivex/rxjs');
+const Rx = require('rxjs/Rx');
 
 describe('childOf', () => {
   it('filters messages that have the same parent', () => {


### PR DESCRIPTION
Getting us partway to #444 by installing `rxjs@5.0.0-beta.6` and `enchannel-zmq-backend@2.0.0`, as well as switching imports to use `require('rxjs/Rx')`.
