### PR TITLE
chore(deps): bump electron@1.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
 node_js:
 - '6'
 env:
+  global:
+  - CXX=g++-4.9
+  - CC=gcc-4.9
   matrix:
   - GROUP=coverage
   - GROUP=functional

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "greenkeeper": {
     "ignore": [
       "commonmark",
-      "electron-prebuilt",
       "redux-observable"
     ]
   },
@@ -114,10 +113,10 @@
     "chai": "^3.4.1",
     "chai-immutable": "^1.6.0",
     "cross-env": "^3.0.0",
+    "electron": "1.4.3",
     "electron-mocha": "^3.0.6",
     "electron-osx-sign": "^0.3.1",
     "electron-packager": "^8.0.0",
-    "electron-prebuilt": "1.1.3",
     "electron-react-devtools": "^0.4.0",
     "enzyme": "^2.2.0",
     "esdoc": "^0.4.8",

--- a/scripts/rebuild.js
+++ b/scripts/rebuild.js
@@ -1,25 +1,19 @@
 #!/usr/bin/env node
-if (process.platform === 'win32') {
-  var exec = require('child_process').exec;
-  var deps = require('../package.json').devDependencies;
-  var version = deps.electron || deps['electron-prebuilt'];
+var exec = require('child_process').exec;
+var deps = require('../package.json').devDependencies;
+var version = deps.electron || deps['electron-prebuilt'];
 
-  if (typeof version != 'string' || version.search(/>|<|~|\*|x/) > -1) {
-    throw Error('No explicit electron version in package.json found.')
-  };
+if (typeof version != 'string' || version.search(/>|<|~|\*|x/) > -1) {
+  throw Error('No explicit electron version in package.json found.')
+};
 
-  var cmd = 'npm rebuild zmq-prebuilt --runtime=electron --target=' + version +
-    ' --disturl=https://atom.io/download/atom-shell --build-from-source'
+var cmd = 'npm rebuild zmq-prebuilt --runtime=electron --target=' + version +
+  ' --disturl=https://atom.io/download/atom-shell --build-from-source'
 
-  exec(cmd, function(err, stdout, stderr) {
-    console.log(stdout);
-    console.log(stderr);
-    if (err) {
-      throw err;
-    }
-  });
-} else if (process.platform === 'linux' || process.platform === 'darwin') {
-  console.log('No postinstall step required for platform' + process.platform);
-} else {
-  console.log(process.platform + ' is not yet supported.');
-}
+exec(cmd, function(err, stdout, stderr) {
+  console.log(stdout);
+  console.log(stderr);
+  if (err) {
+    throw err;
+  }
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -66,6 +66,8 @@ mock('plotly.js/dist/plotly', {
   'newPlot': function(data, layout, config) {},
 })
 
+mock('enchannel-zmq-backend', {})
+
 mock('electron', {
   'shell': {
     'openExternal': function(url) { },


### PR DESCRIPTION
Bump electron version, build zmq for electron on `npm install`.

Pros:
- It lets us move to a new Electron version (and every new one after)

Cons:
- This requires linux and mac developers to have [build tools](https://github.com/nteract/zmq-prebuilt/#installation---contributors-and-development) installed

I don't expect us to merge this right away since it'll make installation on linux and os x a lot harder. Just try it out.
