### PR TITLE
style(gangnam): handle loading a bit more cleanly

### DIFF
--- a/src/notebook/components/status-bar.js
+++ b/src/notebook/components/status-bar.js
@@ -21,6 +21,8 @@ export default class StatusBar extends React.Component {
   }
 
   render(): ?React.Element<any> {
+    const name = this.props.kernelSpecName || 'Loading...';
+
     return (
       <div className="status-bar">
         <span className="pull-right">
@@ -31,7 +33,7 @@ export default class StatusBar extends React.Component {
           }
         </span>
         <span className="pull-left">
-          <p>{this.props.kernelSpecName} | {this.props.executionState}</p>
+          <p>{name} | {this.props.executionState}</p>
         </span>
       </div>
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const nodeModules = {
   zmq: 'commonjs zmq',
   jmp: 'commonjs jmp',
   github: 'commonjs github',
+  canvas: 'commonjs canvas',
 };
 
 module.exports = {


### PR DESCRIPTION
This PR makes the status bar show `loading... | not connected` instead of `| not connected` and helps webpack with the initial startup.