### PR TITLE
chore(flow): adapt new nteract assets, ignore flow-typed definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 dist/
 
 test/*.ipynb
+
+# Ignore flow type definitions
+flow-typed/

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mathjax-electron": "^1.1.1",
     "moment": "^2.15.0",
     "normalize.css": "^5.0.0",
-    "nteract-assets": "^2.0.1",
+    "nteract-assets": "^2.1.0",
     "plotly.js": "^1.17.3",
     "react": "^15.3.2",
     "react-addons-pure-render-mixin": "^15.3.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mathjax-electron": "^1.1.1",
     "moment": "^2.15.0",
     "normalize.css": "^5.0.0",
-    "nteract-assets": "^2.0.0",
+    "nteract-assets": "^2.0.1",
     "plotly.js": "^1.17.3",
     "react": "^15.3.2",
     "react-addons-pure-render-mixin": "^15.3.2",


### PR DESCRIPTION
On `master`, running `flow` will error searching for flow definitions for `moment`:

```
$ flow
Launching Flow server for /Users/kylek/code/src/github.com/nteract/nteract
Spawned flow server (pid=97473)
Logs will go to /private/tmp/flow/zSUserszSkylekzScodezSsrczSgithub.comzSnteractzSnteract.log
src/notebook/components/status-bar.js:4
  4: import moment from 'moment';
                        ^^^^^^^^ moment. Required module not found


Found 1 error
```

Using `flow-typed install` fixes this up (though with new issues related to nteract-assets).

Annoyingly, `flow-typed` is better installed globally. We'll need to update our README as well for all the additional dev requirements.
