### PR TITLE
Add electron-react-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "electron-osx-sign": "^0.3.1",
     "electron-packager": "^7.1.0",
     "electron-prebuilt": "1.1.1",
+    "electron-react-devtools": "^0.3.1",
     "enzyme": "^2.2.0",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",

--- a/static/index.html
+++ b/static/index.html
@@ -52,6 +52,9 @@
             console.dir(err);
           }
         }, 1);
+        if (process.env.NODE_ENV !== 'production') {
+            require('electron-react-devtools').inject()
+        }
       };
     </script>
   </body>


### PR DESCRIPTION
This doesn't have to be merged but electron-react-devtools have been really useful to me when debugging and it's been a bit of a bother not having this committed across my different branches.

I think it's fair to include this in master since it's only on dev.
