### PR TITLE
fix(style): ensure property available for styling

### DIFF
--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -48,6 +48,9 @@ export default class Display extends React.Component {
   }
 
   recomputeStyle(): void {
+    if (!this.el) {
+      return;
+    }
     if (!this.props.expanded && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT) {
       this.el.style.height = `${DEFAULT_SCROLL_HEIGHT}px`;
       this.el.style.overflowY = 'scroll';

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -126,10 +126,12 @@ export class Notebook extends React.Component {
   }
 
   componentDidUpdate(): void {
-    // Make sure the document is vertically shifted so the top non-stickied
-    // cell is always visible.
-    this.stickyCellsPlaceholder.style.height =
-      `${this.stickyCellContainer.clientHeight}px`;
+    if (this.stickyCellsPlaceholder) {
+      // Make sure the document is vertically shifted so the top non-stickied
+      // cell is always visible.
+      this.stickyCellsPlaceholder.style.height =
+        `${this.stickyCellContainer.clientHeight}px`;
+    }
   }
 
   componentWillUnmount(): void {


### PR DESCRIPTION
The `stickyCellsPlaceholder` prop was not always defined here,  tripping things up with the nteract theme.
