### PR TITLE
[WIP]: feat(GithubAuth): Added user authentication flow.

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,4 +1,4 @@
-import { dialog, app, shell, Menu } from 'electron';
+import { dialog, app, shell, Menu, ipcRenderer as ipc, remote} from 'electron';
 import * as path from 'path';
 
 import { launch, launchNewNotebook } from './launch';
@@ -18,6 +18,7 @@ function createSender(eventName, obj) {
     send(focusedWindow, eventName, obj);
   };
 }
+
 
 export const fileSubMenus = {
   new: {
@@ -72,6 +73,10 @@ export const fileSubMenus = {
   publish: {
     label: '&Publish',
     submenu: [
+      {
+        label: '&Authenticate',
+        click: createSender('menu:publish:auth'),
+      },
       {
         label: '&To Gist',
         click: createSender('menu:publish:gist'),
@@ -348,6 +353,7 @@ export function generateDefaultTemplate() {
 }
 
 export const defaultMenu = Menu.buildFromTemplate(generateDefaultTemplate());
+
 
 export function loadFullMenu() {
   return kernelspecs.findAll().then((kernelSpecs) => {

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -1,4 +1,4 @@
-import { shell } from 'electron';
+import { shell, ipcRenderer as ipc } from 'electron';
 
 import {
   overwriteMetadata,
@@ -34,8 +34,12 @@ const Github = require('github');
 export const githubAuthObservable = () =>
   Observable.create(observer => {
     const github = new Github();
-    if (process.env.GITHUB_TOKEN) {
-      github.authenticate({ type: 'oauth', token: process.env.GITHUB_TOKEN });
+    let auth = false
+    ipc.on('github:token', (event, token) => {
+      auth = token
+    });
+    if (auth) {
+      github.authenticate({ type: 'oauth', token: auth });
     }
     observer.next(github);
     observer.complete();

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -1,4 +1,4 @@
-import { shell, ipcRenderer as ipc } from 'electron';
+import { shell } from 'electron';
 
 import {
   overwriteMetadata,
@@ -34,12 +34,8 @@ const Github = require('github');
 export const githubAuthObservable = () =>
   Observable.create(observer => {
     const github = new Github();
-    let auth = false
-    ipc.on('github:token', (event, token) => {
-      auth = token
-    });
-    if (auth) {
-      github.authenticate({ type: 'oauth', token: auth });
+    if (process.env.GITHUB_TOKEN) {
+      github.authenticate({ type: 'oauth', token: process.env.GITHUB_TOKEN });
     }
     observer.next(github);
     observer.complete();

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -121,25 +121,6 @@ export function dispatchNewKernel(store, evt, name) {
 
 
 
-export function dispatchGithubAuth() {
-
-  const win = new BrowserWindow({show: false});
-  win.webContents.on('dom-ready', () => {
-    win.webContents.executeJavaScript(`
-      require('electron').ipcRenderer.send('auth', document.body.innerHTML);
-    `);
-  });
-
-  remote.ipcMain.on('auth', (event, auth) => {
-
-    console.log(auth);
-    auth = auth.match(/"\w+"/g)[1].match(/[^"]/g).join('')
-    console.log(auth);
-    process.env.GITHUB_TOKEN = auth
-  })
-
-  win.loadURL('http://localhost:3010/login');
-}
 
 
 
@@ -266,7 +247,6 @@ export function initMenuHandlers(store) {
   ipc.on('menu:interrupt-kernel', dispatchInterruptKernel.bind(null, store));
   ipc.on('menu:restart-kernel', dispatchRestartKernel.bind(null, store));
   ipc.on('menu:restart-and-clear-all', dispatchRestartClearAll.bind(null, store));
-  ipc.on('menu:publish:auth', dispatchGithubAuth.bind(null, store));
   ipc.on('menu:publish:gist', dispatchPublishGist.bind(null, store));
   ipc.on('menu:zoom-in', dispatchZoomIn.bind(null, store));
   ipc.on('menu:zoom-out', dispatchZoomOut.bind(null, store));


### PR DESCRIPTION
## ToDone

Browser Window pops up with github information, close upon change of page.
Token gets parsed and saved. 
## Todo
- [ ] Figure out how to store the auth token 
- [ ] Getting a weird error from the behavior around line 28... 

```
Uncaught Exception:
Error: Object has been destroyed
    at Error (native)
    at EventEmitter.webContents.on (/Users/johndetlefs/github/nteract/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources/electron.asar/browser/api/browser-window.js:50:39)
```

Seems to relate to https://github.com/jprichardson/electron-window/issues/5 but none of these fixes help and it actually doesnt stop the code from working. 
- [ ] Remove log statements
- [ ] Add pager for successful authentication
- [ ] Setup real now.sh server to test.

Ask me and I'll give you my server code so you can tests the branch locally. Or I can just create a now.sh server.
