### PR TITLE
dx(logger): remove predicate for COMM

### DIFF
--- a/src/notebook/logger.js
+++ b/src/notebook/logger.js
@@ -4,7 +4,7 @@ const createLogger = require('redux-logger');
 
 module.exports = function clogger() {
   const logger = createLogger({
-    predicate: (getState, action) => action.type.includes('COMM'),
+    // predicate: (getState, action) => action.type.includes('COMM'),
     stateTransformer: (state) =>
       Object.keys(state).reduce((prev, key) =>
         Object.assign(


### PR DESCRIPTION
To enable logging while working in dev mode:

```
DEBUG=true npm run start
```

/cc @peggyrayzis 