### PR TITLE
improve(GithubAuth): Add authenticated to app record, rework auth flow.

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,8 +1,10 @@
 import { dialog, app, shell, Menu, ipcMain as ipc,
          BrowserWindow } from 'electron';
+         
 import * as path from 'path';
 
 import { launch, launchNewNotebook } from './launch';
+import { publishAuth, publishAuthObs} from './auth';
 
 const kernelspecs = require('kernelspecs');
 
@@ -20,26 +22,7 @@ function createSender(eventName, obj) {
   };
 }
 
-export function githubAuth(item, focusedWindow) {
-  const win = new BrowserWindow({ show: false,
-                                  webPreferences: { zoomFactor: 0.75 } });
-  win.webContents.on('dom-ready', () => {
-    if (win.getURL().indexOf('callback?code=') !== -1) {
-      win.webContents.executeJavaScript(`
-        require('electron').ipcRenderer.send('auth', document.body.textContent);
-        `);
-      ipc.on('auth', (event, auth) => {
-        const authorization = JSON.parse(auth);
-        send(focusedWindow, 'menu:publish:auth', authorization.access_token);
-        win.close();
-        return;
-      });
-    } else {
-      win.show();
-    }
-  });
-  win.loadURL('https://nteract-oauth.now.sh/github');
-}
+
 
 export const fileSubMenus = {
   new: {
@@ -95,11 +78,11 @@ export const fileSubMenus = {
     label: '&Publish',
     submenu: [
       {
-        label: '&Authenticate',
-        click: githubAuth,
+        label: '&Authenticated Gist',
+        click: publishAuthObs,
       },
       {
-        label: '&Publish To Gist',
+        label: '&Anonymous Gist',
         click: createSender('menu:publish:gist'),
       },
     ],

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -22,8 +22,8 @@ function createSender(eventName, obj) {
 export function authAndPublish(item, focusedWindow) {
   const win = new BrowserWindow({ show: false,
                                   webPreferences: { zoomFactor: 0.75 } });
-  if(process.env['AUTHENTICATED']) {
-    send(focusedWindow, 'menu:publish:gist')
+  if (process.env.AUTHENTICATED) {
+    send(focusedWindow, 'menu:publish:gist');
     return;
   }
   win.webContents.on('dom-ready', () => {
@@ -33,7 +33,7 @@ export function authAndPublish(item, focusedWindow) {
         `);
       ipc.on('auth', (event, auth) => {
         send(focusedWindow, 'menu:github:auth', JSON.parse(auth).access_token);
-        process.env['AUTHENTICATED'] = true;
+        process.env.AUTHENTICATED = true;
         win.close();
         return;
       });

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -98,7 +98,7 @@ export const fileSubMenus = {
     label: '&Publish',
     submenu: [
       {
-        label: '&Authenticated Gist',
+        label: '&User Gist',
         click: authAndPublish,
       },
       {

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -22,6 +22,10 @@ function createSender(eventName, obj) {
 export function authAndPublish(item, focusedWindow) {
   const win = new BrowserWindow({ show: false,
                                   webPreferences: { zoomFactor: 0.75 } });
+  if(process.env['AUTHENTICATED']) {
+    send(focusedWindow, 'menu:publish:gist')
+    return;
+  }
   win.webContents.on('dom-ready', () => {
     if (win.getURL().indexOf('callback?code=') !== -1) {
       win.webContents.executeJavaScript(`
@@ -29,7 +33,9 @@ export function authAndPublish(item, focusedWindow) {
         `);
       ipc.on('auth', (event, auth) => {
         send(focusedWindow, 'menu:github:auth', JSON.parse(auth).access_token);
+        process.env['AUTHENTICATED'] = true;
         win.close();
+        return;
       });
     } else {
       win.show();

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -103,18 +103,16 @@ export function publishNotebookObservable(github, notebook, filepath,
     } else {
       filename = 'Untitled.ipynb';
     }
-
     const files = {};
     files[filename] = { content: notebookString };
     if (authenticated) {
-      const email = github.users.get({}, function(err, res) {
-        console.log(err, res);
-      });
-
-      notificationSystem.addNotification({
-        title: 'Authenticated',
-        message: 'Authenticated as `${ email}`',
-        level: 'info',
+      github.users.get({}, (err, res) => {
+        if (err) throw err;
+        notificationSystem.addNotification({
+          title: 'Authenticated',
+          message: `Authenticated as ${res.login}`,
+          level: 'info',
+        });
       });
     }
     notificationSystem.addNotification({
@@ -155,7 +153,7 @@ export const publishEpic = (action$, store) =>
       const filename = state.metadata.get('filename');
       const github = state.app.get('github');
       const notificationSystem = state.app.get('notificationSystem');
-      const authenticated = state.document.get('authenticated');
+      const authenticated = state.app.get('authenticated');
       return publishNotebookObservable(github, notebook, filename,
                                        notificationSystem, authenticated);
     })

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -245,8 +245,9 @@ export function dispatchNewNotebook(store, event, kernelSpecName) {
   store.dispatch(newNotebook(kernelSpecName, home()));
 }
 
-export function dispatchPublishAuth(store, event, githubToken) {
+export function dispatchAuthAndPublish(store, event, githubToken) {
   store.dispatch(setGithubToken(githubToken));
+  dispatchPublishGist(store);
 }
 
 
@@ -268,7 +269,7 @@ export function initMenuHandlers(store) {
   ipc.on('menu:zoom-in', dispatchZoomIn.bind(null, store));
   ipc.on('menu:zoom-out', dispatchZoomOut.bind(null, store));
   ipc.on('menu:theme', dispatchSetTheme.bind(null, store));
-  ipc.on('menu:publish:auth', dispatchPublishAuth.bind(null, store));
+  ipc.on('menu:github:auth', dispatchAuthAndPublish.bind(null, store));
   // OCD: This is more like the registration of main -> renderer thread
   ipc.on('main:load', dispatchLoad.bind(null, store));
   ipc.on('main:new', dispatchNewNotebook.bind(null, store));

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -4,7 +4,8 @@ const Github = require('github');
 
 export const AppRecord = new Immutable.Record({
   executionState: 'not connected',
-  github: new Github(), // default to no auth until setup
+  github: new Github(),
+  authenticated: false,
   channels: null,
   spawn: null,
   connectionFile: null,

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -66,7 +66,8 @@ export default handleActions({
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
     const { githubToken } = action;
     const github = new Github();
-    github.authenticate({ type: 'oauth', token: githubToken }); // synchronous, returns immediately
-    return state.set('github', github);
+    github.authenticate({ type: 'oauth', token: githubToken });
+    return state.set('github', github)
+                .set('authenticated', true);
   }
 }, {});

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -189,10 +189,10 @@ describe('menu', () => {
     });
   });
 
-  describe('dispatchPublishAuth', () => {
+  describe('dispatchAuthAndPublish', () => {
     const dispatch = sinon.spy();
     const store = { dispatch };
-    menu.dispatchPublishAuth(store, {}, 'TOKEN');
+    menu.dispatchAuthAndPublish(store, {}, 'TOKEN');
     const expectedAction = { type: 'SET_GITHUB_TOKEN', githubToken: 'TOKEN' };
     expect(dispatch).to.have.been.calledWith(expectedAction);
   });
@@ -280,7 +280,7 @@ describe('menu', () => {
         'menu:restart-kernel',
         'menu:restart-and-clear-all',
         'menu:publish:gist',
-        'menu:publish:auth',
+        'menu:github:auth',
         'menu:zoom-in',
         'menu:zoom-out',
         'menu:theme',

--- a/test/renderer/reducers/app-spec.js
+++ b/test/renderer/reducers/app-spec.js
@@ -223,10 +223,11 @@ describe('newKernel', () => {
 
 describe('setGithubToken', () => {
   it('calls setGithubToken', () => {
-    
+
     const originalState = {
       app: new AppRecord({
         github: new Github(),
+        authenticated: false,
       })
     };
 
@@ -236,7 +237,9 @@ describe('setGithubToken', () => {
     };
 
     const state = reducers(originalState, action);
+    // this is a crappy way of testing this
     expect(state.app.github).to.not.be.null;
+    expect(state.app.authenticated).to.be.true;
   });
 })
 


### PR DESCRIPTION
This is initial work towards fixing the github authorization flow. I think adding 'authenticated' to the app record is a good idea. Initially my thought was to go with a function in src/main/menu called publishAuth:

``` javascript
export function githubAuth(item, focusedWindow) {
  const win = new BrowserWindow({ show: false,
                                  webPreferences: { zoomFactor: 0.75 } });
  win.webContents.on('dom-ready', () => {
    if (win.getURL().indexOf('callback?code=') !== -1) {
      win.webContents.executeJavaScript(`
        require('electron').ipcRenderer.send('auth', document.body.textContent);
        `);
      ipc.on('auth', (event, auth) => {
        const authorization = JSON.parse(auth);
        send(focusedWindow, 'menu:publish:auth', authorization.access_token);
        win.close();
        return;
      });
    } else {
      win.show();
    }
  });
  win.loadURL('https://nteract-oauth.now.sh/github');
}
```

and:

``` javascript
publishAuthAndGist(){
   publishAuth();
   createSender('menu:publish:gist');
}
```

but theres some issue with synchronicity. Gonna pair with @captainsafia on this right now.
