### PR TITLE
chore(CodeCov): Remove spammy behavior

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 comment:
   layout: header, changes, diff
-  behavior: spammy
 coverage:
   status:
     patch:


### PR DESCRIPTION
Gets rid of CodeCov's spammy behavior.

To avoid problems with merging PRs that drop coverage like the one that resulted in original addition, be sure to install the CodeCov Chrome extension and examine commit diffs for their coverage.
