### PR TITLE
Introduce docker bits for building Linux release

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,3 @@
+dist
+build
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:6.5.0
+ADD . /nteract
+WORKDIR /nteract
+RUN npm i
+# RUN npm run dist:linux64


### PR DESCRIPTION
Not fully automated (ran into some issues with running the dist in Docker).

```
docker build -t nteract-linux-build .
docker run -it nteract-linux-build /bin/bash
```

Still have to run the dist from the inside then ship the binary from within.

Partial automation is better than none at all.
