### PR TITLE
actually we need node v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python3 -m ipykernel install --user
 
 For all systems, you'll need
 
-- Node.js 5.x
+- Node.js 6.x
 - [`npm`](https://docs.npmjs.com/getting-started/installing-node)
 - [ZeroMQ](http://zeromq.org/intro:get-the-software)
 - Python 2 (for builds - you can still run Python 3 code)


### PR DESCRIPTION
Line 87 already says node 6.x, but this one didn't get updated

fixes #512 
