### PR TITLE
sanity: keep index.js around, which loads build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// Necessary for bootstrapping electron, must be ES5
+require('./build/main/index.js')

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "nteract",
   "version": "0.0.7",
   "description": ":notebook: the nteract notebook",
-  "main": "build/main.js",
+  "main": "index.js",
   "scripts": {
     "prestart": "npm run build",
-    "start": "cross-env NODE_ENV=development electron build/main/index.js",
+    "start": "cross-env NODE_ENV=development electron .",
     "prepublish": "npm run build",
     "clean": "rimraf build dist",
     "lint": "eslint src",


### PR DESCRIPTION
Apparently you can't run a dist copy without ./index.js, for electron to run as `electron .`. This reverts #703.
