### PR TITLE
feat(conda): detect conda environments with ipykernels

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -56,6 +56,7 @@
     "redux-observable": "^0.12.0",
     "rxjs": "^5.0.0-rc.1",
     "shell-env": "^0.2.0",
+    "spawn-rx": "^2.0.3",
     "spawnteract": "^2.2.0",
     "uuid": "^2.0.3",
     "yargs": "^6.0.0"

--- a/src/main/kernels.js
+++ b/src/main/kernels.js
@@ -25,9 +25,6 @@ export function condaInfoObservable() {
     .map(info => JSON.parse(info));
 }
 
-// var condak = require('./src/notebook/epics/conda-kernel-provider-epic');
-// var envy = condak.condaEnvsObservable(condak.condaInfoObservable());
-
 export function condaEnvsObservable(condaInfo$) {
   return condaInfo$.map(info => {
     const envs = info.envs.map(env => ({ name: path.basename(env), prefix: env }));

--- a/src/main/kernels.js
+++ b/src/main/kernels.js
@@ -1,0 +1,72 @@
+import Rx from 'rxjs/Rx';
+
+import {
+  spawn,
+} from 'spawn-rx';
+
+const path = require('path');
+
+// TODO: Check for sys.prefix/share/jupyter/kernels/*/kernel.json
+/**
+ * ipyKernelTryObservable check for existence of ipykernel in an env
+ * @param  {Object} env [description]
+ * @return {[type]}     [description]
+ */
+export function ipyKernelTryObservable(env) {
+  const executable = path.join(env.prefix, 'bin', 'python');
+  return spawn(executable, ['-m', 'ipykernel', '--version'], { split: true })
+    .filter(x => x.source && x.source === 'stdout')
+    .mapTo(env)
+    .catch(err => Rx.Observable.empty());
+}
+
+export function condaInfoObservable() {
+  return spawn('conda', ['info', '--json'])
+    .map(info => JSON.parse(info));
+}
+
+// var condak = require('./src/notebook/epics/conda-kernel-provider-epic');
+// var envy = condak.condaEnvsObservable(condak.condaInfoObservable());
+
+export function condaEnvsObservable(condaInfo$) {
+  return condaInfo$.map(info => {
+    const envs = info.envs.map(env => ({ name: path.basename(env), prefix: env }));
+    envs.push({ name: 'root', prefix: info.root_prefix });
+    return envs;
+  })
+  .map(envs => envs.map(ipyKernelTryObservable))
+  .mergeAll()
+  .mergeAll()
+  .toArray();
+}
+
+export function createKernelSpecsFromEnvs(envs) {
+  const displayPrefix = 'Python'; // Or R
+  const languageKey = 'py'; // or r
+
+  // TODO: Handle Windows & Conda
+  const languageExe = 'bin/python';
+  const jupyterBin = 'bin/jupyter';
+
+  const langEnvs = {};
+
+  for (const env of envs) {
+    const base = env.prefix;
+    const exePath = path.join(base, languageExe);
+    const envName = env.name;
+    const name = `conda-env-${envName}-${languageKey}`;
+    langEnvs[name] = {
+      display_name: `${displayPrefix} [conda env:${envName}]`,
+      // TODO: Support default R kernel
+      argv: [exePath, '-m', 'ipykernel', '-f', '{connection_file}'],
+      language: 'python',
+      // TODO: Provide resource_dir
+    };
+  }
+  return langEnvs;
+}
+
+export function condaKernelsObservable() {
+  return condaEnvsObservable(condaInfoObservable())
+    .map(createKernelSpecsFromEnvs);
+}


### PR DESCRIPTION
This extracts the conda kernel detection out of #847 in preparation for providing it to the menu and to all launched notebooks.

Usage example:

``` js
> var condaKernel$ = require('./app/build/main/kernels').condaKernelsObservable();
undefined
> var sub = condaKernel$.subscribe(x => console.log(x));
undefined
> { 'conda-env-ipy-py':
   { display_name: 'Python [conda env:ipy]',
     argv:
      [ '/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/envs/ipy/bin/python',
        '-m',
        'ipykernel',
        '-f',
        '{connection_file}' ],
     language: 'python' },
  'conda-env-microbots-py':
   { display_name: 'Python [conda env:microbots]',
     argv:
      [ '/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/envs/microbots/bin/python',
        '-m',
        'ipykernel',
        '-f',
        '{connection_file}' ],
     language: 'python' },
  'conda-env-root-py':
   { display_name: 'Python [conda env:root]',
     argv:
      [ '/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/bin/python',
        '-m',
        'ipykernel',
        '-f',
        '{connection_file}' ],
     language: 'python' } }
```

/cc @nhdaly
