### PR TITLE
fix(zoomReset): changed reset level to 0

### DIFF
--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -235,7 +235,7 @@ export function dispatchZoomOut() {
 }
 
 export function dispatchZoomReset() {
-  webFrame.setZoomLevel(1);
+  webFrame.setZoomLevel(0);
 }
 
 export function dispatchSetTheme(store, evt, theme) {

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -139,7 +139,7 @@ describe('menu', () => {
       const setZoomLevel = sinon.spy(webFrame, 'setZoomLevel');
       menu.dispatchZoomReset();
       setZoomLevel.restore();
-      expect(setZoomLevel).to.be.calledWith(1);
+      expect(setZoomLevel).to.be.calledWith(0);
     });
   });
 


### PR DESCRIPTION
I noticed when reseting zoom level to actual (CMD-0) that it wasn't the right size. It's my mistake, when I added this originally, I thought zoom level of 1 was 100%, but I see now it's actually zoom level 1. So I changed the actual reset level 0 to match the default and the corresponding test.