### PR TITLE
chore(Codecov): Post new comment on coverage change

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 comment:
   layout: header, changes, diff
+  behavior: spammy
 coverage:
   status:
     patch:


### PR DESCRIPTION
This will force Codecov to post a new comment on every coverage change.

As the name might suggest, it's quite spammy so be mindful of how frequently pushes are made.
