### PR TITLE
fix(app): Disable asar on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "win": {
       "target": "nsis"
     },
-    "extraResources": "bin"
+    "extraResources": "bin",
+    "asar": false
   },
   "greenkeeper": {
     "ignore": [


### PR DESCRIPTION
It looks like having our example notebooks archived via asar causes some problems with launching the kernel. Currently, asar [has no way of excluding certain directories](https://github.com/electron/asar/issues/2) so I'm settling it for just disabling at all together for now.
