### PR TITLE
refactor(saveDialog): Simplify remote electron require

### DIFF
--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -54,8 +54,7 @@ export function dispatchSaveAs(store, evt, filename) {
   store.dispatch(saveAs(filename, notebook));
 }
 
-const remoteElectron = remote.require('electron');
-const dialog = remoteElectron.dialog;
+const dialog = remote.dialog;
 
 export function showSaveAsDialog(defaultPath) {
   return new Promise((resolve) => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -103,7 +103,7 @@ mock('electron', {
     },
     'dialog': {
       'showSaveDialog': function(config) { },
-    }
+    },
     'BrowserWindow': {
       'getFocusedWindow': function() {
         return {

--- a/test/setup.js
+++ b/test/setup.js
@@ -101,15 +101,9 @@ mock('electron', {
         throw Error('not mocked');
       }
     },
-    'require': function(module) {
-      if (module === 'electron') {
-        return {
-          'dialog': {
-            'showSaveDialog': function(config) { },
-          }
-        };
-      }
-    },
+    'dialog': {
+      'showSaveDialog': function(config) { },
+    }
     'BrowserWindow': {
       'getFocusedWindow': function() {
         return {


### PR DESCRIPTION
Remove unnecessary `require('electron')`