### PR TITLE
fix(launch): Filter out strange first args

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,7 +26,7 @@ const argv = require('yargs')
 
 const notebooks = argv._
   .filter(Boolean)
-  .filter(x => /^(?!-)/.test(x)) // Ignore strangeness on OS X first launch
+  .filter(x => /^(?!-psn)/.test(x)) // Ignore strangeness on OS X first launch
                                  // see #805
   .filter(x => x !== '.'); // Ignore the `electron .`
                            // TODO: Consider opening something for directories

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -16,6 +16,8 @@ const kernelspecs = require('kernelspecs');
 
 const version = require('../../package.json').version;
 
+log.info('args', process.argv);
+
 const sliceAt = process.argv[0].match('nteract') ? 1 : 2;
 
 const argv = require('yargs')
@@ -24,6 +26,8 @@ const argv = require('yargs')
 
 const notebooks = argv._
   .filter(Boolean)
+  .filter(x => /^(?!-)/.test(x)) // Ignore strangeness on OS X first launch
+                                 // see #805
   .filter(x => x !== '.'); // Ignore the `electron .`
                            // TODO: Consider opening something for directories
 
@@ -86,7 +90,14 @@ openFile$
       );
     } else {
       notebooks
-        .forEach(f => launch(resolve(f)));
+        .forEach(f => {
+          try {
+            launch(resolve(f));
+          } catch (e) {
+            log.error(e);
+            console.error(e);
+          }
+        });
     }
     buffer.forEach(openFileFromEvent);
   });


### PR DESCRIPTION
Partial fix for #805.

We're seeing a strange arg passed to the application when launched from Finder on OS X, but only on first launch. This filters that junk arg being passed in out of our notebooks collection.

```
[ '/Users/kylek/Downloads/nteract-darwin-x64/nteract.app/Contents/MacOS/nteract',
  '-psn_0_8046508' ]
```
