### PR TITLE
refactor(geojson): most recent + valid mimetype for geojson

### DIFF
--- a/example-notebooks/geojson.ipynb
+++ b/example-notebooks/geojson.ipynb
@@ -3,7 +3,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -14,13 +14,13 @@
     "\n",
     "def geojson(data):\n",
     "  bundle = {}\n",
-    "  bundle['application/vnd.geo+json'] = data\n",
+    "  bundle['application/geo+json'] = data\n",
     "  IPython.display.display(bundle, raw=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -40,234 +40,225 @@
    ],
    "outputs": [
     {
-     "metadata": {},
      "data": {
-      "application/vnd.geo+json": {
+      "application/geo+json": {
        "type": "FeatureCollection",
        "features": [
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.02827,
-           38.91427
-          ]
-         },
          "properties": {
           "place": "The coffee bar",
           "lat": "38.91427",
-          "lon": "-77.02827",
-          "login": "espresso"
+          "login": "espresso",
+          "lon": "-77.02827"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.02827,
+           38.91427
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.02013,
-           38.91538
-          ]
-         },
          "properties": {
           "place": "Bistro Bohem",
           "lat": "38.91538",
-          "lon": "-77.02013",
-          "login": "2027355895"
+          "login": "2027355895",
+          "lon": "-77.02013"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.02013,
+           38.91538
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.03155,
-           38.91458
-          ]
-         },
          "properties": {
           "place": "Black Cat",
           "lat": "38.91458",
-          "lon": "-77.03155",
-          "login": "luckycat"
+          "login": "luckycat",
+          "lon": "-77.03155"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.03155,
+           38.91458
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.04227,
-           38.92239
-          ]
-         },
          "properties": {
           "place": "Snap",
           "lat": "38.92239",
-          "lon": "-77.04227",
-          "login": "nutella1"
+          "login": "nutella1",
+          "lon": "-77.04227"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.04227,
+           38.92239
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.02854,
-           38.93222
-          ]
-         },
          "properties": {
           "place": "Columbia Heights Coffee",
           "lat": "38.93222",
-          "lon": "-77.02854",
-          "login": "FAIRTRADE1"
+          "login": "FAIRTRADE1",
+          "lon": "-77.02854"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.02854,
+           38.93222
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.02419,
-           38.90842
-          ]
-         },
          "properties": {
           "place": "Azi's Cafe",
           "lat": "38.90842",
-          "lon": "-77.02419",
-          "login": "sunny"
+          "login": "sunny",
+          "lon": "-77.02419"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.02419,
+           38.90842
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.02518,
-           38.91931
-          ]
-         },
          "properties": {
           "place": "Blind Dog Cafe",
           "lat": "38.91931",
-          "lon": "-77.02518",
-          "login": "baxtercantsee"
+          "login": "baxtercantsee",
+          "lon": "-77.02518"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.02518,
+           38.91931
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.03304,
-           38.9326
-          ]
-         },
          "properties": {
           "place": "Le Caprice",
           "lat": "38.93260",
-          "lon": "-77.03304",
-          "login": "baguette"
+          "login": "baguette",
+          "lon": "-77.03304"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.03304,
+           38.9326
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.04509,
-           38.91368
-          ]
-         },
          "properties": {
           "place": "Filter",
           "lat": "38.91368",
-          "lon": "-77.04509",
-          "login": ""
+          "login": "",
+          "lon": "-77.04509"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.04509,
+           38.91368
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -76.99656,
-           38.88516
-          ]
-         },
          "properties": {
           "place": "Peregrine",
           "lat": "38.88516",
-          "lon": "-76.99656",
-          "login": "espresso"
+          "login": "espresso",
+          "lon": "-76.99656"
+         },
+         "geometry": {
+          "coordinates": [
+           -76.99656,
+           38.88516
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.042438,
-           38.921894
-          ]
-         },
          "properties": {
           "place": "Tryst",
           "lat": "38.921894",
-          "lon": "-77.042438",
-          "login": "coupetnt"
+          "login": "coupetnt",
+          "lon": "-77.042438"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.042438,
+           38.921894
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.02821,
-           38.93206
-          ]
-         },
          "properties": {
           "place": "The Coupe",
           "lat": "38.93206",
-          "lon": "-77.02821",
-          "login": "voteforus"
+          "login": "voteforus",
+          "lon": "-77.02821"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.02821,
+           38.93206
+          ],
+          "type": "Point"
          }
         },
         {
          "type": "Feature",
-         "geometry": {
-          "type": "Point",
-          "coordinates": [
-           -77.01239,
-           38.91275
-          ]
-         },
          "properties": {
           "place": "Big Bear Cafe",
           "lat": "38.91275",
-          "lon": "-77.01239",
-          "login": ""
+          "login": "",
+          "lon": "-77.01239"
+         },
+         "geometry": {
+          "coordinates": [
+           -77.01239,
+           38.91275
+          ],
+          "type": "Point"
          }
         }
        ]
       }
      },
