### PR TITLE
feat(CSS): add styling for blockquotes in markdown cells

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -64,6 +64,26 @@ th {
     text-align: left;
 }
 
+blockquote{
+  padding: .75em .5em .75em 1em;
+  background: white;
+  border-left: 0.5em solid #DDD;
+}
+
+blockquote::before {
+  display: block;
+  height: 0;
+  content: "“";
+  margin-left: -.95em;
+  font: italic 400%/1 Open Serif,Georgia,"Times New Roman", serif;
+  color: #999;
+}
+
+/* for nested paragraphs in block quotes */
+blockquote p {
+  display: inline;
+}
+
 /*
   Notebook
  */

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -66,7 +66,7 @@ th {
 
 blockquote{
   padding: .75em .5em .75em 1em;
-  background: white;
+  background: var(--main-bg-color);
   border-left: 0.5em solid #DDD;
 }
 
@@ -76,7 +76,7 @@ blockquote::before {
   content: "“";
   margin-left: -.95em;
   font: italic 400%/1 Open Serif,Georgia,"Times New Roman", serif;
-  color: #999;
+  color: solid var(--primary-border);
 }
 
 /* for nested paragraphs in block quotes */


### PR DESCRIPTION
Resolves #810 by adding in @rgbkrk's css for the blockquote styling.  Modified it to use the `main-bg-color` and `primary-border` colours so it looks nice with the dark theme.  Let me know if I put the CSS in the right place!
