### PR TITLE
Ignore some dependencies with greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "url": "https://github.com/nteract/nteract/issues"
   },
   "homepage": "https://github.com/nteract/nteract",
+  "greenkeeper": {
+    "ignore": ["commonmark", "electron-prebuilt", "redux-observable"]
+  },
   "dependencies": {
     "codemirror": "^5.16.0",
     "commonmark": "^0.24.0",


### PR DESCRIPTION
To let greenkeeper do its thing without massive breakage.
