### PR TITLE
Set overflow:scroll; on outputs

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -203,6 +203,7 @@ td {
 {
     word-wrap: break-word;
     padding: 10px 10px 10px calc(var(--prompt-width) + 10px);
+    overflow: scroll;
 }
 
 .outputs>div:empty


### PR DESCRIPTION
Closes #420.

Behavior people are used to from Jupyter notebook is for outputs to have horizontal scrolling.
