### PR TITLE
Prefer this.context.store.dispatch

### DIFF
--- a/src/notebook/components/cell/cell-creator-buttons.js
+++ b/src/notebook/components/cell/cell-creator-buttons.js
@@ -6,13 +6,17 @@ import {
   createCellAfter,
   createCellBefore,
   createCellAppend,
-  mergeCellAfter } from '../../actions';
+  mergeCellAfter,
+} from '../../actions';
 
 export class CellCreatorButtons extends React.Component {
   static propTypes = {
     above: React.PropTypes.bool,
     id: React.PropTypes.string,
-    dispatch: React.PropTypes.func,
+  };
+
+  static contextTypes = {
+    store: React.PropTypes.object,
   };
 
   constructor() {
@@ -30,19 +34,19 @@ export class CellCreatorButtons extends React.Component {
 
   createCell(type) {
     if (!this.props.id) {
-      this.props.dispatch(createCellAppend(type));
+      this.context.store.dispatch(createCellAppend(type));
       return;
     }
 
     if (this.props.above) {
-      this.props.dispatch(createCellBefore(type, this.props.id));
+      this.context.store.dispatch(createCellBefore(type, this.props.id));
     } else {
-      this.props.dispatch(createCellAfter(type, this.props.id));
+      this.context.store.dispatch(createCellAfter(type, this.props.id));
     }
   }
 
   mergeCell() {
-    this.props.dispatch(mergeCellAfter(this.props.id));
+    this.context.store.dispatch(mergeCellAfter(this.props.id));
   }
 
   render() {

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -37,7 +37,6 @@ const mapStateToProps = (state) => ({
   focusedCell: state.document.get('focusedCell'),
   cellStatuses: state.document.get('cellStatuses'),
   stickyCells: state.document.get('stickyCells'),
-  notificationSystem: state.app.notificationSystem,
 });
 
 class Notebook extends React.Component {
@@ -52,7 +51,6 @@ class Notebook extends React.Component {
     stickyCells: React.PropTypes.instanceOf(Immutable.Map),
     focusedCell: React.PropTypes.string,
     theme: React.PropTypes.string,
-    notificationSystem: React.PropTypes.any,
   };
 
   static defaultProps = {
@@ -60,9 +58,8 @@ class Notebook extends React.Component {
     transforms,
   };
 
-  static propsTypes = {
-    dispatch: React.PropTypes.func,
-    notificationSystem: React.PropTypes.any,
+  static contextTypes = {
+    store: React.PropTypes.object,
   };
 
   constructor() {
@@ -133,19 +130,19 @@ class Notebook extends React.Component {
   }
 
   moveCell(sourceId, destinationId, above) {
-    this.props.dispatch(moveCell(sourceId, destinationId, above));
+    this.context.store.dispatch(moveCell(sourceId, destinationId, above));
   }
 
   copyCell() {
-    this.props.dispatch(copyCell(this.props.focusedCell));
+    this.context.store.dispatch(copyCell(this.props.focusedCell));
   }
 
   cutCell() {
-    this.props.dispatch(cutCell(this.props.focusedCell));
+    this.context.store.dispatch(cutCell(this.props.focusedCell));
   }
 
   pasteCell() {
-    this.props.dispatch(pasteCell());
+    this.context.store.dispatch(pasteCell());
   }
 
 
@@ -178,11 +175,11 @@ class Notebook extends React.Component {
     const cell = cellMap.get(id);
 
     if (e.shiftKey) {
-      this.props.dispatch(focusNextCell(this.props.focusedCell, true));
+      this.context.store.dispatch(focusNextCell(this.props.focusedCell, true));
     }
 
     if (cell.get('cell_type') === 'code') {
-      this.props.dispatch(
+      this.context.store.dispatch(
         executeCell(
           id,
           cell.get('source')

--- a/test/renderer/components/cell/cell-creator-buttons-spec.js
+++ b/test/renderer/components/cell/cell-creator-buttons-spec.js
@@ -6,6 +6,8 @@ import { shallow } from 'enzyme';
 
 import Immutable from 'immutable';
 
+import { dummyStore } from '../../../utils';
+
 import { NEW_CELL_AFTER } from '../../../../src/notebook/constants';
 import { CellCreatorButtons } from '../../../../src/notebook/components/cell/cell-creator-buttons';
 
@@ -18,17 +20,18 @@ describe('CellCreatorButtons', () => {
   });
   it('has create text cell button', () => {
     const component = shallow(
-      <CellCreatorButtons above={false} id='test' context={context} />
+      <CellCreatorButtons above={false} id='test' />
     );
     expect(component.find('button.add-text-cell').length).to.be.greaterThan(0);
   });
   it('has create code cell button', () => {
     const component = shallow(
-      <CellCreatorButtons above={false} id='test' context={context} />
+      <CellCreatorButtons above={false} id='test' />
     );
     expect(component.find('button.add-code-cell').length).to.be.greaterThan(0);
   });
   it('can create text cell', () => {
+    const store = dummyStore();
     return new Promise(resolve => {
       const dispatch = action => {
         expect(action.id).to.equal('test');
@@ -36,13 +39,15 @@ describe('CellCreatorButtons', () => {
         expect(action.type).to.equal(NEW_CELL_AFTER);
         resolve();
       };
+      store.dispatch = dispatch;
       const component = shallow(
-        <CellCreatorButtons above={false} id='test' dispatch={dispatch} />
-      , { context });
+        <CellCreatorButtons above={false} id='test' />
+      , { context: { store } });
       component.find('button.add-text-cell').simulate('click');
     });
   });
   it('can create code cell', () => {
+    const store = dummyStore();
     return new Promise(resolve => {
       const dispatch = action => {
         expect(action.id).to.equal('test');
@@ -50,9 +55,10 @@ describe('CellCreatorButtons', () => {
         expect(action.type).to.equal(NEW_CELL_AFTER);
         resolve();
       };
+      store.dispatch = dispatch;
       const component = shallow(
-        <CellCreatorButtons above={false} id='test' dispatch={dispatch} />
-      , { context });
+        <CellCreatorButtons above={false} id='test' />
+      , { context: { store } });
       component.find('button.add-code-cell').simulate('click');
     });
   });


### PR DESCRIPTION
In support of #677, I'm doing some cleanup on passed props and context.

A bunch of these predate our `<Provider>` that gives the store as context.
