### PR TITLE
chore: simplify webpack now that we have 1 package.json

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,15 +24,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['', '.js', '.jsx'],
-    root: __dirname,
-    // Webpack 1
-    modulesDirectories: [
-      path.resolve(__dirname, 'node_modules'),
-    ],
-    // Webpack 2
-    modules: [
-      path.resolve(__dirname, 'node_modules'),
-    ],
   },
   externals: nodeModules,
   plugins: [


### PR DESCRIPTION
Since there is only one spot for `node_modules`, we don't have to specify where it's at anymore. :smile: