### PR TITLE
Setup an Immutable Record for document store

### DIFF
--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -36,18 +36,23 @@ if (process.env.GITHUB_TOKEN) {
   }, (x) => console.error(x));
 }
 
+const DocumentRecord = new Immutable.Record({
+  notebook: null,
+  filename: '',
+  cellPagers: new Immutable.Map(),
+  cellStatuses: new Immutable.Map(),
+  stickyCells: new Immutable.Map(),
+  focusedCell: null,
+});
+
 ipc.on('main:load', (e, launchData) => {
   const store = configureStore({
     app: {
       executionState: 'not connected',
       github,
     },
-    document: Immutable.fromJS({
-      notebook: null,
+    document: new DocumentRecord({
       filename: launchData.filename,
-      cellPagers: new Immutable.Map(),
-      cellStatuses: new Immutable.Map(),
-      stickyCells: new Immutable.Map(),
     }),
   }, reducers);
 


### PR DESCRIPTION
We can play a little bit less loosey goosey here and make a specific `Record`. Amusingly, if I would have gone with this originally, we could have kept our destructuring in the reducers. :wink:

Worth thinking about this for the notebook model in `commutable` too, for those that we know the key exactly (instead of a `Map`).
