### PR TITLE
Add wget to sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     - g++-4.9
     - uuid-dev
     - libssl-dev
+    - wget
 language: node_js
 node_js:
 - '6'


### PR DESCRIPTION
Fixes failing Travis things.This updates the version of wget used in the build which can handle whatever certificates 0mq is using on their website.
