### PR TITLE
fix: metadata for cells needed to be setIn

### DIFF
--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -47,8 +47,8 @@ export default handleActions({
       .update('cellMap', (cells) =>
         cells.map((value) =>
           value.setIn(['metadata', 'inputHidden'], false)
-                .set(['metadata', 'outputHidden'], false)
-                .set(['metadata', 'outputExpanded'], false)
+                .setIn(['metadata', 'outputHidden'], false)
+                .setIn(['metadata', 'outputExpanded'], false)
                 .set('status', '')));
 
     return state.set('notebook', notebook)


### PR DESCRIPTION
Noticed this while working on #1162.

It looks like status needs to move as well since that's effectively transient information related to the kernel (yet not explicitly from the kernel).