### PR TITLE
chore(deps): fully migrate off of transformime-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "rxjs": "^5.0.0-beta.12",
     "shell-env": "^0.2.0",
     "spawnteract": "^2.2.0",
-    "transformime-react": "^1.1.0",
     "uuid": "^2.0.3",
     "yargs": "^6.0.0"
   },

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -12,7 +12,7 @@ chai.use(sinonChai);
 
 import { Cell } from '../../../../src/notebook/components/cell/cell';
 import * as commutable from 'commutable';
-import { displayOrder, transforms } from 'transformime-react';
+import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 const sharedProps = { displayOrder, transforms };
 describe('Cell', () => {

--- a/test/renderer/components/cell/code-cell-spec.js
+++ b/test/renderer/components/cell/code-cell-spec.js
@@ -6,7 +6,7 @@ import {expect} from 'chai';
 
 import CodeCell from '../../../../src/notebook/components/cell/code-cell';
 import * as commutable from 'commutable';
-import { displayOrder, transforms } from 'transformime-react';
+import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 const sharedProps = { displayOrder, transforms };
 describe('CodeCell', () => {

--- a/test/renderer/components/cell/display-area/richest-mime-spec.js
+++ b/test/renderer/components/cell/display-area/richest-mime-spec.js
@@ -11,7 +11,7 @@ chai.use(sinonChai);
 
 import RichestMime from '../../../../../src/notebook/components/cell/display-area/richest-mime'
 import * as commutable from 'commutable';
-import { displayOrder, transforms } from 'transformime-react';
+import { displayOrder, transforms } from '../../../../../src/notebook/components/transforms';
 
 describe('RichestMime', () => {
   it('renders a mimebundle', () => {

--- a/test/renderer/components/cell/draggable-cell-spec.js
+++ b/test/renderer/components/cell/draggable-cell-spec.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 
 import DraggableCell from '../../../../src/notebook/components/cell/draggable-cell';
 import * as commutable from 'commutable';
-import { displayOrder, transforms } from 'transformime-react';
+import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 // Spoof DND manager for tests.
 const dragDropManager = {

--- a/test/renderer/components/cell/markdown-cell-spec.js
+++ b/test/renderer/components/cell/markdown-cell-spec.js
@@ -14,7 +14,7 @@ import {
 } from '../../../../src/notebook/actions';
 
 import * as commutable from 'commutable';
-import { displayOrder, transforms } from 'transformime-react';
+import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 import { dummyStore } from '../../../utils';
 

--- a/test/renderer/components/notebook-spec.js
+++ b/test/renderer/components/notebook-spec.js
@@ -4,7 +4,7 @@ import { shallow, mount } from 'enzyme';
 
 import Immutable from 'immutable';
 
-import { displayOrder, transforms } from 'transformime-react';
+import { displayOrder, transforms } from '../../../src/notebook/components/transforms';
 
 const TestBackend = require('react-dnd-test-backend');
 import { DragDropContext } from 'react-dnd';


### PR DESCRIPTION
Circling back on updating tests and removing the dependency now that it's part of nteract/nteract.
