### PR TITLE
Unit testing Notebook component

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "mocha": "^3.0.2",
     "nyc": "^8.0.0",
     "react-addons-test-utils": "^15.3.1",
+    "react-dnd-test-backend": "^1.0.2",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0",

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -39,7 +39,7 @@ const mapStateToProps = (state) => ({
   stickyCells: state.document.get('stickyCells'),
 });
 
-class Notebook extends React.Component {
+export class Notebook extends React.Component {
   static propTypes = {
     channels: React.PropTypes.any,
     dispatch: React.PropTypes.func,
@@ -51,11 +51,13 @@ class Notebook extends React.Component {
     stickyCells: React.PropTypes.instanceOf(Immutable.Map),
     focusedCell: React.PropTypes.string,
     theme: React.PropTypes.string,
+    CellComponent: React.PropTypes.any,
   };
 
   static defaultProps = {
     displayOrder,
     transforms,
+    CellComponent: DraggableCell,
   };
 
   static contextTypes = {
@@ -243,13 +245,16 @@ class Notebook extends React.Component {
     const cellMap = this.props.notebook.get('cellMap');
     const cell = cellMap.get(id);
     const isStickied = this.props.stickyCells.get(id);
+
+    const CellComponent = this.props.CellComponent;
+
     return (
       <div key={`cell-container-${id}`} ref="container">
         {isStickied ?
           <div className="cell-placeholder">
             <span className="octicon octicon-link-external" />
           </div> :
-          <DraggableCell {...this.createCellProps(id, cell)} />}
+          <CellComponent {...this.createCellProps(id, cell)} />}
         <CellCreator key={`creator-${id}`} id={id} above={false} />
       </div>);
   }

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -147,7 +147,11 @@ class Notebook extends React.Component {
 
 
   keyDown(e) {
+    // Global event registration for copy paste handling of cells
     if (e.keyCode !== 13) {
+      // Cut, Copy, Paste rely on (ctrl|cmd + shift + c/p/x) to not interfere with
+      // native copy of outputs or with CodeMirror
+      // TODO: Add cell CCP to the menu
       const cmdOrCtrl = e.ctrlKey || e.metaKey;
       if (cmdOrCtrl && e.shiftKey && e.keyCode === 67) {
         this.copyCell();

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -8,12 +8,10 @@ import * as constants from '../constants';
 export default handleActions({
   [constants.SET_NOTEBOOK]: function setNotebook(state, action) {
     const notebook = action.data;
-    let cellStatuses = new Immutable.Map();
-    notebook.get('cellOrder').map((cellID) => {
-      cellStatuses = cellStatuses.setIn([cellID, 'outputHidden'], false)
-        .setIn([cellID, 'inputHidden'], false);
-      return cellStatuses;
-    });
+    const cellStatuses = notebook.get('cellOrder')
+      .reduce((statuses, cellID) =>
+        statuses.set(cellID, Immutable.fromJS({ outputHidden: false, inputHidden: false })),
+      new Immutable.Map());
 
     return state.set('notebook', notebook)
       .set('focusedCell', notebook.getIn(['cellOrder', 0]))

--- a/test/renderer/components/notebook_spec.js
+++ b/test/renderer/components/notebook_spec.js
@@ -185,6 +185,7 @@ describe('Notebook DnD', () => {
     const manager = component.get(0).getManager();
     const backend = manager.getBackend();
 
+    // TODO: Write tests for cell drag and drop
   })
 })
 

--- a/test/renderer/components/notebook_spec.js
+++ b/test/renderer/components/notebook_spec.js
@@ -27,10 +27,10 @@ import {
 import { Notebook, ConnectedNotebook } from '../../../src/notebook/components/notebook';
 
 // Boilerplate test to make sure the testing setup is configured
-describe('ConnectedNotebook', () => {
+describe('Notebook', () => {
   it('accepts an Immutable.List of cells', () => {
     const component = shallow(
-      <ConnectedNotebook
+      <Notebook
         notebook={dummyCommutable}
         cellPagers={new Immutable.Map()}
         cellStatuses={new Immutable.Map()}
@@ -39,6 +39,7 @@ describe('ConnectedNotebook', () => {
           // triggered.
           .set(dummyCommutable.getIn(['cellOrder', 0]), true)
         }
+        CellComponent={Cell}
         outputStatuses={new Immutable.Map()}
       />
     );
@@ -51,13 +52,14 @@ describe('ConnectedNotebook', () => {
                                 .setIn([cellID, 'inputHidden'], false);
     });
     const component = mount(
-      <ConnectedNotebook
+      <Notebook
         notebook={dummyCommutable}
         cellPagers={new Immutable.Map()}
         cellStatuses={cellStatuses}
         stickyCells={new Immutable.Map()}
         displayOrder={displayOrder.delete('text/html')}
         transforms={transforms.delete('text/html')}
+        CellComponent={Cell}
       />
     );
     expect(component.find('.notebook').length).to.be.above(0, '.notebook');

--- a/test/renderer/components/notebook_spec.js
+++ b/test/renderer/components/notebook_spec.js
@@ -73,8 +73,100 @@ describe('Notebook', () => {
     expect(component.find('.notebook .cell.code .input-container .input').length).to.be.above(0, '.notebook .cell.code .input-container .input');
     expect(component.find('.notebook .cell.code .outputs').length).to.be.above(0, '.notebook .cell.code .outputs');
   });
-});
 
+  it('dispatches cut/copy/paste actions', () => {
+    // Note: because the notebook component is so heavy to load, this test is
+    // bulked up with all the cut, copy, paste goodness
+    const focusedCell = dummyCommutable.getIn(['cellOrder', 0]);
+
+    const context = {
+      store: dummyStore(),
+    }
+
+    context.store.dispatch = sinon.spy();
+
+    const component = shallow(
+      <Notebook
+        notebook={dummyCommutable}
+        cellPagers={new Immutable.Map()}
+        cellStatuses={dummyCellStatuses}
+        stickyCells={(new Immutable.Map())}
+        outputStatuses={new Immutable.Map()}
+        CellComponent={Cell}
+        focusedCell={focusedCell}
+      />, { context });
+
+    const inst = component.instance();
+
+    inst.copyCell();
+    expect(context.store.dispatch.firstCall).to.have.been.calledWith({
+      type: 'COPY_CELL',
+      id: focusedCell,
+    })
+
+    inst.cutCell();
+    expect(context.store.dispatch.secondCall).to.have.been.calledWith({
+      type: 'CUT_CELL',
+      id: focusedCell,
+    })
+
+    inst.pasteCell();
+    expect(context.store.dispatch.thirdCall).to.have.been.calledWith({
+      type: 'PASTE_CELL'
+    });
+  });
+
+  it('responds via ctrl-shift-c with a COPY_CELL action', () => {
+    // Note: because the notebook component is so heavy to load, this test is
+    // bulked up with all the cut, copy, paste goodness
+    const focusedCell = dummyCommutable.getIn(['cellOrder', 0]);
+
+    const context = {
+      store: dummyStore(),
+    }
+
+    context.store.dispatch = sinon.spy();
+
+    const component = shallow(
+      <Notebook
+        notebook={dummyCommutable}
+        cellPagers={new Immutable.Map()}
+        cellStatuses={dummyCellStatuses}
+        stickyCells={(new Immutable.Map())}
+        outputStatuses={new Immutable.Map()}
+        CellComponent={Cell}
+        focusedCell={focusedCell}
+      />, { context });
+
+    const inst = component.instance();
+
+    // Note that we can't use enzyme's simulate because the event listener is
+    // document level not React level
+    const ev = new window.CustomEvent('keydown');
+    ev.ctrlKey = true;
+    ev.shiftKey = true;
+    ev.keyCode = 'c'.charCodeAt(0) - 32; // get the key code
+
+    inst.keyDown(ev);
+    expect(context.store.dispatch).to.have.been.calledWith({
+      type: 'COPY_CELL',
+      id: focusedCell,
+    })
+
+    ev.keyCode = 'v'.charCodeAt(0) - 32;
+    inst.keyDown(ev);
+    expect(context.store.dispatch).to.have.been.calledWith({
+      type: 'PASTE_CELL',
+    })
+
+    ev.keyCode = 'x'.charCodeAt(0) - 32;
+    inst.keyDown(ev);
+    expect(context.store.dispatch).to.have.been.calledWith({
+      type: 'CUT_CELL',
+      id: focusedCell,
+    })
+  })
+})
 
 describe('Notebook DnD', () => {
   it('drag and drop can be tested', () => {
@@ -98,67 +190,5 @@ describe('Notebook DnD', () => {
 
 
 describe('Notebook.copyCell', () => {
-  it('triggers a COPY_CELL action', () => {
-    const focusedCell = dummyCommutable.getIn(['cellOrder', 0]);
 
-    const context = {
-      store: dummyStore(),
-    }
-
-    context.store.dispatch = sinon.spy();
-
-    const component = shallow(
-      <Notebook
-        notebook={dummyCommutable}
-        cellPagers={new Immutable.Map()}
-        cellStatuses={dummyCellStatuses}
-        stickyCells={(new Immutable.Map())}
-        outputStatuses={new Immutable.Map()}
-        CellComponent={Cell}
-        focusedCell={focusedCell}
-      />, { context });
-
-    const inst = component.instance();
-    inst.copyCell();
-
-    expect(context.store.dispatch).to.have.been.calledWith({
-      type: 'COPY_CELL',
-      id: focusedCell,
-    })
-  })
-  it('responds via ctrl-shift-c with a COPY_CELL action', () => {
-    const focusedCell = dummyCommutable.getIn(['cellOrder', 0]);
-
-    const context = {
-      store: dummyStore(),
-    }
-
-    context.store.dispatch = sinon.spy();
-
-    const component = shallow(
-      <Notebook
-        notebook={dummyCommutable}
-        cellPagers={new Immutable.Map()}
-        cellStatuses={dummyCellStatuses}
-        stickyCells={(new Immutable.Map())}
-        outputStatuses={new Immutable.Map()}
-        CellComponent={Cell}
-        focusedCell={focusedCell}
-      />, { context });
-
-    // Note that we can't use enzyme's simulate because the event listener is
-    // document level not React level
-    const ev = new window.CustomEvent('keydown');
-    ev.ctrlKey = true;
-    ev.shiftKey = true;
-    ev.keyCode = 'c'.charCodeAt(0) - 32; // get the key code
-
-    const inst = component.instance();
-    inst.keyDown(ev);
-
-    expect(context.store.dispatch).to.have.been.calledWith({
-      type: 'COPY_CELL',
-      id: focusedCell,
-    })
-  })
 })

--- a/test/renderer/components/notebook_spec.js
+++ b/test/renderer/components/notebook_spec.js
@@ -1,21 +1,33 @@
 import React from 'react';
 
-import { expect } from 'chai';
-
 import { shallow, mount } from 'enzyme';
 
 import Immutable from 'immutable';
 
 import { displayOrder, transforms } from 'transformime-react';
 
+const TestBackend = require('react-dnd-test-backend');
+import { DragDropContext } from 'react-dnd';
+
+import Cell from '../../../src/notebook/components/cell/cell';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require("sinon-chai");
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+import { dummyStore } from '../../utils';
+
 import {
   dummyCommutable,
 } from '../dummy-nb';
 
-import { ConnectedNotebook } from '../../../src/notebook/components/notebook';
+import { Notebook, ConnectedNotebook } from '../../../src/notebook/components/notebook';
 
 // Boilerplate test to make sure the testing setup is configured
-describe('Notebook', () => {
+describe('ConnectedNotebook', () => {
   it('accepts an Immutable.List of cells', () => {
     const component = shallow(
       <ConnectedNotebook
@@ -60,3 +72,70 @@ describe('Notebook', () => {
     expect(component.find('.notebook .cell.code .outputs').length).to.be.above(0, '.notebook .cell.code .outputs');
   });
 });
+
+
+describe('Notebook DnD', () => {
+  it('drag and drop could be tested', () => {
+    const TestNotebook = DragDropContext(TestBackend)(Notebook);
+    const notebook = dummyCommutable;
+    const cellStatuses = notebook.get('cellOrder')
+      .reduce((statuses, cellID) =>
+        statuses.set(cellID, Immutable.fromJS({ outputHidden: false, inputHidden: false })),
+      new Immutable.Map());
+
+    const focusedCell = notebook.getIn(['cellOrder', 0]);
+
+    const component = mount(
+      <TestNotebook
+        notebook={dummyCommutable}
+        cellPagers={new Immutable.Map()}
+        cellStatuses={cellStatuses}
+        stickyCells={(new Immutable.Map())}
+        outputStatuses={new Immutable.Map()}
+      />
+    );
+
+    const manager = component.get(0).getManager();
+    const backend = manager.getBackend();
+
+  })
+})
+
+
+describe('Notebook', () => {
+  it('can be tested separately', () => {
+    const notebook = dummyCommutable;
+    const cellStatuses = notebook.get('cellOrder')
+      .reduce((statuses, cellID) =>
+        statuses.set(cellID, Immutable.fromJS({ outputHidden: false, inputHidden: false })),
+      new Immutable.Map());
+
+    const focusedCell = notebook.getIn(['cellOrder', 0]);
+
+    const context = {
+      store: dummyStore(),
+    }
+
+    context.store.dispatch = sinon.spy();
+
+    const component = mount(
+      <Notebook
+        notebook={dummyCommutable}
+        cellPagers={new Immutable.Map()}
+        cellStatuses={cellStatuses}
+        stickyCells={(new Immutable.Map())}
+        outputStatuses={new Immutable.Map()}
+        CellComponent={Cell}
+        focusedCell={focusedCell}
+      />, { context });
+
+    const inst = component.instance();
+    inst.copyCell();
+
+    expect(context.store.dispatch).to.have.been.calledWith({
+      type: 'COPY_CELL',
+      id: focusedCell,
+    })
+
+  })
+})

--- a/test/renderer/dummy-nb.js
+++ b/test/renderer/dummy-nb.js
@@ -3,7 +3,7 @@ import * as commutable from 'commutable';
 export const dummy = '{"cells":[{"cell_type":"markdown","metadata":{},\
 "source":["## The Notable Nteract Notebook\\n","\\n","**It\'s a notebook!**\\n"]},\
 {"cell_type":"code","execution_count":11,"metadata":{"collapsed":false},\
-"outputs":[{"data":{"text/html":["<h1>Multiple</h1>"],\
+"outputs":[{"data":{"text/plain":["<h1>Multiple</h1>"],\
 "text/plain":["<IPython.core.display.HTML object>"]},"metadata":{},"output_type":"display_data"}],\
 "source":["import IPython\\n","\\n","from IPython.display import HTML\\n",\
 "from IPython.display import Markdown\\n","from IPython.display import display\\n","\\n",\


### PR DESCRIPTION
This sets up a few things to make testing the `Notebook` component much easier:
- Test section for a Drag and Drop Notebook, to test that drag and drop works
- Notebook without Drag and Drop

While doing this I also noticed a bit of an anti-pattern in `SET_NOTEBOOK` for when it sets up the cellStatuses. It boils down to doing a `reduce` to create a map from the `cellOrder`.
