### PR TITLE
Remove indeterminate executeCell test

### DIFF
--- a/test/renderer/agendas/index_spec.js
+++ b/test/renderer/agendas/index_spec.js
@@ -4,24 +4,18 @@ import { updateCellSource, executeCell } from '../../../src/notebook/actions';
 import { liveStore, dispatchQueuePromise, waitForOutputs } from '../../utils';
 
 describe('agendas.executeCell', () => {
-  it('produces the right output', function() {
-    this.timeout(4000);
-    this.retries(10);
-    return liveStore((kernel, dispatch, store) => {
-      const cellId = store.getState().document.getIn(['notebook', 'cellOrder', 0]);
-      const source = 'print("a")';
-      dispatch(updateCellSource(cellId, source));
+  it('is a thunk (returns a function)', function() {
+    const thunk = executeCell();
+    expect(thunk).to.not.be.undefined;
+    expect(thunk).to.be.a('function');
+  });
+  it('thunk returns an observable', function() {
+    const thunk = executeCell();
+    expect(thunk).to.not.be.undefined;
+    expect(thunk).to.be.a('function');
 
-      return Promise.resolve()
-        .then(() => dispatch(executeCell(kernel.channels, cellId, source, true, undefined)))
-        .then(() => dispatchQueuePromise(dispatch))
-        .then(() => waitForOutputs(store, cellId))
-        .then(() => {
-          const output = store.getState().document.getIn(['notebook', 'cellMap', cellId, 'outputs', 0]).toJS();
-          expect(output.name).to.equal('stdout');
-          expect(output.text).to.equal('a\n');
-          expect(output.output_type).to.equal('stream');
-        });
-    });
+    const observable = thunk();
+    expect(observable).to.not.be.undefined;
+    expect(observable.subscribe).to.be.a('function');
   });
 });


### PR DESCRIPTION
I'm on a test killing crusade.  Each unit test should execute in ~1ms, this one does not, therefor it will die. :skull: 
