### PR TITLE
Sign OS X packages on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dist": "electron-packager . nteract --prune --out dist",
     "dist:linux64": "npm run dist -- --platform=linux --arch=x64",
     "dist:linux32": "npm run dist -- --platform=linux --arch=ia32",
-    "dist:osx": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
+    "dist:osx": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract --osx-sign",
     "postdist": "npm install"
   },
   "repository": {
@@ -88,6 +88,7 @@
     "codecov": "^1.0.1",
     "coveralls": "^2.11.9",
     "electron-mocha": "^1.0.3",
+    "electron-osx-sign": "^0.3.1",
     "electron-prebuilt": "^0.37.4",
     "enzyme": "^2.2.0",
     "eslint": "^2.9.0",


### PR DESCRIPTION
In order to build a copy, you'll need to [set up certificates](https://github.com/nwjs/nw.js/wiki/MAS%3A-Requesting-certificates), creating a "Developer ID" type certificate via Apple.

Originally I built and tested this using the full string:

```
electron-osx-sign dist/nteract-darwin-x64/nteract.app --identity "8E54RDNN6Z"
```

then whittled it down to:

```
electron-osx-sign dist/nteract-darwin-x64/nteract.app
```

since my default was the developer ID I needed. After that, I set the option for `electron-packager` to do it all.
