### PR TITLE
(fix) kernel menu setting

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -390,6 +390,7 @@ export function loadFullMenu() {
         ...kernelMenuItems,
       ],
     };
+
     const template = [];
 
     if (process.platform === 'darwin') {
@@ -401,15 +402,13 @@ export function loadFullMenu() {
       submenu: [
         {
           label: '&New',
-          submenu: [
-            ...newNotebookItems,
-          ],
+          submenu: newNotebookItems,
         },
         fileSubMenus.open,
         fileSubMenus.save,
         fileSubMenus.saveAs,
         fileSubMenus.duplicate,
-        file.SubMenus.publish,
+        fileSubMenus.publish,
       ],
     };
 


### PR DESCRIPTION
I noticed the kernel menu wasn't loading anymore. Digging into this was rough because the error from this function wasn't being thrown or logged anywhere since it was async and part of the main process.

Oh well, New --> Notebook (Lang), and Language --> (Lang) are back now!
