### PR TITLE
Allow the main entry point to be run in tests.

### DIFF
--- a/test/renderer/components/cell/cell-toolbar-spec.js
+++ b/test/renderer/components/cell/cell-toolbar-spec.js
@@ -36,6 +36,7 @@ describe('Toolbar.executeCell', () => {
   it('dispatches an executeCell action', () => {
     const cell = commutable.emptyCodeCell.set('source', 'print("sup")')
     const store = dummyStore();
+    store.dispatch = sinon.spy();
 
     const toolbar = mount(
       <Toolbar id={'0-1-2-3'} cell={cell} />,
@@ -46,7 +47,11 @@ describe('Toolbar.executeCell', () => {
       .find('.executeButton');
 
     button.simulate('click');
-    // TODO: Check on the dispatched actions
 
+    expect(store.dispatch.firstCall).to.be.calledWith({
+      type: 'EXECUTE_CELL',
+      source: 'print("sup")',
+      id: '0-1-2-3',
+    });
   });
 });

--- a/test/renderer/components/notebook-spec.js
+++ b/test/renderer/components/notebook-spec.js
@@ -195,4 +195,3 @@ describe('Notebook DnD', () => {
     // TODO: Write tests for cell drag and drop
   })
 })
-

--- a/test/renderer/index-spec.js
+++ b/test/renderer/index-spec.js
@@ -1,0 +1,1 @@
+require('../../src/notebook');

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,7 +4,7 @@ var jsdom = require('jsdom').jsdom;
 
 var exposedProperties = ['window', 'navigator', 'document'];
 
-global.document = jsdom('');
+global.document = jsdom('<html><body><div id="app"></div></html>');
 global.window = document.defaultView;
 Object.keys(document.defaultView).forEach((property) => {
   if (typeof global[property] === 'undefined') {
@@ -56,6 +56,11 @@ mock('electron', {
         };
       }
     },
+    'getCurrentWindow': function() {
+      return {
+        'setTitle': function(){},
+      };
+    }
   },
   'webFrame': {
     'setZoomLevel': function(zoom) { },


### PR DESCRIPTION
This will be a tiny bit crazy.

I'm merely `requir(e)`ing `src/notebook/index.js` to force the entire entry point to run (now that it's no longer wrapped in an `ipc` main call.

I'll be interested to see what CodeCov thinks of this.
