### PR TITLE
Fix issue with travis and clearCellOutput test

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -14,7 +14,7 @@ import createStore from '../src/notebook/store';
 import { reducers } from '../src/notebook/reducers';
 import { acquireKernelInfo } from '../src/notebook/agendas';
 
-import { AppRecord, DocumentRecord } from '../src/notebook/records';
+import { AppRecord, DocumentRecord, MetadataRecord } from '../src/notebook/records';
 
 import {
   createExecuteRequest,
@@ -134,7 +134,12 @@ export function dummyStore() {
     }),
     app: AppRecord({
       executionState: 'not connected',
-    })
+    }),
+    metadata: MetadataRecord({
+      filename: 'dummy-store-nb.ipynb',
+      past: new Immutable.List(),
+      future: new Immutable.List(),
+    }),
   }, reducers);
 }
 


### PR DESCRIPTION
This fixes Travis and the issues that we were having with the clearCellOutput test.

`clearCellOutput` is one of the undoable tasks so when it is called `setBackwardCheckpoint` is called which looks for a `past` key in the `metadata` record. Since we passed a `dummyStore` without a `metadata` record to the context of the toolbar component, the tests got upset.
