### PR TITLE
chore(err): Provide an up to date guide to fixing an nteract dev install

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -71,7 +71,7 @@
               break;
             default:
               if(/Module version mismatch/.test(err.message)) {
-                msgContainer.innerHTML = '<pre>nteract <a href="https://github.com/nteract/nteract#dependencies">requires node 6 for dev install</a></pre>';
+                msgContainer.innerHTML = `<p>nteract's native modules mismatch, try running <a href="https://github.com/nteract/nteract#troubleshooting"><pre>npm run reinstall</pre></a> from the root of the git clone</p>`;
               }
           }
           el.appendChild(headerEl);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -71,7 +71,7 @@
               break;
             default:
               if(/Module version mismatch/.test(err.message)) {
-                msgContainer.innerHTML = `<p>nteract's native modules mismatch, try running <a href="https://github.com/nteract/nteract#troubleshooting"><pre>npm run reinstall</pre></a> from the root of the git clone</p>`;
+                msgContainer.innerHTML = `<p>nteract's native modules mismatch, try running <a href="https://github.com/nteract/nteract#troubleshooting"><pre>npm install</pre></a> from the root of the git clone</p>`;
               }
           }
           el.appendChild(headerEl);


### PR DESCRIPTION
While commenting on another repo to mention how we handle displaying errors for native module mismatches, I noticed this was out of date. Now it's more relevant.