### PR TITLE
reduce calls to setExecutionState

### DIFF
--- a/src/notebook/epics/kernelLaunch.js
+++ b/src/notebook/epics/kernelLaunch.js
@@ -80,12 +80,10 @@ export function newKernelObservable(kernelSpecName, cwd) {
 
 export const watchExecutionStateEpic = action$ =>
   action$.ofType(NEW_KERNEL)
-    .mergeMap(action =>
+    .switchMap(action =>
       action.channels.iopub
         .filter(msg => msg.header.msg_type === 'status')
         .map(msg => setExecutionState(msg.content.execution_state))
-          // TODO: Determine if the execution state gets set elsewhere (I think it does)
-          // TODO: Possibly only grab the first for this one or unsubscribe
     );
 
 export const acquireKernelInfoEpic = action$ =>
@@ -94,7 +92,7 @@ export const acquireKernelInfoEpic = action$ =>
       // TODO: This Observable should be cancelled if another NEW_KERNEL occurs
       acquireKernelInfo(action.channels)
         // delay request for kernel to _really_ be ready
-        .delay(200)
+        .delay(100)
     );
 
 export const newKernelEpic = action$ =>

--- a/src/notebook/epics/kernelLaunch.js
+++ b/src/notebook/epics/kernelLaunch.js
@@ -81,18 +81,18 @@ export function newKernelObservable(kernelSpecName, cwd) {
 export const watchExecutionStateEpic = action$ =>
   action$.ofType(NEW_KERNEL)
     .switchMap(action =>
-      action.channels.iopub
-        .filter(msg => msg.header.msg_type === 'status')
-        .map(msg => setExecutionState(msg.content.execution_state))
+      Rx.Observable.merge(
+        action.channels.iopub
+          .filter(msg => msg.header.msg_type === 'status')
+          .map(msg => setExecutionState(msg.content.execution_state)),
+        Rx.Observable.of(setExecutionState('idle'))
+      )
     );
 
 export const acquireKernelInfoEpic = action$ =>
   action$.ofType(NEW_KERNEL)
-    .mergeMap(action =>
-      // TODO: This Observable should be cancelled if another NEW_KERNEL occurs
+    .switchMap(action =>
       acquireKernelInfo(action.channels)
-        // delay request for kernel to _really_ be ready
-        .delay(100)
     );
 
 export const newKernelEpic = action$ =>

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -18,7 +18,6 @@ import Notebook from './components/notebook';
 import {
   setNotebook,
   setNotificationSystem,
-  setExecutionState,
 } from './actions';
 
 import { initMenuHandlers } from './menu';
@@ -28,8 +27,6 @@ import { initGlobalHandlers } from './global-events';
 import { AppRecord, DocumentRecord, MetadataRecord } from './records';
 
 const Github = require('github');
-
-const Rx = require('rxjs/Rx');
 
 const github = new Github();
 
@@ -54,23 +51,6 @@ ipc.on('main:load', (e, launchData) => {
   }, reducers);
 
   const { dispatch } = store;
-
-  Rx.Observable.from(store)
-    .pluck('app')
-    .pluck('channels')
-    .distinctUntilChanged()
-    .switchMap(channels => {
-      if (!channels || !channels.iopub) {
-        return Rx.Observable.of('not connected');
-      }
-      return channels
-        .iopub
-        .ofMessageType('status')
-        .pluck('content', 'execution_state');
-    })
-    .subscribe(st => {
-      dispatch(setExecutionState(st));
-    });
 
   window.store = store;
 

--- a/test/renderer/epics/kernelLaunch_spec.js
+++ b/test/renderer/epics/kernelLaunch_spec.js
@@ -4,11 +4,14 @@ const Rx = require('rxjs/Rx');
 
 const EventEmitter = require('events');
 
+import { ActionsObservable } from 'redux-observable';
+
 import * as constants from '../../../src/notebook/constants';
 
 import {
   setLanguageInfo,
   acquireKernelInfo,
+  watchExecutionStateEpic,
 } from '../../../src/notebook/epics/kernelLaunch';
 
 import {
@@ -77,5 +80,12 @@ describe('acquireKernelInfo', () => {
       })
       done();
     })
+  })
+})
+
+describe('watchExecutionStateEpic', () => {
+  it('returns an Observable with an initial state of idle', () => {
+    const action$ = new ActionsObservable();
+    const obs = watchExecutionStateEpic(action$);
   })
 })


### PR DESCRIPTION
Now that we have one solid kernel state watcher in an epic, it's time to remove this one being run a bit externally to the store.
