### PR TITLE
chore(addScript): Add kernelspec script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "dist:osx": "npm run dist -- --platform=darwin --arch=x64 --icon ./static/icon.icns --extend-info=./static/extend.plist --app-category-type=public.app-category.developer-tools --app-bundle-id=io.nteract.nteract",
     "dist:osx:signed": "npm run dist:osx -- --osx-sign",
     "dist:win": "npm run dist -- --platform=win32 --icon ./static/icon.ico",
-    "flow": "flow; test $? -eq 0 -o $? -eq 2"
+    "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "diagnostics": "scripts/kernelspecs.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/kernelspecs.js
+++ b/scripts/kernelspecs.js
@@ -1,1 +1,2 @@
+#!/usr/bin/env node
 require('kernelspecs').findAll().then(console.log.bind(console)).catch(console.error.bind(console))

--- a/scripts/kernelspecs.js
+++ b/scripts/kernelspecs.js
@@ -1,0 +1,1 @@
+require('kernelspecs').findAll().then(console.log.bind(console)).catch(console.error.bind(console))


### PR DESCRIPTION
When debugging kernelspec problems, this script lists all available kernels. We can just ask that a user with problems runs `node scripts/kernelspec.js`. We can also add this to the package.json scripts. 
