### PR TITLE
Pre-emptively handle deprecated APIs for Electron

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,11 +1,9 @@
-import app from 'app';
-
 import {
   launchFilename,
   launchNewNotebook,
 } from './launch';
 
-import { Menu } from 'electron';
+import { Menu, app } from 'electron';
 import { defaultMenu, loadFullMenu } from './menu';
 import { resolve } from 'path';
 

--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -1,7 +1,6 @@
-import BrowserWindow from 'browser-window';
 import path from 'path';
 
-import { shell } from 'electron';
+import { shell, BrowserWindow } from 'electron';
 
 import { emptyNotebook, emptyCodeCell, appendCell, fromJS } from 'commutable';
 import * as immutable from 'immutable';

--- a/src/notebook/api/save.js
+++ b/src/notebook/api/save.js
@@ -1,7 +1,10 @@
 import * as path from 'path';
 
-import remote from 'remote';
-const dialog = remote.require('dialog');
+const electron = require('electron');
+const { remote } = electron;
+
+const remoteElectron = remote.require('electron');
+const dialog = remoteElectron.dialog;
 
 export function showSaveAsDialog(defaultPath) {
   return new Promise((resolve) => {

--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -1,4 +1,5 @@
-import { getCurrentWindow } from 'remote';
+import { remote } from 'electron';
+const { getCurrentWindow } = remote;
 import home from 'home-dir';
 import path from 'path';
 


### PR DESCRIPTION
In advance of switching to Electron 1.1.0, extracted from #453.
