### PR TITLE
Refactor app/document store structure

### DIFF
--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -47,7 +47,6 @@ const AppRecord = new Immutable.Record({
 
 const DocumentRecord = new Immutable.Record({
   notebook: null,
-  filename: '',
   cellPagers: new Immutable.Map(),
   cellStatuses: new Immutable.Map(),
   stickyCells: new Immutable.Map(),
@@ -56,12 +55,19 @@ const DocumentRecord = new Immutable.Record({
   msgCellAssociations: new Immutable.Map(),
 });
 
+const DocumentMetadataRecord = new Immutable.Record({
+  past: new Immutable.List(),
+  future: new Immutable.List(),
+  filename: '',
+  document: new DocumentRecord(),
+});
+
 ipc.on('main:load', (e, launchData) => {
   const store = configureStore({
     app: new AppRecord({
       github,
     }),
-    document: new DocumentRecord({
+    documentMetadata: new DocumentMetadataRecord({
       filename: launchData.filename,
     }),
   }, reducers);
@@ -111,7 +117,7 @@ ipc.on('main:load', (e, launchData) => {
     componentDidMount() {
       dispatch(setNotificationSystem(this.refs.notificationSystem));
       const state = store.getState();
-      const filename = (state && state.app.filename) || launchData.filename;
+      const filename = (state && state.documentMetadata.filename) || launchData.filename;
       dispatch(setNotebook(launchData.notebook, filename));
     }
     render() {

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -22,7 +22,7 @@ import { initMenuHandlers } from './menu';
 import { initNativeHandlers } from './native-window';
 import { initGlobalHandlers } from './global-events';
 
-import { AppRecord, DocumentRecord } from './records';
+import { AppRecord, DocumentMetadataRecord } from './records';
 
 const Github = require('github');
 

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -22,7 +22,7 @@ import { initMenuHandlers } from './menu';
 import { initNativeHandlers } from './native-window';
 import { initGlobalHandlers } from './global-events';
 
-import { AppRecord, DocumentMetadataRecord } from './records';
+import { AppRecord, DocumentRecord, MetadataRecord } from './records';
 
 const Github = require('github');
 
@@ -42,11 +42,10 @@ ipc.on('main:load', (e, launchData) => {
     app: new AppRecord({
       github,
     }),
-    documentMetadata: new DocumentMetadataRecord({
-      metadata: {
-        filename: launchData.filename,
-      },
+    metadata: new MetadataRecord({
+      filename: launchData.filename,
     }),
+    document: new DocumentRecord(),
   }, reducers);
 
   const { dispatch } = store;
@@ -67,6 +66,8 @@ ipc.on('main:load', (e, launchData) => {
     .subscribe(st => {
       dispatch(setExecutionState(st));
     });
+
+  window.store = store;
 
   initNativeHandlers(store);
   initMenuHandlers(store, dispatch);
@@ -94,7 +95,7 @@ ipc.on('main:load', (e, launchData) => {
     componentDidMount() {
       dispatch(setNotificationSystem(this.refs.notificationSystem));
       const state = store.getState();
-      const filename = (state && state.documentMetadata.filename) || launchData.filename;
+      const filename = (state && state.metadata.filename) || launchData.filename;
       dispatch(setNotebook(launchData.notebook, filename));
     }
     render() {

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -43,7 +43,9 @@ ipc.on('main:load', (e, launchData) => {
       github,
     }),
     documentMetadata: new DocumentMetadataRecord({
-      filename: launchData.filename,
+      metadata: {
+        filename: launchData.filename,
+      },
     }),
   }, reducers);
 

--- a/src/notebook/records/index.js
+++ b/src/notebook/records/index.js
@@ -21,11 +21,8 @@ export const DocumentRecord = new Immutable.Record({
   msgCellAssociations: new Immutable.Map(),
 });
 
-export const DocumentMetadataRecord = new Immutable.Record({
-  metadata: new Immutable.Map({
-    past: new Immutable.List(),
-    future: new Immutable.List(),
-    filename: '',
-  }),
-  document: new DocumentRecord(),
+export const MetadataRecord = new Immutable.Record({
+  past: new Immutable.List(),
+  future: new Immutable.List(),
+  filename: '',
 });

--- a/src/notebook/records/index.js
+++ b/src/notebook/records/index.js
@@ -22,8 +22,10 @@ export const DocumentRecord = new Immutable.Record({
 });
 
 export const DocumentMetadataRecord = new Immutable.Record({
-  past: new Immutable.List(),
-  future: new Immutable.List(),
-  filename: '',
+  metadata: new Immutable.Map({
+    past: new Immutable.List(),
+    future: new Immutable.List(),
+    filename: '',
+  }),
   document: new DocumentRecord(),
 });

--- a/src/notebook/records/index.js
+++ b/src/notebook/records/index.js
@@ -14,11 +14,17 @@ export const AppRecord = new Immutable.Record({
 
 export const DocumentRecord = new Immutable.Record({
   notebook: null,
-  filename: '',
   cellPagers: new Immutable.Map(),
   cellStatuses: new Immutable.Map(),
   stickyCells: new Immutable.Map(),
   focusedCell: null,
   cellMsgAssociations: new Immutable.Map(),
   msgCellAssociations: new Immutable.Map(),
+});
+
+export const DocumentMetadataRecord = new Immutable.Record({
+  past: new Immutable.List(),
+  future: new Immutable.List(),
+  filename: '',
+  document: new DocumentRecord(),
 });

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -158,9 +158,6 @@ export default handleActions({
     const { field, value } = action;
     return state.setIn(['notebook', 'metadata', field], Immutable.fromJS(value));
   },
-  [constants.CHANGE_FILENAME]: function changeFilename(state, action) {
-    return action.filename ? state.set('filename', action.filename) : state;
-  },
   [constants.ASSOCIATE_CELL_TO_MSG]: function associateCellToMsg(state, action) {
     const { cellId, msgId } = action;
 

--- a/src/notebook/reducers/index.js
+++ b/src/notebook/reducers/index.js
@@ -1,8 +1,12 @@
 import app from './app';
 import document from './document';
+import metadata from './metadata';
 import { combineReducers } from 'redux';
 
 export default combineReducers({
   app,
-  document,
+  documentMetadata: combineReducers({
+    metadata,
+    document,
+  }),
 });

--- a/src/notebook/reducers/index.js
+++ b/src/notebook/reducers/index.js
@@ -5,8 +5,6 @@ import { combineReducers } from 'redux';
 
 export default combineReducers({
   app,
-  documentMetadata: combineReducers({
-    metadata,
-    document,
-  }),
+  metadata,
+  document,
 });

--- a/src/notebook/reducers/metadata.js
+++ b/src/notebook/reducers/metadata.js
@@ -1,4 +1,3 @@
-import Immutable from 'immutable';
 import { handleActions } from 'redux-actions';
 
 import * as constants from '../constants';

--- a/src/notebook/reducers/metadata.js
+++ b/src/notebook/reducers/metadata.js
@@ -5,6 +5,9 @@ import * as constants from '../constants';
 
 export default handleActions({
   [constants.CHANGE_FILENAME]: function changeFilename(state, action) {
-    return state.set('filename', action.filename);
+    if (action.filename) {
+      return state.set('filename', action.filename);
+    }
+    return state;
   },
 }, {});

--- a/src/notebook/reducers/metadata.js
+++ b/src/notebook/reducers/metadata.js
@@ -1,0 +1,10 @@
+import Immutable from 'immutable';
+import { handleActions } from 'redux-actions';
+
+import * as constants from '../constants';
+
+export default handleActions({
+  [constants.CHANGE_FILENAME]: function changeFilename(state, action) {
+    return state.set('filename', action.filename);
+  },
+}, {});

--- a/test/renderer/reducers/document_spec.js
+++ b/test/renderer/reducers/document_spec.js
@@ -317,35 +317,3 @@ describe('overwriteMetadata', () => {
     expect(state.document.getIn(['notebook', 'metadata', 'name'])).to.equal("javascript");
   });
 });
-
-describe('changeFilename', () => {
-  it('returns the same originalState if filename is undefined', () => {
-    const originalState = {
-      document: new DocumentRecord({
-        filename: 'original',
-      })
-    };
-
-    const action = {
-      type: constants.CHANGE_FILENAME,
-    };
-
-    const state = reducers(originalState, action);
-    expect(state.document.filename).to.equal('original');
-  });
-  it('sets the filename if given a valid one', () => {
-    const originalState = {
-      document: new DocumentRecord({
-        filename: 'original',
-      })
-    };
-
-    const action = {
-      type: constants.CHANGE_FILENAME,
-      filename: 'test.ipynb',
-    };
-
-    const state = reducers(originalState, action);
-    expect(state.document.filename).to.equal('test.ipynb');
-  });
-});

--- a/test/renderer/reducers/metadata_spec.js
+++ b/test/renderer/reducers/metadata_spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import * as constants from '../../../src/notebook/constants';
+
+import { MetadataRecord } from '../../../src/notebook/records';
+
+import reducers from '../../../src/notebook/reducers';
+
+describe('changeFilename', () => {
+  it('returns the same originalState if filename is undefined', () => {
+    const originalState = {
+      metadata: new MetadataRecord({
+        filename: 'original.ipynb',
+      })
+    };
+
+    const action = {
+      type: constants.CHANGE_FILENAME,
+    };
+
+    const state = reducers(originalState, action);
+    expect(state.metadata.filename).to.equal('original.ipynb');
+  });
+  it('sets the filename if given a valid one', () => {
+    const originalState = {
+      metadata: new MetadataRecord({
+        filename: 'original.ipynb',
+      })
+    };
+    
+    const action = {
+      type: constants.CHANGE_FILENAME,
+      filename: 'test.ipynb',
+    };
+
+    const state = reducers(originalState, action);
+    expect(state.metadata.filename).to.equal('test.ipynb');
+  });
+});


### PR DESCRIPTION
This PR is meant to rework how we currently have the state store set up. Our current setup,

```
{
   app: {}
   document: {}
}
```

presents some difficulties when trying to address things like undo and redo. For undo/redo, we want to store the stack of past and future states in an object that is not `document`, but storing it in `app` forces us to have to expose the overall state tree to some actions in the app or document reducer.

The result is to rework our state store tree and our reducers to something like this.

```
{
    app: {},
    documentMetadata: {
       past: [],
       future: [],
       filename: '',
       document: {}
    }
}
```

This is very WIP, but my goal is that we can have reducers that focus purely on application-level stuff (kernels and stuff), a reducer for managing document metadata and actions on the _entire_ document object (just undo/redo for now, but I imagine there will be other situations where we want to manipulate an entire document object), and reducer on the document itself (cell-level operations).

TL;DR: Reworking state tree so that it better reflects the kind of data access our actions need.

I'm about to BREAK ALL THE THINGS.
