### PR TITLE
Refactor notification system

### DIFF
--- a/src/notebook/actions/index.js
+++ b/src/notebook/actions/index.js
@@ -258,14 +258,6 @@ export function overwriteMetadata(field, value) {
   };
 }
 
-export const startedUploading = {
-  type: constants.STARTED_UPLOADING,
-};
-
-export const doneUploading = {
-  type: constants.DONE_UPLOADING,
-};
-
 export const killKernel = {
   type: constants.KILL_KERNEL,
 };

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -40,6 +40,7 @@ ipc.on('main:load', (e, launchData) => {
   const store = configureStore({
     app: {
       executionState: 'not connected',
+      github,
     },
     document: {
       notebook: null,
@@ -47,7 +48,6 @@ ipc.on('main:load', (e, launchData) => {
       cellPagers: new Immutable.Map(),
       cellStatuses: new Immutable.Map(),
       stickyCells: new Immutable.Map(),
-      github,
     },
   }, reducers);
 

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -103,7 +103,7 @@ ipc.on('main:load', (e, launchData) => {
       return (
         <Provider
           rx={{ dispatch, store }}
-          notificationSystem={this.state.document && this.state.document.notificationSystem}
+          notificationSystem={this.state.app && this.state.app.notificationSystem}
           executionState={this.state.app && this.state.app.executionState}
           channels={this.state.app && this.state.app.channels}
         >

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -64,7 +64,9 @@ export function dispatchNewkernel(store, dispatch, evt, name) {
 
 export function dispatchPublishGist(store, dispatch) {
   const state = store.getState();
-  const { filename, notebook, github, notificationSystem } = state.document;
+  const { filename, notebook, github } = state.document;
+  const { notificationSystem } = state.app;
+
   const agenda = publish(github, notebook, filename, notificationSystem);
 
   agenda.subscribe((action) => {

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -64,8 +64,8 @@ export function dispatchNewkernel(store, dispatch, evt, name) {
 
 export function dispatchPublishGist(store, dispatch) {
   const state = store.getState();
-  const { filename, notebook, github } = state.document;
-  const { notificationSystem } = state.app;
+  const { filename, notebook } = state.document;
+  const { notificationSystem, github } = state.app;
 
   const agenda = publish(github, notebook, filename, notificationSystem);
 

--- a/src/notebook/publication/github.js
+++ b/src/notebook/publication/github.js
@@ -5,8 +5,6 @@ const path = require('path');
 import { shell } from 'electron';
 
 import {
-  doneUploading,
-  startedUploading,
   overwriteMetadata,
 } from '../actions';
 
@@ -41,7 +39,6 @@ function createGistCallback(hotOffThePresses, agenda, filename, notificationSyst
     if (hotOffThePresses) {
       agenda.next(overwriteMetadata('gist_id', gistID));
     }
-    agenda.next(doneUploading);
   };
 }
 
@@ -60,7 +57,11 @@ export function publish(github, notebook, filepath, notificationSystem) {
     const files = {};
     files[filename] = { content: notebookString };
 
-    agenda.next(startedUploading);
+    notificationSystem.addNotification({
+      title: 'Uploading gist...',
+      message: 'Your notebook is being uploaded as a GitHub gist',
+      level: 'info',
+    });
 
     // Already in a gist, update the gist
     if (notebook.hasIn(['metadata', 'gist_id'])) {

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -61,4 +61,11 @@ export default handleActions({
     }
     return { ...state, filename };
   },
+  [constants.SET_NOTIFICATION_SYSTEM]: function setNotificationsSystem(state, action) {
+    const { notificationSystem } = action;
+    return {
+      ...state,
+      notificationSystem,
+    };
+  },
 }, {});

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -6,8 +6,6 @@ import { handleActions } from 'redux-actions';
 
 import Immutable from 'immutable';
 
-const noop = state => state;
-
 export default handleActions({
   [constants.SET_NOTEBOOK]: function setNotebook(state, action) {
     const notebook = action.data;
@@ -228,23 +226,6 @@ export default handleActions({
     return {
       ...state,
       notebook: notebook.setIn(['metadata', field], Immutable.fromJS(value)),
-    };
-  },
-  [constants.STARTED_UPLOADING]: function startedUploadingGist(state) {
-    const { notificationSystem } = state;
-    notificationSystem.addNotification({
-      title: 'Uploading gist...',
-      message: 'Your notebook is being uploaded as a GitHub gist',
-      level: 'info',
-    });
-    return state;
-  },
-  [constants.DONE_UPLOADING]: noop,
-  [constants.SET_NOTIFICATION_SYSTEM]: function setNotificationsSystem(state, action) {
-    const { notificationSystem } = action;
-    return {
-      ...state,
-      notificationSystem,
     };
   },
 }, {});


### PR DESCRIPTION
This moves notifications (which are asynchronous) out of the reducer. The alternative to this is to treat the notification system like React, subscribing to a state change on "uploading gist", etc. (model, meet view).
