### PR TITLE
chore(kernel-launch): Added tests, added observer.complete()

### DIFF
--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -71,7 +71,6 @@ export function newKernelObservable(kernelSpecName, cwd) {
           control: createControlSubject(identity, config),
           stdin: createStdinSubject(identity, config),
         };
-
         observer.next(setNotebookKernelInfo({
           name: kernelSpecName,
           spec: kernelSpec,
@@ -87,7 +86,6 @@ export function newKernelObservable(kernelSpecName, cwd) {
         });
         observer.complete();
       });
-
   });
 }
 

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -85,7 +85,9 @@ export function newKernelObservable(kernelSpecName, cwd) {
           kernelSpecName,
           kernelSpec,
         });
+        observer.complete();
       });
+
   });
 }
 

--- a/test/renderer/epics/kernel-launch-spec.js
+++ b/test/renderer/epics/kernel-launch-spec.js
@@ -148,7 +148,7 @@ describe('newKernelEpic', () => {
       (x) => actionBuffer.push(x.type),
       (err) => expect.fail(err, null),
       () => {
-        expect(actionBuffer).to.deep.equal([constants.ERROR_KERNEL_LAUNCH_FAILED]); // ;
+        expect(actionBuffer).to.deep.equal([constants.SET_KERNEL_INFO, constants.NEW_KERNEL]); // ;
         done();
       },
     )

--- a/test/setup.js
+++ b/test/setup.js
@@ -73,7 +73,20 @@ mock('plotly.js/dist/plotly', {
   'newPlot': function(data, layout, config) {},
 })
 
-mock('enchannel-zmq-backend', {})
+mock('enchannel-zmq-backend', {
+  'createControlSubject': function(config, identity) {
+    return;
+  },
+  'createStdinSubject': function(config, identity) {
+    return;
+  },
+  createIOPubSubject: function(config, identity) {
+    return;
+  },
+  createShellSubject: function(config, identity) {
+    return;
+  },
+})
 
 mock('electron', {
   'shell': {
@@ -118,6 +131,7 @@ mock('electron', {
   },
   'ipcRenderer': {
     'on': function() {},
+    'send': function(message, action) {}
   },
 });
 
@@ -139,7 +153,25 @@ mock('react-notification-system', function () {
 });
 
 mock('spawnteract', {
-  'launch': function(kernelSpec, config) { return new Promise() },
+  'launch': function(kernelSpec, config) {
+    function writeConnectionFile(config) { return new Promise((resolve, reject) => {
+        try {
+         resolve({config, connectionFile: 'connectionFile'});
+        }
+        catch (err) {
+          reject(err);
+        }
+      })
+    }
+    return writeConnectionFile('config').then((c) => {
+      return {
+        spawn: 'runningKernel',
+        connectionFile: c.connectionFile,
+        config: c.config,
+        kernelSpec,
+      };
+    });
+  },
 });
 
 mock('fs', {


### PR DESCRIPTION
Mocked enchannel-zmq-backend, ipcRenderer, and spawnteract to test the newKernelObservable.
Added a (missing?) `observer.complete()` call in newKernelObservable.