### PR TITLE
chore(install): Check for python2.7

### DIFF
--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -20,7 +20,7 @@ if (process.platform === 'win32') {
     'make',
     'gcc',
     'wget',
-    'python2'
+    'python2.7'
   ];
 
   depedencies.forEach(function(dep) {


### PR DESCRIPTION
`python2.7` is preinstalled on a clean install of OS X or Ubuntu 16.04.
