### PR TITLE
[WIP] fix(CodeCell): Disable input focus on click in CodeCell

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -115,7 +115,6 @@ export class Cell extends React.Component {
           <MarkdownCell
             focusAbove={this.focusAboveCell}
             focusBelow={this.focusBelowCell}
-            focused={focused}
             cell={cell}
             id={this.props.id}
             theme={this.props.theme}
@@ -123,7 +122,6 @@ export class Cell extends React.Component {
             <CodeCell
               focusAbove={this.focusAboveCell}
               focusBelow={this.focusBelowCell}
-              outputFocused={focused}
               cell={cell}
               id={this.props.id}
               theme={this.props.theme}

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -123,7 +123,7 @@ export class Cell extends React.Component {
             <CodeCell
               focusAbove={this.focusAboveCell}
               focusBelow={this.focusBelowCell}
-              focused={focused}
+              outputFocused={focused}
               cell={cell}
               id={this.props.id}
               theme={this.props.theme}

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -18,7 +18,6 @@ type Props = {
   language: string,
   theme: string,
   transforms: ImmutableMap<string, any>,
-  outputFocused: boolean,
   pagers: ImmutableList<any>,
   running: boolean,
   focusAbove: Function,

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -18,7 +18,7 @@ type Props = {
   language: string,
   theme: string,
   transforms: ImmutableMap<string, any>,
-  focused: boolean,
+  outputFocused: boolean,
   pagers: ImmutableList<any>,
   running: boolean,
   focusAbove: Function,
@@ -68,7 +68,6 @@ class CodeCell extends React.Component {
               tabSize={this.props.tabSize}
               input={this.props.cell.get('source')}
               language={this.props.language}
-              focused={this.props.focused}
               theme={this.props.theme}
               focusAbove={this.props.focusAbove}
               focusBelow={this.props.focusBelow}

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -171,11 +171,6 @@ export default class Editor extends React.Component {
   }
 
   componentDidMount(): void {
-    // On first load, if focused, set codemirror to focus
-    if (this.props.focused) {
-      this.codemirror.focus();
-    }
-
     const cm = this.codemirror.getCodeMirror();
     const store = this.context.store;
 
@@ -207,13 +202,6 @@ export default class Editor extends React.Component {
   }
 
   componentDidUpdate(prevProps: Props): void {
-    if (this.props.focused && prevProps.focused !== this.props.focused) {
-      this.codemirror.focus();
-    } else if (!this.props.focused && prevProps.focused !== this.props.focused) {
-      const cm = this.codemirror.getCodeMirror();
-      cm.getInputField().blur();
-    }
-
     if (this.theme !== this.props.theme) {
       this.theme = this.props.theme;
       this.codemirror.getCodeMirror().refresh();
@@ -273,6 +261,7 @@ export default class Editor extends React.Component {
           className="cell_cm"
           options={options}
           onChange={this.onChange}
+          onClick={this.focus}
         />
       </div>
     );

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -43,7 +43,6 @@ type Props = {
   matchBrackets?: boolean,
   theme: string,
   cmtheme?: string,
-  focused: boolean,
   focusAbove: Function,
   focusBelow: Function,
 };

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -13,7 +13,6 @@ type Props = {
   theme: string,
   focusAbove: Function,
   focusBelow: Function,
-  focused: boolean,
 };
 
 type State = {
@@ -40,10 +39,6 @@ export default class MarkdownCell extends React.Component {
     store: React.PropTypes.object,
   };
 
-  static defaultProps = {
-    focused: false,
-  };
-
   constructor(props: Props): void {
     super(props);
     this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
@@ -65,16 +60,6 @@ export default class MarkdownCell extends React.Component {
     this.setState({
       source: nextProps.cell.get('source'),
     });
-  }
-
-  componentDidUpdate(): void {
-    this.updateFocus();
-  }
-
-  updateFocus(): void {
-    if (this.state && this.state.view && this.props.focused) {
-      this.rendered.focus();
-    }
   }
 
   /**
@@ -149,7 +134,6 @@ export default class MarkdownCell extends React.Component {
                  theme={this.props.theme}
                  focusAbove={this.props.focusAbove}
                  focusBelow={this.props.focusBelow}
-                 focused={this.props.focused}
                />
              </div>
              <div className="outputs">


### PR DESCRIPTION
The Editor now manages its own focused set via CodeMirror instead of receiving props from the parent CodeCell component.

![nteract-no-focus](https://cloud.githubusercontent.com/assets/1857993/19622203/05ba9704-986a-11e6-8a56-c5906e29ffb4.gif)

Closes #429.
