### PR TITLE
style(height): increase the default scroll height

### DIFF
--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -18,7 +18,7 @@ type Props = {
   isHidden: boolean,
 }
 
-const DEFAULT_SCROLL_HEIGHT = 300;
+const DEFAULT_SCROLL_HEIGHT = 600;
 
 export default class Display extends React.Component {
   props: Props;


### PR DESCRIPTION
To accomodate the default `df.head()`, plotly plot, etc. on a typical screen.