### PR TITLE
chore(deps): bump enchannel-zmq-backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "electron-json-storage": "^2.0.0",
     "electron-log": "^1.1.0",
     "enchannel": "^1.1.3",
-    "enchannel-zmq-backend": "^2.3.1",
+    "enchannel-zmq-backend": "^2.4.0",
     "github": "^4.0.0",
     "home-dir": "^1.0.0",
     "immutable": "^3.7.6",


### PR DESCRIPTION
Bringing us up to date with `zmq-prebuilt` from deep within.

/cc @lgeiger @captainsafia 

We can _probably_ evaluate upgrading electron after this too, using the `rebuild` that Lukas outlined.
