### PR TITLE
chore(exampleNotebookMenu): move example notebooks to directly under file menu

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -18,17 +18,18 @@ A new notebook can be created by accessing the menu,
 ### Opening a Notebook
 There are several ways to open a notebook in nteract:
 
-1. From the menu:
+- From the menu:
 ```
   File
     ⮑  Open
-          ⮑  Open
 ```
-2. Double-click a notebook file :tada::  ***Note: currently this works only in macOS***
-
-3. From the Command Line (assuming you have shell commands installed), run `nteract notebook.ipynb`:
 
 *Keyboard shortcut ⌘O on macOS and Ctrl-O on Windows/Linux*
+
+- Double-click a notebook file :tada:  ***Note: currently this works only in macOS***
+
+- From the Command Line (assuming you have shell commands installed), run `nteract notebook.ipynb`:
+
 
 ### Saving a Notebook
 

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -56,9 +56,33 @@ export const fileSubMenus = {
   },
   open: {
     label: '&Open',
+    click: () => {
+      const opts = {
+        title: 'Open a notebook',
+        filters: [
+          { name: 'Notebooks', extensions: ['ipynb'] },
+        ],
+        properties: [
+          'openFile',
+        ],
+      };
+      if (process.cwd() === '/') {
+        opts.defaultPath = app.getPath('home');
+      }
+
+      dialog.showOpenDialog(opts, (fname) => {
+        if (fname) {
+          launch(fname[0]);
+        }
+      });
+    },
+    accelerator: 'CmdOrCtrl+O',
+  },
+  openExampleNotebooks: {
+    label: '&Open Example Notebooks',
     submenu: [
       {
-        label: '&Open',
+        label: '&Geojson',
         click: () => {
           const opts = {
             title: 'Open a notebook',
@@ -69,112 +93,83 @@ export const fileSubMenus = {
               'openFile',
             ],
           };
-          if (process.cwd() === '/') {
-            opts.defaultPath = app.getPath('home');
-          }
-
-          dialog.showOpenDialog(opts, (fname) => {
-            if (fname) {
-              launch(fname[0]);
-            }
-          });
+          launch(path.join(exampleNotebooksDirectory, 'geojson.ipynb'));
         },
-        accelerator: 'CmdOrCtrl+O',
       },
       {
-        label: '&Example Notebooks',
-        submenu: [
-          {
-            label: '&Geojson',
-            click: () => {
-              const opts = {
-                title: 'Open a notebook',
-                filters: [
-                  { name: 'Notebooks', extensions: ['ipynb'] },
-                ],
-                properties: [
-                  'openFile',
-                ],
-              };
-              launch(path.join(exampleNotebooksDirectory, 'geojson.ipynb'));
-            },
-          },
-          {
-            label: '&Plotly',
-            click: () => {
-              const opts = {
-                title: 'Open a notebook',
-                filters: [
-                  { name: 'Notebooks', extensions: ['ipynb'] },
-                ],
-                properties: [
-                  'openFile',
-                ],
-              };
-              launch(path.join(exampleNotebooksDirectory, 'plotly.ipynb'));
-            },
-          },
-          {
-            label: '&Pandas to GeoJSON',
-            click: () => {
-              const opts = {
-                title: 'Open a notebook',
-                filters: [
-                  { name: 'Notebooks', extensions: ['ipynb'] },
-                ],
-                properties: [
-                  'openFile',
-                ],
-              };
-              launch(path.join(exampleNotebooksDirectory, 'pandas-to-geojson.ipynb'));
-            },
-          },
-          {
-            label: '&Download Stats',
-            click: () => {
-              const opts = {
-                title: 'Open a notebook',
-                filters: [
-                  { name: 'Notebooks', extensions: ['ipynb'] },
-                ],
-                properties: [
-                  'openFile',
-                ],
-              };
-              launch(path.join(exampleNotebooksDirectory, 'download-stats.ipynb'));
-            },
-          },
-          {
-            label: '&Plotlyr',
-            click: () => {
-              const opts = {
-                title: 'Open a notebook',
-                filters: [
-                  { name: 'Notebooks', extensions: ['ipynb'] },
-                ],
-                properties: [
-                  'openFile',
-                ],
-              };
-              launch(path.join(exampleNotebooksDirectory, 'plotlyr.ipynb'));
-            },
-          },
-          {
-            label: '&Intro',
-            click: () => {
-              const opts = {
-                title: 'Open a notebook',
-                filters: [
-                  { name: 'Notebooks', extensions: ['ipynb'] },
-                ],
-                properties: [
-                  'openFile',
-                ],
-              };
-              launch(path.join(exampleNotebooksDirectory, 'intro.ipynb'));
-            },
-          }
-        ]
+        label: '&Plotly',
+        click: () => {
+          const opts = {
+            title: 'Open a notebook',
+            filters: [
+              { name: 'Notebooks', extensions: ['ipynb'] },
+            ],
+            properties: [
+              'openFile',
+            ],
+          };
+          launch(path.join(exampleNotebooksDirectory, 'plotly.ipynb'));
+        },
+      },
+      {
+        label: '&Pandas to GeoJSON',
+        click: () => {
+          const opts = {
+            title: 'Open a notebook',
+            filters: [
+              { name: 'Notebooks', extensions: ['ipynb'] },
+            ],
+            properties: [
+              'openFile',
+            ],
+          };
+          launch(path.join(exampleNotebooksDirectory, 'pandas-to-geojson.ipynb'));
+        },
+      },
+      {
+        label: '&Download nteract Stats',
+        click: () => {
+          const opts = {
+            title: 'Open a notebook',
+            filters: [
+              { name: 'Notebooks', extensions: ['ipynb'] },
+            ],
+            properties: [
+              'openFile',
+            ],
+          };
+          launch(path.join(exampleNotebooksDirectory, 'download-stats.ipynb'));
+        },
+      },
+      {
+        label: '&Plotlyr',
+        click: () => {
+          const opts = {
+            title: 'Open a notebook',
+            filters: [
+              { name: 'Notebooks', extensions: ['ipynb'] },
+            ],
+            properties: [
+              'openFile',
+            ],
+          };
+          launch(path.join(exampleNotebooksDirectory, 'plotlyr.ipynb'));
+        },
+      },
+      {
+        label: '&Intro',
+        click: () => {
+          const opts = {
+            title: 'Open a notebook',
+            filters: [
+              { name: 'Notebooks', extensions: ['ipynb'] },
+            ],
+            properties: [
+              'openFile',
+            ],
+          };
+          launch(path.join(exampleNotebooksDirectory, 'intro.ipynb'));
+        },
       }
     ]
   },
@@ -226,6 +221,7 @@ export const file = {
   submenu: [
     fileSubMenus.new,
     fileSubMenus.open,
+    fileSubMenus.openExampleNotebooks,
     fileSubMenus.save,
     fileSubMenus.saveAs,
     fileSubMenus.publish,
@@ -581,6 +577,7 @@ export function loadFullMenu() {
           submenu: newNotebookItems,
         },
         fileSubMenus.open,
+        fileSubMenus.openExampleNotebooks,
         fileSubMenus.save,
         fileSubMenus.saveAs,
         fileSubMenus.publish,


### PR DESCRIPTION
- Per discussion in #1032, moved example notebooks back one level in file menu to avoid doubly nested items
- Updated USER_GUIDE docs to reflect change in opening a notebook from menu
