### PR TITLE
Anonymize after Authentication

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -23,7 +23,7 @@ export function authAndPublish(item, focusedWindow) {
   const win = new BrowserWindow({ show: false,
                                   webPreferences: { zoomFactor: 0.75 } });
   if (process.env.AUTHENTICATED) {
-    send(focusedWindow, 'menu:publish:gist');
+    send(focusedWindow, 'menu:github:auth');
     return;
   }
   win.webContents.on('dom-ready', () => {

--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -232,9 +232,14 @@ export function changeCellType(id, to) {
     to,
   };
 }
-export function setGithub() {
+export function setAnonGithub() {
   return {
-    type: constants.SET_GITHUB,
+    type: constants.SET_ANON_GITHUB,
+  };
+}
+export function setAuthGithub() {
+  return {
+    type: constants.SET_AUTH_GITHUB,
   };
 }
 export function setGithubToken(githubToken) {

--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -232,6 +232,11 @@ export function changeCellType(id, to) {
     to,
   };
 }
+export function setGithub() {
+  return {
+    type: constants.SET_GITHUB,
+  };
+}
 export function setGithubToken(githubToken) {
   return {
     type: constants.SET_GITHUB_TOKEN,

--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -237,9 +237,9 @@ export function setAnonGithub() {
     type: constants.SET_ANON_GITHUB,
   };
 }
-export function setAuthGithub() {
+export function setUserGithub() {
   return {
-    type: constants.SET_AUTH_GITHUB,
+    type: constants.SET_USER_GITHUB,
   };
 }
 export function setGithubToken(githubToken) {

--- a/src/notebook/constants.js
+++ b/src/notebook/constants.js
@@ -73,7 +73,8 @@ export const SET_THEME = 'SET_THEME';
 
 export const REGISTER_COMM_TARGET = 'REGISTER_COMM_TARGET';
 export const SET_GITHUB_TOKEN = 'SET_GITHUB_TOKEN';
-export const SET_GITHUB = 'SET_GITHUB';
+export const SET_ANON_GITHUB = 'SET_ANON_GITHUB';
+export const SET_AUTH_GITHUB = 'SET_AUTH_GITHUB';
 
 export const COMM_OPEN = 'COMM_OPEN';
 export const COMM_MESSAGE = 'COMM_MESSAGE';

--- a/src/notebook/constants.js
+++ b/src/notebook/constants.js
@@ -73,6 +73,7 @@ export const SET_THEME = 'SET_THEME';
 
 export const REGISTER_COMM_TARGET = 'REGISTER_COMM_TARGET';
 export const SET_GITHUB_TOKEN = 'SET_GITHUB_TOKEN';
+export const SET_GITHUB = 'SET_GITHUB';
 
 export const COMM_OPEN = 'COMM_OPEN';
 export const COMM_MESSAGE = 'COMM_MESSAGE';

--- a/src/notebook/constants.js
+++ b/src/notebook/constants.js
@@ -74,7 +74,7 @@ export const SET_THEME = 'SET_THEME';
 export const REGISTER_COMM_TARGET = 'REGISTER_COMM_TARGET';
 export const SET_GITHUB_TOKEN = 'SET_GITHUB_TOKEN';
 export const SET_ANON_GITHUB = 'SET_ANON_GITHUB';
-export const SET_USER_GITHUB = 'SET_AUTH_GITHUB';
+export const SET_USER_GITHUB = 'SET_USER_GITHUB';
 
 export const COMM_OPEN = 'COMM_OPEN';
 export const COMM_MESSAGE = 'COMM_MESSAGE';

--- a/src/notebook/constants.js
+++ b/src/notebook/constants.js
@@ -74,7 +74,7 @@ export const SET_THEME = 'SET_THEME';
 export const REGISTER_COMM_TARGET = 'REGISTER_COMM_TARGET';
 export const SET_GITHUB_TOKEN = 'SET_GITHUB_TOKEN';
 export const SET_ANON_GITHUB = 'SET_ANON_GITHUB';
-export const SET_AUTH_GITHUB = 'SET_AUTH_GITHUB';
+export const SET_USER_GITHUB = 'SET_AUTH_GITHUB';
 
 export const COMM_OPEN = 'COMM_OPEN';
 export const COMM_MESSAGE = 'COMM_MESSAGE';

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -87,7 +87,7 @@ export function createGistCallback(firstTimePublish, observer, filename, notific
  * notification of the user that the gist has been published.
  */
 export function publishNotebookObservable(github, notebook, filepath,
-                                          notificationSystem, authenticated) {
+                                          notificationSystem, publishAsUser) {
   return Rx.Observable.create((observer) => {
     const notebookString = JSON.stringify(
       commutable.toJS(notebook.update('cellMap', cells =>
@@ -105,7 +105,7 @@ export function publishNotebookObservable(github, notebook, filepath,
     }
     const files = {};
     files[filename] = { content: notebookString };
-    if (authenticated) {
+    if (publishAsUser) {
       github.users.get({}, (err, res) => {
         if (err) throw err;
         notificationSystem.addNotification({
@@ -153,9 +153,9 @@ export const publishEpic = (action$, store) =>
       const filename = state.metadata.get('filename');
       const github = state.app.get('github');
       const notificationSystem = state.app.get('notificationSystem');
-      const authenticated = state.app.get('authenticated');
+      const publishAsUser = state.app.get('publishAsUser');
       return publishNotebookObservable(github, notebook, filename,
-                                       notificationSystem, authenticated);
+                                       notificationSystem, publishAsUser);
     })
     .catch((err) => {
       const state = store.getState();

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -35,7 +35,7 @@ import {
   pasteCell,
   createCellAfter,
   setAnonGithub,
-  setAuthGithub,
+  setUserGithub,
   setGithubToken,
 } from './actions';
 
@@ -256,7 +256,7 @@ export function dispatchPublishUserGist(store, event, githubToken) {
     const token = state.app.get('token');
     store.dispatch(setGithubToken(token));
   }
-  store.dispatch(setAuthGithub());
+  store.dispatch(setUserGithub());
   store.dispatch({ type: 'PUBLISH_GIST' });
 }
 

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -257,7 +257,7 @@ export function dispatchPublishUserGist(store, event, githubToken) {
     store.dispatch(setGithubToken(token));
   }
   store.dispatch(setAuthGithub());
-  store.dispatch({type:'PUBLISH_GIST'});
+  store.dispatch({ type: 'PUBLISH_GIST' });
 }
 
 

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -35,7 +35,7 @@ import {
   pasteCell,
   createCellAfter,
   setGithub,
-  setGithubToken
+  setGithubToken,
 } from './actions';
 
 import {

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -158,8 +158,8 @@ export function dispatchNewKernel(store, evt, name) {
 }
 
 export function dispatchPublishGist(store) {
-  store.dispatch(setGithub);
-  store.dispatch({ type: PUBLISH_GIST });
+  store.dispatch(setGithub());
+  store.dispatch({ type: 'PUBLISH_GIST' });
 }
 
 export function dispatchRunAll(store) {
@@ -248,8 +248,9 @@ export function dispatchNewNotebook(store, event, kernelSpecName) {
 }
 
 export function dispatchAuthAndPublish(store, event, githubToken) {
-  if (githubToken) { store.dispatch(setGithubToken(githubToken)) }
-  else {
+  if (githubToken) {
+    store.dispatch(setGithubToken(githubToken));
+  } else {
     const state = store.getState();
     const token = state.app.get('token');
     store.dispatch(setGithubToken(token));

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -34,7 +34,8 @@ import {
   cutCell,
   pasteCell,
   createCellAfter,
-  setGithubToken,
+  setGithub,
+  setGithubToken
 } from './actions';
 
 import {
@@ -157,6 +158,7 @@ export function dispatchNewKernel(store, evt, name) {
 }
 
 export function dispatchPublishGist(store) {
+  store.dispatch(setGithub);
   store.dispatch({ type: PUBLISH_GIST });
 }
 
@@ -246,8 +248,13 @@ export function dispatchNewNotebook(store, event, kernelSpecName) {
 }
 
 export function dispatchAuthAndPublish(store, event, githubToken) {
-  store.dispatch(setGithubToken(githubToken));
-  dispatchPublishGist(store);
+  if (githubToken) { store.dispatch(setGithubToken(githubToken)) }
+  else {
+    const state = store.getState();
+    const token = state.app.get('token');
+    store.dispatch(setGithubToken(token));
+  }
+  store.dispatch({type:'PUBLISH_GIST'})
 }
 
 

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -34,7 +34,8 @@ import {
   cutCell,
   pasteCell,
   createCellAfter,
-  setGithub,
+  setAnonGithub,
+  setAuthGithub,
   setGithubToken,
 } from './actions';
 
@@ -157,8 +158,8 @@ export function dispatchNewKernel(store, evt, name) {
   store.dispatch(newKernel(name, spawnOptions));
 }
 
-export function dispatchPublishGist(store) {
-  store.dispatch(setGithub());
+export function dispatchPublishAnonGist(store) {
+  store.dispatch(setAnonGithub());
   store.dispatch({ type: 'PUBLISH_GIST' });
 }
 
@@ -247,7 +248,7 @@ export function dispatchNewNotebook(store, event, kernelSpecName) {
   store.dispatch(newNotebook(kernelSpecName, home()));
 }
 
-export function dispatchAuthAndPublish(store, event, githubToken) {
+export function dispatchPublishUserGist(store, event, githubToken) {
   if (githubToken) {
     store.dispatch(setGithubToken(githubToken));
   } else {
@@ -255,7 +256,8 @@ export function dispatchAuthAndPublish(store, event, githubToken) {
     const token = state.app.get('token');
     store.dispatch(setGithubToken(token));
   }
-  store.dispatch({type:'PUBLISH_GIST'})
+  store.dispatch(setAuthGithub());
+  store.dispatch({type:'PUBLISH_GIST'});
 }
 
 
@@ -273,11 +275,11 @@ export function initMenuHandlers(store) {
   ipc.on('menu:interrupt-kernel', dispatchInterruptKernel.bind(null, store));
   ipc.on('menu:restart-kernel', dispatchRestartKernel.bind(null, store));
   ipc.on('menu:restart-and-clear-all', dispatchRestartClearAll.bind(null, store));
-  ipc.on('menu:publish:gist', dispatchPublishGist.bind(null, store));
+  ipc.on('menu:publish:gist', dispatchPublishAnonGist.bind(null, store));
   ipc.on('menu:zoom-in', dispatchZoomIn.bind(null, store));
   ipc.on('menu:zoom-out', dispatchZoomOut.bind(null, store));
   ipc.on('menu:theme', dispatchSetTheme.bind(null, store));
-  ipc.on('menu:github:auth', dispatchAuthAndPublish.bind(null, store));
+  ipc.on('menu:github:auth', dispatchPublishUserGist.bind(null, store));
   // OCD: This is more like the registration of main -> renderer thread
   ipc.on('main:load', dispatchLoad.bind(null, store));
   ipc.on('main:new', dispatchNewNotebook.bind(null, store));

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -5,7 +5,7 @@ const Github = require('github');
 export const AppRecord = new Immutable.Record({
   executionState: 'not connected',
   github: new Github(),
-  authenticated: false,
+  token: null,
   channels: null,
   spawn: null,
   connectionFile: null,

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -6,6 +6,7 @@ export const AppRecord = new Immutable.Record({
   executionState: 'not connected',
   github: new Github(),
   token: null,
+  publishAsUser: false,
   channels: null,
   spawn: null,
   connectionFile: null,

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -68,7 +68,7 @@ export default handleActions({
     return state.set('github', github)
                 .set('publishAsUser', false);
   },
-  [constants.SET_AUTH_GITHUB]: function setAuthGithub(state) {
+  [constants.SET_USER_GITHUB]: function setUserGithub(state) {
     return state.set('publishAsUser', true);
   },
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -63,11 +63,15 @@ export default handleActions({
   [constants.SET_THEME]: function setTheme(state, action) {
     return state.set('theme', action.theme);
   },
+  [constants.SET_GITHUB]: function setGithub(state) {
+    const github = new Github();
+    return state.set('github', github);
+  },
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
     const { githubToken } = action;
     const github = new Github();
     github.authenticate({ type: 'oauth', token: githubToken });
     return state.set('github', github)
-                .set('authenticated', true);
+                .set('token', githubToken);
   }
 }, {});

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -76,6 +76,6 @@ export default handleActions({
     const github = new Github();
     github.authenticate({ type: 'oauth', token: githubToken });
     return state.set('github', github)
-                .set('token', githubToken)
+                .set('token', githubToken);
   },
 }, {});

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -63,10 +63,13 @@ export default handleActions({
   [constants.SET_THEME]: function setTheme(state, action) {
     return state.set('theme', action.theme);
   },
-  [constants.SET_GITHUB]: function setGithub(state) {
+  [constants.SET_ANON_GITHUB]: function setAnonGithub(state) {
     const github = new Github();
     return state.set('github', github)
                 .set('publishAsUser', false);
+  },
+  [constants.SET_AUTH_GITHUB]: function setAuthGithub(state) {
+    return state.set('publishAsUser', true);
   },
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
     const { githubToken } = action;
@@ -74,6 +77,5 @@ export default handleActions({
     github.authenticate({ type: 'oauth', token: githubToken });
     return state.set('github', github)
                 .set('token', githubToken)
-                .set('publishAsUser', true);
-  }
+  },
 }, {});

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -65,13 +65,15 @@ export default handleActions({
   },
   [constants.SET_GITHUB]: function setGithub(state) {
     const github = new Github();
-    return state.set('github', github);
+    return state.set('github', github)
+                .set('publishAsUser', false);
   },
   [constants.SET_GITHUB_TOKEN]: function setGithubToken(state, action) {
     const { githubToken } = action;
     const github = new Github();
     github.authenticate({ type: 'oauth', token: githubToken });
     return state.set('github', github)
-                .set('token', githubToken);
+                .set('token', githubToken)
+                .set('publishAsUser', true);
   }
 }, {});

--- a/test/renderer/actions-spec.js
+++ b/test/renderer/actions-spec.js
@@ -313,10 +313,26 @@ describe('changeCellType', () => {
 });
 
 describe('setGithubToken', () => {
-  it('create a SET_GITHUB_TOKEN action', () => {
+  it('creates a SET_GITHUB_TOKEN action', () => {
     expect(actions.setGithubToken('token_string')).to.deep.equal({
       type: constants.SET_GITHUB_TOKEN,
       githubToken: 'token_string',
+    });
+  });
+});
+
+describe('setAuthGithub', () => {
+  it('creates a SET_ANON_GITHUB action', () => {
+    expect(actions.setAnonGithub()).to.deep.equal({
+      type: constants.SET_ANON_GITHUB,
+    });
+  });
+});
+
+describe('setUserGithub', () => {
+  it('creates a SET_USER_GITHUB action', () => {
+    expect(actions.setUserGithub()).to.deep.equal({
+      type: constants.SET_USER_GITHUB,
     });
   });
 });

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -178,21 +178,24 @@ describe('menu', () => {
     });
   });
 
-  describe('dispatchPublishGist', () => {
+  describe('dispatchPublishAnonGist', () => {
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
-    menu.dispatchPublishGist(store);
+    menu.dispatchPublishAnonGist(store);
 
     expect(store.dispatch.firstCall).to.be.calledWith({
+      type: 'SET_ANON_GITHUB',
+    });
+    expect(store.dispatch.secondCall).to.be.calledWith({
       type: 'PUBLISH_GIST',
     });
   });
 
-  describe('dispatchAuthAndPublish', () => {
+  describe('dispatchPublishUserGist', () => {
     const dispatch = sinon.spy();
     const store = { dispatch };
-    menu.dispatchAuthAndPublish(store, {}, 'TOKEN');
+    menu.dispatchPublishUserGist(store, {}, 'TOKEN');
     const expectedAction = { type: 'SET_GITHUB_TOKEN', githubToken: 'TOKEN' };
     expect(dispatch).to.have.been.calledWith(expectedAction);
   });

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -193,11 +193,29 @@ describe('menu', () => {
   });
 
   describe('dispatchPublishUserGist', () => {
-    const dispatch = sinon.spy();
-    const store = { dispatch };
-    menu.dispatchPublishUserGist(store, {}, 'TOKEN');
-    const expectedAction = { type: 'SET_GITHUB_TOKEN', githubToken: 'TOKEN' };
-    expect(dispatch).to.have.been.calledWith(expectedAction);
+    it('sets github token if token provided', () => {
+      const store = dummyStore();
+      store.dispatch = sinon.spy();
+      menu.dispatchPublishUserGist(store, {}, 'TOKEN');
+      const expectedAction = { type: 'SET_GITHUB_TOKEN', githubToken: 'TOKEN' };
+      expect(store.dispatch).to.have.been.calledWith(expectedAction);
+    });
+    it('gets token from state if none provided', () => {
+      const store = dummyStore();
+      store.dispatch = sinon.spy();
+      menu.dispatchPublishUserGist(store, {});
+      const expectedAction = { type: 'SET_GITHUB_TOKEN', githubToken: 'TOKEN' };
+      expect(store.dispatch).to.have.been.calledWith(expectedAction);
+    });
+    it('dispatches setUserGithub and publishes gist', () => {
+      const store = dummyStore();
+      store.dispatch = sinon.spy();
+      menu.dispatchPublishUserGist(store, {});
+      const expectedSecondAction = { type: 'SET_USER_GITHUB' };
+      const expectedThirdAction = { type: 'PUBLISH_GIST' };
+      expect(store.dispatch).to.have.been.calledWith(expectedSecondAction);
+      expect(store.dispatch).to.have.been.calledWith(expectedThirdAction);
+    });
   });
 
   describe('dispatchNewKernel', () => {

--- a/test/renderer/reducers/app-spec.js
+++ b/test/renderer/reducers/app-spec.js
@@ -227,7 +227,7 @@ describe('setGithubToken', () => {
     const originalState = {
       app: new AppRecord({
         github: new Github(),
-        authenticated: false,
+        token: null,
       })
     };
 
@@ -239,9 +239,42 @@ describe('setGithubToken', () => {
     const state = reducers(originalState, action);
     // this is a crappy way of testing this
     expect(state.app.github).to.not.be.null;
-    expect(state.app.authenticated).to.be.true;
+    expect(state.app.token).to.not.be.null;
   });
 })
+
+describe('setAuthGithub', () => {
+  it('changes publishAsUser', () => {
+
+    const originalState = {
+      app: new AppRecord({
+        publishAsUser: false,
+      })
+    }
+
+    const action = {
+      type: constants.SET_AUTH_GITHUB,
+    }
+    const state = reducers(originalState, action);
+    expect(state.app.publishAsUser).to.be.true;
+  });
+});
+
+describe('setAnonGithub', () => {
+  it('changes PublishAsUser', () => {
+
+    const originalState = {
+      app: new AppRecord({
+        publishAsUser: true,
+      })
+    }
+    const action = {
+      type: constants.SET_ANON_GITHUB,
+    }
+    const state = reducers(originalState, action);
+    expect(state.app.publishAsUser).to.be.false;
+  });
+});
 
 describe('exit', () => {
   it('calls cleanupKernel', () => {

--- a/test/renderer/reducers/app-spec.js
+++ b/test/renderer/reducers/app-spec.js
@@ -251,9 +251,8 @@ describe('setAuthGithub', () => {
         publishAsUser: false,
       })
     }
-
     const action = {
-      type: constants.SET_AUTH_GITHUB,
+      type: constants.SET_USER_GITHUB,
     }
     const state = reducers(originalState, action);
     expect(state.app.publishAsUser).to.be.true;

--- a/test/utils.js
+++ b/test/utils.js
@@ -37,7 +37,9 @@ export function dummyStore(config) {
       executionState: 'not connected',
       notificationSystem: {
         addNotification: sinon.spy(),
-      }
+      },
+      publishAsUser: false,
+      token: 'TOKEN',
     }),
     metadata: MetadataRecord({
       filename: (config && config.noFilename) ? null : 'dummy-store-nb.ipynb',


### PR DESCRIPTION
## Changed
- App record now has publishAsUser boolean
- Separated setGithubToken and setPublishAsUser
- DispatchPublishUserGist has clearer logic
- DispatchPublishAnonGist has clearer logic
- Add SET_USER_GITHUB, SET_ANON_GITHUB actions
- Add action/reducer menu tests 
- Add menu spec tests
- Add publish user to dummy store
