### PR TITLE
fix(JsonDisplay): Metadata prop is an Immutable Map

### DIFF
--- a/src/notebook/components/transforms/json.js
+++ b/src/notebook/components/transforms/json.js
@@ -66,7 +66,7 @@ export default class JsonDisplay extends React.Component {
   }
 
   shouldExpandNode(): boolean {
-    if (this.props.metadata && this.props.metadata.expanded) {
+    if (this.props.metadata && this.props.metadata.get('expanded')) {
       return true;
     }
     return false;

--- a/test/renderer/components/transforms/json-spec.js
+++ b/test/renderer/components/transforms/json-spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Immutable from 'immutable';
 
 import { expect } from 'chai';
 
@@ -27,7 +28,7 @@ describe('JsonDisplay', () => {
 
   it('should expand json tree if expanded metadata is true', () => {
     const data = { name: 'Octocat' };
-    const metadata = { expanded: true };
+    const metadata = Immutable.fromJS({ expanded: true });
     const component = shallow(
       <JsonDisplay data={data} theme='light' metadata={metadata} />
     );


### PR DESCRIPTION
Related to https://github.com/nteract/nteract/issues/962

I didn't notice in the previous PR for `JsonDisplay` that the `metadata` prop is passed in as an Immutable Map.
