### PR TITLE
chore(install): Remove prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "reinstall": "npm run clean && rimraf node_modules app/node_modules/ && npm install",
     "prestart": "npm run build",
     "start": "cross-env NODE_ENV=development ./node_modules/electron/cli.js ./app/",
-    "prepublish": "npm run build",
     "clean": "rimraf ./app/build dist",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",


### PR DESCRIPTION
It won't build after `npm install` and removes the following warning on Node 7:

```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts will run only for `npm publish`.
npm WARN prepublish-on-install (In npm@4 and previous versions, it also runs for `npm install`.)
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```
