### PR TITLE
Defer loading of the dev logger to a module

### DIFF
--- a/src/notebook/logger.js
+++ b/src/notebook/logger.js
@@ -1,0 +1,17 @@
+import Immutable from 'immutable';
+
+const createLogger = require('redux-logger');
+
+export default function clogger() {
+  const logger = createLogger({
+    stateTransformer: (state) =>
+      Object.keys(state).reduce((prev, key) =>
+        Object.assign(
+          {},
+          prev,
+          { [key]: Immutable.Iterable.isIterable(state[key]) ? state[key].toJS() : state[key] }
+        )
+    , {}),
+  });
+  return logger;
+}

--- a/src/notebook/store.js
+++ b/src/notebook/store.js
@@ -1,24 +1,10 @@
-import Immutable from 'immutable';
-
 import { createStore, applyMiddleware } from 'redux';
 
 import middlewares from './middlewares';
 import rootReducer from './reducers';
 
 if (process.env.NODE_ENV === 'development') {
-  const createLogger = require('redux-logger');  // eslint-disable-line global-require
-
-  const logger = createLogger({
-    stateTransformer: (state) =>
-      Object.keys(state).reduce((prev, key) =>
-        Object.assign(
-          {},
-          prev,
-          { [key]: Immutable.Iterable.isIterable(state[key]) ? state[key].toJS() : state[key] }
-        )
-    , {}),
-  });
-  middlewares.push(logger);
+  middlewares.push(require('./logger')()); // eslint-disable-line global-require
 }
 
 export default function configureStore(initialState) {


### PR DESCRIPTION
This will end up increasing our code coverage a tiny bit. We don't want/need to run this in our tests (by setting `NODE_ENV=developerment). Otherwise we'll get a stream of action logging in between our test output.

To true coverage counting!
