### PR TITLE
fix(defaultKernel): default to py3, py2, then 1st lexicographically

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -67,8 +67,13 @@ openFile$
     // based on if arguments went through argv or through open-file events
     if (notebooks.length <= 0 && buffer.length <= 0) {
       log.info('launching an empty notebook by default');
-      kernelSpecsPromise.then(specs =>
-        launchNewNotebook(Object.keys(specs)[0])
+      kernelSpecsPromise.then(specs => {
+        const defaultKernel = 'python3';
+        const specList = Object.keys(specs).sort();
+        const kernel = specList.python3 || specList.python2 || specList[0];
+
+        launchNewNotebook(kernel);
+      }
       );
     } else {
       notebooks


### PR DESCRIPTION
We used to default to Python3. This brings that back while falling back to Python 2 followed by whatever is the first kernel in their kernelspecs.

Honestly, I think we're now pushing the limits of what we should do without a config file. I'll make that a priority after this to start speccing out.
