### PR TITLE
fix(css): Remove max-width restriction to accommodate longer type ahead completions

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -405,7 +405,6 @@ code {
 
 .CodeMirror-hint {
   border-radius: 0px;
-  max-width: 19em;
   white-space: pre;
   cursor: pointer;
   color: var(--cm-hint-color);


### PR DESCRIPTION
Since code mirror auto sizes completion pop-ups depending on the text width. 

Closes #734 
