### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
-  "extends": "airbnb/legacy",
+  "extends": "airbnb",
   "env": {
     "browser": true,
     "node": true,


### PR DESCRIPTION
The legacy tag was an unnecessary change I didn't revert last night. The upgrade to eslint 3.5 fixed everything.
