### PR TITLE
Minimalist fix to get packaging working

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -11,7 +11,7 @@ const program = require('commander');
 const version = require('../../package.json').version;
 
 program._name = 'nteract';
-process.argv.splice(1,0,'')
+process.argv.splice(1, 0, '');
 
 program
   .version(version)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -10,9 +10,12 @@ import { resolve } from 'path';
 const program = require('commander');
 const version = require('../../package.json').version;
 
+program._name = 'nteract';
+process.argv.splice(1,0,'')
+
 program
   .version(version)
-  .option('-k', '--kernel [kernel]', '')
+  .option('-k, --kernel [kernel]', 'kernel')
   .parse(process.argv);
 
 const notebooks = program.args;


### PR DESCRIPTION
Commander expects process.argv be `node`name.js`[args]. We are running an executable so`Commander's parse function gobbles up the first and second `process.argv` args. For this reason I spliced in an empty string as a hacky fix to get everything working. I changed .option because if you look at program initially `--kernel [kernel]` was the description of the flag and not an actual option. Now the option name is `program.kernel`.
## Todo?

As mentioned in the slack channel, currently we reject a promise and hang while opening no notebook if a file specified doesn't exist in the path. How do we want to go about fixing this?
