### PR TITLE
fix(loading): Bring back some loading text

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -12,6 +12,7 @@
   </head>
   <body>
     <div id="app">
+      Loading...
     </div>
     <script>
       window.onload = function deferredLoad() {


### PR DESCRIPTION
In some of the runs I've seen, there's no context given to a user that the app is still loading (which is currently fairly slow for us).