+     "metadata": {},
      "output_type": "display_data"
     }
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [],
-   "outputs": []
   }
  ],
  "metadata": {
@@ -280,16 +271,16 @@
    "display_name": "Python 3"
   },
   "language_info": {
-   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
    "file_extension": ".py",
-   "version": "3.5.2",
    "mimetype": "text/x-python",
-   "name": "python",
    "codemirror_mode": {
-    "version": 3,
-    "name": "ipython"
+    "name": "ipython",
+    "version": 3
    },
-   "nbconvert_exporter": "python"
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4

--- a/example-notebooks/pandas-to-geojson.ipynb
+++ b/example-notebooks/pandas-to-geojson.ipynb
@@ -70,10 +70,10 @@
    },
    "outputs": [
     {
+     "name": "stdout",
      "text": [
       "We have 20 rows\n"
      ],
-     "name": "stdout",
      "output_type": "stream"
     },
     {
@@ -130,15 +130,30 @@
    },
    "outputs": [
     {
-     "text": [
-      "We have 11 geotagged rows\n"
-     ],
      "name": "stdout",
+     "text": [
+      "We have 8 geotagged rows\n"
+     ],
      "output_type": "stream"
     },
     {
      "metadata": {},
      "data": {
+      "text/plain": [
+       "                  issue_description                              issue_type  \\\n",
+       "12                      Application                        Business License   \n",
+       "13         Residential Bulky Pickup                    Refuse and Recycling   \n",
+       "14        Commercial Special Pickup                    Refuse and Recycling   \n",
+       "16  Illegal Dumping - City Property  Streets, Utilities, and Transportation   \n",
+       "19         Residential Service Stop                    Refuse and Recycling   \n",
+       "\n",
+       "     latitude   longitude    street_address ticket_status  \n",
+       "12  37.857073 -122.258698  2918 Florence St        Closed  \n",
+       "13  37.857077 -122.240570    47 Alvarado Rd        Closed  \n",
+       "14  37.865041 -122.264094     2230 Haste St        Closed  \n",
+       "16  37.864497 -122.293439     2240 Ninth St        Closed  \n",
+       "19  37.876000 -122.293046   1127 Hopkins St        Closed  "
+      ],
       "text/html": [
        "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -155,68 +170,53 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>Residential Service Start</td>\n",
+       "      <th>12</th>\n",
+       "      <td>Application</td>\n",
+       "      <td>Business License</td>\n",
+       "      <td>37.857073</td>\n",
+       "      <td>-122.258698</td>\n",
+       "      <td>2918 Florence St</td>\n",
+       "      <td>Closed</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>Residential Bulky Pickup</td>\n",
        "      <td>Refuse and Recycling</td>\n",
-       "      <td>37.864035</td>\n",
-       "      <td>-122.261878</td>\n",
-       "      <td>2321 Blake St</td>\n",
+       "      <td>37.857077</td>\n",
+       "      <td>-122.240570</td>\n",
+       "      <td>47 Alvarado Rd</td>\n",
        "      <td>Closed</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11</th>\n",
-       "      <td>Illegal Dumping - City Property</td>\n",
-       "      <td>Streets, Utilities, and Transportation</td>\n",
-       "      <td>37.864073</td>\n",
-       "      <td>-122.274153</td>\n",
-       "      <td>2421 Grant St</td>\n",
-       "      <td>Closed</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
+       "      <th>14</th>\n",
        "      <td>Commercial Special Pickup</td>\n",
        "      <td>Refuse and Recycling</td>\n",
-       "      <td>37.869593</td>\n",
-       "      <td>-122.285732</td>\n",
-       "      <td>1316 University Ave</td>\n",
+       "      <td>37.865041</td>\n",
+       "      <td>-122.264094</td>\n",
+       "      <td>2230 Haste St</td>\n",
        "      <td>Closed</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>16</th>\n",
-       "      <td>Commercial Reminder</td>\n",
-       "      <td>Refuse and Recycling</td>\n",
-       "      <td>37.885906</td>\n",
-       "      <td>-122.270686</td>\n",
-       "      <td>2075 Eunice St</td>\n",
+       "      <td>Illegal Dumping - City Property</td>\n",
+       "      <td>Streets, Utilities, and Transportation</td>\n",
+       "      <td>37.864497</td>\n",
+       "      <td>-122.293439</td>\n",
+       "      <td>2240 Ninth St</td>\n",
        "      <td>Closed</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
-       "      <td>Residential Bulky Pickup</td>\n",
+       "      <td>Residential Service Stop</td>\n",
        "      <td>Refuse and Recycling</td>\n",
-       "      <td>37.851409</td>\n",
-       "      <td>-122.274282</td>\n",
-       "      <td>3118 King St</td>\n",
+       "      <td>37.876000</td>\n",
+       "      <td>-122.293046</td>\n",
+       "      <td>1127 Hopkins St</td>\n",
        "      <td>Closed</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                  issue_description                              issue_type  \\\n",
-       "10        Residential Service Start                    Refuse and Recycling   \n",
-       "11  Illegal Dumping - City Property  Streets, Utilities, and Transportation   \n",
-       "15        Commercial Special Pickup                    Refuse and Recycling   \n",
-       "16              Commercial Reminder                    Refuse and Recycling   \n",
-       "19         Residential Bulky Pickup                    Refuse and Recycling   \n",
-       "\n",
-       "     latitude   longitude       street_address ticket_status  \n",
-       "10  37.864035 -122.261878        2321 Blake St        Closed  \n",
-       "11  37.864073 -122.274153        2421 Grant St        Closed  \n",
-       "15  37.869593 -122.285732  1316 University Ave        Closed  \n",
-       "16  37.885906 -122.270686       2075 Eunice St        Closed  \n",
-       "19  37.851409 -122.274282         3118 King St        Closed  "
       ]
      },
      "execution_count": 7,
@@ -242,9 +242,9 @@
      "metadata": {},
      "data": {
       "text/plain": [
-       "Refuse and Recycling                      8\n",
-       "Streets, Utilities, and Transportation    2\n",
-       "General Questions/information             1\n",
+       "Refuse and Recycling                      6\n",
+       "Streets, Utilities, and Transportation    1\n",
+       "Business License                          1\n",
        "Name: issue_type, dtype: int64"
       ]
      },
@@ -326,186 +326,138 @@
     {
      "metadata": {},
      "data": {
-      "application/vnd.geo+json": {
+      "application/geo+json": {
+       "type": "FeatureCollection",
        "features": [
         {
-         "properties": {
-          "issue_description": "Residential Lost or Stolen Cart",
-          "street_address": "618 Neilson St",
-          "issue_type": "Refuse and Recycling",
-          "ticket_status": "Closed"
-         },
+         "type": "Feature",
          "geometry": {
           "coordinates": [
-           -122.28663348,
-           37.8961979
+           -122.27359041,
+           37.88639765
           ],
           "type": "Point"
          },
-         "type": "Feature"
+         "properties": {
+          "street_address": "1938 Hopkins St",
+          "issue_description": "Residential Reminder",
+          "issue_type": "Refuse and Recycling",
+          "ticket_status": "Closed"
+         }
         },
         {
+         "type": "Feature",
+         "geometry": {
+          "coordinates": [
+           -122.26823527,
+           37.8677399
+          ],
+          "type": "Point"
+         },
          "properties": {
+          "street_address": "2286 Shattuck Ave",
           "issue_description": "Commercial Missed Pickup",
-          "street_address": "1491 San Pablo Ave",
           "issue_type": "Refuse and Recycling",
           "ticket_status": "Closed"
-         },
+         }
+        },
+        {
+         "type": "Feature",
          "geometry": {
           "coordinates": [
-           -122.29423071,
-           37.87667572
+           -122.2912973,
+           37.86847657
           ],
           "type": "Point"
          },
-         "type": "Feature"
-        },
-        {
          "properties": {
-          "issue_description": "Miscellaneous Service Request",
-          "street_address": "1725 Oxford St",
-          "issue_type": "General Questions/information",
-          "ticket_status": "Closed"
-         },
-         "geometry": {
-          "coordinates": [
-           -122.26624735,
-           37.87632996
-          ],
-          "type": "Point"
-         },
-         "type": "Feature"
-        },
-        {
-         "properties": {
-          "issue_description": "Residential Site Inspection",
-          "street_address": "2329 Grant St",
+          "street_address": "1111 Addison St",
+          "issue_description": "Commercial Customer Complaint",
           "issue_type": "Refuse and Recycling",
           "ticket_status": "Closed"
-         },
+         }
+        },
+        {
+         "type": "Feature",
          "geometry": {
           "coordinates": [
-           -122.27431864,
-           37.86560646
+           -122.25869821,
+           37.85707272
           ],
           "type": "Point"
          },
-         "type": "Feature"
-        },
-        {
          "properties": {
-          "issue_description": "Residential Cart Size Decrease",
-          "street_address": "2701 Buena Vista Way",
-          "issue_type": "Refuse and Recycling",
+          "street_address": "2918 Florence St",
+          "issue_description": "Application",
+          "issue_type": "Business License",
           "ticket_status": "Closed"
-         },
+         }
+        },
+        {
+         "type": "Feature",
          "geometry": {
           "coordinates": [
-           -122.25776331,
-           37.881966
+           -122.24056952,
+           37.85707668
           ],
           "type": "Point"
          },
-         "type": "Feature"
-        },
-        {
          "properties": {
-          "issue_description": "Illegal Dumping - City Property",
-          "street_address": "1636 Sixty-Third St",
-          "issue_type": "Streets, Utilities, and Transportation",
-          "ticket_status": "Closed"
-         },
-         "geometry": {
-          "coordinates": [
-           -122.27390227,
-           37.84721363
-          ],
-          "type": "Point"
-         },
-         "type": "Feature"
-        },
-        {
-         "properties": {
-          "issue_description": "Residential Service Start",
-          "street_address": "2321 Blake St",
-          "issue_type": "Refuse and Recycling",
-          "ticket_status": "Closed"
-         },
-         "geometry": {
-          "coordinates": [
-           -122.26187786,
-           37.86403489
-          ],
-          "type": "Point"
-         },
-         "type": "Feature"
-        },
-        {
-         "properties": {
-          "issue_description": "Illegal Dumping - City Property",
-          "street_address": "2421 Grant St",
-          "issue_type": "Streets, Utilities, and Transportation",
-          "ticket_status": "Closed"
-         },
-         "geometry": {
-          "coordinates": [
-           -122.27415312,
-           37.86407292
-          ],
-          "type": "Point"
-         },
-         "type": "Feature"
-        },
-        {
-         "properties": {
-          "issue_description": "Commercial Special Pickup",
-          "street_address": "1316 University Ave",
-          "issue_type": "Refuse and Recycling",
-          "ticket_status": "Closed"
-         },
-         "geometry": {
-          "coordinates": [
-           -122.28573192,
-           37.86959343
-          ],
-          "type": "Point"
-         },
-         "type": "Feature"
-        },
-        {
-         "properties": {
-          "issue_description": "Commercial Reminder",
-          "street_address": "2075 Eunice St",
-          "issue_type": "Refuse and Recycling",
-          "ticket_status": "Closed"
-         },
-         "geometry": {
-          "coordinates": [
-           -122.27068606,
-           37.8859065
-          ],
-          "type": "Point"
-         },
-         "type": "Feature"
-        },
-        {
-         "properties": {
+          "street_address": "47 Alvarado Rd",
           "issue_description": "Residential Bulky Pickup",
-          "street_address": "3118 King St",
           "issue_type": "Refuse and Recycling",
           "ticket_status": "Closed"
-         },
+         }
+        },
+        {
+         "type": "Feature",
          "geometry": {
           "coordinates": [
-           -122.27428159,
-           37.85140875
+           -122.2640937,
+           37.86504135
           ],
           "type": "Point"
          },
-         "type": "Feature"
+         "properties": {
+          "street_address": "2230 Haste St",
+          "issue_description": "Commercial Special Pickup",
+          "issue_type": "Refuse and Recycling",
+          "ticket_status": "Closed"
+         }
+        },
+        {
+         "type": "Feature",
+         "geometry": {
+          "coordinates": [
+           -122.29343892,
+           37.86449705
+          ],
+          "type": "Point"
+         },
+         "properties": {
+          "street_address": "2240 Ninth St",
+          "issue_description": "Illegal Dumping - City Property",
+          "issue_type": "Streets, Utilities, and Transportation",
+          "ticket_status": "Closed"
+         }
+        },
+        {
+         "type": "Feature",
+         "geometry": {
+          "coordinates": [
+           -122.29304648,
+           37.87599977
+          ],
+          "type": "Point"
+         },
+         "properties": {
+          "street_address": "1127 Hopkins St",
+          "issue_description": "Residential Service Stop",
+          "issue_type": "Refuse and Recycling",
+          "ticket_status": "Closed"
+         }
         }
-       ],
-       "type": "FeatureCollection"
+       ]
       }
      },
      "output_type": "display_data"
