### PR TITLE
dx(build): provide means of build watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,23 @@ Use your distribution's package manager to install.
 
 As you make changes, close the entire app (cmd-q on OS X, or ctrl-c at the terminal) then run `npm run start` again.
 
+##### Progressive Webpack build for the notebook 
+
+In separate terminals run:
+
+```
+npm run build:main
+npm run build:renderer:watch
+```
+
+and
+
+```
+NODE_ENV=development ./node_modules/electron/cli.js ./app/
+```
+
+The webpack build will keep occurring as you modify source. When you open a new notebook, you'll get the freshest copy of the notebook app.
+
 #### Build Documentation
 You can run nteract's documentation generator by running
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,8 +38,5 @@ module.exports = {
   externals: nodeModules,
   plugins: [
     new webpack.IgnorePlugin(/\.(css|less)$/),
-    new webpack.BannerPlugin('require("source-map-support").install();',
-                             { raw: true, entryOnly: false })
   ],
-  devtool: 'sourcemap'
 };


### PR DESCRIPTION
You can now run:

```
npm run build:main
npm run build:renderer:watch
```

in one terminal and

```
NODE_ENV=development ./node_modules/electron/cli.js ./app/
```

in another. This allows you to keep making changes to the notebook source (not the main process) and to see changes you only need to open a new notebook (File -> New...)

Source maps have been taken out here because they cause a memory leak during watched builds.