### PR TITLE
fix dist lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,10 @@
     "precoverage": "nyc npm run test:unit",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov",
     "predist": "npm run build && rimraf dist",
-    "dist": "set NODE_ENV=production electron-packager . nteract --prune --out dist",
+    "dist": "cross-env NODE_ENV=production electron-packager . nteract --prune --out dist",
     "dist:linux64": "npm run dist -- --platform=linux --arch=x64",
     "dist:linux32": "npm run dist -- --platform=linux --arch=ia32",
-    "dist:osx": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract --osx-sign",
-    "postdist": "npm install",
-    "postinstall": "electron-rebuild"
+    "dist:osx": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract --osx-sign"
   },
   "repository": {
     "type": "git",
@@ -98,6 +96,7 @@
     "babel-preset-es2015-node6": "^0.3.0",
     "babel-preset-react": "^6.11.1",
     "chai": "^3.4.1",
+    "cross-env": "^2.0.0",
     "electron-mocha": "^3.0.5",
     "electron-osx-sign": "^0.3.1",
     "electron-packager": "^7.7.0",


### PR DESCRIPTION
When packaging the last few releases I noticed that the dist folder wasn't getting
created and I ended up having to run the dist manually. Turns out it was because of
the `set` used here, as it literally `set` NODE_ENV to the long string and didn't
actually run electron-packager.
