### PR TITLE
feat(splash): show a splash page on slow loading

### DIFF
--- a/static/splash.html
+++ b/static/splash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div id="loading" style="
+      position: absolute;
+      width: 900px;
+      height: 400px;
+      left: calc(50% - 450px);
+      top: calc(50% - 200px);
+    ">
+      <img src="loading.gif" /><br>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
A splash page!

![screenflow](https://cloud.githubusercontent.com/assets/836375/18942175/b93ef1e6-85cb-11e6-9a6d-49ebcb45addb.gif)

I'd rather this show up after the first window is fully loaded. This at least starts us off for situtations where the users' env takes a while to determine on startup. We may want to take out the extra GIF inside the notebook window as well.
