### PR TITLE
chore(Components): Resolved all Flow errors for typed components

### DIFF
--- a/src/notebook/components/cell/cell-creator-buttons.js
+++ b/src/notebook/components/cell/cell-creator-buttons.js
@@ -1,7 +1,7 @@
 /* eslint class-methods-use-this: 0 */
 // @flow
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { connect } from 'react-redux';
 
 import {
@@ -18,25 +18,30 @@ type Props = {
 
 export class CellCreatorButtons extends React.Component {
   props: Props;
+  shouldComponentUpdate: (p: Props, s: any) => boolean;
+  createCodeCell: (type: string) => void;
+  createTextCell: (type: string) => void;
+  createCell: (type: string) => void;
+  mergeCell: () => void;
 
   static contextTypes = {
     store: React.PropTypes.object,
   };
 
-  constructor() {
+  constructor(): void {
     super();
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.createCodeCell = this.createCell.bind(this, 'code');
     this.createTextCell = this.createCell.bind(this, 'markdown');
     this.createCell = this.createCell.bind(this);
     this.mergeCell = this.mergeCell.bind(this);
   }
 
-  shouldComponentUpdate() {
+  shouldComponentUpdate(p: Props, s: any): boolean {
     return false;
   }
 
-  createCell(type) {
+  createCell(type: string): void {
     if (!this.props.id) {
       this.context.store.dispatch(createCellAppend(type));
       return;
@@ -49,11 +54,11 @@ export class CellCreatorButtons extends React.Component {
     }
   }
 
-  mergeCell() {
+  mergeCell(): void {
     this.context.store.dispatch(mergeCellAfter(this.props.id));
   }
 
-  render() {
+  render(): ?React.Element<any> {
     const mergeButton = (
       <button onClick={this.mergeCell} title="merge cells">
         <span className="octicon octicon-arrow-up" />

--- a/src/notebook/components/cell/cell-creator.js
+++ b/src/notebook/components/cell/cell-creator.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import CellCreatorButtons from './cell-creator-buttons';
 
@@ -9,12 +9,21 @@ type Props = {
     id: string,
 };
 
+type State = {
+    show: boolean,
+};
+
 export default class CellCreator extends React.Component {
   props: Props;
+  state: State;
+  shouldComponentUpdate: (p: Props, s: State) => boolean;
+  setHoverElement: (el: Object) => void;
+  updateVisibility: (mouseEvent: Object) => void;
+  hoverElement: Object;
 
-  constructor() {
+  constructor(): void {
     super();
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.setHoverElement = this.setHoverElement.bind(this);
     this.updateVisibility = this.updateVisibility.bind(this);
   }
@@ -23,7 +32,7 @@ export default class CellCreator extends React.Component {
     show: false,
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     // Listen to the page level mouse move event and manually check for
     // intersection because we don't want the hover region to actually capture
     // any mouse events.  The hover region is an invisible element that
@@ -31,15 +40,15 @@ export default class CellCreator extends React.Component {
     document.addEventListener('mousemove', this.updateVisibility, false);
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     document.removeEventListener('mousemove', this.updateVisibility);
   }
 
-  setHoverElement(el) {
+  setHoverElement(el: Object): void {
     this.hoverElement = el;
   }
 
-  updateVisibility(mouseEvent) {
+  updateVisibility(mouseEvent: Object): void {
     if (this.hoverElement) {
       const x = mouseEvent.clientX;
       const y = mouseEvent.clientY;
@@ -51,7 +60,7 @@ export default class CellCreator extends React.Component {
   }
 
 
-  render() {
+  render(): ?React.Element<any> {
     return (
       <div className="creator-hover-mask">
         <div className="creator-hover-region" ref={this.setHoverElement}>

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -1,8 +1,7 @@
 /* @flow weak */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
-
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import CodeCell from './code-cell';
@@ -27,16 +26,26 @@ type Props = {
   transforms: ImmutableMap<any>,
 };
 
+type State = {
+  hoverCell: boolean,
+}
+
 export class Cell extends React.Component {
   props: Props;
+  state: State;
+  shouldComponentUpdate: (p: Props, s: State) => boolean;
+  selectCell: () => void;
+  focusAboveCell: () => void;
+  focusBelowCell: () => void;
+  setCellHoverState: (mouseEvent: Object) => void;
 
   static contextTypes = {
     store: React.PropTypes.object,
   };
 
-  constructor() {
+  constructor(): void {
     super();
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.selectCell = this.selectCell.bind(this);
     this.focusAboveCell = this.focusAboveCell.bind(this);
     this.focusBelowCell = this.focusBelowCell.bind(this);
@@ -47,7 +56,7 @@ export class Cell extends React.Component {
     hoverCell: false,
   };
 
-  componentDidMount() {
+  componentDidMount(): void {
     // Listen to the page level mouse move event and manually check for
     // intersection because we don't want the hover region to actually capture
     // any mouse events.  The hover region is an invisible element that
@@ -55,11 +64,11 @@ export class Cell extends React.Component {
     document.addEventListener('mousemove', this.setCellHoverState, false);
   }
 
-  componentWillUnmount() {
+  componentWillUnmount(): void {
     document.removeEventListener('mousemove', this.setCellHoverState);
   }
 
-  setCellHoverState(mouseEvent) {
+  setCellHoverState(mouseEvent: Object): void {
     if (this.refs.cell) {
       const cell = ReactDOM.findDOMNode(this.refs.cell);
       if (cell) {
@@ -73,19 +82,19 @@ export class Cell extends React.Component {
     }
   }
 
-  selectCell() {
+  selectCell(): void {
     this.context.store.dispatch(focusCell(this.props.id));
   }
 
-  focusAboveCell() {
+  focusAboveCell(): void {
     this.context.store.dispatch(focusPreviousCell(this.props.id));
   }
 
-  focusBelowCell() {
+  focusBelowCell(): void {
     this.context.store.dispatch(focusNextCell(this.props.id, true));
   }
 
-  render() {
+  render(): ?React.Element<any> {
     const cell = this.props.cell;
     const type = cell.get('cell_type');
     const focused = this.props.focusedCell === this.props.id;

--- a/src/notebook/components/cell/inputs.js
+++ b/src/notebook/components/cell/inputs.js
@@ -1,6 +1,6 @@
 // @flow
-import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import React from 'react';
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 type Props = {
   executionCount: any,
@@ -8,14 +8,15 @@ type Props = {
 };
 
 export default class Inputs extends React.Component {
-  props: Props;
+  props: Props
+  shouldComponentUpdate: (p: Props, s: void) => boolean;
 
-  constructor(props) {
-    super(props);
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
+  constructor(): void {
+    super();
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
   }
 
-  render() {
+  render(): ?React.Element<any> {
     const { executionCount, running } = this.props;
     const count = !executionCount ? ' ' : executionCount;
     const input = running ? '*' : count;


### PR DESCRIPTION
Hey nteract team! I resolved all Flow errors for the components that were previously typed. I tried to maintain as much of the project's original style as I could, but I'm open for suggestions if you would like to make any adjustments. :)

```
❯ npm run flow

> nteract@0.0.13 flow /Users/mrayzis/projects/open-source/nteract
> flow; test $? -eq 0 -o $? -eq 2

No errors!
```
