### PR TITLE
chore(Cell): Add Flow types to Cell, edited .flowconfig to reduce errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,18 @@
                 "ignoreUrls": true,
                 "ignoreTemplateLiterals": true
             }
+        ],
+        "react/sort-comp": [
+          1,
+          {
+            order: [
+              'type-annotations',
+              'static-methods',
+              'lifecycle',
+              'everything-else',
+              'render'
+            ]
+          }
         ]
   },
   "settings": {

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,7 @@
+[options]
+module.ignore_non_literal_requires=true
+
 [ignore]
-.*node_modules/*
+node_modules/
 .*static/*
 .*test/*

--- a/src/notebook/components/cell/cell-creator-buttons.js
+++ b/src/notebook/components/cell/cell-creator-buttons.js
@@ -11,7 +11,14 @@ import {
   mergeCellAfter,
 } from '../../actions';
 
+type Props = {
+  above: boolean,
+  id: string,
+};
+
 export class CellCreatorButtons extends React.Component {
+  props: Props;
+
   static contextTypes = {
     store: React.PropTypes.object,
   };
@@ -28,11 +35,6 @@ export class CellCreatorButtons extends React.Component {
   shouldComponentUpdate() {
     return false;
   }
-
-  props: {
-    above: boolean,
-    id: string,
-  };
 
   createCell(type) {
     if (!this.props.id) {

--- a/src/notebook/components/cell/cell-creator.js
+++ b/src/notebook/components/cell/cell-creator.js
@@ -4,8 +4,13 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 import CellCreatorButtons from './cell-creator-buttons';
 
-export default class CellCreator extends React.Component {
+type Props = {
+    above: boolean,
+    id: string,
+};
 
+export default class CellCreator extends React.Component {
+  props: Props;
 
   constructor() {
     super();
@@ -33,11 +38,6 @@ export default class CellCreator extends React.Component {
   setHoverElement(el) {
     this.hoverElement = el;
   }
-
-  props: {
-    above: boolean,
-    id: string,
-  };
 
   updateVisibility(mouseEvent) {
     if (this.hoverElement) {

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -1,8 +1,9 @@
+/* @flow weak */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-import Immutable from 'immutable';
+import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import CodeCell from './code-cell';
 import MarkdownCell from './markdown-cell';
@@ -14,18 +15,19 @@ import {
   focusNextCell,
 } from '../../actions';
 
+type Props = {
+  cell: any,
+  displayOrder: ImmutableList<any>,
+  id: string,
+  focusedCell: string,
+  language: string,
+  running: boolean,
+  theme: string,
+  pagers: ImmutableList<any>,
+  transforms: ImmutableMap<any>,
+};
+
 export class Cell extends React.Component {
-  static propTypes = {
-    cell: React.PropTypes.any,
-    displayOrder: React.PropTypes.instanceOf(Immutable.List),
-    id: React.PropTypes.string,
-    focusedCell: React.PropTypes.string,
-    language: React.PropTypes.string,
-    running: React.PropTypes.bool,
-    theme: React.PropTypes.string,
-    pagers: React.PropTypes.instanceOf(Immutable.List),
-    transforms: React.PropTypes.instanceOf(Immutable.Map),
-  };
 
   static contextTypes = {
     store: React.PropTypes.object,
@@ -39,6 +41,8 @@ export class Cell extends React.Component {
     this.focusBelowCell = this.focusBelowCell.bind(this);
     this.setCellHoverState = this.setCellHoverState.bind(this);
   }
+
+  props: Props;
 
   state = {
     hoverCell: false,

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -28,6 +28,7 @@ type Props = {
 };
 
 export class Cell extends React.Component {
+  props: Props;
 
   static contextTypes = {
     store: React.PropTypes.object,
@@ -41,8 +42,6 @@ export class Cell extends React.Component {
     this.focusBelowCell = this.focusBelowCell.bind(this);
     this.setCellHoverState = this.setCellHoverState.bind(this);
   }
-
-  props: Props;
 
   state = {
     hoverCell: false,

--- a/src/notebook/components/cell/inputs.js
+++ b/src/notebook/components/cell/inputs.js
@@ -2,16 +2,18 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
+type Props = {
+  executionCount: any,
+  running: boolean,
+};
+
 export default class Inputs extends React.Component {
+  props: Props;
+
   constructor(props) {
     super(props);
     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
   }
-
-  props: {
-    executionCount: any,
-    running: boolean,
-  };
 
   render() {
     const { executionCount, running } = this.props;

--- a/src/notebook/components/status-bar.js
+++ b/src/notebook/components/status-bar.js
@@ -3,7 +3,16 @@
 import React from 'react';
 import moment from 'moment';
 
+type Props = {
+  notebook: any,
+  lastSaved: typeof Date,
+  kernelSpecName: string,
+  executionState: string,
+};
+
 export default class StatusBar extends React.Component {
+  props: Props;
+
   shouldComponentUpdate(nextProps) {
     if (this.props.notebook !== nextProps.notebook ||
         this.props.lastSaved !== nextProps.lastSaved) {
@@ -11,13 +20,6 @@ export default class StatusBar extends React.Component {
     }
     return false;
   }
-
-  props: {
-    notebook: any,
-    lastSaved: typeof Date,
-    kernelSpecName: string,
-    executionState: string,
-  };
 
   render() {
     return (


### PR DESCRIPTION
Happy Hacktoberfest!

As requested, I added Flow typing for the props of the Cell component. When I ran Flow, I noticed a lot of node_module errors and adjusted the flowconfig to suppress those errors. Please let me know if you would also like me to Flow type the rest of the file. There are still a lot of errors when you run Flow because nothing else is typed. Also, I created an actual type for Props instead of defining them inline like this PR: 
https://github.com/nteract/nteract/blob/master/src/notebook/components/status-bar.js#L15-L20

I have no problem reverting to inline, just wasn't sure what you preferred.

Here's a list of the remaining Flow errors, I'd be happy to clean them up for you! :)

``` bash

src/notebook/components/cell/cell-creator-buttons.js:21
 21:     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
              ^^^^^^^^^^^^^^^^^^^^^ property `shouldComponentUpdate`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator-buttons.js:22
 22:     this.createCodeCell = this.createCell.bind(this, 'code');
              ^^^^^^^^^^^^^^ property `createCodeCell`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator-buttons.js:23
 23:     this.createTextCell = this.createCell.bind(this, 'markdown');
              ^^^^^^^^^^^^^^ property `createTextCell`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator-buttons.js:24
 24:     this.createCell = this.createCell.bind(this);
              ^^^^^^^^^^ property `createCell`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator-buttons.js:25
 25:     this.mergeCell = this.mergeCell.bind(this);
              ^^^^^^^^^ property `mergeCell`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator-buttons.js:37
 37:   createCell(type) {
                  ^^^^ parameter `type`. Missing annotation

src/notebook/components/cell/cell-creator-buttons.js:61
 61:         <button onClick={this.createTextCell} title="create text cell" className="add-text-cell">
                                   ^^^^^^^^^^^^^^ property `createTextCell`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator-buttons.js:64
 64:         <button onClick={this.createCodeCell} title="create code cell" className="add-code-cell">
                                   ^^^^^^^^^^^^^^ property `createCodeCell`. Property not found in
 14: export class CellCreatorButtons extends React.Component {
                  ^^^^^^^^^^^^^^^^^^ CellCreatorButtons

src/notebook/components/cell/cell-creator.js:12
 12:     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
              ^^^^^^^^^^^^^^^^^^^^^ property `shouldComponentUpdate`. Property not found in
  7: export default class CellCreator extends React.Component {
                          ^^^^^^^^^^^ CellCreator

src/notebook/components/cell/cell-creator.js:13
 13:     this.setHoverElement = this.setHoverElement.bind(this);
              ^^^^^^^^^^^^^^^ property `setHoverElement`. Property not found in
  7: export default class CellCreator extends React.Component {
                          ^^^^^^^^^^^ CellCreator

src/notebook/components/cell/cell-creator.js:14
 14:     this.updateVisibility = this.updateVisibility.bind(this);
              ^^^^^^^^^^^^^^^^ property `updateVisibility`. Property not found in
  7: export default class CellCreator extends React.Component {
                          ^^^^^^^^^^^ CellCreator

src/notebook/components/cell/cell-creator.js:33
 33:   setHoverElement(el) {
                       ^^ parameter `el`. Missing annotation

src/notebook/components/cell/cell-creator.js:34
 34:     this.hoverElement = el;
              ^^^^^^^^^^^^ property `hoverElement`. Property not found in
  7: export default class CellCreator extends React.Component {
                          ^^^^^^^^^^^ CellCreator

src/notebook/components/cell/cell-creator.js:42
 42:   updateVisibility(mouseEvent) {
                        ^^^^^^^^^^ parameter `mouseEvent`. Missing annotation

src/notebook/components/cell/cell-creator.js:46
 46:       const regionRect = this.hoverElement.getBoundingClientRect();
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `getBoundingClientRect`. Method cannot be called on
 46:       const regionRect = this.hoverElement.getBoundingClientRect();
                              ^^^^^^^^^^^^^^^^^ property `hoverElement` of unknown type

src/notebook/components/cell/cell.js:38
 38:     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
              ^^^^^^^^^^^^^^^^^^^^^ property `shouldComponentUpdate`. Property not found in
 30: export class Cell extends React.Component {
                  ^^^^ Cell

src/notebook/components/cell/cell.js:39
 39:     this.selectCell = this.selectCell.bind(this);
              ^^^^^^^^^^ property `selectCell`. Property not found in
 30: export class Cell extends React.Component {
                  ^^^^ Cell

src/notebook/components/cell/cell.js:40
 40:     this.focusAboveCell = this.focusAboveCell.bind(this);
              ^^^^^^^^^^^^^^ property `focusAboveCell`. Property not found in
 30: export class Cell extends React.Component {
                  ^^^^ Cell

src/notebook/components/cell/cell.js:41
 41:     this.focusBelowCell = this.focusBelowCell.bind(this);
              ^^^^^^^^^^^^^^ property `focusBelowCell`. Property not found in
 30: export class Cell extends React.Component {
                  ^^^^ Cell

src/notebook/components/cell/cell.js:42
 42:     this.setCellHoverState = this.setCellHoverState.bind(this);
              ^^^^^^^^^^^^^^^^^ property `setCellHoverState`. Property not found in
 30: export class Cell extends React.Component {
                  ^^^^ Cell

src/notebook/components/cell/inputs.js:6
  6:   constructor(props) {
                   ^^^^^ parameter `props`. Missing annotation

src/notebook/components/cell/inputs.js:8
  8:     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
              ^^^^^^^^^^^^^^^^^^^^^ property `shouldComponentUpdate`. Property not found in
  5: export default class Inputs extends React.Component {
                          ^^^^^^ Inputs

r 8b5e2a6 Fixed flowconfig to avoid node_modules related errors
fix(flowconfig): Fixed flowconfig to avoid node_modules related errors

Found 22 errors
```
