### PR TITLE
feat(cli): Make CLI nicer

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -19,8 +19,15 @@ const log = require('electron-log');
 const kernelspecs = require('kernelspecs');
 
 const argv = require('yargs')
-  .alias('k', 'kernel')
+  .version()
+  .usage('Usage: nteract <notebooks> [options]')
+  .example('nteract notebook1.ipynb notebook2.ipynb', 'Open notebooks')
+  .example('nteract --kernel javascript', 'Launch a kernel')
+  .describe('kernel', 'Launch a kernel')
   .default('kernel', 'python3')
+  .alias('k', 'kernel')
+  .describe('verbose', 'Display debug information')
+  .help('help')
   .argv;
 
 log.info('args', argv);


### PR DESCRIPTION
This won't do much in the published release since the `nteract` script uses `nohup` to execute in the background.

I'll look into doing something similar to https://github.com/atom/atom/blob/master/atom.sh minus the path guessing.

You can try it with `npm start -- --help`.
