### PR TITLE
Live rendered markdown

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -108,6 +108,7 @@ export class Cell extends React.Component {
             focusBelow={this.focusBelowCell}
             focused={focused}
             cell={cell}
+            cellStatus={this.props.cellStatus}
             id={this.props.id}
             theme={this.props.theme}
           /> :

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -108,7 +108,6 @@ export class Cell extends React.Component {
             focusBelow={this.focusBelowCell}
             focused={focused}
             cell={cell}
-            cellStatus={this.props.cellStatus}
             id={this.props.id}
             theme={this.props.theme}
           /> :

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-
+import { TogglableDisplay } from 'react-jupyter-display-area';
 import Editor from './editor';
 import LatexRenderer from '../latex';
 
@@ -86,7 +86,7 @@ export default class MarkdownCell extends React.Component {
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === 'Enter') {
-      this.setState({ view: true });
+      this.setState({ view: false });
       return false;
     }
 
@@ -108,6 +108,8 @@ export default class MarkdownCell extends React.Component {
 
   render() {
     return (
+      <div>
+      {
         (this.state && this.state.view) ?
           <div
             className="rendered"
@@ -139,6 +141,20 @@ export default class MarkdownCell extends React.Component {
               />
             </div>
           </div>
+        }
+        {
+        (!this.state.view) ?
+          <div className="outputs">
+            <LatexRenderer>
+            { mdRender(
+              this.state.source ?
+              this.state.source :
+              '*Empty markdown cell, double click me to add content.*')
+            }
+            </LatexRenderer>
+          </div> : null
+        }
+      </div>
     );
   }
 }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import Immutable from 'immutable';
 import Editor from './editor';
 import LatexRenderer from '../latex';
 
@@ -10,7 +9,7 @@ const MarkdownRenderer = require('commonmark-react-renderer');
 const parser = new CommonMark.Parser();
 const renderer = new MarkdownRenderer();
 
-const mdRender = (input) => renderer.render(parser.parse(input));
+const mdRender = input => renderer.render(parser.parse(input));
 
 export default class MarkdownCell extends React.Component {
   static propTypes = {
@@ -83,7 +82,6 @@ export default class MarkdownCell extends React.Component {
    * Handles when a keydown event occurs on the rendered MD cell
    */
   renderedKeyDown(e) {
-    console.log('renderedKeyDown')
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === 'Enter') {
@@ -108,27 +106,26 @@ export default class MarkdownCell extends React.Component {
   }
 
   render() {
-    console.log(this.state.view);
     return (
        (this.state && this.state.view) ?
-       <div
-         className="rendered"
-         onDoubleClick={this.openEditor}
-         onKeyDown={this.renderedKeyDown}
-         ref="rendered"
-         tabIndex="0"
-       >
-         <LatexRenderer>
-          {mdRender(
+         <div
+           className="rendered"
+           onDoubleClick={this.openEditor}
+           onKeyDown={this.renderedKeyDown}
+           ref="rendered"
+           tabIndex="0"
+         >
+           <LatexRenderer>
+           {mdRender(
             this.state.source ?
             this.state.source :
                '*Empty markdown cell, double click me to add content.*')
-          }
-         </LatexRenderer>
-       </div> :
-       <div onKeyDown={this.editorKeyDown}>
-         <div className="input-container">
-           <div className="prompt" />
+           }
+           </LatexRenderer>
+         </div> :
+         <div onKeyDown={this.editorKeyDown}>
+           <div className="input-container">
+             <div className="prompt" />
              <Editor
                language="markdown"
                id={this.props.id}
@@ -140,12 +137,12 @@ export default class MarkdownCell extends React.Component {
                focused={this.props.focused}
              />
            </div>
-         <div className="outputs">
-           <LatexRenderer>
-             {mdRender(this.state.source)}
-           </LatexRenderer>
+           <div className="outputs">
+             <LatexRenderer>
+            {mdRender(this.state.source)}
+             </LatexRenderer>
+           </div>
          </div>
-       </div>
     );
   }
 }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import Immutable from 'immutable';
 import { TogglableDisplay } from 'react-jupyter-display-area';
 import Editor from './editor';
 import LatexRenderer from '../latex';
@@ -14,6 +15,7 @@ const mdRender = (input) => renderer.render(parser.parse(input));
 
 export default class MarkdownCell extends React.Component {
   static propTypes = {
+    cellStatus: React.PropTypes.instanceOf(Immutable.Map).isRequired,
     cell: React.PropTypes.any,
     id: React.PropTypes.string,
     theme: React.PropTypes.string,
@@ -106,11 +108,19 @@ export default class MarkdownCell extends React.Component {
     return true;
   }
 
+  isOutputHidden() {
+    return this.props.cellStatus.get('outputHidden');
+  }
+
+  isInputHidden() {
+    return this.props.cellStatus.get('inputHidden');
+  }
+
   render() {
     return (
       <div>
       {
-        (this.state && this.state.view) ?
+        (this.state && this.state.view && !this.isInputHidden()) ?
           <div
             className="rendered"
             onDoubleClick={this.openEditor}
@@ -143,12 +153,10 @@ export default class MarkdownCell extends React.Component {
           </div>
         }
         {
-        (!this.state.view) ?
+        (!this.state.view && !this.isOutputHidden()) ?
           <div className="outputs">
             <LatexRenderer>
-            { mdRender(
-              this.state.source)
-            }
+              {mdRender(this.state.source)}
             </LatexRenderer>
           </div> : null
         }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -119,38 +119,41 @@ export default class MarkdownCell extends React.Component {
   render() {
     return (
       <div>
-      {
-        (this.state && this.state.view && !this.isInputHidden()) ?
-          <div
-            className="rendered"
-            onDoubleClick={this.openEditor}
-            onKeyDown={this.renderedKeyDown}
-            ref="rendered"
-            tabIndex="0"
-          >
-            <LatexRenderer>
+      { !this.isInputHidden() ?
+        <div>
+          { (this.state && this.state.view) ?
+            <div
+              className="rendered"
+              onDoubleClick={this.openEditor}
+              onKeyDown={this.renderedKeyDown}
+              ref="rendered"
+              tabIndex="0"
+            >
+              <LatexRenderer>
               {mdRender(
                 this.state.source ?
-                  this.state.source :
-                  '*Empty markdown cell, double click me to add content.*')
+                this.state.source :
+                '*Empty markdown cell, double click me to add content.*')
               }
-            </LatexRenderer>
-          </div> :
-          <div onKeyDown={this.editorKeyDown}>
-            <div className="input-container">
-              <div className="prompt" />
-              <Editor
-                language="markdown"
-                id={this.props.id}
-                lineWrapping
-                input={this.state.source}
-                theme={this.props.theme}
-                focusAbove={this.props.focusAbove}
-                focusBelow={this.props.focusBelow}
-                focused={this.props.focused}
-              />
+              </LatexRenderer>
+            </div> :
+            <div onKeyDown={this.editorKeyDown}>
+              <div className="input-container">
+                <div className="prompt" />
+                <Editor
+                  language="markdown"
+                  id={this.props.id}
+                  lineWrapping
+                  input={this.state.source}
+                  theme={this.props.theme}
+                  focusAbove={this.props.focusAbove}
+                  focusBelow={this.props.focusBelow}
+                  focused={this.props.focused}
+                />
+              </div>
             </div>
-          </div>
+          }
+        </div> : null
         }
         {
         (!this.state.view && !this.isOutputHidden()) ?

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -99,7 +99,6 @@ export default class MarkdownCell extends React.Component {
         this.props.focusBelow();
         break;
       case 'Enter':
-        console.log('entering!')
         this.openEditor();
         e.preventDefault();
         return false;
@@ -111,23 +110,22 @@ export default class MarkdownCell extends React.Component {
   render() {
     console.log(this.state.view);
     return (
-      <div>
-       { (this.state && this.state.view) ?
-         <div
-            className="rendered"
-            onDoubleClick={this.openEditor}
-            onKeyDown={this.renderedKeyDown}
-            ref="rendered"
-            tabIndex="0"
-         >
-           <LatexRenderer>
-             {mdRender(
-               this.state.source ?
-               this.state.source :
+       (this.state && this.state.view) ?
+       <div
+         className="rendered"
+         onDoubleClick={this.openEditor}
+         onKeyDown={this.renderedKeyDown}
+         ref="rendered"
+         tabIndex="0"
+       >
+         <LatexRenderer>
+          {mdRender(
+            this.state.source ?
+            this.state.source :
                '*Empty markdown cell, double click me to add content.*')
-             }
-           </LatexRenderer>
-         </div> :
+          }
+         </LatexRenderer>
+       </div> :
        <div onKeyDown={this.editorKeyDown}>
          <div className="input-container">
            <div className="prompt" />
@@ -142,15 +140,11 @@ export default class MarkdownCell extends React.Component {
                focused={this.props.focused}
              />
            </div>
-         </div>
-       }
-       { (!this.state.view) ?
          <div className="outputs">
            <LatexRenderer>
              {mdRender(this.state.source)}
            </LatexRenderer>
-         </div> : null
-       }
+         </div>
        </div>
     );
   }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import Immutable from 'immutable';
-import { TogglableDisplay } from 'react-jupyter-display-area';
 import Editor from './editor';
 import LatexRenderer from '../latex';
 
@@ -15,7 +14,6 @@ const mdRender = (input) => renderer.render(parser.parse(input));
 
 export default class MarkdownCell extends React.Component {
   static propTypes = {
-    cellStatus: React.PropTypes.instanceOf(Immutable.Map).isRequired,
     cell: React.PropTypes.any,
     id: React.PropTypes.string,
     theme: React.PropTypes.string,
@@ -108,62 +106,49 @@ export default class MarkdownCell extends React.Component {
     return true;
   }
 
-  isOutputHidden() {
-    return this.props.cellStatus.get('outputHidden');
-  }
-
-  isInputHidden() {
-    return this.props.cellStatus.get('inputHidden');
-  }
-
   render() {
     return (
       <div>
-      { !this.isInputHidden() ?
-        <div>
-          { (this.state && this.state.view) ?
-            <div
-              className="rendered"
-              onDoubleClick={this.openEditor}
-              onKeyDown={this.renderedKeyDown}
-              ref="rendered"
-              tabIndex="0"
-            >
-              <LatexRenderer>
-              {mdRender(
-                this.state.source ?
-                this.state.source :
-                '*Empty markdown cell, double click me to add content.*')
-              }
-              </LatexRenderer>
-            </div> :
-            <div onKeyDown={this.editorKeyDown}>
-              <div className="input-container">
-                <div className="prompt" />
-                <Editor
-                  language="markdown"
-                  id={this.props.id}
-                  lineWrapping
-                  input={this.state.source}
-                  theme={this.props.theme}
-                  focusAbove={this.props.focusAbove}
-                  focusBelow={this.props.focusBelow}
-                  focused={this.props.focused}
-                />
-              </div>
-            </div>
-          }
-        </div> : null
-        }
-        {
-        (!this.state.view && !this.isOutputHidden()) ?
-          <div className="outputs">
-            <LatexRenderer>
-              {mdRender(this.state.source)}
-            </LatexRenderer>
-          </div> : null
-        }
-      </div>
+       { (this.state && this.state.view) ?
+         <div
+            className="rendered"
+            onDoubleClick={this.openEditor}
+            onKeyDown={this.renderedKeyDown}
+            ref="rendered"
+            tabIndex="0"
+         >
+           <LatexRenderer>
+             {mdRender(
+               this.state.source ?
+               this.state.source :
+               '*Empty markdown cell, double click me to add content.*')
+             }
+           </LatexRenderer>
+         </div> :
+       <div onKeyDown={this.editorKeyDown}>
+         <div className="input-container">
+           <div className="prompt" />
+             <Editor
+               language="markdown"
+               id={this.props.id}
+               lineWrapping
+               input={this.state.source}
+               theme={this.props.theme}
+               focusAbove={this.props.focusAbove}
+               focusBelow={this.props.focusBelow}
+               focused={this.props.focused}
+             />
+           </div>
+         </div>
+       }
+       { (!this.state.view) ?
+         <div className="outputs">
+           <LatexRenderer>
+             {mdRender(this.state.source)}
+           </LatexRenderer>
+         </div> : null
+       }
+       </div>
     );
   }
 }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -83,10 +83,11 @@ export default class MarkdownCell extends React.Component {
    * Handles when a keydown event occurs on the rendered MD cell
    */
   renderedKeyDown(e) {
+    console.log('renderedKeyDown')
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === 'Enter') {
-      this.setState({ view: false });
+      this.setState({ view: true });
       return false;
     }
 
@@ -98,6 +99,7 @@ export default class MarkdownCell extends React.Component {
         this.props.focusBelow();
         break;
       case 'Enter':
+        console.log('entering!')
         this.openEditor();
         e.preventDefault();
         return false;
@@ -107,6 +109,7 @@ export default class MarkdownCell extends React.Component {
   }
 
   render() {
+    console.log(this.state.view);
     return (
       <div>
        { (this.state && this.state.view) ?

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -147,9 +147,7 @@ export default class MarkdownCell extends React.Component {
           <div className="outputs">
             <LatexRenderer>
             { mdRender(
-              this.state.source ?
-              this.state.source :
-              '*Empty markdown cell, double click me to add content.*')
+              this.state.source)
             }
             </LatexRenderer>
           </div> : null

--- a/test/renderer/components/cell/markdown-cell-spec.js
+++ b/test/renderer/components/cell/markdown-cell-spec.js
@@ -22,12 +22,13 @@ describe('MarkdownCell', () => {
 
     // Starts in view mode
     expect(cell.state('view')).to.be.true;
+
+    cell.simulate('keydown', { key: 'Enter'})
+    expect(cell.state('view')).to.be.false;
     cell.simulate('keydown', { key: 'Enter', shiftKey: true })
     // Stays in view mode on shift enter
     expect(cell.state('view')).to.be.true;
     // Enter key enters edit mode
-    cell.simulate('keydown', { key: 'Enter'})
-    expect(cell.state('view')).to.be.false;
     // Back to view mode
     cell.simulate('keydown', { key: 'Enter', shiftKey: true })
     expect(cell.state('view')).to.be.true;


### PR DESCRIPTION
Check it!

![markdown](https://cloud.githubusercontent.com/assets/10944582/18458943/93d7bda6-791a-11e6-858c-07b2cf62c1a0.gif)

The live-ness of it has its perks and its downside, we should probably make this a toggleable feature? 
