### PR TITLE
feat(CSS): add 'nteract' theme

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -195,6 +195,10 @@ const theme_menu = [
     label: 'Classic',
     click: createSender('menu:theme', 'classic'),
   },
+  {
+    label: 'nteract',
+    click: createSender('menu:theme', 'nteract'),
+  },
 ];
 
 const today = new Date();

--- a/static/styles/theme-nteract.css
+++ b/static/styles/theme-nteract.css
@@ -1,0 +1,321 @@
+:root {
+  --main-bg-color: #1b2a3e;
+  --main-fg-color: #edf3f7;
+
+  --primary-border: #495F7D;
+
+  --cell-bg: #334863;
+  --cell-bg-hover: #495F7D;
+  --cell-bg-focus: #5e7697;
+
+  --toolbar-bg: #fff;
+  --toolbar-button: #aaa;
+  --toolbar-button-hover: var(--cell-bg);
+
+  --dropdown-content: var(--cell-bg);
+  --dropdown-content-hover: var(--toolbar-button-hover);
+
+  --pager-bg: #354a66;
+  --input-color: #fafafa;
+
+  --cm-background: #23354C;
+  --cm-color: rgba(255,255,255,0.4);
+
+  --cm-gutter-bg: #777;
+
+  --cm-comment: inherit;
+  --cm-keyword: #43F3C5;
+  --cm-string: #43d4f3;
+  --cm-builtin: #FFF66E;
+  --cm-special: #1abc9c;
+  --cm-variable: inherit;
+  --cm-number: #ff9bc6;
+  --cm-meta: #95a5a6;
+  --cm-link: var(--cm-keyword);
+  --cm-operator: inherit;
+  --cm-def: #D77BFB;
+
+  --cm-activeline-bg: #e8f2ff;
+  --cm-matchingbracket-outline: grey;
+  --cm-matchingbracket-color: white;
+
+  --cm-hint-color: var(--main-fg-color);
+  --cm-hint-color-active: var(--cm-color);
+  --cm-hint-bg: var(--main-bg-color);
+  --cm-hint-bg-active: var(--pager-bg);
+
+  --status-bar: transparent;
+}
+
+/* -------------------- */
+/* Focus on Active Card */
+/* -------------------- */
+
+.cell,
+.notebook .cell:focus,
+.notebook .cell.focused
+{
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+.notebook .cell:hover
+{
+  box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+}
+
+.cell:focus .cm-s-composition.CodeMirror,
+.cell.focused .cm-s-composition.CodeMirror,
+.cell.focused .rendered
+{
+  background: var(--cell-bg);
+}
+
+.outputs,
+.CodeMirror-lines
+{
+  opacity: 0.75;
+}
+
+.cell .rendered
+{
+  background: var(--cm-background);
+}
+
+.cell:focus .CodeMirror-lines,
+.cell.focused .CodeMirror-lines,
+.cell.focused .outputs,
+.cell.focused .rendered
+{
+  opacity: 1;
+  color: var(--main-fg-color);
+}
+
+.cell.focused .input-container
+{
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+/* -------------------------- */
+/* CodeMirror Colors & Styles */
+/* -------------------------- */
+
+.cm-property
+{
+  color: #9CAFEA;
+}
+
+.cm-comment
+{
+  font-style: italic;
+  opacity: 0.3;
+}
+
+.CodeMirror-selected,
+.CodeMirror-focused .CodeMirror-selected
+{
+  background: rgba(0,0,0,0.3);
+}
+
+.cm-s-composition span.cm-string.cm-url
+{
+  color: var(--cm-link);
+  opacity: 0.5;
+}
+
+/* Override Inline Styles */
+/* These styles are used for code errors in the CodeMirror output */
+
+span[style="color: rgb(187, 0, 0);"]
+{
+  color: var(--cm-keyword) !important;
+  font-weight: bold;
+}
+
+span[style="color: rgb(0, 187, 0);"]
+{
+  color: var(--cm-string) !important;
+}
+
+span[style="color: rgb(0, 187, 187);"]
+{
+  color: var(--main-fg-color) !important;
+}
+
+span[style="color: rgb(0, 0, 187);"]
+{
+  color: inherit !important;
+}
+
+span[style="color: rgb(0, 255, 0);"]
+{
+  color: rgba(255,255,255,0.3) !important;
+}
+
+/* ---------------------- */
+/* Markdown & Text Styles */
+/* ---------------------- */
+
+.outputs a,
+.rendered a
+{
+  color: var(--cm-link);
+}
+
+.outputs > div
+{
+  background-color: rgba(29,49,76,0.7);
+}
+
+/* Tables */
+
+th
+{
+  background: rgba(0,0,0,0.25);
+}
+
+tr:nth-of-type(even)
+{
+  background: rgba(255,255,255,0.075);
+}
+
+tr:hover
+{
+  background: rgba(0,0,0,0.4);
+}
+
+/* Blockquotes */
+
+.notebook blockquote::before
+{
+  content: '';
+  background-color: var(--cm-special);
+  background-image: repeating-linear-gradient(-45deg, transparent, transparent 5px, rgba(27, 42, 62, 0.2) 5px, rgba(27, 42, 62, 0.2) 10px);
+  width: 0.75rem;
+  height: 100%;
+  display: block;
+  margin: 0;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.notebook blockquote
+{
+  position: relative;
+  border: 0;
+  margin-left: 0;
+  padding-left: 1.5rem;
+}
+
+/* Lists */
+
+ul li
+{
+  list-style: none;
+}
+
+ul li::before
+{
+  content: '\f078';
+  font: normal normal normal 16px/1 octicons;
+  display: inline-block;
+  text-decoration: none;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  text-indent: -1rem;
+  color: var(--cm-special);
+}
+
+/* --------------------------- */
+/* Create & Edit Cell Toolbars */
+/* --------------------------- */
+
+.notebook .cell-creator,
+.cell-toolbar
+{
+  padding: 0.125em 0.25em;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+.notebook .cell-creator:hover,
+.cell-toolbar:hover
+{
+  box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);  
+}
+
+.notebook .cell-creator
+{
+  background: var(--toolbar-bg);
+  border-radius: 5px;
+}
+
+.cell-toolbar
+{
+  border-radius: 0 0 0 5px;
+  padding: 0.125em 0.25em;
+}
+
+/* ------------ */
+/* Sticky Cells */
+/* ------------ */
+
+.notebook .sticky-cell-container
+{
+  padding-top: 0;
+  padding-bottom: 0;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+  z-index: 2000;
+}
+
+.sticky-cell-container > div ~ div
+{
+  margin-top: 2rem;
+}
+
+/* The container itself has a shadow, so let's kill the shadow on the last box */
+
+.sticky-cell-container .cell:last-of-type
+{
+  box-shadow: none !important;
+}
+
+.sticky-cell-container .stickyButton span
+{
+  color: var(--cm-special);
+}
+
+/* Thanks, Lea Verou! http://lea.verou.me/css3patterns/#diagonal-stripes */
+
+.sticky-cell-container .prompt
+{
+  background-image: repeating-linear-gradient(-45deg, transparent, transparent 15px, rgba(255,255,255,0.1) 15px, rgba(255, 255, 255, 0.1) 30px);
+}
+
+/* -------------------- */
+/* Miscellaneous Styles */
+/* -------------------- */
+
+body
+{
+  line-height: 1.3 !important;
+}
+
+.cell .prompt,
+.notebook .cell-creator,
+button,
+a,
+tr
+{
+  transition: all 0.1s ease-in-out;
+}
+
+.status-bar
+{
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.5)) !important;
+  text-shadow: 0.1em 0.1em 0.3em #000;
+}

--- a/static/styles/theme-nteract.css
+++ b/static/styles/theme-nteract.css
@@ -44,7 +44,7 @@
   --cm-hint-bg: var(--main-bg-color);
   --cm-hint-bg-active: var(--pager-bg);
 
-  --status-bar: transparent;
+  --status-bar: var(--main-bg-color);
 }
 
 /* -------------------- */
@@ -312,10 +312,4 @@ a,
 tr
 {
   transition: all 0.1s ease-in-out;
-}
-
-.status-bar
-{
-  background: linear-gradient(transparent, rgba(0, 0, 0, 0.5)) !important;
-  text-shadow: 0.1em 0.1em 0.3em #000;
 }


### PR DESCRIPTION
Add 'nteract' to theme selector
Create 'nteract' theme

This theme uses colors pulled from the nteract logo animation (and a few new ones for syntax highlighting). Cells in this theme are a bit different than they are in Light or Dark: unfocused cells are slightly dimmed to help you focus only on your active cell.

Visual preview:

![Screenshot](https://cloud.githubusercontent.com/assets/6765732/19022666/1f7208f2-88a3-11e6-9279-59780ba02888.png)

Closes #848
