### PR TITLE
Object rest rampage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,9 @@
   {
     "presets": [
-      "es2015-node6/object-rest",
+      "es2015-node6",
       "react"
     ],
     "plugins": [
-      "transform-class-properties",
-      "transform-object-rest-spread"
+      "transform-class-properties"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "babel-core": "^6.9.0",
     "babel-eslint": "^6.0.4",
     "babel-plugin-transform-class-properties": "^6.9.0",
-    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015-node6": "^0.2.0",
     "babel-preset-react": "^6.3.13",
     "chai": "^3.4.1",

--- a/src/notebook/components/cell/cell-creator.js
+++ b/src/notebook/components/cell/cell-creator.js
@@ -53,7 +53,7 @@ export default class CellCreator extends React.Component {
       <div className="creator-hover-mask">
         <div className="creator-hover-region" ref={this.setHoverElement}>
           {this.state.show || this.props.id === null ?
-            (<CellCreatorButtons {...this.props} />) :
+            (<CellCreatorButtons above={this.props.above} id={this.props.id} />) :
             ''}
         </div>
       </div>);

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
+import Immutable from 'immutable';
+
 import CodeCell from './code-cell';
 import MarkdownCell from './markdown-cell';
 import Toolbar from './toolbar';
@@ -11,11 +13,16 @@ import { focusCell, focusPreviousCell, focusNextCell } from '../../actions';
 class Cell extends React.Component {
   static propTypes = {
     cell: React.PropTypes.any,
+    displayOrder: React.PropTypes.instanceOf(Immutable.List),
     id: React.PropTypes.string,
+    getCompletions: React.PropTypes.func,
     focusedCell: React.PropTypes.string,
+    language: React.PropTypes.string,
     onCellChange: React.PropTypes.func,
     running: React.PropTypes.bool,
     theme: React.PropTypes.string,
+    pagers: React.PropTypes.instanceOf(Immutable.List),
+    transforms: React.PropTypes.instanceOf(Immutable.Map),
   };
 
   static contextTypes = {
@@ -93,7 +100,8 @@ class Cell extends React.Component {
           this.state.hoverCell || this.state.hoverToolbar ? <Toolbar
             type={type}
             setHoverState={this.setToolbarHoverState}
-            { ...this.props }
+            cell={this.props.cell}
+            id={this.props.id}
           /> : null
         }
         {
@@ -102,13 +110,23 @@ class Cell extends React.Component {
             focusAbove={this.focusAboveCell}
             focusBelow={this.focusBelowCell}
             focused={this.props.id === this.props.focusedCell}
-            {...this.props}
+            cell={this.props.cell}
+            id={this.props.id}
+            theme={this.props.theme}
           /> :
           <CodeCell
             focusAbove={this.focusAboveCell}
             focusBelow={this.focusBelowCell}
             focused={this.props.id === this.props.focusedCell}
-            {...this.props}
+            cell={this.props.cell}
+            id={this.props.id}
+            theme={this.props.theme}
+            language={this.props.language}
+            displayOrder={this.props.displayOrder}
+            transforms={this.props.transforms}
+            pagers={this.props.pagers}
+            running={this.props.running}
+            getCompletions={this.props.getCompletions}
           />
         }
       </div>

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -15,7 +15,7 @@ class CodeCell extends React.Component {
   static propTypes = {
     cell: React.PropTypes.instanceOf(Immutable.Map).isRequired,
     displayOrder: React.PropTypes.instanceOf(Immutable.List).isRequired,
-    getCompletions: React.PropTypes.any,
+    getCompletions: React.PropTypes.func,
     id: React.PropTypes.string,
     language: React.PropTypes.string,
     theme: React.PropTypes.string,


### PR DESCRIPTION
Taking out `transform-object-rest-spread`! nteract, now with less babel config.

We can [still use spread within JSX](https://facebook.github.io/react/docs/transferring-props.html), on Arrays, and of course destructuring.
