### PR TITLE
chore(cleanup): removing errant console.log()

### DIFF
--- a/test/renderer/epics/github-publish-spec.js
+++ b/test/renderer/epics/github-publish-spec.js
@@ -65,7 +65,6 @@ describe('createGistCallback', () => {
       dummyCommutable, './test.ipynb', notificationSystem);
     const callback = createGistCallback(true, publishNotebookObs,
       './test.ipynb', notificationSystem);
-    console.log(callback);
     expect((typeof(callback))).to.equal('function');
   });
 });


### PR DESCRIPTION
Stumbled upon this when poking through the tests.
