### PR TITLE
chore(gh-pr): clean up PR template text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
-<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them)-->
+<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->
 
 - [ ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
 - [ ] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.
 
-Questions? Feel free to ping us on [slack](https://slack.nteract.in)
+<!-- Questions? Feel free to ping us on https://slack.nteract.in -->


### PR DESCRIPTION
The "Questions?" section is supposed to be there for the submitter to see, not everyone when they make the PR (otherwise it makes it look like the author is saying feel free to ask questions on Slack).