### PR TITLE
Bring in react jupyter display area directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "eslint-plugin-jsx-a11y": "^2.2.0",
     "eslint-plugin-react": "^6.0.0",
     "jsdom": "^9.4.2",
+    "jsx-chai": "^4.0.0",
     "mocha": "^3.0.2",
     "mock-require": "^1.3.0",
     "nyc": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     ]
   },
   "dependencies": {
+    "ansi-to-react": "0.0.4",
     "codemirror": "^5.18.2",
     "commonmark": "^0.26.0",
     "commonmark-react-renderer": "^4.3.1",

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import { TogglableDisplay } from 'react-jupyter-display-area';
 import Immutable from 'immutable';
 
 import Inputs from './inputs';
+import { TogglableDisplay } from './display-area';
 
 import Editor from './editor';
 import LatexRenderer from '../latex';

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -74,7 +74,7 @@ class CodeCell extends React.Component {
                 className="pager"
                 displayOrder={this.props.displayOrder}
                 transforms={this.props.transforms}
-                data={pager.get('data')}
+                bundle={pager.get('data')}
                 key={key}
               />
             )

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Immutable from 'immutable';
+
+import { transforms, displayOrder } from 'transformime-react';
+
+import Output from './output';
+
+export default function Display(props) {
+  const order = props.displayOrder;
+  const tf = props.transforms;
+  return (
+    <div className="cell_display">
+      {
+        props.outputs.map((output, index) =>
+          <Output
+            key={index}
+            output={output}
+            displayOrder={order}
+            transforms={tf}
+          />
+        )
+      }
+    </div>
+  );
+}
+
+Display.propTypes = {
+  displayOrder: React.PropTypes.instanceOf(Immutable.List),
+  outputs: React.PropTypes.instanceOf(Immutable.List),
+  transforms: React.PropTypes.instanceOf(Immutable.Map),
+};
+
+Display.defaultProps = {
+  transforms,
+  displayOrder,
+};

--- a/src/notebook/components/cell/display-area/index.js
+++ b/src/notebook/components/cell/display-area/index.js
@@ -1,0 +1,6 @@
+import Display from './display';
+import TogglableDisplay from './togglable-display';
+
+export default Display;
+
+export { Display, TogglableDisplay };

--- a/src/notebook/components/cell/display-area/output.js
+++ b/src/notebook/components/cell/display-area/output.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import Immutable from 'immutable';
+import { transforms, displayOrder } from 'transformime-react';
+
+import RichestMime from './richest-mime';
+
+const Ansi = require('ansi-to-react');
+
+export default function Output(props) {
+  const output = props.output;
+  const outputType = output.get('output_type');
+  switch (outputType) {
+    case 'execute_result':
+      // We can defer to display data here, the cell number will be handled
+      // separately. For reference, it is output.get('execution_count')
+      // The execution_count belongs in the component above if
+      // this is a code cell
+
+      // falls through
+    case 'display_data': {
+      const bundle = output.get('data');
+      return (
+        <RichestMime
+          bundle={bundle}
+          displayOrder={props.displayOrder}
+          transforms={props.transforms}
+        />);
+    }
+    case 'stream': {
+      const text = output.get('text');
+      switch (output.get('name')) {
+        case 'stdout':
+        case 'stderr':
+          return <Ansi>{text}</Ansi>;
+        default:
+          return null;
+      }
+    }
+    case 'error': {
+      const traceback = output.get('traceback');
+      if (!traceback) {
+        return <Ansi>{`${output.get('ename')}: ${output.get('evalue')}`}</Ansi>;
+      }
+      return <Ansi>{traceback.join('\n')}</Ansi>;
+    }
+    default:
+      return null;
+  }
+}
+
+Output.propTypes = {
+  displayOrder: React.PropTypes.instanceOf(Immutable.List),
+  output: React.PropTypes.any,
+  transforms: React.PropTypes.instanceOf(Immutable.Map),
+};
+
+Output.defaultProps = {
+  transforms,
+  displayOrder,
+};

--- a/src/notebook/components/cell/display-area/richest-mime.js
+++ b/src/notebook/components/cell/display-area/richest-mime.js
@@ -3,21 +3,33 @@ import Immutable from 'immutable';
 
 import { richestMimetype, transforms, displayOrder } from 'transformime-react';
 
-export default function RichestMime(props) {
-  const mimetype = richestMimetype(
-    props.bundle,
-    props.displayOrder,
-    props.transforms
-  );
+export default class RichestMime extends React.Component {
+  static propTypes = {
+    displayOrder: React.PropTypes.instanceOf(Immutable.List).isRequired,
+    transforms: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+    bundle: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+  };
 
-  if (!mimetype) {
-    // If no mimetype is supported, don't return a component
-    return null;
+  shouldComponentUpdate() {  // eslint-disable-line class-methods-use-this
+    return false;
   }
 
-  const Transform = props.transforms.get(mimetype);
-  const data = props.bundle.get(mimetype);
-  return <Transform key={mimetype} data={data} />;
+  render() {
+    const mimetype = richestMimetype(
+      this.props.bundle,
+      this.props.displayOrder,
+      this.props.transforms
+    );
+
+    if (!mimetype) {
+      // If no mimetype is supported, don't return a component
+      return null;
+    }
+
+    const Transform = this.props.transforms.get(mimetype);
+    const data = this.props.bundle.get(mimetype);
+    return <Transform data={data} />;
+  }
 }
 
 RichestMime.propTypes = {

--- a/src/notebook/components/cell/display-area/richest-mime.js
+++ b/src/notebook/components/cell/display-area/richest-mime.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Immutable from 'immutable';
+
+import { richestMimetype, transforms, displayOrder } from 'transformime-react';
+
+export default function RichestMime(props) {
+  const mimetype = richestMimetype(
+    props.bundle,
+    props.displayOrder,
+    props.transforms
+  );
+
+  if (!mimetype) {
+    // If no mimetype is supported, don't return a component
+    return null;
+  }
+
+  const Transform = props.transforms.get(mimetype);
+  const data = props.bundle.get(mimetype);
+  return <Transform key={mimetype} data={data} />;
+}
+
+RichestMime.propTypes = {
+  bundle: React.PropTypes.instanceOf(Immutable.Map).isRequired,
+  displayOrder: React.PropTypes.instanceOf(Immutable.List),
+  transforms: React.PropTypes.instanceOf(Immutable.Map),
+};
+
+RichestMime.defaultProps = { transforms, displayOrder };

--- a/src/notebook/components/cell/display-area/togglable-display.js
+++ b/src/notebook/components/cell/display-area/togglable-display.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Immutable from 'immutable';
+
+import { transforms, displayOrder } from 'transformime-react';
+
+import Display from './display';
+
+export default function TogglableDisplay(props) {
+  if (!props.isHidden) {
+    return (
+      <Display
+        outputs={props.outputs}
+        displayOrder={props.displayOrder}
+        transforms={props.transforms}
+      />
+    );
+  }
+  return null;
+}
+
+TogglableDisplay.propTypes = {
+  displayOrder: React.PropTypes.instanceOf(Immutable.List),
+  outputs: React.PropTypes.instanceOf(Immutable.List),
+  transforms: React.PropTypes.instanceOf(Immutable.Map),
+  isHidden: React.PropTypes.bool,
+};
+
+TogglableDisplay.defaultProps = {
+  transforms,
+  displayOrder,
+};

--- a/src/notebook/components/cell/pager.js
+++ b/src/notebook/components/cell/pager.js
@@ -1,31 +1,4 @@
-import React from 'react';
+import RichestMime from './display-area/richest-mime';
 
-import Immutable from 'immutable';
-
-import { richestMimetype } from 'transformime-react';
-
-class Pager extends React.Component {
-  static propTypes = {
-    displayOrder: React.PropTypes.instanceOf(Immutable.List).isRequired,
-    transforms: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-    data: React.PropTypes.instanceOf(Immutable.Map).isRequired,
-  };
-
-  shouldComponentUpdate() { // eslint-disable-line class-methods-use-this
-    // It's always brand new
-    return false;
-  }
-
-  render() {
-    const bundle = this.props.data;
-    const mimetype = richestMimetype(bundle, this.props.displayOrder, this.props.transforms);
-    if (!mimetype) {
-      return null;
-    }
-
-    const Transform = this.props.transforms.get(mimetype);
-    return <Transform data={bundle.get(mimetype)} />;
-  }
-}
-
-export default Pager;
+// The pager is really just the RichestMime component
+export default RichestMime;

--- a/test/renderer/components/cell/code-cell-spec.js
+++ b/test/renderer/components/cell/code-cell-spec.js
@@ -28,8 +28,7 @@ describe('CodeCell', () => {
     const cell = mount(
       <CodeCell cell={commutable.emptyCodeCell} {...sharedProps}
       cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}
-      pagers={Immutable.Map({'content':
-        Immutable.Map({'data': Immutable.Map({'text/plain': 'one'})})})}/>
+      pagers={Immutable.fromJS([{'data': {'text/plain': 'one'}}])} />
     );
     expect(cell.find('.pagers').length).to.be.greaterThan(0);
   });

--- a/test/renderer/components/cell/display-area/output-spec.js
+++ b/test/renderer/components/cell/display-area/output-spec.js
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import chai, { expect } from 'chai';
+import jsxChai from 'jsx-chai';
+
+chai.use(jsxChai);
+
+import Immutable from 'immutable';
+
+import {
+  createRenderer,
+} from 'react-addons-test-utils';
+
+import Output from '../../../../../src/notebook/components/cell/display-area/output'
+import RichestMime from '../../../../../src/notebook/components/cell/display-area/richest-mime';
+
+const Ansi = require('ansi-to-react');
+
+describe('Output', () => {
+  it('handles display data', () => {
+    const output = Immutable.fromJS({
+      output_type: 'display_data',
+      data:
+          { 'text/html': '<h1>Multiple</h1>',
+            'text/plain': '<IPython.core.display.HTML object>' },
+      metadata: {},
+    });
+
+    const renderer = createRenderer();
+    renderer.render(<Output output={output} />);
+    const result = renderer.getRenderOutput();
+    expect(result.type).to.eq(RichestMime);
+    expect(result.props.bundle).to.eq(output.get('data'));
+  });
+  it('handles execute_result', () => {
+    const output = Immutable.fromJS({
+      data: {
+        'text/html': [
+          '<img src="https://avatars2.githubusercontent.com/u/12401040?v=3&s=200"/>',
+        ],
+        'text/plain': [
+          '<IPython.core.display.Image object>',
+        ],
+      },
+      execution_count: 7,
+      metadata: {},
+      output_type: 'execute_result',
+    });
+
+    const renderer = createRenderer();
+    renderer.render(<Output output={output} />);
+    const result = renderer.getRenderOutput();
+    expect(result.type).to.eq(RichestMime);
+    expect(result.props.bundle).to.eq(output.get('data'));
+  });
+  it('handles stream data', () => {
+    const renderer = createRenderer();
+
+    const output = Immutable.fromJS({
+      output_type: 'stream',
+      name: 'stdout',
+      text: 'hey',
+    });
+
+    renderer.render(<Output output={output} />);
+    const result = renderer.getRenderOutput();
+    expect(result).to.deep.equal(<Ansi>hey</Ansi>);
+  });
+  it('handles errors/tracebacks', () => {
+    const renderer = createRenderer();
+
+    const output = Immutable.fromJS({
+      output_type: 'error',
+      traceback: ['whoa there buckaroo!'],
+      ename: 'BuckarooException',
+      evalue: 'whoa!',
+    });
+
+    renderer.render(<Output output={output} />);
+    const result = renderer.getRenderOutput();
+
+    expect(result).to.deep.equal(<Ansi>{output.get('traceback').join('\n')}</Ansi>);
+    const outputNoTraceback = Immutable.fromJS({
+      output_type: 'error',
+      ename: 'BuckarooException',
+      evalue: 'whoa!',
+    });
+
+    renderer.render(<Output output={outputNoTraceback} />);
+    const result2 = renderer.getRenderOutput();
+
+    expect(result2).to.deep.equal(
+      <Ansi>BuckarooException: whoa!</Ansi>
+    );
+  });
+});

--- a/test/renderer/components/cell/display-area/richest-mime-spec.js
+++ b/test/renderer/components/cell/display-area/richest-mime-spec.js
@@ -3,39 +3,38 @@ import Immutable from 'immutable';
 
 import { shallow } from 'enzyme';
 import chai, { expect } from 'chai';
-import { dummyStore } from '../../../utils'
 
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 chai.use(sinonChai);
 
-import Pager from '../../../../src/notebook/components/cell/pager';
+import RichestMime from '../../../../../src/notebook/components/cell/display-area/richest-mime'
 import * as commutable from 'commutable';
 import { displayOrder, transforms } from 'transformime-react';
 
-describe('Pager', () => {
+describe('RichestMime', () => {
   it('renders a mimebundle', () => {
-    const pager = shallow(
-      <Pager
+    const rm = shallow(
+      <RichestMime
         displayOrder={displayOrder}
         transforms={transforms}
-        data={Immutable.fromJS({"text/plain": "THE DATA"})}
+        bundle={Immutable.fromJS({"text/plain": "THE DATA"})}
       />
     );
 
-    expect(pager.instance().shouldComponentUpdate()).to.be.false;
-    expect(pager.first().props()).to.deep.equal({data: 'THE DATA'});
+    expect(rm.instance().shouldComponentUpdate()).to.be.false;
+    expect(rm.first().props()).to.deep.equal({data: 'THE DATA'});
   })
   it('does not render unknown mimetypes', () => {
-    const pager = shallow(
-      <Pager
+    const rm = shallow(
+      <RichestMime
         displayOrder={displayOrder}
         transforms={transforms}
-        data={Immutable.fromJS({"application/ipynb+json": "{}"})}
+        bundle={Immutable.fromJS({"application/ipynb+json": "{}"})}
       />
     );
 
-    expect(pager.type()).to.be.null;
+    expect(rm.type()).to.be.null;
   })
 })

--- a/test/renderer/components/cell/display-area/togglable-display-spec.js
+++ b/test/renderer/components/cell/display-area/togglable-display-spec.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import chai, { expect } from 'chai';
+import jsxChai from 'jsx-chai';
+
+chai.use(jsxChai);
+
+import Immutable from 'immutable';
+
+import {
+  createRenderer
+} from 'react-addons-test-utils';
+
+import TogglableDisplay from '../../../../../src/notebook/components/cell/display-area/togglable-display';
+
+describe('TogglableDisplay', () => {
+  it('does not display when status is hidden', () => {
+    const renderer = createRenderer();
+    renderer.render(<TogglableDisplay isHidden={true} />);
+    const component = renderer.getRenderOutput();
+    expect(component).to.be.null;
+  });
+  it('displays status when it is not hidden', () => {
+    const renderer = createRenderer();
+    renderer.render(<TogglableDisplay isHidden={false} />);
+    const component = renderer.getRenderOutput();
+    expect(component).to.not.be.null;
+  });
+});

--- a/test/renderer/components/cell/toolbar-spec.js
+++ b/test/renderer/components/cell/toolbar-spec.js
@@ -185,8 +185,6 @@ describe('Toolbar.changeCellType', () => {
     const button = toolbar
       .find('.changeType');
 
-    console.log(button);
-
     button.simulate('click');
 
     expect(store.dispatch.firstCall).to.be.calledWith({


### PR DESCRIPTION
Here comes [react-jupyter-display-area](https://github.com/nteract/react-jupyter-display-area).

Leading us towards monorepo (#549) and subrendering the transforms (#691).

Leaving this WIP because I imagine that this is going to lower code coverage. I'll be adding on tests and using the implementation of RichestMime here for the pager (definite duplication from before).
