### PR TITLE
Title cleanup

### DIFF
--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -18,8 +18,8 @@ export function launch(filename) {
   let win = new BrowserWindow({
     width: 800,
     height: 1000,
-    title: !filename ? 'Untitled' : path.relative('.', filename.replace(/.ipynb$/, '')),
     icon: iconPath,
+    title: 'nteract',
   });
 
   const index = path.join(__dirname, '..', '..', 'static', 'index.html');

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -33,6 +33,7 @@ const mapStateToProps = (state) => ({
   cellPagers: state.document.get('cellPagers'),
   focusedCell: state.document.get('focusedCell'),
   stickyCells: state.document.get('stickyCells'),
+  executionState: state.app.get('executionState'),
 });
 
 export class Notebook extends React.Component {
@@ -47,6 +48,7 @@ export class Notebook extends React.Component {
     lastSaved: React.PropTypes.instanceOf(Date),
     kernelSpecName: React.PropTypes.string,
     CellComponent: React.PropTypes.any,
+    executionState: React.PropTypes.string,
   };
 
   static defaultProps = {
@@ -253,6 +255,7 @@ export class Notebook extends React.Component {
           notebook={this.props.notebook}
           lastSaved={this.props.lastSaved}
           kernelSpecName={this.props.kernelSpecName}
+          executionState={this.props.executionState}
         />
         <link rel="stylesheet" href={`../static/styles/theme-${this.props.theme}.css`} />
       </div>

--- a/src/notebook/components/status-bar.js
+++ b/src/notebook/components/status-bar.js
@@ -6,6 +6,7 @@ export default class StatusBar extends React.Component {
     notebook: React.PropTypes.any,
     lastSaved: React.PropTypes.instanceOf(Date),
     kernelSpecName: React.PropTypes.string,
+    executionState: React.PropTypes.string,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -26,7 +27,7 @@ export default class StatusBar extends React.Component {
         }
         </span>
         <span className="pull-left">
-          <p>nteract | {this.props.kernelSpecName}</p>
+          <p>{this.props.kernelSpecName} | {this.props.executionState}</p>
         </span>
       </div>
     );

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -75,7 +75,6 @@ export function triggerWindowRefresh(store, filename) {
   const executionState = state.app.get('executionState');
   const notebook = state.document.get('notebook');
   store.dispatch(saveAs(filename, notebook));
-  BrowserWindow.getFocusedWindow().setTitle(`${tildify(filename)} - ${executionState}`);
 }
 
 export function dispatchRestartKernel(store) {

--- a/src/notebook/native-window.js
+++ b/src/notebook/native-window.js
@@ -36,9 +36,7 @@ export function setTitleFromAttributes(attributes) {
   win.setTitle(title);
 }
 
-export function initNativeHandlers(store) {
-  const state$ = Rx.Observable.from(store);
-
+export function createTitleFeed(state$) {
   const modified$ = state$
     .map(state => state.document.get('notebook'))
     .scan((prev, notebook) => ({
@@ -54,7 +52,7 @@ export function initNativeHandlers(store) {
     .map(state => state.app.get('executionState'))
     .debounceTime(200);
 
-  Rx.Observable
+  return Rx.Observable
     .combineLatest(
       modified$,
       fullpath$,
@@ -62,6 +60,11 @@ export function initNativeHandlers(store) {
       (modified, fullpath, executionState) => ({ modified, fullpath, executionState })
     )
     .distinctUntilChanged()
-    .switchMap(i => Rx.Observable.of(i))
+    .switchMap(i => Rx.Observable.of(i));
+}
+
+export function initNativeHandlers(store) {
+  const state$ = Rx.Observable.from(store);
+  return createTitleFeed(state$)
     .subscribe(setTitleFromAttributes, (err) => console.error(err));
 }

--- a/src/notebook/native-window.js
+++ b/src/notebook/native-window.js
@@ -30,12 +30,10 @@ export function setTitleFromAttributes(attributes) {
   // TODO: Investigate if setRepresentedFilename() is a no-op on non-OS X
   if (filename && win.setRepresentedFilename) {
     win.setRepresentedFilename(attributes.fullpath);
-    // TODO: win.setDocumentEdited(prevNotebook !== currNotebook)
     win.setDocumentEdited(attributes.modified);
-  } else {
-    const title = `${filename} - ${executionState}`;
-    win.setTitle(title);
   }
+  const title = `${filename} - ${executionState}`;
+  win.setTitle(title);
 }
 
 export function initNativeHandlers(store) {

--- a/src/notebook/native-window.js
+++ b/src/notebook/native-window.js
@@ -22,40 +22,48 @@ export function tildify(p) {
   return (s.indexOf(HOME) === 0 ? s.replace(HOME + path.sep, `~${path.sep}`) : s).slice(0, -1);
 }
 
-export function selectTitleAttributes(state) {
-  return {
-    executionState: state.app.get('executionState'),
-    filename: state.metadata.get('filename') || 'Untitled',
-    displayName: state.document.getIn([
-      'notebook', 'metadata', 'kernelspec', 'display_name'], '...'),
-  };
-}
-
 export function setTitleFromAttributes(attributes) {
-  const filename = tildify(attributes.filename);
-  const { executionState, displayName } = attributes;
-
-  const title = `${filename} - ${displayName} - ${executionState}`;
+  const filename = tildify(attributes.fullpath);
+  const { executionState } = attributes;
 
   const win = getCurrentWindow();
   // TODO: Investigate if setRepresentedFilename() is a no-op on non-OS X
   if (filename && win.setRepresentedFilename) {
-    // TODO: this needs to be the full path to the file
-    win.setRepresentedFilename(filename);
-  }
-  if (win.setDocumentEdited) {
+    win.setRepresentedFilename(attributes.fullpath);
+    // TODO: win.setDocumentEdited(prevNotebook !== currNotebook)
     win.setDocumentEdited(attributes.modified);
+  } else {
+    const title = `${filename} - ${executionState}`;
+    win.setTitle(title);
   }
-  win.setTitle(title);
 }
 
 export function initNativeHandlers(store) {
   const state$ = Rx.Observable.from(store);
 
-  state$
-    .map(selectTitleAttributes)
+  const modified$ = state$
+    .map(state => state.document.get('notebook'))
+    .scan((prev, notebook) => ({
+      modified: prev.notebook === notebook,
+      notebook,
+    }), {})
+    .pluck('modified');
+
+  const fullpath$ = state$
+    .map(state => state.metadata.get('filename') || 'Untitled');
+
+  const executionState$ = state$
+    .map(state => state.app.get('executionState'))
+    .debounceTime(200);
+
+  Rx.Observable
+    .combineLatest(
+      modified$,
+      fullpath$,
+      executionState$,
+      (modified, fullpath, executionState) => ({ modified, fullpath, executionState })
+    )
     .distinctUntilChanged()
     .switchMap(i => Rx.Observable.of(i))
-    .debounceTime(200)
     .subscribe(setTitleFromAttributes, (err) => console.error(err));
 }

--- a/test/setup.js
+++ b/test/setup.js
@@ -78,6 +78,7 @@ mock('electron', {
       return {
         'setTitle': function(){},
         'setDocumentEdited': function(){},
+        'setRepresentedFilename': function() {},
       };
     }
   },


### PR DESCRIPTION
- Only set title in one place
- Test the observable that pulls properties from the store/state
- Go back to using native API on OS X for represented filename

This brings back something @Carreau provided us, which is this native behavior:

![screen shot 2016-09-22 at 11 54 17 am](https://cloud.githubusercontent.com/assets/836375/18761813/516b6f82-80bb-11e6-8ce5-80c4af69488a.png)
