### PR TITLE
feat(GithubAuth): Add initial work for github user authentication

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -22,13 +22,14 @@ function createSender(eventName, obj) {
 
 export function githubAuth() {
   const win = new BrowserWindow({show: false, webPreferences: {zoomFactor: .75}});
+  let count = 0;
   win.webContents.on('dom-ready', () => {
-    if( win.getURL().match('authorize') ) {
+    if(count == 1){
+      win.destroy();
+      return githubAuth();
+    }
+    if(win.getURL().match('authorize')) {
       win.show();
-      win.on('page-title-updated', () => {
-        win.close()
-        return githubAuth();
-      });
     }
     else {
       win.webContents.executeJavaScript(`
@@ -40,6 +41,7 @@ export function githubAuth() {
         console.log(auth);
       });
     }
+    count += 1;
   });
   win.loadURL('http://localhost:3010/login');
 }

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -20,7 +20,7 @@ function createSender(eventName, obj) {
   };
 }
 
-export function githubAuth() {
+export function githubAuth(item, focusedWindow) {
   const win = new BrowserWindow({show: false, webPreferences: {zoomFactor: .75}});
   win.webContents.on('dom-ready', () => {
     if( win.getURL().indexOf('callback?code=') != -1 ) {
@@ -29,7 +29,7 @@ export function githubAuth() {
         `);
       ipc.on('auth', (event, auth) => {
         auth = JSON.parse(auth)
-        createSender('menu:publish:auth', auth['access_token']);
+        send(focusedWindow, 'menu:publish:auth', auth['access_token']);
         win.close();
         return;
       });
@@ -95,7 +95,7 @@ export const fileSubMenus = {
     submenu: [
       {
         label: '&Authenticate',
-        click: () => githubAuth(),
+        click: githubAuth,
       },
       {
         label: '&Publish To Gist',

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -37,7 +37,7 @@ export function githubAuth(item, focusedWindow) {
       win.show();
     }
   });
-  win.loadURL('https://oauth.nteract.io/github');
+  win.loadURL('https://nteract-oauth.now.sh/github');
 }
 
 export const fileSubMenus = {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -22,26 +22,20 @@ function createSender(eventName, obj) {
 
 export function githubAuth() {
   const win = new BrowserWindow({show: false, webPreferences: {zoomFactor: .75}});
-  let count = 0;
   win.webContents.on('dom-ready', () => {
-    if(count == 1){
-      win.destroy();
-      return githubAuth();
-    }
-    if(win.getURL().match('authorize')) {
-      win.show();
-    }
-    else {
+    if( win.getURL().indexOf('callback?code=') != -1 ) {
       win.webContents.executeJavaScript(`
         require('electron').ipcRenderer.send('auth', document.body.textContent);
         `);
       ipc.on('auth', (event, auth) => {
-      // hacky parse of JSON
         auth = JSON.parse(auth)
-        console.log(auth['access_token']);
+        createSender('menu:publish:auth', auth['access_token']);
+        win.close();
+        return;
       });
+    } else {
+      win.show();
     }
-    count += 1;
   });
   win.loadURL('http://localhost:3010/login');
 }

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -92,7 +92,7 @@ export const fileSubMenus = {
     accelerator: 'CmdOrCtrl+Shift+S',
   },
   publish: {
-    label: '&Github',
+    label: '&Publish',
     submenu: [
       {
         label: '&Authenticate',

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -21,15 +21,16 @@ function createSender(eventName, obj) {
 }
 
 export function githubAuth(item, focusedWindow) {
-  const win = new BrowserWindow({show: false, webPreferences: {zoomFactor: .75}});
+  const win = new BrowserWindow({ show: false,
+                                  webPreferences: { zoomFactor: 0.75 } });
   win.webContents.on('dom-ready', () => {
-    if( win.getURL().indexOf('callback?code=') != -1 ) {
+    if (win.getURL().indexOf('callback?code=') !== -1) {
       win.webContents.executeJavaScript(`
         require('electron').ipcRenderer.send('auth', document.body.textContent);
         `);
       ipc.on('auth', (event, auth) => {
-        auth = JSON.parse(auth)
-        send(focusedWindow, 'menu:publish:auth', auth['access_token']);
+        const authorization = JSON.parse(auth);
+        send(focusedWindow, 'menu:publish:auth', authorization.access_token);
         win.close();
         return;
       });

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -33,12 +33,12 @@ export function githubAuth() {
     }
     else {
       win.webContents.executeJavaScript(`
-        require('electron').ipcRenderer.send('auth', document.body.innerHTML);
+        require('electron').ipcRenderer.send('auth', document.body.textContent);
         `);
       ipc.on('auth', (event, auth) => {
       // hacky parse of JSON
-        auth = auth.match(/"\w+"/g)[1].match(/[^"]/g).join('')
-        console.log(auth);
+        auth = JSON.parse(auth)
+        console.log(auth['access_token']);
       });
     }
     count += 1;

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -37,7 +37,7 @@ export function githubAuth(item, focusedWindow) {
       win.show();
     }
   });
-  win.loadURL('http://localhost:3010/login');
+  win.loadURL('https://oauth.nteract.io/github');
 }
 
 export const fileSubMenus = {

--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -232,3 +232,9 @@ export function changeCellType(id, to) {
     to,
   };
 }
+export function setGithubToken(githubToken) {
+  return {
+    type: constants.SET_GITHUB_TOKEN,
+    githubToken,
+  };
+}

--- a/src/notebook/constants.js
+++ b/src/notebook/constants.js
@@ -71,6 +71,6 @@ export const SET_MODIFIED = 'SET_MODIFIED';
 
 export const SET_THEME = 'SET_THEME';
 
-export const SET_GITHUB = 'SET_GITHUB';
 
 export const REGISTER_COMM_TARGET = 'REGISTER_COMM_TARGET';
+export const SET_GITHUB_TOKEN = 'SET_GITHUB_TOKEN';

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -131,8 +131,6 @@ export function publishNotebookObservable(github, notebook, filepath, notificati
   });
 }
 
-
-
 /**
  * Epic to capture the end to end action of publishing and receiving the
  * response from the Github API.

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -4,10 +4,6 @@ import {
   overwriteMetadata,
 } from '../actions';
 
-import {
-  SET_GITHUB,
-} from '../constants';
-
 const commutable = require('commutable');
 const path = require('path');
 
@@ -25,49 +21,7 @@ const Github = require('github');
  * line.
  */
 
-/**
- * Create an observable stream containing the Github API
- * @param {object} authOptions - The authorization information, right now
- * this is just oauth token and corresponding type, but can be username
- * and password later, https://developer.github.com/v3/#authentication
- */
-export const githubAuthObservable = () =>
-  Observable.create(observer => {
-    const github = new Github();
-    if (process.env.GITHUB_TOKEN) {
-      github.authenticate({ type: 'oauth', token: process.env.GITHUB_TOKEN });
-    }
-    observer.next(github);
-    observer.complete();
-  });
-
-/**
- * setGithub is an action creator for redux, creates a plain object to be
- * merged into the state tree.
- * @param {object} github - Node-github object for using the Github API.
- * @return plain object for merging into redux state tree.
- */
-export const setGithub = (github) => ({
-  type: SET_GITHUB,
-  github,
-});
-
 export const PUBLISH_GIST = 'PUBLISH_GIST';
-
-/**
- * Return an observer that handles authorization.
- * @return Observer containing oauth token.
- */
-export const initialGitHubAuthEpic = function foo() {
-  return githubAuthObservable()
-    .catch(err => {
-      // TODO: Prompt?
-      // Leaving this here in case authentication becomes more complicated.
-      console.error(err);
-      return new Github(); // Fall back to no auth
-    })
-    .map(setGithub);
-};
 
 /**
  * Notify the notebook user that it has been published as a gist.
@@ -176,6 +130,8 @@ export function publishNotebookObservable(github, notebook, filepath, notificati
     }
   });
 }
+
+
 
 /**
  * Epic to capture the end to end action of publishing and receiving the

--- a/src/notebook/epics/index.js
+++ b/src/notebook/epics/index.js
@@ -24,7 +24,6 @@ import {
 } from './theming';
 
 import {
-  initialGitHubAuthEpic,
   publishEpic,
 } from './github-publish';
 
@@ -34,7 +33,6 @@ import {
 
 const epics = [
   commListenEpic,
-  initialGitHubAuthEpic,
   publishEpic,
   getStoredThemeEpic,
   setThemeEpic,

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -34,6 +34,7 @@ import {
   cutCell,
   pasteCell,
   createCellAfter,
+  setGithubToken,
 } from './actions';
 
 import {
@@ -244,6 +245,11 @@ export function dispatchNewNotebook(store, event, kernelSpecName) {
   store.dispatch(newNotebook(kernelSpecName, home()));
 }
 
+export function dispatchPublishAuth(store, event, githubToken) {
+  store.dispatch(setGithubToken(githubToken));
+}
+
+
 export function initMenuHandlers(store) {
   ipc.on('menu:new-kernel', dispatchNewKernel.bind(null, store));
   ipc.on('menu:run-all', dispatchRunAll.bind(null, store));
@@ -262,7 +268,7 @@ export function initMenuHandlers(store) {
   ipc.on('menu:zoom-in', dispatchZoomIn.bind(null, store));
   ipc.on('menu:zoom-out', dispatchZoomOut.bind(null, store));
   ipc.on('menu:theme', dispatchSetTheme.bind(null, store));
-
+  ipc.on('menu:publish:auth', dispatchPublishAuth.bind(null, store));
   // OCD: This is more like the registration of main -> renderer thread
   ipc.on('main:load', dispatchLoad.bind(null, store));
   ipc.on('main:new', dispatchNewNotebook.bind(null, store));

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -6,6 +6,8 @@ import {
   shutdownKernel,
 } from '../kernel/shutdown';
 
+const Github = require('github');
+
 function cleanupKernel(state) {
   const kernel = {
     channels: state.channels,
@@ -64,4 +66,9 @@ export default handleActions({
   [constants.SET_GITHUB]: function setGithub(state, action) {
     return state.set('github', action.github);
   },
+  [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
+    const {githubToken} = action;
+    const github = new Github({token: githubToken});
+    return state.set('github', github);
+  }
 }, {});

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -63,12 +63,10 @@ export default handleActions({
   [constants.SET_THEME]: function setTheme(state, action) {
     return state.set('theme', action.theme);
   },
-  [constants.SET_GITHUB]: function setGithub(state, action) {
-    return state.set('github', action.github);
-  },
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
     const {githubToken} = action;
-    const github = new Github({token: githubToken});
+    const github = new Github();
+    github.authenticate({ type: 'oauth', token: githubToken }) // synchronous, returns immediately
     return state.set('github', github);
   }
 }, {});

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -64,9 +64,9 @@ export default handleActions({
     return state.set('theme', action.theme);
   },
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
-    const {githubToken} = action;
+    const { githubToken } = action;
     const github = new Github();
-    github.authenticate({ type: 'oauth', token: githubToken }) // synchronous, returns immediately
+    github.authenticate({ type: 'oauth', token: githubToken }); // synchronous, returns immediately
     return state.set('github', github);
   }
 }, {});

--- a/test/renderer/actions-spec.js
+++ b/test/renderer/actions-spec.js
@@ -311,3 +311,12 @@ describe('changeCellType', () => {
     });
   });
 });
+
+describe('setGithubToken', () => {
+  it('create a SET_GITHUB_TOKEN action', () => {
+    expect(actions.setGithubToken('token_string')).to.deep.equal({
+      type: constants.SET_GITHUB_TOKEN,
+      githubToken: 'token_string',
+    });
+  });
+});

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -189,6 +189,14 @@ describe('menu', () => {
     });
   });
 
+  describe('dispatchPublishAuth', () => {
+    const dispatch = sinon.spy();
+    const store = { dispatch };
+    menu.dispatchPublishAuth(store, {}, 'TOKEN');
+    const expectedAction = { type: 'SET_GITHUB_TOKEN', githubToken: 'TOKEN' };
+    expect(dispatch).to.have.been.calledWith(expectedAction);
+  });
+
   describe('dispatchNewKernel', () => {
     const store = dummyStore();
     store.dispatch = sinon.spy();
@@ -272,6 +280,7 @@ describe('menu', () => {
         'menu:restart-kernel',
         'menu:restart-and-clear-all',
         'menu:publish:gist',
+        'menu:publish:auth',
         'menu:zoom-in',
         'menu:zoom-out',
         'menu:theme',

--- a/test/renderer/reducers/app-spec.js
+++ b/test/renderer/reducers/app-spec.js
@@ -16,6 +16,8 @@ import Immutable from 'immutable';
 
 import { AppRecord } from '../../../src/notebook/records';
 
+const Github = require('github');
+
 describe('cleanupKernel', () => {
   it('nullifies entries for the kernel in originalState', () => {
     const originalState = {
@@ -218,6 +220,25 @@ describe('newKernel', () => {
     expect(state.app.channels).to.equal('test_channels');
   });
 });
+
+describe('setGithubToken', () => {
+  it('calls setGithubToken', () => {
+    
+    const originalState = {
+      app: new AppRecord({
+        github: new Github(),
+      })
+    };
+
+    const action = {
+      type: constants.SET_GITHUB_TOKEN,
+      token: 'TOKEN'
+    };
+
+    const state = reducers(originalState, action);
+    expect(state.app.github).to.not.be.null;
+  });
+})
 
 describe('exit', () => {
   it('calls cleanupKernel', () => {


### PR DESCRIPTION
## ToDone

Browser Window pops up with github information, close upon change of page.
Token gets parsed and saved. 
## Todo
- [x] Figure out how to store the auth token 
- [x] Getting a weird error from the behavior around line 28... 

```
Uncaught Exception:
Error: Object has been destroyed
    at Error (native)
    at EventEmitter.webContents.on (/Users/johndetlefs/github/nteract/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources/electron.asar/browser/api/browser-window.js:50:39)
```

Seems to relate to https://github.com/jprichardson/electron-window/issues/5 but none of these fixes help and it actually doesnt stop the code from working. 
- [x] Remove log statements
- [ ] Add pager for successful authentication
- [ ] Improve user flow for authenticated publish and unauthenticated publish
- [x] Add tests
- [x] Setup real now.sh server to test.

Ask me and I'll give you my server code so you can tests the branch locally. Or I can just create a now.sh server.
