### PR TITLE
Make toolbar fixed

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -98,7 +98,7 @@ export class Cell extends React.Component {
         onContextMenu={this.contextMenu}
       >
         {
-          this.state.hoverCell ? <Toolbar
+          this.state.hoverCell || focused ? <Toolbar
             type={type}
             cell={cell}
             id={this.props.id}

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -42,12 +42,10 @@ export class Cell extends React.Component {
     this.focusAboveCell = this.focusAboveCell.bind(this);
     this.focusBelowCell = this.focusBelowCell.bind(this);
     this.setCellHoverState = this.setCellHoverState.bind(this);
-    this.setToolbarHoverState = this.setToolbarHoverState.bind(this);
   }
 
   state = {
     hoverCell: false,
-    hoverToolbar: false,
   };
 
   componentWillMount() {
@@ -76,10 +74,6 @@ export class Cell extends React.Component {
     }
   }
 
-  setToolbarHoverState(hoverToolbar) {
-    this.setState({ hoverToolbar });
-  }
-
   selectCell() {
     this.context.store.dispatch(focusCell(this.props.id));
   }
@@ -104,10 +98,9 @@ export class Cell extends React.Component {
         onContextMenu={this.contextMenu}
       >
         {
-          this.state.hoverCell || this.state.hoverToolbar ? <Toolbar
+          this.state.hoverCell ? <Toolbar
             type={type}
-            setHoverState={this.setToolbarHoverState}
-            cell={this.props.cell}
+            cell={cell}
             id={this.props.id}
           /> : null
         }
@@ -116,16 +109,16 @@ export class Cell extends React.Component {
           <MarkdownCell
             focusAbove={this.focusAboveCell}
             focusBelow={this.focusBelowCell}
-            focused={this.props.id === this.props.focusedCell}
-            cell={this.props.cell}
+            focused={focused}
+            cell={cell}
             id={this.props.id}
             theme={this.props.theme}
           /> :
           <CodeCell
             focusAbove={this.focusAboveCell}
             focusBelow={this.focusBelowCell}
-            focused={this.props.id === this.props.focusedCell}
-            cell={this.props.cell}
+            focused={focused}
+            cell={cell}
             id={this.props.id}
             theme={this.props.theme}
             language={this.props.language}

--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -22,7 +22,6 @@ export class Toolbar extends React.Component {
     channels: React.PropTypes.object,
     id: React.PropTypes.string,
     type: React.PropTypes.string,
-    setHoverState: React.PropTypes.func,
   };
 
   static contextTypes = {
@@ -35,39 +34,12 @@ export class Toolbar extends React.Component {
     this.removeCell = this.removeCell.bind(this);
     this.executeCell = this.executeCell.bind(this);
     this.clearCellOutput = this.clearCellOutput.bind(this);
-    this.setHoverState = this.setHoverState.bind(this);
     this.toggleStickyCell = this.toggleStickyCell.bind(this);
     this.changeOutputVisibility = this.changeOutputVisibility.bind(this);
   }
 
-  componentWillMount() {
-    // Listen to the page level mouse move event and manually check for
-    // intersection because we don't want the hover region to actually capture
-    // any mouse events.  The hover region is an invisible element that
-    // describes the "hot region" that toggles the creator buttons.
-    document.addEventListener('mousemove', this.setHoverState, false);
-  }
-
   shouldComponentUpdate() {
     return false;
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousemove', this.setHoverState);
-  }
-
-  setHoverState(mouseEvent) {
-    if (this.refs.mask) {
-      const mask = ReactDOM.findDOMNode(this.refs.mask);
-      if (mask) {
-        const x = mouseEvent.clientX;
-        const y = mouseEvent.clientY;
-        const regionRect = mask.getBoundingClientRect();
-        const hover = (regionRect.left < x && x < regionRect.right) &&
-                     (regionRect.top < y && y < regionRect.bottom);
-        this.props.setHoverState(hover);
-      }
-    }
   }
 
   toggleStickyCell() {

--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -16,7 +15,7 @@ const mapStateToProps = (state) => ({
   channels: state.app.channels,
 });
 
-export class Toolbar extends React.Component {
+export class DumbToolbar extends React.Component {
   static propTypes = {
     cell: React.PropTypes.any,
     channels: React.PropTypes.object,
@@ -87,4 +86,4 @@ export class Toolbar extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(Toolbar);
+export default connect(mapStateToProps)(DumbToolbar);

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -115,22 +115,21 @@ td {
 .cell-toolbar-mask
 {
     position: absolute;
-    top: -37px;
-    right: -5px;
+    top: 0px;
+    right: 0px;
     z-index: 99;
     height: 34px;
-
+    opacity: .5;
     /* Set the left padding to 50px to give users extra room to move their
     mouse to the toolbar without causing the cell to go out of focus and thus
     hide the toolbar before they get there. */
-    padding: 5px 5px 0px 50px;
+    padding: 0px 0px 0px 50px;
 }
 
 .cell-toolbar
 {
     display: inline-box;
     background: var(--toolbar-bg);
-    box-shadow: 0 1px 2px 0 rgba(0,0,0,.50);
 }
 
 .cell-toolbar button

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -13,29 +13,26 @@ import { displayOrder, transforms } from 'transformime-react';
 const sharedProps = { displayOrder, transforms };
 describe('Cell', () => {
   it('should be able to render a markdown cell', () => {
+    const store = dummyStore();
     const cell = mount(
-      <Cell cell={commutable.emptyMarkdownCell} {...sharedProps}/>
+      <Cell cell={commutable.emptyMarkdownCell} {...sharedProps} />,
+      {
+        context: { store }
+      }
     );
     expect(cell).to.not.be.null;
     expect(cell.find('div.cell.text').length).to.be.greaterThan(0);
   });
   it('should be able to render a code cell', () => {
+    const store = dummyStore();
     const cell = mount(
       <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>
+      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>,
+      {
+        context: { store }
+      }
     );
     expect(cell).to.not.be.null;
     expect(cell.find('div.code.cell').length).to.be.greaterThan(0);
-  });
-  it('setCellHoverState does not error', () => {
-    const cell = mount(
-      <Cell cell={commutable.emptyCodeCell} {...sharedProps}
-      cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>
-    );
-
-    expect(() => cell.instance().setCellHoverState({
-      clientX: 0,
-      clientY: 0,
-    })).to.not.throw(Error);
   });
 });

--- a/test/renderer/components/cell/cell-toolbar-spec.js
+++ b/test/renderer/components/cell/cell-toolbar-spec.js
@@ -12,7 +12,7 @@ const expect = chai.expect;
 import * as commutable from 'commutable';
 import { dummyStore } from '../../../utils';
 
-import { Toolbar } from '../../../../src/notebook/components/cell/toolbar';
+import { DumbToolbar as Toolbar } from '../../../../src/notebook/components/cell/toolbar';
 import { setNotificationSystem } from '../../../../src/notebook/actions';
 
 
@@ -23,15 +23,6 @@ describe('Toolbar', () => {
     );
     expect(toolbar).to.not.be.null;
     expect(toolbar.find('div.cell-toolbar').length).to.be.greaterThan(0);
-  });
-  it('setHoverState does not error', () => {
-    const toolbar = mount(
-      <Toolbar setHoverState={() => {}}/>
-    );
-    expect(() => toolbar.instance().setHoverState({
-      clientX: 0,
-      clientY: 0,
-    })).to.not.throw(Error);
   });
   it('clearCellOutput does not throw error', () => {
     const toolbar = mount(


### PR DESCRIPTION
## Changes made
- Changed css such that a slightly transparent toolbar renders inside the cell
- The toolbar should render when the cell is in focus only, but this currently only works for mousevents. I need help to actually just tie this to the cell being focused. 
## Todo
- [x] Cleanup hover logic
- [x] Fix toolbar rendering logic
- [ ] Add button for dropdown menu
- [ ] Update cell tests in the style of the markdown spec
