### PR TITLE
docs(releases): provide an "example" notebook that looks at our download counts

### DIFF
--- a/example-notebooks/download-stats.ipynb
+++ b/example-notebooks/download-stats.ipynb
@@ -1,0 +1,340 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# Download counts for nteract"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import IPython.display\n",
+    "import pandas as pd"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "import requests\n",
+    "\n",
+    "# Note: \n",
+    "data = requests.get('https://api.github.com/repos/nteract/nteract/releases').json()"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "print(\"{}:\\n\\t{}\\n\\t{}\".format(\n",
+    "  data[0]['tag_name'],\n",
+    "  data[0]['assets'][0]['browser_download_url'],\n",
+    "  data[0]['assets'][0]['download_count']\n",
+    "))\n"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "text": [
+      "v0.0.13:\n",
+      "\thttps://github.com/nteract/nteract/releases/download/v0.0.13/nteract-darwin-x64.zip\n",
+      "\t39\n"
+     ],
+     "output_type": "stream"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "The releases API only has context of the filename, so we'll convert:\n",
+    "\n",
+    "```\n",
+    "https://github.com/nteract/nteract/releases/download/v0.0.13/nteract-darwin-x64.zip\n",
+    "```\n",
+    "\n",
+    "to\n",
+    "\n",
+    "```\n",
+    "darwin-x64\n",
+    "```\n",
+    "\nWhich means we're reliant on our release naming to keep this a nice consistent structure"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "def strip_off_release(browser_download_url):\n",
+    "    filename = browser_download_url.split('/')[-1]\n",
+    "    basename = filename.split('.')[0]\n",
+    "    system = basename.split('-')[1:]\n",
+    "    return \"-\".join(system)"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "releases = [\n",
+    "  {\n",
+    "    'version': x['tag_name'], \n",
+    "    'counts': { strip_off_release(y['browser_download_url']): y['download_count'] for y in x['assets'] }\n",
+    "  } \n",
+    "    for x in data\n",
+    "]\n",
+    "releases"
+   ],
+   "outputs": [
+    {
+     "execution_count": 18,
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "[{'counts': {'darwin-x64': 39, 'linux-x64': 88, 'win32-x64': 8},\n",
+       "  'version': 'v0.0.13'},\n",
+       " {'counts': {'darwin-x64': 108}, 'version': 'v0.0.12'},\n",
+       " {'counts': {'darwin-x64': 5}, 'version': 'v0.0.11'},\n",
+       " {'counts': {'darwin-x64': 15, 'linux-x64': 11}, 'version': 'v0.0.10'},\n",
+       " {'counts': {'darwin-x64': 10}, 'version': 'v0.0.9'},\n",
+       " {'counts': {'darwin-x64': 20, 'linux-x64': 1}, 'version': 'v0.0.8'},\n",
+       " {'counts': {'darwin-x64': 41}, 'version': 'v0.0.7'},\n",
+       " {'counts': {'darwin-x64': 2}, 'version': 'v0.0.6'},\n",
+       " {'counts': {'darwin-x64': 30}, 'version': 'v0.0.5'},\n",
+       " {'counts': {'darwin-x64': 8}, 'version': 'v0.0.4'},\n",
+       " {'counts': {'linux-ia32': 3, 'linux-x64': 18, 'os-x': 110},\n",
+       "  'version': 'v0.0.3'},\n",
+       " {'counts': {'linux-ia32': 0, 'linux-x64': 0, 'os-x': 4}, 'version': 'v0.0.2'}]"
+      ]
+     },
+     "output_type": "execute_result"
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "versions = []\n",
+    "frames = []\n",
+    "\n",
+    "for release in releases:\n",
+    "    versions.append(release['version'])\n",
+    "    frames.append(pd.DataFrame.from_dict(release['counts'], orient='index'))\n",
+    "\npd.concat(frames, keys=versions)"
+   ],
+   "outputs": [
+    {
+     "execution_count": 19,
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "                      0\n",
+       "v0.0.13 win32-x64     8\n",
+       "        darwin-x64   39\n",
+       "        linux-x64    88\n",
+       "v0.0.12 darwin-x64  108\n",
+       "v0.0.11 darwin-x64    5\n",
+       "v0.0.10 darwin-x64   15\n",
+       "        linux-x64    11\n",
+       "v0.0.9  darwin-x64   10\n",
+       "v0.0.8  darwin-x64   20\n",
+       "        linux-x64     1\n",
+       "v0.0.7  darwin-x64   41\n",
+       "v0.0.6  darwin-x64    2\n",
+       "v0.0.5  darwin-x64   30\n",
+       "v0.0.4  darwin-x64    8\n",
+       "v0.0.3  os-x        110\n",
+       "        linux-x64    18\n",
+       "        linux-ia32    3\n",
+       "v0.0.2  os-x          4\n",
+       "        linux-x64     0\n",
+       "        linux-ia32    0"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">v0.0.13</th>\n",
+       "      <th>win32-x64</th>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>39</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-x64</th>\n",
+       "      <td>88</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.12</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>108</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.11</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">v0.0.10</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>15</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-x64</th>\n",
+       "      <td>11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.9</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">v0.0.8</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-x64</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.7</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>41</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.6</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.5</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>v0.0.4</th>\n",
+       "      <th>darwin-x64</th>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">v0.0.3</th>\n",
+       "      <th>os-x</th>\n",
+       "      <td>110</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-x64</th>\n",
+       "      <td>18</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-ia32</th>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"3\" valign=\"top\">v0.0.2</th>\n",
+       "      <th>os-x</th>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-x64</th>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>linux-ia32</th>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "output_type": "execute_result"
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It would be really interesting to know how these counts change over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  }
+ ],
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "language": "python",
+   "display_name": "Python 3"
+  },
+  "kernel_info": {
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "mimetype": "text/x-python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ }
+}


### PR DESCRIPTION
Dog fooding our app by taking a look at download counts.

Some improvements I'd love to see (which I can post an issue for, def new-contributor-friendly):
- Rely completely on pandas for fetching the json and stripping out what we need (potentially)
- Plot with x-axis being version, y-axis being count, and a line for each download type
