### PR TITLE
fix(icon): load icon on windows by fixing path join

### DIFF
--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -18,7 +18,7 @@ export function deferURL(event, url) {
   }
 }
 
-const iconPath = path.join(__dirname, '../../static/icon.png');
+const iconPath = path.join(__dirname, '..', '..', 'static', 'icon.png');
 
 export function launch(filename) {
   let win = new BrowserWindow({
@@ -57,4 +57,3 @@ export function launchNewNotebook(kernelSpecName) {
   });
   return win;
 }
-


### PR DESCRIPTION
When I was working with nteract on Windows I noticed the image didn't load properly. I skimmed past that annoyance though and was happy Windows was working period.

While doing the webpack and `electron-builder` refactor, I noticed the culprit here. 🎉 
