### PR TITLE
[WIP] feat(expandedDisplay): load cell expansion preference from nteract.json

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -81,7 +81,7 @@ const prepJupyterObservable = prepareEnv
         if (err.code === 'ENOENT') {
           return writeFileObservable(nteractConfigFilename, JSON.stringify({
             theme: 'light',
-            expanded: true,
+            expanded: false,
           }));
         }
         throw err;

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -81,6 +81,7 @@ const prepJupyterObservable = prepareEnv
         if (err.code === 'ENOENT') {
           return writeFileObservable(nteractConfigFilename, JSON.stringify({
             theme: 'light',
+            expanded: true,
           }));
         }
         throw err;

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -22,6 +22,7 @@ export type CellProps = {
   language: string,
   running: boolean,
   theme: string,
+  expanded: boolean,
   pagers: ImmutableList<any>,
   transforms: ImmutableMap<string, any>,
 };
@@ -119,6 +120,7 @@ export class Cell extends React.Component {
             cell={cell}
             id={this.props.id}
             theme={this.props.theme}
+            expanded={this.props.expanded}
           /> :
             <CodeCell
               focusAbove={this.focusAboveCell}
@@ -127,6 +129,7 @@ export class Cell extends React.Component {
               cell={cell}
               id={this.props.id}
               theme={this.props.theme}
+              expanded={this.props.expanded}
               language={this.props.language}
               displayOrder={this.props.displayOrder}
               transforms={this.props.transforms}

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -17,6 +17,7 @@ type Props = {
   id: string,
   language: string,
   theme: string,
+  expanded: boolean,
   transforms: ImmutableMap<string, any>,
   focused: boolean,
   pagers: ImmutableList<any>,
@@ -70,6 +71,7 @@ class CodeCell extends React.Component {
               language={this.props.language}
               focused={this.props.focused}
               theme={this.props.theme}
+              expanded={this.props.expanded}
               focusAbove={this.props.focusAbove}
               focusBelow={this.props.focusBelow}
             />
@@ -86,6 +88,7 @@ class CodeCell extends React.Component {
                 transforms={this.props.transforms}
                 bundle={pager.get('data')}
                 theme={this.props.theme}
+                expanded={this.props.expanded}
                 key={key}
               />
             )
@@ -100,7 +103,7 @@ class CodeCell extends React.Component {
             displayOrder={this.props.displayOrder}
             transforms={this.props.transforms}
             theme={this.props.theme}
-            expanded={this.isOutputExpanded()}
+            expanded={this.props.expanded}
             isHidden={this.isOutputHidden()}
           />
         </div>

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -5,6 +5,8 @@ import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
+import { connect } from 'react-redux';
+
 import { transforms, displayOrder } from '../../transforms';
 
 import Output from './output';
@@ -20,7 +22,11 @@ type Props = {
 
 const DEFAULT_SCROLL_HEIGHT = 300;
 
-export default class Display extends React.Component {
+const mapStateToProps = (state: Object) => ({
+  expanded: state.config.get('expanded'),
+});
+
+export class Display extends React.Component {
   props: Props;
   shouldComponentUpdate: (p: Props, s: any) => boolean;
   recomputeStyle: () => void;
@@ -30,7 +36,6 @@ export default class Display extends React.Component {
     transforms,
     displayOrder,
     isHidden: false,
-    expanded: false,
   };
 
   constructor() {
@@ -85,3 +90,4 @@ export default class Display extends React.Component {
     return null;
   }
 }
+export default connect(mapStateToProps)(Display);

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -22,11 +22,13 @@ type Props = {
 
 const DEFAULT_SCROLL_HEIGHT = 300;
 
-const mapStateToProps = (state: Object) => ({
-  expanded: state.config.get('expanded'),
-});
+// const exp = this.props.get('expanded');
 
-export class Display extends React.Component {
+// const mapStateToProps = (state: Object) => ({
+//   expanded: state.config.get('expanded'),
+// });
+
+export default class Display extends React.Component {
   props: Props;
   shouldComponentUpdate: (p: Props, s: any) => boolean;
   recomputeStyle: () => void;
@@ -81,6 +83,7 @@ export class Display extends React.Component {
                 displayOrder={order}
                 transforms={tf}
                 theme={this.props.theme}
+                expanded={this.props.expanded}
               />
             )
           }
@@ -90,4 +93,4 @@ export class Display extends React.Component {
     return null;
   }
 }
-export default connect(mapStateToProps)(Display);
+// export default connect(mapStateToProps)(Display);

--- a/src/notebook/components/cell/display-area/output.js
+++ b/src/notebook/components/cell/display-area/output.js
@@ -12,6 +12,7 @@ type Props = {
   output: any,
   transforms: ImmutableMap<string, any>,
   theme: string,
+  expanded: boolean,
 }
 
 export default function Output(props: Props): ?React.Element<any>|null {
@@ -35,6 +36,7 @@ export default function Output(props: Props): ?React.Element<any>|null {
           displayOrder={props.displayOrder}
           transforms={props.transforms}
           theme={props.theme}
+          expanded={props.expanded}
         />);
     }
     case 'stream': {

--- a/src/notebook/components/cell/display-area/richest-mime.js
+++ b/src/notebook/components/cell/display-area/richest-mime.js
@@ -10,6 +10,7 @@ type Props = {
   bundle: ImmutableMap<string, any>,
   metadata: ImmutableMap<string, any>,
   theme: string,
+  expanded: boolean,
 };
 
 export default class RichestMime extends React.Component {
@@ -19,6 +20,7 @@ export default class RichestMime extends React.Component {
     transforms,
     displayOrder,
     theme: 'light',
+    expanded: false,
     metadata: new ImmutableMap(),
     bundle: new ImmutableMap(),
   };
@@ -45,6 +47,11 @@ export default class RichestMime extends React.Component {
     const Transform = this.props.transforms.get(mimetype);
     const data = this.props.bundle.get(mimetype);
     const metadata = this.props.metadata.get(mimetype);
-    return <Transform data={data} metadata={metadata} theme={this.props.theme} />;
+    return (<Transform
+      data={data}
+      metadata={metadata}
+      theme={this.props.theme}
+      expanded={this.props.expanded}
+    />);
   }
 }

--- a/src/notebook/components/cell/draggable-cell.js
+++ b/src/notebook/components/cell/draggable-cell.js
@@ -24,6 +24,7 @@ type Props = {
   language: string,
   running: boolean,
   theme: string,
+  expanded: boolean,
   pagers: ImmutableList<any>,
   moveCell: (source: string, dest: string, above: boolean) => Object,
 };
@@ -165,6 +166,7 @@ class DraggableCell extends React.Component {
             language={this.props.language}
             running={this.props.running}
             theme={this.props.theme}
+            expanded={this.props.expanded}
             pagers={this.props.pagers}
             transforms={this.props.transforms}
           />

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -11,6 +11,7 @@ type Props = {
   cell: any,
   id: string,
   theme: string,
+  expanded: boolean,
   focusAbove: Function,
   focusBelow: Function,
   focused: boolean,
@@ -147,6 +148,7 @@ export default class MarkdownCell extends React.Component {
                  lineWrapping
                  input={this.state.source}
                  theme={this.props.theme}
+                 expanded={this.props.expanded}
                  focusAbove={this.props.focusAbove}
                  focusBelow={this.props.focusBelow}
                  focused={this.props.focused}

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -57,6 +57,7 @@ type Props = {
   kernelSpecName: string,
   CellComponent: any,
   executionState: string,
+  expanded: boolean,
 };
 
 export function getLanguageMode(notebook: any): string {
@@ -102,6 +103,7 @@ export function scrollToElement(el: HTMLElement): number {
 
 const mapStateToProps = (state: Object) => ({
   theme: state.config.get('theme'),
+  expanded: state.config.get('expanded'),
   lastSaved: state.app.get('lastSaved'),
   kernelSpecName: state.app.get('kernelSpecName'),
   notebook: state.document.get('notebook'),
@@ -226,6 +228,7 @@ export class Notebook extends React.Component {
       // Theme is passed through to let the Editor component know when to
       // tell CodeMirror to remeasure
       theme: this.props.theme,
+      expanded: this.props.expanded,
     };
   }
 

--- a/test/renderer/components/cell/display-area/richest-mime-spec.js
+++ b/test/renderer/components/cell/display-area/richest-mime-spec.js
@@ -25,7 +25,7 @@ describe('RichestMime', () => {
     );
 
     expect(rm.instance().shouldComponentUpdate()).to.be.false;
-    expect(rm.first().props()).to.deep.equal({data: 'THE DATA', theme: 'light', metadata: 'alright'});
+    expect(rm.first().props()).to.deep.equal({data: 'THE DATA', theme: 'light', metadata: 'alright', expanded: false});
   })
   it('does not render unknown mimetypes', () => {
     const rm = shallow(


### PR DESCRIPTION
Attempt at #1098. Currently fails here:

<details>
<summary>Failing tests</summary>

``` bash
293 passing (2s)
  2 pending
  6 failing

  1) CodeCell creates an editor:
     Invariant Violation: Could not find "store" in either the context or props of "Connect(Display)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Display)".
      at invariant (app/node_modules/invariant/invariant.js:42:15)
      at new Connect (app/node_modules/react-redux/lib/components/connect.js:131:36)
      at app/node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (app/node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at ReactCompositeComponentWrapper._constructComponentWithoutOwner (app/node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at ReactCompositeComponentWrapper._constructComponent (app/node_modules/react/lib/ReactCompositeComponent.js:279:21)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at mountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:105:32)
      at ReactReconcileTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at batchedMountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:127:15)
      at ReactDefaultBatchingStrategyTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at Object._renderNewRootComponent (app/node_modules/react/lib/ReactMount.js:321:18)
      at Object._renderSubtreeIntoContainer (app/node_modules/react/lib/ReactMount.js:402:32)
      at Object.render (app/node_modules/react/lib/ReactMount.js:423:23)
      at Object.renderIntoDocument (app/node_modules/react/lib/ReactTestUtils.js:84:21)
      at renderWithOptions (node_modules/enzyme/build/react-compat.js:187:26)
      at new ReactWrapper (node_modules/enzyme/build/ReactWrapper.js:94:59)
      at mount (node_modules/enzyme/build/mount.js:19:10)
      at Context.it (test/renderer/components/cell/code-cell-spec.js:27:18)

  2) CodeCell creates a pager:
     Invariant Violation: Could not find "store" in either the context or props of "Connect(Display)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Display)".
      at invariant (app/node_modules/invariant/invariant.js:42:15)
      at new Connect (app/node_modules/react-redux/lib/components/connect.js:131:36)
      at app/node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (app/node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at ReactCompositeComponentWrapper._constructComponentWithoutOwner (app/node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at ReactCompositeComponentWrapper._constructComponent (app/node_modules/react/lib/ReactCompositeComponent.js:279:21)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at mountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:105:32)
      at ReactReconcileTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at batchedMountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:127:15)
      at ReactDefaultBatchingStrategyTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at Object._renderNewRootComponent (app/node_modules/react/lib/ReactMount.js:321:18)
      at Object._renderSubtreeIntoContainer (app/node_modules/react/lib/ReactMount.js:402:32)
      at Object.render (app/node_modules/react/lib/ReactMount.js:423:23)
      at Object.renderIntoDocument (app/node_modules/react/lib/ReactTestUtils.js:84:21)
      at renderWithOptions (node_modules/enzyme/build/react-compat.js:187:26)
      at new ReactWrapper (node_modules/enzyme/build/ReactWrapper.js:94:59)
      at mount (node_modules/enzyme/build/mount.js:19:10)
      at Context.it (test/renderer/components/cell/code-cell-spec.js:40:18)

  3) Display does not display when status is hidden:
     Invariant Violation: Could not find "store" in either the context or props of "Connect(Display)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Display)".
      at invariant (app/node_modules/invariant/invariant.js:42:15)
      at new Connect (app/node_modules/react-redux/lib/components/connect.js:131:36)
      at app/node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (app/node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at ShallowComponentWrapper._constructComponentWithoutOwner (app/node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at ShallowComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactShallowRenderer._render (app/node_modules/react/lib/ReactTestUtils.js:402:21)
      at _batchedRender (app/node_modules/react/lib/ReactTestUtils.js:383:12)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:61:7)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at ReactShallowRenderer.render (app/node_modules/react/lib/ReactTestUtils.js:376:16)
      at ReactShallowRenderer.render (node_modules/enzyme/build/react-compat.js:158:39)
      at node_modules/enzyme/build/ShallowWrapper.js:90:26
      at ReactDefaultBatchingStrategyTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at node_modules/enzyme/build/ShallowWrapper.js:89:41
      at withSetStateAllowed (node_modules/enzyme/build/Utils.js:204:3)
      at new ShallowWrapper (node_modules/enzyme/build/ShallowWrapper.js:88:38)
      at shallow (node_modules/enzyme/build/shallow.js:19:10)
      at Context.it (test/renderer/components/cell/display-area/display-spec.js:18:23)

  4) Display displays status when it is not hidden:
     Invariant Violation: Could not find "store" in either the context or props of "Connect(Display)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Display)".
      at invariant (app/node_modules/invariant/invariant.js:42:15)
      at new Connect (app/node_modules/react-redux/lib/components/connect.js:131:36)
      at app/node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (app/node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at ShallowComponentWrapper._constructComponentWithoutOwner (app/node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at ShallowComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactShallowRenderer._render (app/node_modules/react/lib/ReactTestUtils.js:402:21)
      at _batchedRender (app/node_modules/react/lib/ReactTestUtils.js:383:12)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:61:7)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at ReactShallowRenderer.render (app/node_modules/react/lib/ReactTestUtils.js:376:16)
      at ReactShallowRenderer.render (node_modules/enzyme/build/react-compat.js:158:39)
      at node_modules/enzyme/build/ShallowWrapper.js:90:26
      at ReactDefaultBatchingStrategyTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at node_modules/enzyme/build/ShallowWrapper.js:89:41
      at withSetStateAllowed (node_modules/enzyme/build/Utils.js:204:3)
      at new ShallowWrapper (node_modules/enzyme/build/ShallowWrapper.js:88:38)
      at shallow (node_modules/enzyme/build/shallow.js:19:10)
      at Context.it (test/renderer/components/cell/display-area/display-spec.js:34:23)

  5) Notebook implements the correct css spec:
     Invariant Violation: Could not find "store" in either the context or props of "Connect(Display)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Display)".
      at invariant (app/node_modules/invariant/invariant.js:42:15)
      at new Connect (app/node_modules/react-redux/lib/components/connect.js:131:36)
      at app/node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (app/node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at ReactCompositeComponentWrapper._constructComponentWithoutOwner (app/node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at ReactCompositeComponentWrapper._constructComponent (app/node_modules/react/lib/ReactCompositeComponent.js:279:21)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at mountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:105:32)
      at ReactReconcileTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at batchedMountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:127:15)
      at ReactDefaultBatchingStrategyTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at Object._renderNewRootComponent (app/node_modules/react/lib/ReactMount.js:321:18)
      at Object._renderSubtreeIntoContainer (app/node_modules/react/lib/ReactMount.js:402:32)
      at Object.render (app/node_modules/react/lib/ReactMount.js:423:23)
      at Object.renderIntoDocument (app/node_modules/react/lib/ReactTestUtils.js:84:21)
      at renderWithOptions (node_modules/enzyme/build/react-compat.js:187:26)
      at new ReactWrapper (node_modules/enzyme/build/ReactWrapper.js:94:59)
      at mount (node_modules/enzyme/build/mount.js:19:10)
      at Context.it (test/renderer/components/notebook-spec.js:53:23)

  6) Notebook DnD drag and drop can be tested:
     Invariant Violation: Could not find "store" in either the context or props of "Connect(Display)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Display)".
      at invariant (app/node_modules/invariant/invariant.js:42:15)
      at new Connect (app/node_modules/react-redux/lib/components/connect.js:131:36)
      at app/node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (app/node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at ReactCompositeComponentWrapper._constructComponentWithoutOwner (app/node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at ReactCompositeComponentWrapper._constructComponent (app/node_modules/react/lib/ReactCompositeComponent.js:279:21)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.mountChildren (app/node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent._createInitialChildren (app/node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.mountComponent (app/node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactCompositeComponentWrapper.performInitialMount (app/node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at ReactCompositeComponentWrapper.mountComponent (app/node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.mountComponent (app/node_modules/react/lib/ReactReconciler.js:47:35)
      at mountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:105:32)
      at ReactReconcileTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at batchedMountComponentIntoNode (app/node_modules/react/lib/ReactMount.js:127:15)
      at ReactDefaultBatchingStrategyTransaction.perform (app/node_modules/react/lib/Transaction.js:138:20)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at Object.batchedUpdates (app/node_modules/react/lib/ReactUpdates.js:98:20)
      at Object._renderNewRootComponent (app/node_modules/react/lib/ReactMount.js:321:18)
      at Object._renderSubtreeIntoContainer (app/node_modules/react/lib/ReactMount.js:402:32)
      at Object.render (app/node_modules/react/lib/ReactMount.js:423:23)
      at Object.renderIntoDocument (app/node_modules/react/lib/ReactTestUtils.js:84:21)
      at renderWithOptions (node_modules/enzyme/build/react-compat.js:187:26)
      at new ReactWrapper (node_modules/enzyme/build/ReactWrapper.js:94:59)
      at mount (node_modules/enzyme/build/mount.js:19:10)
      at Context.it (test/renderer/components/notebook-spec.js:160:23)
```

</details>

Any guidance much appreciated, thanks!
