### PR TITLE
Fix multiline completion

### DIFF
--- a/src/notebook/components/cell/editor/complete.js
+++ b/src/notebook/components/cell/editor/complete.js
@@ -12,9 +12,7 @@ export function formChangeObject(cm, change) {
   };
 }
 
-export function codeComplete(channels, cursor, code) {
-  const cursorPos = cursor.ch;
-
+export function codeComplete(channels, cursorPos, line, code) {
   const message = createMessage('complete_request');
   message.content = {
     code,
@@ -30,11 +28,11 @@ export function codeComplete(channels, cursor, code) {
       .map(results => ({
         list: results.matches,
         from: {
-          line: cursor.line,
+          line,
           ch: results.cursor_start,
         },
         to: {
-          line: cursor.line,
+          line,
           ch: results.cursor_end,
         },
       }))

--- a/src/notebook/components/cell/editor/complete.js
+++ b/src/notebook/components/cell/editor/complete.js
@@ -12,7 +12,11 @@ export function formChangeObject(cm, change) {
   };
 }
 
-export function codeComplete(channels, cursorPos, line, code) {
+export function codeComplete(channels, editor) {
+  const cursor = editor.getCursor();
+  const cursorPos = editor.indexFromPos(cursor);
+  const code = editor.getValue();
+
   const message = createMessage('complete_request');
   message.content = {
     code,
@@ -27,14 +31,8 @@ export function codeComplete(channels, cursorPos, line, code) {
       .first()
       .map(results => ({
         list: results.matches,
-        from: {
-          line,
-          ch: results.cursor_start,
-        },
-        to: {
-          line,
-          ch: results.cursor_end,
-        },
+        from: editor.posFromIndex(results.cursor_start),
+        to: editor.posFromIndex(results.cursor_end),
       }))
       .timeout(2000), // 4s
     message,

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -158,14 +158,11 @@ export default class Editor extends React.Component {
     if (!this.props.completion) {
       return;
     }
-    const cursor = editor.getCursor();
-    const cursorPos = editor.indexFromPos(cursor);
-    const code = editor.getValue();
 
     const state = this.context.store.getState();
     const channels = state.app.channels;
 
-    const { observable, message } = codeComplete(channels, cursorPos, cursor.line, code);
+    const { observable, message } = codeComplete(channels, editor);
 
     observable.subscribe(callback);
     channels.shell.next(message);

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -159,12 +159,13 @@ export default class Editor extends React.Component {
       return;
     }
     const cursor = editor.getCursor();
+    const cursorPos = editor.indexFromPos(cursor);
     const code = editor.getValue();
 
     const state = this.context.store.getState();
     const channels = state.app.channels;
 
-    const { observable, message } = codeComplete(channels, cursor, code);
+    const { observable, message } = codeComplete(channels, cursorPos, cursor.line, code);
 
     observable.subscribe(callback);
     channels.shell.next(message);

--- a/test/renderer/components/cell/editor-spec.js
+++ b/test/renderer/components/cell/editor-spec.js
@@ -49,8 +49,9 @@ describe('Editor', () => {
 
     const editor = editorWrapper.instance();
     const cm = {
-      getCursor: () => 'MY CURSOR',
+      getCursor: () => ({line: 12}),
       getValue: () => 'MY VALUE',
+      indexFromPos: () => 90001,
     };
 
     const callback = sinon.spy();
@@ -58,7 +59,7 @@ describe('Editor', () => {
     const completer = sinon.spy(complete, 'codeComplete');
     sent.subscribe(msg => {
       expect(msg.content.code).to.equal('MY VALUE');
-      expect(completer).to.have.been.calledWith(state.app.channels, 'MY CURSOR', 'MY VALUE');
+      expect(completer).to.have.been.calledWith(state.app.channels, 90001, 12, 'MY VALUE');
       completer.restore();
       done();
     });
@@ -88,6 +89,7 @@ describe('Editor', () => {
     const cm = {
       getCursor: () => 'MY CURSOR',
       getValue: () => 'MY VALUE',
+      indexFromPos: () => 90001,
     };
 
     const callback = sinon.spy();
@@ -101,22 +103,18 @@ describe('Editor', () => {
 
 describe('complete', () => {
   it('handles code completion', (done) => {
-    const cursor = {
-      line: 1,
-      ch: 9,
-    };
-    const code = 'import thi';
-
     const sent = new Rx.Subject();
     const received = new Rx.Subject();
-
     const mockSocket = Rx.Subject.create(sent, received);
-
     const channels = {
       shell: mockSocket,
     };
 
-    const {observable, message} = complete.codeComplete(channels, cursor, code);
+    const code = 'import thi';
+    const cursorPos = 9;
+    const line = 1;
+
+    const {observable, message} = complete.codeComplete(channels, cursorPos, line, code);
 
     // Test the message created for sending
     expect(message.content).to.deep.equal({


### PR DESCRIPTION
Apparently this was not getting the full cursor position for Jupyter (by index, including newlines), which would affect cells with more than one line. Now it is and using CodeMirror's `indexFromPos`.
