### PR TITLE
chore(cleanup): converts TODOs within src/notebook to github issues

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -216,7 +216,6 @@ export class Notebook extends React.Component {
       cell,
       language: getLanguageMode(this.props.notebook),
       key: id,
-      // TODO: This map _has_ to be cleaned up when cells are deleted
       ref: (el) => { this.cellElements = this.cellElements.set(id, el); },
       displayOrder: this.props.displayOrder,
       transforms: this.props.transforms,

--- a/src/notebook/components/transforms/geojson.js
+++ b/src/notebook/components/transforms/geojson.js
@@ -34,7 +34,6 @@ export class GeoJSONTransform extends React.Component {
     }
     this.map = L.map(this.el);
     this.map.scrollWheelZoom.disable();
-    // TODO: Determine a strategy for picking tiles
     L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw', {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       id: `mapbox.${this.props.theme}`,

--- a/src/notebook/epics/execute.js
+++ b/src/notebook/epics/execute.js
@@ -295,7 +295,6 @@ export function executeCellEpic(action$, store) {
               state.app.executionState === 'not connected');
 
           if (!kernelConnected) {
-            // TODO: Switch this to dispatching an error
             state.app.notificationSystem.addNotification({
               title: 'Could not execute cell',
               message: 'The cell could not be executed because the kernel is not connected.',

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -63,7 +63,6 @@ export function createGistCallback(firstTimePublish, observer, filename, notific
 
     notifyUser(filename, gistID, notificationSystem);
     if (firstTimePublish) {
-      // TODO: Move this up and out to be handled as a return on the observable
       observer.next(overwriteMetadata('gist_id', gistID));
     }
   };
@@ -144,7 +143,6 @@ export function handleGistError(store, err) {
   const notificationSystem = state.app.get('notificationSystem');
   try {
     const error = JSON.parse(err);
-    // TODO: Let this go into the general error flow
     if (error.message) {
       if (error.message === 'Bad credentials') {
         notificationSystem.addNotification({

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -47,9 +47,6 @@ export function acquireKernelInfo(channels) {
     .first()
     .pluck('content', 'language_info')
     .map(setLanguageInfo);
-    // TODO: After a timeout, send kernel_info_request again
-    //       the retry may be better architecturally out of this function
-    //       though, by retrying this function entirely.
 
   return Rx.Observable.create(observer => {
     const subscription = obs.subscribe(observer);

--- a/src/notebook/epics/loading.js
+++ b/src/notebook/epics/loading.js
@@ -33,7 +33,7 @@ export const extractNewKernel = (filename, notebook) => {
   const kernelName = notebook.getIn(
     ['metadata', 'kernelspec', 'name'], notebook.getIn(
       ['metadata', 'language_info', 'name'],
-        'python3')); // TODO: keep default kernel consistent
+        'python3'));
   return newKernel(kernelName, cwd);
 };
 
@@ -41,8 +41,6 @@ export const convertRawNotebook = (filename, data) => ({
   filename,
   notebook: commutable.fromJS(JSON.parse(data)),
 });
-
-// TODO: ERROR_LOADING response
 
 export const loadEpic = actions =>
   actions.ofType(LOAD)

--- a/src/notebook/global-events.js
+++ b/src/notebook/global-events.js
@@ -18,7 +18,5 @@ export function unload(store) {
 }
 
 export function initGlobalHandlers(store) {
-  // TODO: use beforeunload to ask user to save
-  // global.window.onbeforeunload = beforeUnload.bind(null, store, dispatch);
   global.window.onunload = unload.bind(null, store);
 }

--- a/src/notebook/kernel/messaging.js
+++ b/src/notebook/kernel/messaging.js
@@ -6,7 +6,6 @@ import Rx from 'rxjs/Rx';
 
 const Observable = Rx.Observable;
 
-// TODO: the session ID should likely be in the state tree, not a singleton
 export const session = uuid.v4();
 
 export function getUsername() {

--- a/src/notebook/native-window.js
+++ b/src/notebook/native-window.js
@@ -24,7 +24,6 @@ export function setTitleFromAttributes(attributes) {
   const { executionState } = attributes;
 
   const win = remote.getCurrentWindow();
-  // TODO: Investigate if setRepresentedFilename() is a no-op on non-macOS
   if (filename && win.setRepresentedFilename) {
     win.setRepresentedFilename(attributes.fullpath);
     win.setDocumentEdited(attributes.modified);

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -55,7 +55,6 @@ export default handleActions({
   },
   [constants.TOGGLE_STICKY_CELL]: function toggleStickyCell(state, action) {
     const { id } = action;
-    // TODO: Switch this structure to an Immutable.Set
     const stickyCells = state.get('stickyCells');
     if (stickyCells.get(id)) {
       return state.set('stickyCells', stickyCells.delete(id));

--- a/src/notebook/reducers/metadata.js
+++ b/src/notebook/reducers/metadata.js
@@ -11,5 +11,5 @@ function changeFilename(state, action) {
 
 export default handleActions({
   [constants.CHANGE_FILENAME]: changeFilename,
-  [constants.SET_NOTEBOOK]: changeFilename, // TODO: Group these or tear this metadata tree out
+  [constants.SET_NOTEBOOK]: changeFilename,
 }, {});


### PR DESCRIPTION
There are a couple of outlier `TODO`s still in the code. I wasn't 100% clear on their meaning, so wasn't sure how to convert them into actionable issues. They can be found here:
- `/src/main/index.js`
- `/src/notebook/epics/kernel-launch.js`
- `/src/notebook/reducers/document.js`  
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.
