### PR TITLE
style(themes): style dropdown menus

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -420,7 +420,6 @@ code {
 /* Overwrite some of the hint Styling */
 
 .CodeMirror-hints {
-
   -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
   -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
   box-shadow: 2px 3px 5px rgba(0,0,0,.2);
@@ -455,12 +454,12 @@ li.CodeMirror-hint-active {
     display: none;
     opacity:  1.0;
     position: absolute;
-    left: 8px;
+    top: 0.2em;
+    right: 0;
     border-style: none;
-    padding: 10px;
-    padding-top: 0px;
-    padding-right: 0px;
+    padding: 0;
     font-size: 11px;
+    line-height: 1.5;
     margin: 20px 0;
     background-color: var(--dropdown-content);
 }
@@ -468,11 +467,16 @@ li.CodeMirror-hint-active {
 .dropdown__content ul {
     list-style: none;
     text-align: left;
-    padding-left: 5px;
+    padding: 0;
+    margin: 0;
     opacity: 1.0;
 }
 
-.dropdown__content ul li:hover {
+.dropdown__content li {
+  padding: 0.5rem;
+}
+
+.dropdown__content li:hover {
     background-color: var(--dropdown-content-hover);
     cursor: pointer;
 }

--- a/static/styles/theme-classic.css
+++ b/static/styles/theme-classic.css
@@ -12,8 +12,8 @@
   --toolbar-button: #aaa;
   --toolbar-button-hover: #555;
 
-  --dropdown-content: white;
-  --dropdown-content-hover: var(--toolbar-button-hover);
+  --dropdown-content: var(--cm-background);
+  --dropdown-content-hover: #eee;
 
   --pager-bg: white;
   --input-color: #3241a0;
@@ -137,4 +137,8 @@
   border-color: #66bb6a;
   border-left-width: 0px;
   background: linear-gradient(to right, #66bb6a -40px, #66bb6a 5px, transparent 5px, transparent 100%);
+}
+
+.dropdown__content ul {
+  box-shadow: -1px 1px 5px rgba(0,0,0,0.2);
 }

--- a/static/styles/theme-dark.css
+++ b/static/styles/theme-dark.css
@@ -12,8 +12,8 @@
   --toolbar-button: #aaa;
   --toolbar-button-hover: #555;
 
-  --dropdown-content: var(--cell-bg);
-  --dropdown-content-hover: var(--toolbar-button-hover);
+  --dropdown-content: var(--cell-bg-focus);
+  --dropdown-content-hover: var(--cell-bg-hover);
 
   --pager-bg: #111;
   --input-color: #fafafa;

--- a/static/styles/theme-halloween.css
+++ b/static/styles/theme-halloween.css
@@ -9,10 +9,10 @@
   --cell-bg-focus: #E26710;
 
   --toolbar-bg: rgba(255,255,255,0.3);
-  --toolbar-button: #aaa;
-  --toolbar-button-hover: #555;
+  --toolbar-button: rgba(255,255,255,0.75);
+  --toolbar-button-hover: #fff;
 
-  --dropdown-content: white;
+  --dropdown-content: rgba(255,255,255,0.85);
   --dropdown-content-hover:  var(--toolbar-button-hover);
 
   --pager-bg: #fafafa;

--- a/static/styles/theme-light.css
+++ b/static/styles/theme-light.css
@@ -12,8 +12,8 @@
   --toolbar-button: #aaa;
   --toolbar-button-hover: #555;
 
-  --dropdown-content: white;
-  --dropdown-content-hover: rgb(210,210,210);
+  --dropdown-content: var(--cell-bg-hover);
+  --dropdown-content-hover: var(--cell-bg-focus);
 
   --pager-bg: #fafafa;
   --input-color: #8c8a8e;

--- a/static/styles/theme-nteract.css
+++ b/static/styles/theme-nteract.css
@@ -5,7 +5,7 @@
   --primary-border: #495F7D;
 
   --cell-bg: #334863;
-  --cell-bg-hover: #495F7D;
+  --cell-bg-hover: var(--primary-border);
   --cell-bg-focus: #5e7697;
 
   --toolbar-bg: #fff;
@@ -13,7 +13,7 @@
   --toolbar-button-hover: var(--cell-bg);
 
   --dropdown-content: var(--main-bg-color);
-  --dropdown-content-hover: var(--toolbar-button-hover);
+  --dropdown-content-hover: var(--cm-background);
 
   --pager-bg: #354a66;
   --input-color: #fafafa;
@@ -352,21 +352,13 @@ ul li::before
 /* Dropdown Content */
 /* ---------------- */
 
-.dropdown__content {
-  right: 0;
+.notebook .dropdown__content {
   top: 0.75rem;
-  left: initial;
-  padding: 0 !important;
   border-radius: var(--border-radius) 0 0 var(--border-radius);
   box-shadow: var(--small-shadow);
 }
 
-.dropdown__content ul {
-  padding: 0;
-  margin: 0;
-}
-
-.dropdown__content li {
+.notebook .dropdown__content li {
   padding: 0.5rem;
 }
 


### PR DESCRIPTION
Recolor dropdown menus in Classic, Light, Dark, and Pumpkin Spice
Adjust global CSS for dropdowns to allow for better spacing
Modify CSS in nteract theme to compensate for the above

(Per conversation in #991)

Purely cosmetic! Shadows were only added to Classic (since a shadow was already used there), and no rounded corners were added because the other themes don't use them elsewhere. Partial transparency for the dropdown was used in Pumpkin Spice to match the cell toolbars.
# Light

![image](https://cloud.githubusercontent.com/assets/6765732/19369939/4f8b6f6e-916e-11e6-9a36-d9a3520b0813.png)
# Dark

![image](https://cloud.githubusercontent.com/assets/6765732/19369955/711256f2-916e-11e6-95ab-4fbf44d7e17b.png)
# Classic

![image](https://cloud.githubusercontent.com/assets/6765732/19369978/806d1eac-916e-11e6-93ec-8b63271806a1.png)
# Pumpkin Spice

![image](https://cloud.githubusercontent.com/assets/6765732/19370034/c30f7624-916e-11e6-8022-e93d46d69dcb.png)
