### PR TITLE
fix(config): Ignore the case of no config file

### DIFF
--- a/src/notebook/epics/config.js
+++ b/src/notebook/epics/config.js
@@ -31,9 +31,11 @@ export const loadConfigEpic = actions =>
       readFileObservable(CONFIG_FILE_PATH)
         .map(JSON.parse)
         .map(configLoaded)
-        .catch((err) =>
-          Observable.of({ type: 'ERROR', payload: err, error: true })
-        )
+        .catch((err) => {
+          if (!err.message.includes('ENOENT')) {
+            Observable.of({ type: 'ERROR', payload: err, error: true });
+          }
+        })
     );
 
 export const saveConfigOnChangeEpic = actions =>


### PR DESCRIPTION
I couldn't get the writeFileObservable to work right in the catch so I just had it ignore the case in which there is no config file for now. 

I think it is fine to not create an nteract.json if the user doesn't have one for now (since it is a "hidden" feature), but maybe provide a notification in the future?
