### PR TITLE
skip jupyter install for linting tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "babel src --out-dir build",
     "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
     "build:watch": "npm run build -- --watch",
-    "test": "npm run test:functional && npm run test:unit",
+    "test": "npm run test:unit",
     "pretest:functional": "npm run build",
     "test:functional": "electron-mocha --compilers js:babel-core/register 'test/main/**/*.js'",
     "test:unit": "mocha -r test/setup.js --compilers js:babel-core/register 'test/renderer/**/*.js'",

--- a/travis_before_install
+++ b/travis_before_install
@@ -48,3 +48,12 @@ else
   make install
 fi
 cd ..
+
+if [ "${TEST}" == "lint" ]; then
+  echo "skipping mega-install"
+  return
+fi
+
+pip install jupyter_console --user
+pip install ipywidgets --user
+jupyter kernelspec install-self --user


### PR DESCRIPTION
it would be even better if we could do an install that skips the zmq
compilation too, but I think that solution would be overengineered
vs. just finishing zmq-prebuilt for Linux and letting it install.
