### PR TITLE
Remove cell toolbar ghosts

### DIFF
--- a/src/notebook/components/cell/cell-creator.js
+++ b/src/notebook/components/cell/cell-creator.js
@@ -11,6 +11,7 @@ export default class CellCreator extends React.Component {
   constructor() {
     super();
     this.setHoverElement = this.setHoverElement.bind(this);
+    this.updateVisibility = this.updateVisibility.bind(this);
   }
 
   state = {
@@ -22,12 +23,11 @@ export default class CellCreator extends React.Component {
     // intersection because we don't want the hover region to actually capture
     // any mouse events.  The hover region is an invisible element that
     // describes the "hot region" that toggles the creator buttons.
-    this.boundUpdateVisibility = this.updateVisibility.bind(this);
-    document.addEventListener('mousemove', this.boundUpdateVisibility, false);
+    document.addEventListener('mousemove', this.updateVisibility, false);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousemove', this.boundUpdateVisibility);
+    document.removeEventListener('mousemove', this.updateVisibility);
   }
 
   setHoverElement(el) {

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -23,4 +23,13 @@ describe('Cell', () => {
     expect(cell).to.not.be.null;
     expect(cell.find('div.code.cell').length).to.be.greaterThan(0);
   });
+  it('setCellHoverState does not error', () => {
+    const cell = mount(
+      <Cell cell={commutable.emptyCodeCell} {...sharedProps}/>
+    );
+    expect(() => cell.instance().setCellHoverState({
+      clientX: 0,
+      clientY: 0,
+    })).to.not.throw(Error);
+  });
 });

--- a/test/renderer/components/cell/cell-toolbar-spec.js
+++ b/test/renderer/components/cell/cell-toolbar-spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+import {expect} from 'chai';
+
+import Toolbar from '../../../../src/notebook/components/cell/toolbar';
+
+describe('Toolbar', () => {
+  it('should be able to render a toolbar', () => {
+    const toolbar = mount(
+      <Toolbar />
+    );
+    expect(toolbar).to.not.be.null;
+    expect(toolbar.find('div.cell-toolbar').length).to.be.greaterThan(0);
+  });
+  it('setHoverState does not error', () => {
+    const toolbar = mount(
+      <Toolbar setHoverState={() => {}}/>
+    );
+    expect(() => toolbar.instance().setHoverState({
+      clientX: 0,
+      clientY: 0,
+    })).to.not.throw(Error);
+  });
+});


### PR DESCRIPTION
I hate having to do this, but it's the workaround I've settled on because both React and native mouseleave events are not firing reliably...

closes #465 
