### PR TITLE
Add metaKey check for Cmd key

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -142,7 +142,7 @@ class Notebook extends React.Component {
 
   keyDown(e) {
     if (e.keyCode !== 13) {
-      const cmdOrCtrl = e.ctrlKey;
+      const cmdOrCtrl = e.ctrlKey || e.metaKey;
       if (cmdOrCtrl && e.keyCode === 67) {
         this.copyCell();
       } else if (cmdOrCtrl && e.keyCode === 86) {


### PR DESCRIPTION
The reason copy-paste wasn't working was because I was checking for the Ctrl key on Windows and not the Cmd key on Mac as well. This fixes that.
