### PR TITLE
fix(display): scroll

### DIFF
--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -25,7 +25,7 @@ export default class Display extends React.Component {
     transforms,
     displayOrder,
     isHidden: false,
-    expanded: true,
+    expanded: false,
   };
 
   constructor() {
@@ -51,6 +51,12 @@ export default class Display extends React.Component {
       return true;
     }
 
+    // Since expanded is a boolean, we need to make sure it's a property directly.
+    if ({}.hasOwnProperty.call(nextProps, 'expanded') &&
+      nextProps.expanded !== this.props.expanded) {
+      return true;
+    }
+
     return false;
   }
 
@@ -59,7 +65,7 @@ export default class Display extends React.Component {
   }
 
   recomputeStyle() {
-    if (this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT) {
+    if (!this.props.expanded && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT) {
       this.el.style.height = `${DEFAULT_SCROLL_HEIGHT}px`;
       this.el.style.overflowY = 'scroll';
       return;

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -16,6 +16,8 @@ type Props = {
   isHidden: boolean,
 }
 
+const DEFAULT_SCROLL_HEIGHT = 300;
+
 export default class Display extends React.Component {
   props: Props;
 
@@ -25,6 +27,15 @@ export default class Display extends React.Component {
     isHidden: false,
     expanded: true,
   };
+
+  constructor() {
+    super();
+    this.recomputeStyle = this.recomputeStyle.bind(this);
+  }
+
+  componentDidMount() {
+    this.recomputeStyle();
+  }
 
   shouldComponentUpdate(nextProps: Props): boolean {
     if (!nextProps || !this.props) {
@@ -43,17 +54,28 @@ export default class Display extends React.Component {
     return false;
   }
 
+  componentDidUpdate() {
+    this.recomputeStyle();
+  }
+
+  recomputeStyle() {
+    if (this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT) {
+      this.el.style.height = `${DEFAULT_SCROLL_HEIGHT}px`;
+      this.el.style.overflowY = 'scroll';
+      return;
+    }
+
+    this.el.style.height = 'auto';
+    this.el.style.overflowY = 'overflow';
+  }
+
   render() {
     const order = this.props.displayOrder;
     const tf = this.props.transforms;
-    const style = {
-      height: this.props.expanded ? '300px' : 'auto',
-      overflow: this.props.expanded ? 'scroll' : 'overflow',
-    };
 
     if (!this.props.isHidden) {
       return (
-        <div className="cell_display" style={style}>
+        <div className="cell_display" ref={(el) => { this.el = el; }}>
           {
             this.props.outputs.map((output, index) =>
               <Output

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react';
 
-import Immutable, { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+
+import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import { transforms, displayOrder } from '../../transforms';
 
@@ -20,6 +22,9 @@ const DEFAULT_SCROLL_HEIGHT = 300;
 
 export default class Display extends React.Component {
   props: Props;
+  shouldComponentUpdate: (p: Props, s: any) => boolean;
+  recomputeStyle: () => void;
+  el: HTMLElement;
 
   static defaultProps = {
     transforms,
@@ -31,40 +36,18 @@ export default class Display extends React.Component {
   constructor() {
     super();
     this.recomputeStyle = this.recomputeStyle.bind(this);
+    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
   }
 
   componentDidMount() {
     this.recomputeStyle();
   }
 
-  shouldComponentUpdate(nextProps: Props): boolean {
-    if (!nextProps || !this.props) {
-      return false;
-    }
-
-    const themeChanged = nextProps.theme && nextProps.theme !== this.props.theme;
-    if (themeChanged) {
-      return true;
-    }
-
-    if (nextProps.outputs && !nextProps.outputs.equals(this.props.outputs)) {
-      return true;
-    }
-
-    // Since expanded is a boolean, we need to make sure it's a property directly.
-    if ({}.hasOwnProperty.call(nextProps, 'expanded') &&
-      nextProps.expanded !== this.props.expanded) {
-      return true;
-    }
-
-    return false;
-  }
-
   componentDidUpdate() {
     this.recomputeStyle();
   }
 
-  recomputeStyle() {
+  recomputeStyle(): void {
     if (!this.props.expanded && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT) {
       this.el.style.height = `${DEFAULT_SCROLL_HEIGHT}px`;
       this.el.style.overflowY = 'scroll';

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -27,7 +27,20 @@ export default class Display extends React.Component {
   };
 
   shouldComponentUpdate(nextProps: Props): boolean {
-    return true;
+    if (!nextProps || !this.props) {
+      return false;
+    }
+
+    const themeChanged = nextProps.theme && nextProps.theme !== this.props.theme;
+    if (themeChanged) {
+      return true;
+    }
+
+    if (nextProps.outputs && !nextProps.outputs.equals(this.props.outputs)) {
+      return true;
+    }
+
+    return false;
   }
 
   render() {

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 
-import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+import Immutable, { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import { transforms, displayOrder } from '../../transforms';
 
@@ -16,37 +16,45 @@ type Props = {
   isHidden: boolean,
 }
 
-export default function Display(props: Props): ?React.Element<any> {
-  const order = props.displayOrder;
-  const tf = props.transforms;
-  const style = {
-    height: props.expanded ? '300px' : 'auto',
-    overflow: props.expanded ? 'scroll' : 'overflow',
+export default class Display extends React.Component {
+  props: Props;
+
+  static defaultProps = {
+    transforms,
+    displayOrder,
+    isHidden: false,
+    expanded: true,
   };
 
-  if (!props.isHidden) {
-    return (
-      <div className="cell_display" style={style}>
-        {
-          props.outputs.map((output, index) =>
-            <Output
-              key={index}
-              output={output}
-              displayOrder={order}
-              transforms={tf}
-              theme={props.theme}
-            />
-          )
-        }
-      </div>
-    );
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return true;
   }
-  return null;
-}
 
-Display.defaultProps = {
-  transforms,
-  displayOrder,
-  isHidden: false,
-  expanded: true,
-};
+  render() {
+    const order = this.props.displayOrder;
+    const tf = this.props.transforms;
+    const style = {
+      height: this.props.expanded ? '300px' : 'auto',
+      overflow: this.props.expanded ? 'scroll' : 'overflow',
+    };
+
+    if (!this.props.isHidden) {
+      return (
+        <div className="cell_display" style={style}>
+          {
+            this.props.outputs.map((output, index) =>
+              <Output
+                key={index}
+                output={output}
+                displayOrder={order}
+                transforms={tf}
+                theme={this.props.theme}
+              />
+            )
+          }
+        </div>
+      );
+    }
+    return null;
+  }
+}

--- a/src/notebook/kernel/shutdown.js
+++ b/src/notebook/kernel/shutdown.js
@@ -11,7 +11,6 @@ export function cleanupKernel(kernel, closeChannels, _fs = fs) {
       kernel.channels.stdin.complete();
       kernel.channels.control.complete();
     } catch (err) {
-      // nom nom nom
       console.warn(`Could not cleanup kernel channels, have they already
         been completed?`, kernel.channels);
     }

--- a/src/notebook/middlewares.js
+++ b/src/notebook/middlewares.js
@@ -7,8 +7,34 @@ import * as constants from './constants';
 
 const rootEpic = combineEpics(...epics);
 
+const errorMiddleware = store => next => action => {
+  if (!action.type.includes('ERROR')) {
+    return next(action);
+  }
+  console.error(action);
+  let errorText;
+  if (action.payload) {
+    errorText = action.payload;
+  } else {
+    errorText = JSON.stringify(action, 2, 2);
+  }
+  const state = store.getState();
+  const notificationSystem = state.app.get('notificationSystem');
+  if (notificationSystem) {
+    notificationSystem.addNotification({
+      title: action.type,
+      message: errorText,
+      dismissible: true,
+      position: 'tr',
+      level: 'error',
+    });
+  }
+  return next(action);
+};
+
 const middlewares = [
   createEpicMiddleware(rootEpic),
+  errorMiddleware,
 ];
 
 export default middlewares;


### PR DESCRIPTION
The scrollable display was looking like this for smaller outputs:

![image](https://cloud.githubusercontent.com/assets/836375/19406731/a78b2358-9240-11e6-960f-837408c968db.png)

Now it adjusts dynamically based on the content (really, as a consequence of new outputs or a theme change):

![display](https://cloud.githubusercontent.com/assets/836375/19405849/3d235968-9231-11e6-8e7d-e86776097075.gif)

Follow up to #972.
