### PR TITLE
Add ability to duplicate a notebook

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "remark-react": "^2.1.0",
     "rxjs": "^5.0.0-beta.6",
     "spawnteract": "^2.0.0",
+    "tmp": "0.0.28",
     "transformime-react": "^1.0.0",
     "uuid": "^2.0.2"
   },

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -70,6 +70,10 @@ export const fileSubMenus = {
     },
     accelerator: 'CmdOrCtrl+Shift+S',
   },
+  duplicate: {
+    label: '&Duplicate Notebook',
+    click: createSender('menu:duplicate-notebook'),
+  },
 };
 
 export const file = {
@@ -404,6 +408,7 @@ export function loadFullMenu() {
         fileSubMenus.open,
         fileSubMenus.save,
         fileSubMenus.saveAs,
+        fileSubMenus.duplicate,
       ],
     };
 

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -194,6 +194,9 @@ export function dispatchZoomOut() {
   webFrame.setZoomLevel(webFrame.getZoomLevel() - 1);
 }
 
+export function dispatchDuplidate(store, dispath) {
+}
+
 export function initMenuHandlers(store, dispatch) {
   ipc.on('menu:undo', dispatchUndo.bind(null, store, dispatch));
   ipc.on('menu:redo', dispatchRedo.bind(null, store, dispatch));
@@ -202,6 +205,7 @@ export function initMenuHandlers(store, dispatch) {
   ipc.on('menu:clear-all', dispatchClearAll.bind(null, store, dispatch));
   ipc.on('menu:save', dispatchSave.bind(null, store, dispatch));
   ipc.on('menu:save-as', dispatchSaveAs.bind(null, store, dispatch));
+  ipc.on('menu:duplicate-notebook', dispatchDuplicate.bind(null, store, dispatch));
   ipc.on('menu:kill-kernel', dispatchKillKernel.bind(null, store, dispatch));
   ipc.on('menu:interrupt-kernel', dispatchInterruptKernel.bind(null, store, dispatch));
   ipc.on('menu:restart-kernel', dispatchRestartKernel.bind(null, store, dispatch));

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -4,7 +4,7 @@ import {
   showSaveAsDialog,
 } from '../api/save';
 
-import { tildify } from '../native-window';
+import { tildify, launchFilename } from '../native-window';
 
 import {
   executeCell,
@@ -21,7 +21,6 @@ import {
 } from '../actions';
 
 import { copyNotebook } from '../utils';
-import { launchFilename } from '../../main/launch';
 
 import { ipcRenderer as ipc, webFrame, remote } from 'electron';
 const BrowserWindow = remote.BrowserWindow;

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -20,6 +20,7 @@ import {
   setForwardCheckpoint,
 } from '../actions';
 
+import { launch } from '../../main/launch';
 
 import { ipcRenderer as ipc, webFrame, remote } from 'electron';
 const BrowserWindow = remote.BrowserWindow;
@@ -194,7 +195,19 @@ export function dispatchZoomOut() {
   webFrame.setZoomLevel(webFrame.getZoomLevel() - 1);
 }
 
-export function dispatchDuplidate(store, dispath) {
+export function dispatchDuplicate(store, dispatch) {
+  const state = store.getState();
+  const { notificationSystem } = state.app;
+  if (state.metadata.get('filename')) {
+  } else {
+    notificationSystem.addNotification({
+      title: 'Can\'t Duplicate Unsaved Notebook',
+      message: 'A notebook must be saved before it can be duplicated.',
+      dismissble: true,
+      position: 'tr',
+      level: 'warning',
+    });
+  }
 }
 
 export function initMenuHandlers(store, dispatch) {

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -195,7 +195,7 @@ export function dispatchZoomOut() {
   webFrame.setZoomLevel(webFrame.getZoomLevel() - 1);
 }
 
-export function dispatchDuplicate(store, dispatch) {
+export function dispatchDuplicate(store) {
   const state = store.getState();
   const { notificationSystem } = state.app;
   const filename = state.metadata.get('filename');
@@ -222,7 +222,7 @@ export function initMenuHandlers(store, dispatch) {
   ipc.on('menu:clear-all', dispatchClearAll.bind(null, store, dispatch));
   ipc.on('menu:save', dispatchSave.bind(null, store, dispatch));
   ipc.on('menu:save-as', dispatchSaveAs.bind(null, store, dispatch));
-  ipc.on('menu:duplicate-notebook', dispatchDuplicate.bind(null, store, dispatch));
+  ipc.on('menu:duplicate-notebook', dispatchDuplicate.bind(null, store));
   ipc.on('menu:kill-kernel', dispatchKillKernel.bind(null, store, dispatch));
   ipc.on('menu:interrupt-kernel', dispatchInterruptKernel.bind(null, store, dispatch));
   ipc.on('menu:restart-kernel', dispatchRestartKernel.bind(null, store, dispatch));

--- a/src/notebook/menu/index.js
+++ b/src/notebook/menu/index.js
@@ -20,7 +20,8 @@ import {
   setForwardCheckpoint,
 } from '../actions';
 
-import { launch } from '../../main/launch';
+import { copyNotebook } from '../utils';
+import { launchFilename } from '../../main/launch';
 
 import { ipcRenderer as ipc, webFrame, remote } from 'electron';
 const BrowserWindow = remote.BrowserWindow;
@@ -198,7 +199,11 @@ export function dispatchZoomOut() {
 export function dispatchDuplicate(store, dispatch) {
   const state = store.getState();
   const { notificationSystem } = state.app;
-  if (state.metadata.get('filename')) {
+  const filename = state.metadata.get('filename');
+  if (filename) {
+    copyNotebook(filename).then((value) => {
+      launchFilename(value);
+    });
   } else {
     notificationSystem.addNotification({
       title: 'Can\'t Duplicate Unsaved Notebook',

--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -5,6 +5,8 @@ import fs from 'fs';
 import path from 'path';
 import { fromJS } from 'commutable';
 
+import { deferURL } from '../../main/launch';
+
 import Rx from 'rxjs/Rx';
 
 const HOME = home();

--- a/src/notebook/native-window/index.js
+++ b/src/notebook/native-window/index.js
@@ -1,7 +1,9 @@
 import { remote } from 'electron';
-const { getCurrentWindow } = remote;
+const { BrowserWindow, getCurrentWindow } = remote;
 import home from 'home-dir';
+import fs from 'fs';
 import path from 'path';
+import { fromJS } from 'commutable';
 
 import Rx from 'rxjs/Rx';
 
@@ -41,4 +43,39 @@ export function initNativeHandlers(store) {
       }
       win.setTitle(res.title);
     });
+}
+
+function launch(notebook, filename) {
+  let win = new BrowserWindow({
+    width: 800,
+    height: 1000,
+    title: !filename ? 'Untitled' : path.relative('.', filename.replace(/.ipynb$/, '')),
+  });
+
+  const index = path.join(__dirname, '..', '..', '..', 'static', 'index.html');
+  win.loadURL(`file://${index}`);
+
+  win.webContents.on('did-finish-load', () => {
+    win.webContents.send('main:load', { notebook: notebook.toJS(), filename });
+  });
+
+  win.webContents.on('will-navigate', deferURL);
+
+  win.on('closed', () => {
+    win = null;
+  });
+
+  return win;
+}
+
+export function launchFilename(filename) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filename, {}, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(launch(fromJS(JSON.parse(data)), filename));
+      }
+    });
+  });
 }

--- a/src/notebook/utils/index.js
+++ b/src/notebook/utils/index.js
@@ -1,10 +1,28 @@
 import fs from 'fs';
 import path from 'path';
 
+function fileExists(filename) {
+  if (!filename) {
+    return false;
+  } else {
+    try {
+      return fs.statSync(filename).isFile();
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
 function getCopiedFilename(filename) {
   const base = path.basename(filename, '.ipynb');
   const dir = path.dirname(filename);
-  return dir + '/' +  base + ' Copy.ipynb';
+  var index = 1;
+  var newFilename = `${dir}/${base}-Copy${index}.ipynb`;
+  while (fileExists(newFilename)) {
+    index = index + 1;
+    newFilename = `${dir}/${base}-Copy${index}.ipynb`;
+  }
+  return newFilename;
 }
 
 export function copyNotebook(filename) {

--- a/src/notebook/utils/index.js
+++ b/src/notebook/utils/index.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+
+function getCopiedFilename(filename) {
+  const base = path.basename(filename, '.ipynb');
+  const dir = path.dirname(filename);
+  return dir + '/' +  base + ' Copy.ipynb';
+}
+
+export function copyNotebook(filename) {
+  return new Promise(function(resolve, reject) {
+    const readStream = fs.createReadStream(filename);
+    readStream.on('error', reject);
+
+    const newFilename = getCopiedFilename(filename);
+    const writeStream = fs.createWriteStream(newFilename);
+    writeStream.on('error', reject);
+
+    readStream.pipe(writeStream);
+    writeStream.on('close', resolve(newFilename));
+  });
+}

--- a/src/notebook/utils/index.js
+++ b/src/notebook/utils/index.js
@@ -1,40 +1,24 @@
 import fs from 'fs';
 import path from 'path';
-
-function fileExists(filename) {
-  if (!filename) {
-    return false;
-  }
-
-  try {
-    return fs.statSync(filename).isFile();
-  } catch (e) {
-    return false;
-  }
-}
-
-function getCopiedFilename(filename) {
-  const base = path.basename(filename, '.ipynb');
-  const dir = path.dirname(filename);
-  let index = 1;
-  let newFilename = `${dir}/${base}-Copy${index}.ipynb`;
-  while (fileExists(newFilename)) {
-    index = index + 1;
-    newFilename = `${dir}/${base}-Copy${index}.ipynb`;
-  }
-  return newFilename;
-}
+import tmp from 'tmp';
 
 export function copyNotebook(filename) {
   return new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(filename);
     readStream.on('error', reject);
 
-    const newFilename = getCopiedFilename(filename);
-    const writeStream = fs.createWriteStream(newFilename);
-    writeStream.on('error', reject);
+    const base = path.basename(filename, '.ipynb');
 
-    readStream.pipe(writeStream);
-    writeStream.on('close', resolve(newFilename));
+    tmp.tmpName({ prefix: `${base}-Copy` , postfix: '.ipynb' }, (err, path) => {
+      if (err) {
+        reject(err);
+      }
+
+      const writeStream = fs.createWriteStream(path);
+      writeStream.on('error', reject);
+
+      readStream.pipe(writeStream);
+      writeStream.on('close', resolve(path));
+    });
   });
 }

--- a/src/notebook/utils/index.js
+++ b/src/notebook/utils/index.js
@@ -4,20 +4,20 @@ import path from 'path';
 function fileExists(filename) {
   if (!filename) {
     return false;
-  } else {
-    try {
-      return fs.statSync(filename).isFile();
-    } catch (e) {
-      return false;
-    }
+  }
+
+  try {
+    return fs.statSync(filename).isFile();
+  } catch (e) {
+    return false;
   }
 }
 
 function getCopiedFilename(filename) {
   const base = path.basename(filename, '.ipynb');
   const dir = path.dirname(filename);
-  var index = 1;
-  var newFilename = `${dir}/${base}-Copy${index}.ipynb`;
+  let index = 1;
+  let newFilename = `${dir}/${base}-Copy${index}.ipynb`;
   while (fileExists(newFilename)) {
     index = index + 1;
     newFilename = `${dir}/${base}-Copy${index}.ipynb`;
@@ -26,7 +26,7 @@ function getCopiedFilename(filename) {
 }
 
 export function copyNotebook(filename) {
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     const readStream = fs.createReadStream(filename);
     readStream.on('error', reject);
 

--- a/src/notebook/utils/index.js
+++ b/src/notebook/utils/index.js
@@ -9,16 +9,16 @@ export function copyNotebook(filename) {
 
     const base = path.basename(filename, '.ipynb');
 
-    tmp.tmpName({ prefix: `${base}-Copy` , postfix: '.ipynb' }, (err, path) => {
+    tmp.tmpName({ prefix: `${base}-Copy`, postfix: '.ipynb' }, (err, newFilename) => {
       if (err) {
         reject(err);
       }
 
-      const writeStream = fs.createWriteStream(path);
+      const writeStream = fs.createWriteStream(newFilename);
       writeStream.on('error', reject);
 
       readStream.pipe(writeStream);
-      writeStream.on('close', resolve(path));
+      writeStream.on('close', resolve(newFilename));
     });
   });
 }


### PR DESCRIPTION
Closes #523.

WIP because I'm debugging a weird issue where it complains that `electron.BrowserWindow is not a constructor` when launching from a new file.

I also wanna figure out a better way to create multiple copies, as in the `getCopiedFilename` should have a way of creating non-colliding filenames.
