### PR TITLE
chore(ci): disable cache for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ env:
   - GROUP=flow
 
 cache:
-  pip: true
   apt: true
-  directories:
-    - node_modules
 
 before_install:
   - source scripts/travis_before_install


### PR DESCRIPTION
We're running into some sort of breaking change with a linting rule. If we can clear the cache we can probably get around it.
