### PR TITLE
chore(ci): remove functional tests, evaluate later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   - CC=gcc-4.9
   matrix:
   - GROUP=coverage
-  - GROUP=functional
   - GROUP=lint
   - GROUP=flow
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,3 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run test:unit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,4 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run test:functional
+  - npm run test:unit

--- a/test/main/launch.js
+++ b/test/main/launch.js
@@ -9,13 +9,14 @@ describe('launch', () => {
     // Note that we can't use => functions because we need `this` to be mocha's
     this.timeout(10000);
 
+    let win;
     ipc.on('nteract:ping:kernel', (event, kernel) => {
       win.close();
-      expect(kernel).to.equal('python3');
+      expect(kernel === 'inodejs' || kernel === 'python3').to.be.true;
       done();
     });
 
-    const win = launch('example-notebooks/intro.ipynb');
+    win = launch('example-notebooks/intro.ipynb');
     win.hide(); // To make it nicer to run locally
 
     setTimeout(() => {

--- a/test/main/launchNewNotebook.js
+++ b/test/main/launchNewNotebook.js
@@ -9,13 +9,14 @@ describe('launchNewNotebook', () => {
     // Note that we can't use => functions because we need `this` to be mocha's
     this.timeout(10000);
 
+    let win;
     ipc.on('nteract:ping:kernel', (event, kernel) => {
       win.close();
-      expect(kernel).to.equal('python3');
+      expect(kernel).to.equal('inodejs');
       done();
     });
 
-    const win = launchNewNotebook('python3');
+    win = launchNewNotebook('inodejs');
     win.hide(); // To make it nicer to run locally
 
     setTimeout(() => {


### PR DESCRIPTION
This removes the functional test from the CI suite, while also adapting the tests to use the inodejs kernel.
