### PR TITLE
refactor(refs): Remove all usage of string refs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,6 @@
       "camelcase": [0],
       "no-console": [2, { allow: ["warn", "error"] }],
       "no-underscore-dangle": [0],
-       "react/no-string-refs": [0],
        "import/prefer-default-export": [0],
        "import/no-named-as-default": [0],
        "react/forbid-prop-types": [0],

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -111,6 +111,7 @@ export class Notebook extends React.Component {
     this.createStickyCellElement = this.createStickyCellElement.bind(this);
     this.keyDown = this.keyDown.bind(this);
     this.moveCell = this.moveCell.bind(this);
+    this.cellElements = new ImmutableMap();
   }
 
   componentDidMount(): void {
@@ -176,7 +177,7 @@ export class Notebook extends React.Component {
     const viewportHeight = window.innerHeight;
     const viewportOffset = document.body.scrollTop;
 
-    const focusedCell = this.refs[id];
+    const focusedCell = this.cellElements.get(id);
 
     if (focusedCell) {
       const cellTop = focusedCell.offsetTop;
@@ -206,7 +207,8 @@ export class Notebook extends React.Component {
       cell,
       language: getLanguageMode(this.props.notebook),
       key: id,
-      ref: id,
+      // TODO: This map _has_ to be cleaned up when cells are deleted
+      ref: (el) => { this.cellElements = this.cellElements.set(id, el); },
       displayOrder: this.props.displayOrder,
       transforms: this.props.transforms,
       moveCell: this.moveCell,

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -229,7 +229,7 @@ export class Notebook extends React.Component {
     const CellComponent = this.props.CellComponent;
 
     return (
-      <div key={`cell-container-${id}`} ref="container">
+      <div key={`cell-container-${id}`}>
         {isStickied ?
           <div className="cell-placeholder">
             <span className="octicon octicon-link-external" />
@@ -243,7 +243,7 @@ export class Notebook extends React.Component {
     const cellMap = this.props.notebook.get('cellMap');
     const cell = cellMap.get(id);
     return (
-      <div key={`cell-container-${id}`} ref="container">
+      <div key={`cell-container-${id}`}>
         <Cell {...this.createCellProps(id, cell)} />
       </div>);
   }
@@ -257,7 +257,7 @@ export class Notebook extends React.Component {
     const cellOrder = this.props.notebook.get('cellOrder');
     return (
       <div>
-        <div className="notebook" ref="cells">
+        <div className="notebook">
           <div
             className="sticky-cells-placeholder"
             ref={(ref) => { this.stickyCellsPlaceholder = ref; }}

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -47,14 +47,16 @@ class App extends React.Component {
     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
   }
   componentDidMount() {
-    store.dispatch(setNotificationSystem(this.refs.notificationSystem));
+    store.dispatch(setNotificationSystem(this.notificationSystem));
   }
   render() { // eslint-disable-line class-methods-use-this
     return (
       <Provider store={store}>
         <div>
           <Notebook />
-          <NotificationSystem ref="notificationSystem" />
+          <NotificationSystem
+            ref={(notificationSystem) => { this.notificationSystem = notificationSystem; }}
+          />
           <link rel="stylesheet" href="../static/styles/main.css" />
         </div>
       </Provider>


### PR DESCRIPTION
This cleans up the last of string based refs in react components.

While doing this, I noticed the scariest use of refs in our app (once adapted), which is a ref to every cell. They don't get cleaned up when a cell is deleted. I think that the cells likely need to handle scroll position themselves rather than the overall notebook (by passing some amount of information).
