### PR TITLE
fix(newKernel): Set kernel directory to ~

### DIFF
--- a/src/notebook/epics/loading.js
+++ b/src/notebook/epics/loading.js
@@ -91,6 +91,6 @@ export const newNotebookEpic = action$ =>
           type: 'SET_NOTEBOOK',
           notebook: starterNotebook,
         },
-        newKernel(action.kernelSpecName),
+        newKernel(action.kernelSpecName, action.cwd),
       )
     );

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -6,6 +6,8 @@ import {
 
 import * as path from 'path';
 
+import home from 'home-dir';
+
 import { tildify } from './native-window';
 
 import { executeCell } from './epics/execute';
@@ -221,7 +223,7 @@ export function dispatchLoad(store, event, filename) {
 }
 
 export function dispatchNewNotebook(store, event, kernelSpecName) {
-  store.dispatch(newNotebook(kernelSpecName, remote.app.getPath('home')));
+  store.dispatch(newNotebook(kernelSpecName, home()));
 }
 
 export function initMenuHandlers(store) {

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -221,7 +221,7 @@ export function dispatchLoad(store, event, filename) {
 }
 
 export function dispatchNewNotebook(store, event, kernelSpecName) {
-  store.dispatch(newNotebook(kernelSpecName));
+  store.dispatch(newNotebook(kernelSpecName, remote.app.getPath('home')));
 }
 
 export function initMenuHandlers(store) {

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -248,7 +248,7 @@ describe('menu', () => {
     expect(store.dispatch.firstCall).to.be.calledWith({
       type: 'NEW_NOTEBOOK',
       kernelSpecName: 'perl',
-      cwd: process.cwd(),
+      cwd: require('home-dir')(),
     });
   });
 


### PR DESCRIPTION
This sets the working directory on a new kernel to the home directory. We're now passing the home dir directly to the kernel launcher instead of making it rely on `process.cwd()`.

Closes #707.
