### PR TITLE
newNotebookKernelEpic should allow filename to be blank

### DIFF
--- a/src/notebook/epics/kernelLaunch.js
+++ b/src/notebook/epics/kernelLaunch.js
@@ -108,9 +108,6 @@ export const newNotebookKernelEpic = action$ =>
       if (!action.data) {
         throw new Error('newNotebookKernel needs notebook data');
       }
-      if (!action.filename) {
-        throw new Error('newNotebookKernel needs a filename');
-      }
     }).map(action => {
       const { filename, data } = action;
       const cwd = (filename && path.dirname(path.resolve(filename))) || process.cwd();


### PR DESCRIPTION
Since we use it as `cwd` guidance and have a fallback.
