### PR TITLE
dx(debug): expose logging and channels when DEBUG=1

### DIFF
--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -105,9 +105,12 @@ export const watchExecutionStateEpic = action$ =>
 
 export const acquireKernelInfoEpic = action$ =>
   action$.ofType(NEW_KERNEL)
-    .switchMap(action =>
-      acquireKernelInfo(action.channels)
-    );
+    .switchMap(action => {
+      if (process.env.DEBUG) {
+        window.channels = action.channels;
+      }
+      return acquireKernelInfo(action.channels);
+    });
 
 export const newKernelEpic = action$ =>
   action$.ofType(LAUNCH_KERNEL)

--- a/src/notebook/store.js
+++ b/src/notebook/store.js
@@ -3,7 +3,7 @@ import { createStore, applyMiddleware } from 'redux';
 import middlewares from './middlewares';
 import rootReducer from './reducers';
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.DEBUG) {
   const logger = require('./logger'); // eslint-disable-line global-require
 
   middlewares.push(logger());


### PR DESCRIPTION
dx === developer experience

Log redux actions and expose channels directly when `DEBUG` is set as an environment variable.
