### PR TITLE
When shift-enter or ctrl-enter is hit, keep view on MD cell

### DIFF
--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -78,6 +78,13 @@ export default class MarkdownCell extends React.Component {
    * Handles when a keydown event occurs on the rendered MD cell
    */
   renderedKeyDown(e) {
+    const shift = e.shiftKey;
+    const ctrl = e.ctrlKey;
+    if ((shift || ctrl) && e.key === 'Enter') {
+      this.setState({ view: true });
+      return false;
+    }
+
     switch (e.key) {
       case 'ArrowUp':
         this.props.focusAbove();

--- a/test/renderer/components/cell/markdown-cell-spec.js
+++ b/test/renderer/components/cell/markdown-cell-spec.js
@@ -14,9 +14,7 @@ describe('MarkdownCell', () => {
     );
     expect(cell).to.not.be.null;
   });
-});
 
-describe('MarkdownCell', () => {
   it('toggles view mode with key events', () => {
     const cell = mount(
       <MarkdownCell cell={commutable.emptyMarkdownCell} {...{ displayOrder, transforms }}/>
@@ -34,4 +32,13 @@ describe('MarkdownCell', () => {
     cell.simulate('keydown', { key: 'Enter', shiftKey: true })
     expect(cell.state('view')).to.be.true;
   });
+
+  it('sets the state of the text based on cell source', () => {
+    const cell = mount(
+      <MarkdownCell cell={commutable.emptyMarkdownCell} {...{ displayOrder, transforms }}/>
+    );
+
+    cell.setProps({'cell': commutable.emptyMarkdownCell.set('source', 'test')});
+    expect(cell.state('source')).to.equal('test');
+  })
 });

--- a/test/renderer/components/cell/markdown-cell-spec.js
+++ b/test/renderer/components/cell/markdown-cell-spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import {expect} from 'chai';
 
 import MarkdownCell from '../../../../src/notebook/components/cell/markdown-cell';
@@ -13,5 +13,25 @@ describe('MarkdownCell', () => {
       <MarkdownCell cell={commutable.emptyMarkdownCell} {...{ displayOrder, transforms }}/>
     );
     expect(cell).to.not.be.null;
+  });
+});
+
+describe('MarkdownCell', () => {
+  it('toggles view mode with key events', () => {
+    const cell = mount(
+      <MarkdownCell cell={commutable.emptyMarkdownCell} {...{ displayOrder, transforms }}/>
+    );
+
+    // Starts in view mode
+    expect(cell.state('view')).to.be.true;
+    cell.simulate('keydown', { key: 'Enter', shiftKey: true })
+    // Stays in view mode on shift enter
+    expect(cell.state('view')).to.be.true;
+    // Enter key enters edit mode
+    cell.simulate('keydown', { key: 'Enter'})
+    expect(cell.state('view')).to.be.false;
+    // Back to view mode
+    cell.simulate('keydown', { key: 'Enter', shiftKey: true })
+    expect(cell.state('view')).to.be.true;
   });
 });


### PR DESCRIPTION
Allow for shift-entering your way through a notebook via Markdown Cells. Classic.
