### PR TITLE
fix(messaging): ofMessageType takes an array of message types

### DIFF
--- a/src/notebook/components/cell/editor/complete.js
+++ b/src/notebook/components/cell/editor/complete.js
@@ -17,7 +17,7 @@ export function formChangeObject(cm, change) {
 export function codeCompleteObservable(channels, editor, message) {
   const completion$ = channels.shell
     .childOf(message)
-    .ofMessageType('complete_reply')
+    .ofMessageType(['complete_reply'])
     .pluck('content')
     .first()
     .map(results => ({

--- a/src/notebook/epics/execute.js
+++ b/src/notebook/epics/execute.js
@@ -168,7 +168,7 @@ export function executeCellStream(channels, id, code) {
 
   // Payload streams in general
   const payloadStream = shell.childOf(executeRequest)
-    .ofMessageType('execute_reply')
+    .ofMessageType(['execute_reply'])
     .pluck('content', 'payload')
     .filter(Boolean)
     .flatMap(payloads => Rx.Observable.from(payloads));

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -43,7 +43,7 @@ export function acquireKernelInfo(channels) {
 
   const obs = channels.shell
     .childOf(message)
-    .ofMessageType('kernel_info_reply')
+    .ofMessageType(['kernel_info_reply'])
     .first()
     .pluck('content', 'language_info')
     .map(setLanguageInfo);


### PR DESCRIPTION
Noticed this while working on #1162. This adapts all our code that erroneously uses `ofMessageType(type)` to use `ofMessageType([type])`. We should make `ofMessageType` allow for either. For now though, this fixes what we have (as for why this worked sometimes - it would filter valid and invalid yet the plucks here would not find the right content keys).