### PR TITLE
Cleanup filename state

### DIFF
--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -92,7 +92,7 @@ ipc.on('main:load', (e, launchData) => {
     componentDidMount() {
       dispatch(setNotificationSystem(this.refs.notificationSystem));
       const state = store.getState();
-      const filename = (state && state.app.filename) || launchData.filename;
+      const filename = (state && state.document.filename) || launchData.filename;
       dispatch(setNotebook(launchData.notebook, filename));
     }
     render() {

--- a/src/notebook/records/index.js
+++ b/src/notebook/records/index.js
@@ -3,12 +3,11 @@ import Immutable from 'immutable';
 export const AppRecord = new Immutable.Record({
   executionState: 'not connected',
   github: null,
-  channels: false,
-  spawn: false,
-  connectionFile: false,
+  channels: null,
+  spawn: null,
+  connectionFile: null,
   notificationSystem: null,
   kernelSpecName: null,
-  filename: null,
   isSaving: false,
 });
 

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -49,9 +49,6 @@ export default handleActions({
   [constants.DONE_SAVING]: function doneSaving(state) {
     return state.set('isSaving', false);
   },
-  [constants.CHANGE_FILENAME]: function changeFilename(state, action) {
-    return state.set('filename', action.filename);
-  },
   [constants.SET_NOTIFICATION_SYSTEM]: function setNotificationsSystem(state, action) {
     return state.set('notificationSystem', action.notificationSystem);
   },

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -158,6 +158,9 @@ export default handleActions({
     const { field, value } = action;
     return state.setIn(['notebook', 'metadata', field], Immutable.fromJS(value));
   },
+  [constants.CHANGE_FILENAME]: function changeFilename(state, action) {
+    return action.filename ? state.set('filename', action.filename) : state;
+  },
   [constants.ASSOCIATE_CELL_TO_MSG]: function associateCellToMsg(state, action) {
     const { cellId, msgId } = action;
 

--- a/test/renderer/reducers/app_spec.js
+++ b/test/renderer/reducers/app_spec.js
@@ -33,42 +33,6 @@ describe('cleanupKernel', () => {
   });
 });
 
-describe('changeFilename', () => {
-  it('returns the same originalState if filename is undefined', () => {
-    const originalState = {
-      app: new AppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false,
-      })
-    };
-
-    const action = {
-      type: constants.CHANGE_FILENAME,
-    };
-
-    const state = reducers(originalState, action);
-    expect(state.app.filename).to.be.undefined;
-  });
-  it('sets the filename if given a valid one', () => {
-    const originalState = {
-      app: new AppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false,
-     })
-    };
-
-    const action = {
-      type: constants.CHANGE_FILENAME,
-      filename: 'test.ipynb',
-    };
-
-    const state = reducers(originalState, action);
-    expect(state.app.filename).to.equal('test.ipynb');
-  });
-});
-
 describe('setNotificationSystem', () => {
   it('returns the same originalState if notificationSystem is undefined', () => {
     const originalState = {

--- a/test/renderer/reducers/document_spec.js
+++ b/test/renderer/reducers/document_spec.js
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import * as commutable from 'commutable';
 import * as constants from '../../../src/notebook/constants';
 
+import { DocumentRecord } from '../../../src/notebook/records';
+
 import reducers from '../../../src/notebook/reducers';
 
 import {
@@ -313,5 +315,37 @@ describe('overwriteMetadata', () => {
 
     const state = reducers(originalState, action);
     expect(state.document.getIn(['notebook', 'metadata', 'name'])).to.equal("javascript");
+  });
+});
+
+describe('changeFilename', () => {
+  it.only('returns the same originalState if filename is undefined', () => {
+    const originalState = {
+      document: new DocumentRecord({
+        filename: 'original',
+      })
+    };
+
+    const action = {
+      type: constants.CHANGE_FILENAME,
+    };
+
+    const state = reducers(originalState, action);
+    expect(state.document.filename).to.equal('original');
+  });
+  it('sets the filename if given a valid one', () => {
+    const originalState = {
+      document: new DocumentRecord({
+        filename: 'original',
+      })
+    };
+
+    const action = {
+      type: constants.CHANGE_FILENAME,
+      filename: 'test.ipynb',
+    };
+
+    const state = reducers(originalState, action);
+    expect(state.document.filename).to.equal('test.ipynb');
   });
 });

--- a/test/renderer/reducers/document_spec.js
+++ b/test/renderer/reducers/document_spec.js
@@ -319,7 +319,7 @@ describe('overwriteMetadata', () => {
 });
 
 describe('changeFilename', () => {
-  it.only('returns the same originalState if filename is undefined', () => {
+  it('returns the same originalState if filename is undefined', () => {
     const originalState = {
       document: new DocumentRecord({
         filename: 'original',


### PR DESCRIPTION
`filename` was being set and used in both the `app` tree and the `document` tree. To keep it consistent, I switched it over to the the `document` tree.
