### PR TITLE
Handle bunk mimetypes in pager, test it

### DIFF
--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -75,7 +75,7 @@ class CodeCell extends React.Component {
                 className="pager"
                 displayOrder={this.props.displayOrder}
                 transforms={this.props.transforms}
-                pager={pager}
+                data={pager.get('data')}
                 key={key}
               />
             )

--- a/src/notebook/components/cell/pager.js
+++ b/src/notebook/components/cell/pager.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 import Immutable from 'immutable';
 
@@ -9,17 +8,21 @@ class Pager extends React.Component {
   static propTypes = {
     displayOrder: React.PropTypes.instanceOf(Immutable.List).isRequired,
     transforms: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-    pager: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+    data: React.PropTypes.instanceOf(Immutable.Map).isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  shouldComponentUpdate() { // eslint-disable-line class-methods-use-this
+    // It's always brand new
+    return false;
   }
 
   render() {
-    const bundle = this.props.pager.get('data');
+    const bundle = this.props.data;
     const mimetype = richestMimetype(bundle, this.props.displayOrder, this.props.transforms);
+    if (!mimetype) {
+      return null;
+    }
+
     const Transform = this.props.transforms.get(mimetype);
     return <Transform data={bundle.get(mimetype)} />;
   }

--- a/test/renderer/components/cell/pager-spec.js
+++ b/test/renderer/components/cell/pager-spec.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Immutable from 'immutable';
+
+import { shallow } from 'enzyme';
+import chai, { expect } from 'chai';
+import { dummyStore } from '../../../utils'
+
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+
+import Pager from '../../../../src/notebook/components/cell/pager';
+import * as commutable from 'commutable';
+import { displayOrder, transforms } from 'transformime-react';
+
+describe('Pager', () => {
+  it('renders a mimebundle', () => {
+    const pager = shallow(
+      <Pager
+        displayOrder={displayOrder}
+        transforms={transforms}
+        data={Immutable.fromJS({"text/plain": "THE DATA"})}
+      />
+    );
+
+    expect(pager.instance().shouldComponentUpdate()).to.be.false;
+    expect(pager.first().props()).to.deep.equal({data: 'THE DATA'});
+  })
+  it('does not render unknown mimetypes', () => {
+    const pager = shallow(
+      <Pager
+        displayOrder={displayOrder}
+        transforms={transforms}
+        data={Immutable.fromJS({"application/ipynb+json": "{}"})}
+      />
+    );
+
+    expect(pager.type()).to.be.null;
+  })
+})


### PR DESCRIPTION
We were passing in way more than necessary for the pager here. This scopes it a little nicer. Additionally, mimetypes that aren't found return `null` components now and everything is tested!
