### PR TITLE
Refactor out some string refs, improve app perf

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -69,17 +69,12 @@ export class Cell extends React.Component {
   }
 
   setCellHoverState(mouseEvent: MouseEvent): void {
-    if (this.refs.cell) {
-      const cell = ReactDOM.findDOMNode(this.refs.cell);
-      if (cell) {
-        const x = mouseEvent.clientX;
-        const y = mouseEvent.clientY;
-        const regionRect = cell.getBoundingClientRect();
-        const hoverCell = (regionRect.left < x && x < regionRect.right) &&
-                     (regionRect.top < y && y < regionRect.bottom);
-        this.setState({ hoverCell });
-      }
-    }
+    const x = mouseEvent.clientX;
+    const y = mouseEvent.clientY;
+    const regionRect = this.cellDiv.getBoundingClientRect();
+    const hoverCell = (regionRect.left < x && x < regionRect.right) &&
+                 (regionRect.top < y && y < regionRect.bottom);
+    this.setState({ hoverCell });
   }
 
   selectCell(): void {
@@ -102,7 +97,7 @@ export class Cell extends React.Component {
       <div
         className={`cell ${type === 'markdown' ? 'text' : 'code'} ${focused ? 'focused' : ''}`}
         onClick={this.selectCell}
-        ref="cell"
+        ref={(el) => { this.cellDiv = el; }}
       >
         {
           focused ? <Toolbar

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -74,7 +74,10 @@ export class Cell extends React.Component {
     const regionRect = this.cellDiv.getBoundingClientRect();
     const hoverCell = (regionRect.left < x && x < regionRect.right) &&
                  (regionRect.top < y && y < regionRect.bottom);
-    this.setState({ hoverCell });
+
+    if (this.state.hoverCell !== hoverCell) {
+      this.setState({ hoverCell });
+    }
   }
 
   selectCell(): void {

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -161,10 +161,10 @@ export default class Editor extends React.Component {
   componentDidMount() {
     // On first load, if focused, set codemirror to focus
     if (this.props.focused) {
-      this.refs.codemirror.focus();
+      this.codemirror.focus();
     }
 
-    const cm = this.refs.codemirror.getCodeMirror();
+    const cm = this.codemirror.getCodeMirror();
     cm.on('topBoundary', this.props.focusAbove);
     cm.on('bottomBoundary', this.props.focusBelow);
 
@@ -194,15 +194,15 @@ export default class Editor extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.focused && prevProps.focused !== this.props.focused) {
-      this.refs.codemirror.focus();
+      this.codemirror.focus();
     } else if (!this.props.focused && prevProps.focused !== this.props.focused) {
-      const cm = this.refs.codemirror.getCodeMirror();
+      const cm = this.codemirror.getCodeMirror();
       cm.getInputField().blur();
     }
 
     if (this.theme !== this.props.theme) {
       this.theme = this.props.theme;
-      this.refs.codemirror.getCodeMirror().refresh();
+      this.codemirror.getCodeMirror().refresh();
     }
   }
 
@@ -255,7 +255,7 @@ export default class Editor extends React.Component {
       <div className="input">
         <CodeMirror
           value={this.state.source}
-          ref="codemirror"
+          ref={(el) => { this.codemirror = el; }}
           className="cell_cm"
           options={options}
           onChange={this.onChange}


### PR DESCRIPTION
This refactors out a few components that still relied on string refs and `findDOMNode`.

While I was at it I noticed something that really helps performance in the notebook. Our global handlers for seeing if the mouse was hovering over a cell were firing `setState` _every time the mouse was moved_. 😨 
