### PR TITLE
chore(deps): airbnb eslint requires eslint-plugin-import@1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "esdoc": "^0.4.8",
     "eslint": "^3.6.0",
     "eslint-config-airbnb": "^12.0.0",
-    "eslint-plugin-import": "^2.0.0",
+    "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.0",
     "eslint-plugin-react": "^6.3.0",
     "jsdom": "^9.4.2",


### PR DESCRIPTION
Noticed AirBnB wanted a peer dep of 1.16.0 rather than 2.0.0. This reverts an upgrade to keep things in line.
