### PR TITLE
fix(Codemirror): indentUnit and tabSize conflict

### DIFF
--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -23,6 +23,7 @@ class CodeCell extends React.Component {
     running: React.PropTypes.bool,
     focusAbove: React.PropTypes.func,
     focusBelow: React.PropTypes.func,
+    tabSize: React.PropTypes.number,
   };
 
   static defaultProps = {

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -28,6 +28,7 @@ class CodeCell extends React.Component {
   static defaultProps = {
     pagers: new Immutable.List(),
     running: false,
+    tabSize: 4,
   };
 
   constructor(props) {
@@ -55,6 +56,7 @@ class CodeCell extends React.Component {
             <Editor
               completion
               id={this.props.id}
+              tabSize={this.props.tabSize}
               input={this.props.cell.get('source')}
               language={this.props.language}
               focused={this.props.focused}

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -46,6 +46,7 @@ export default class Editor extends React.Component {
     input: React.PropTypes.any,
     completion: React.PropTypes.bool,
     language: React.PropTypes.string,
+    tabSize: React.PropTypes.number,
     lineNumbers: React.PropTypes.bool,
     lineWrapping: React.PropTypes.bool,
     onChange: React.PropTypes.func,
@@ -183,6 +184,8 @@ export default class Editor extends React.Component {
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
       },
+      indentUnit: this.props.tabSize,
+      tabSize: this.props.tabSize,
     };
     return (
       <div className="input">


### PR DESCRIPTION
## Adds:
- `tabSize` as a default codecell prop
- `indentUnit` = `tabSize` in codecell

Really don't have opinions on indenting, if I was supposed to do something else please let me know what direction I should go in.
