### PR TITLE
Populate process.env with the user's shell environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "redux-logger": "^2.6.1",
     "redux-observable": "^0.12.0",
     "rxjs": "^5.0.0-beta.12",
+    "shell-env": "^0.2.0",
     "spawnteract": "^2.2.0",
     "transformime-react": "^1.1.0",
     "uuid": "^2.0.3",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -51,7 +51,7 @@ ipc.on('open-notebook', (event, filename) => {
 const appReady$ = Rx.Observable.zip(
   Rx.Observable.fromEvent(app, 'ready'),
   prepareEnv
-).first()
+).first();
 
 const openFile$ = Rx.Observable.fromEvent(
   app,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -10,6 +10,8 @@ import {
 
 import { defaultMenu, loadFullMenu } from './menu';
 
+import prepareEnv from './prepare-env';
+
 const log = require('electron-log');
 
 const kernelspecs = require('kernelspecs');
@@ -46,7 +48,10 @@ ipc.on('open-notebook', (event, filename) => {
   launch(resolve(filename));
 });
 
-const appReady$ = Rx.Observable.fromEvent(app, 'ready');
+const appReady$ = Rx.Observable.zip(
+  Rx.Observable.fromEvent(app, 'ready'),
+  prepareEnv
+).first()
 
 const openFile$ = Rx.Observable.fromEvent(
   app,
@@ -58,7 +63,9 @@ function openFileFromEvent({ event, path }) {
   launch(resolve(path));
 }
 
-const kernelSpecsPromise = kernelspecs.findAll();
+const kernelSpecsPromise = prepareEnv
+  .toPromise()
+  .then(() => kernelspecs.findAll());
 
 // Since we can't launch until app is ready
 // and OS X will send the open-file events early,

--- a/src/main/prepare-env.js
+++ b/src/main/prepare-env.js
@@ -1,0 +1,42 @@
+import { exec } from 'child_process';
+import Rx from 'rxjs/Rx';
+
+const observeExec = Rx.Observable.bindNodeCallback(exec);
+const env$ = observeExec('env', {
+  cwd: process.cwd(),
+  env: process.env
+});
+
+let i = 0;
+function parseEnv(stdout) {
+  const env = stdout
+    .reduce((acc, str) => {
+      str
+        .split('\n')
+        .filter(Boolean)
+        .forEach(line => {
+          const envVar = line.split('=');
+
+          if (envVar.length === 2) {
+            acc[envVar[0]] = envVar[1];
+          }
+        });
+
+      return acc;
+    }, {});
+
+  Object.assign(process.env, env);
+  console.log(process.env.PATH);
+
+  return env;
+}
+
+const prepareEnv = env$
+  .first()
+  .map(parseEnv)
+  .publishReplay(1);
+
+prepareEnv.connect();
+
+export default prepareEnv;
+

--- a/src/main/prepare-env.js
+++ b/src/main/prepare-env.js
@@ -1,42 +1,15 @@
-import { exec } from 'child_process';
+import shellEnv from 'shell-env';
 import Rx from 'rxjs/Rx';
 
-const observeExec = Rx.Observable.bindNodeCallback(exec);
-const env$ = observeExec('env', {
-  cwd: process.cwd(),
-  env: process.env
-});
-
-let i = 0;
-function parseEnv(stdout) {
-  const env = stdout
-    .reduce((acc, str) => {
-      str
-        .split('\n')
-        .filter(Boolean)
-        .forEach(line => {
-          const envVar = line.split('=');
-
-          if (envVar.length === 2) {
-            acc[envVar[0]] = envVar[1];
-          }
-        });
-
-      return acc;
-    }, {});
-
-  Object.assign(process.env, env);
-  console.log(process.env.PATH);
-
-  return env;
-}
-
-const prepareEnv = env$
+const env$ = Rx.Observable
+  .fromPromise(shellEnv())
   .first()
-  .map(parseEnv)
+  .do(env => {
+    Object.assign(process.env, env);
+  })
   .publishReplay(1);
 
-prepareEnv.connect();
+env$.connect();
 
-export default prepareEnv;
+export default env$;
 


### PR DESCRIPTION
This should copy over all environment variables from `env` into `process.env`.
