### PR TITLE
Fix cell copy paste

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -13,8 +13,6 @@ import {
   focusCell,
   focusPreviousCell,
   focusNextCell,
-  copyCell,
-  pasteCell,
 } from '../../actions';
 
 export class Cell extends React.Component {
@@ -45,16 +43,11 @@ export class Cell extends React.Component {
     this.focusBelowCell = this.focusBelowCell.bind(this);
     this.setCellHoverState = this.setCellHoverState.bind(this);
     this.setToolbarHoverState = this.setToolbarHoverState.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleKeyUp = this.handleKeyUp.bind(this);
-    this.copyCell = this.copyCell.bind(this);
-    this.pasteCell = this.pasteCell.bind(this);
   }
 
   state = {
     hoverCell: false,
     hoverToolbar: false,
-    ctrlDown: false,
   };
 
   componentWillMount() {
@@ -87,24 +80,6 @@ export class Cell extends React.Component {
     this.setState({ hoverToolbar });
   }
 
-  handleKeyDown(event) {
-    if (event.ctrlKey || event.keyCode === 91) {
-      this.setState({ ctrlDown: true });
-    }
-  }
-
-  handleKeyUp(event) {
-    if (this.state.ctrlDown) {
-      if (event.keyCode === 86) {
-        this.setState({ ctrlDown: false });
-        this.pasteCell();
-      } else if (event.keyCode === 67) {
-        this.setState({ ctrlDown: false });
-        this.copyCell();
-      }
-    }
-  }
-
   selectCell() {
     this.context.store.dispatch(focusCell(this.props.id));
   }
@@ -117,14 +92,6 @@ export class Cell extends React.Component {
     this.context.store.dispatch(focusNextCell(this.props.id));
   }
 
-  copyCell() {
-    this.context.store.dispatch(copyCell(this.props.id));
-  }
-
-  pasteCell() {
-    this.context.store.dispatch(pasteCell());
-  }
-
   render() {
     const cell = this.props.cell;
     const type = cell.get('cell_type');
@@ -133,8 +100,6 @@ export class Cell extends React.Component {
       <div
         className={`cell ${type === 'markdown' ? 'text' : 'code'} ${focused ? 'focused' : ''}`}
         onClick={this.selectCell}
-        onKeyDown={this.handleKeyDown}
-        onKeyUp={this.handleKeyUp}
         ref="cell"
         onContextMenu={this.contextMenu}
       >

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -137,7 +137,6 @@ class Notebook extends React.Component {
   }
 
   copyCell() {
-    console.log(this.props.focusedCell);
     this.props.dispatch(copyCell(this.props.focusedCell));
   }
 

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -12,7 +12,13 @@ import { displayOrder, transforms } from 'transformime-react';
 import Cell from './cell/cell';
 import DraggableCell from './cell/draggable-cell';
 import CellCreator from './cell/cell-creator';
-import { executeCell, focusNextCell, moveCell } from '../actions';
+import {
+  executeCell,
+  focusNextCell,
+  moveCell,
+  copyCell,
+  pasteCell,
+} from '../actions';
 
 import complete from '../api/messaging/completion';
 
@@ -69,6 +75,8 @@ class Notebook extends React.Component {
     this.keyDown = this.keyDown.bind(this);
     this.moveCell = this.moveCell.bind(this);
     this.getCompletions = this.getCompletions.bind(this);
+    this.copyCell = this.copyCell.bind(this);
+    this.pasteCell = this.pasteCell.bind(this);
   }
 
   componentDidMount() {
@@ -128,9 +136,24 @@ class Notebook extends React.Component {
     this.props.dispatch(moveCell(sourceId, destinationId, above));
   }
 
+  copyCell() {
+    console.log(this.props.focusedCell);
+    this.props.dispatch(copyCell(this.props.focusedCell));
+  }
+
+  pasteCell() {
+    this.props.dispatch(pasteCell());
+  }
+
 
   keyDown(e) {
     if (e.keyCode !== 13) {
+      const cmdOrCtrl = e.ctrlKey;
+      if (cmdOrCtrl && e.keyCode === 67) {
+        this.copyCell();
+      } else if (cmdOrCtrl && e.keyCode === 86) {
+        this.pasteCell();
+      }
       return;
     }
 

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -220,13 +220,15 @@ export default handleActions({
     const cell = cellMap.get(id);
     return state.set('copied', new Immutable.Map({ id, cell }));
   },
-  [constants.PASTE_CELL]: function copyCell(state) {
-    const copiedCell = state.getIn(['copied', 'cell']);
+  [constants.PASTE_CELL]: function pasteCell(state) {
+    const copiedCell = state.getIn(['copied', 'cell'])
     const copiedId = state.getIn(['copied', 'id']);
     const id = uuid.v4();
 
     return state.update('notebook', (notebook) =>
-        commutable.insertCellAfter(notebook, copiedCell, id, copiedId));
+        commutable.insertCellAfter(notebook, copiedCell, id, copiedId))
+          .setIn(['cellStatuses', id, 'outputHidden'], false)
+          .setIn(['cellStatuses', id, 'inputHidden'], false);
   },
   [constants.CHANGE_CELL_TYPE]: function changeCellType(state, action) {
     const { id, to } = action;

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -221,7 +221,7 @@ export default handleActions({
     return state.set('copied', new Immutable.Map({ id, cell }));
   },
   [constants.PASTE_CELL]: function pasteCell(state) {
-    const copiedCell = state.getIn(['copied', 'cell'])
+    const copiedCell = state.getIn(['copied', 'cell']);
     const copiedId = state.getIn(['copied', 'id']);
     const id = uuid.v4();
 

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -38,42 +38,4 @@ describe('Cell', () => {
       clientY: 0,
     })).to.not.throw(Error);
   });
-  it('handleKeyDown sets ctrlDown properly', () => {
-    const cell = mount(
-      <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>
-    );
-
-    expect(cell.state('ctrlDown')).to.be.false;
-    cell.simulate('keydown', { key: 'Ctrl', ctrlKey: true });
-    expect(cell.state('ctrlDown')).to.be.true;
-  });
-  it('handleKeyUp responds properly to Ctrl + C', () => {
-    const cell = mount(
-      <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>,
-      { context: { store: dummyStore() } }
-    );
-
-    const spy = sinon.spy(cell.instance(), "copyCell"); 
-
-    cell.simulate('keydown', { key: 'Ctrl', ctrlKey: true});
-    cell.simulate('keyup', { keyCode: 67 });
-    expect(cell.state('ctrlDown')).to.be.false;
-    expect(spy.called).to.be.true;
-  });
-  it('handleKeyUp responds properly to Ctrl + V', () => {
-    const cell = mount(
-      <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>,
-      { context: { store: dummyStore() } }
-    );
-
-    const spy = sinon.spy(cell.instance(), "pasteCell"); 
-
-    cell.simulate('keydown', { key: 'Ctrl', ctrlKey: true});
-    cell.simulate('keyup', { keyCode: 86 });
-    expect(cell.state('ctrlDown')).to.be.false;
-    expect(spy.called).to.be.true;
-  });
 });


### PR DESCRIPTION
This fixes the bugs with cell copy paste. I believe this same issue was the cause of the cell duplication bug in #564 but I'm not sure so I won't close this yet.

Also, this moves the logic for copy-paste via keyboard to the Notebook component and applies it on the focused cell. I think we can add something else via the context menu that allows you to copy an unfocused cell.
