### PR TITLE
Pin hard to electron-prebuilt@1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "electron-mocha": "^2.1.0",
     "electron-osx-sign": "^0.3.1",
     "electron-packager": "^7.0.2",
-    "electron-prebuilt": "^1.1.1",
+    "electron-prebuilt": "1.1.1",
     "enzyme": "^2.2.0",
     "eslint": "^2.9.0",
     "eslint-config-airbnb": "^9.0.1",


### PR DESCRIPTION
Something happened with the `1.2.x` builds for electron prebuilt, so let's pin hard to 1.1.1 for now until we sort that out. It could be the bump to Chromium 51, we'll have to check that out as we do want to keep pushing our version forward.

Execution works again now. :smile: /cc @captainsafia @jdfreder 