@@ -513,17 +465,8 @@
    ],
    "source": [
     "import IPython\n",
-    "IPython.display.display({'application/vnd.geo+json': geojson}, raw=True)"
+    "IPython.display.display({'application/geo+json': geojson}, raw=True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "source": [],
-   "outputs": []
   }
  ],
  "metadata": {
@@ -537,16 +480,16 @@
    "display_name": "Python 3"
   },
   "language_info": {
-   "nbconvert_exporter": "python",
    "name": "python",
-   "pygments_lexer": "ipython3",
-   "file_extension": ".py",
-   "version": "3.5.2",
-   "mimetype": "text/x-python",
    "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   }
+    "version": 3,
+    "name": "ipython"
+   },
+   "version": "3.5.1",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py",
+   "pygments_lexer": "ipython3",
+   "mimetype": "text/x-python"
   }
  },
  "nbformat": 4

--- a/src/notebook/components/transforms/geojson.js
+++ b/src/notebook/components/transforms/geojson.js
@@ -6,7 +6,7 @@ const L = require('leaflet');
 
 L.Icon.Default.imagePath = '../node_modules/leaflet/dist/images/';
 
-const MIMETYPE = 'application/vnd.geo+json';
+const MIMETYPE = 'application/geo+json';
 
 export class GeoJSONTransform extends React.Component {
 


### PR DESCRIPTION
BREAKING CHANGE: application/vnd.geo+json is no longer supported

We definitely don't want to make our permanent geojson mimetype be the outdated one. [`application/geo+json` is preferred](http://www.iana.org/assignments/media-types/application/geo+json).

ref: https://github.com/jupyter/jupyter_client/issues/207, https://github.com/jupyter/jupyter/pull/209
