### PR TITLE
fix(bundle): source-map-support needs to be in packaged app

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -57,6 +57,7 @@
     "redux-observable": "^0.12.0",
     "rxjs": "^5.0.0-rc.1",
     "shell-env": "^0.2.0",
+    "source-map-support": "^0.4.5",
     "spawn-rx": "^2.0.3",
     "spawnteract": "^2.2.0",
     "uuid": "^2.0.3",


### PR DESCRIPTION
Trying to make our latest release, couldn't boot it without this (since it's used in the webpack bundle during the initial require).
