### PR TITLE
feat(Windows): Add windows support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/*.js
 test/
+scripts/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ python3 -m ipykernel install --user
 
 Requires [node 6.x and npm 3](https://docs.npmjs.com/getting-started/installing-node).
 
+On windows you additionally need [Visual Studio 2013](https://www.microsoft.com/en-US/download/details.aspx?id=44914) and Python 2.
+
 1. Fork this repo
 2. Clone it `git clone https://github.com/nteract/nteract`
 3. `cd` to where you `clone`d it

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": ":notebook: the nteract notebook",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node scripts/rebuild.js",
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=development electron .",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dist:linux32": "npm run dist -- --platform=linux --arch=ia32",
     "dist:osx": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
     "dist:osx:signed": "npm run dist:osx -- --osx-sign",
+    "dist:win": "npm run dist -- --platform=win32 --icon ./static/icon.ico",
     "flow": "flow; test $? -eq 0 -o $? -eq 2"
   },
   "repository": {

--- a/scripts/rebuild.js
+++ b/scripts/rebuild.js
@@ -1,9 +1,17 @@
 #!/usr/bin/env node
-const exec = require('child_process').exec;
-
 if (process.platform === 'win32') {
-  exec('npm rebuild zmq-prebuilt --runtime=electron --target=1.1.3 --disturl=https://atom.io/download/atom-shell --build-from-source',
-  function(err, stdout, stderr) {
+  var exec = require('child_process').exec;
+  var deps = require('../package.json').devDependencies;
+  var version = deps.electron || deps['electron-prebuilt'];
+
+  if (typeof version != 'string' || version.search(/>|<|~|\*|x/) > -1) {
+    throw Error('No explicit electron version in package.json found.')
+  };
+
+  var cmd = 'npm rebuild zmq-prebuilt --runtime=electron --target=' + version +
+    ' --disturl=https://atom.io/download/atom-shell --build-from-source'
+
+  exec(cmd, function(err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
     if (err) {

--- a/scripts/rebuild.js
+++ b/scripts/rebuild.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const exec = require('child_process').exec;
+
+if (process.platform === 'win32') {
+  exec('npm rebuild zmq-prebuilt --runtime=electron --target=1.1.3 --disturl=https://atom.io/download/atom-shell --build-from-source',
+  function(err, stdout, stderr) {
+    console.log(stdout);
+    console.log(stderr);
+    if (err) {
+      throw err;
+    }
+  });
+} else if (process.platform === 'linux' || process.platform === 'darwin') {
+  console.log('No postinstall step required for platform' + process.platform);
+} else {
+  console.log(process.platform + ' is not yet supported.');
+}


### PR DESCRIPTION
Welcome windows devs! 🎉 

Since we don't have `zmq-prebuilt` for electron on windows (yet),  this will rebuilt zmq from source. Windows devs will need Visual Studio 2013 and Python 2.
