### PR TITLE
fix(launch): filter notebook arguments before processing

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -22,7 +22,10 @@ const argv = require('yargs')
   .version(version)
   .parse(process.argv.slice(sliceAt));
 
-const notebooks = argv._;
+const notebooks = argv._
+  .filter(Boolean)
+  .filter(x => x !== '.'); // Ignore the `electron .`
+                           // TODO: Consider opening something for directories
 
 app.on('window-all-closed', () => {
   // On OS X, we want to keep the app and menu bar active
@@ -69,9 +72,6 @@ openFile$
       );
     } else {
       notebooks
-        .filter(Boolean)
-        .filter(x => x !== '.') // Ignore the `electron .`
-        // TODO: Consider opening something for directories
         .forEach(f => launch(resolve(f)));
     }
     buffer.forEach(openFileFromEvent);


### PR DESCRIPTION
This fixes an issue on dev launch of the notebooks, and is the wise choice given how we check our `buffer.length` and `notebooks.length`.
