### PR TITLE
(style) styles scrollbars according to theme

### DIFF
--- a/static/styles/theme-classic.css
+++ b/static/styles/theme-classic.css
@@ -142,3 +142,24 @@
 .dropdown__content ul {
   box-shadow: -1px 1px 5px rgba(0,0,0,0.2);
 }
+
+/*custom scrollbar for notebook cells and hint box*/
+div::-webkit-scrollbar, ul::-webkit-scrollbar {
+      width: 11px;
+      height: 11px;
+} 
+div::-webkit-scrollbar-track, ul::-webkit-scrollbar-track {
+      -webkit-box-shadow: inset 0 0 2px rgba(0,0,0,0.3);
+} 
+div::-webkit-scrollbar-thumb, ul::-webkit-scrollbar-thumb {
+      background-color: rgba(199,199,199, .4)
+}
+div::-webkit-scrollbar-thumb:hover, ul::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(199,199,199, .6)
+}
+div::-webkit-scrollbar-thumb:active, ul::-webkit-scrollbar-thumb:active {
+      background-color: rgba(199,199,199, .8)
+}
+div::-webkit-scrollbar-corner, ul::-webkit-scrollbar-corner {
+      background-color: transparent;
+}

--- a/static/styles/theme-dark.css
+++ b/static/styles/theme-dark.css
@@ -46,3 +46,24 @@
 
   --status-bar: #111;
 }
+
+/*custom scrollbar for notebook cells and hint box*/
+div::-webkit-scrollbar, ul::-webkit-scrollbar {
+      width: 11px;
+      height: 11px;
+} 
+div::-webkit-scrollbar-track, ul::-webkit-scrollbar-track {
+      -webkit-box-shadow: inset 0 0 10px rgba(0,0,0,0.3);
+} 
+div::-webkit-scrollbar-thumb, ul::-webkit-scrollbar-thumb {
+      background-color: rgba(204,204,204, .6);
+}
+div::-webkit-scrollbar-thumb:hover, ul::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(204,204,204, .7);
+}
+div::-webkit-scrollbar-thumb:active, ul::-webkit-scrollbar-thumb:active {
+      background-color: rgba(204,204,204, .9);
+}
+div::-webkit-scrollbar-corner, ul::-webkit-scrollbar-corner {
+      background-color: transparent;
+}

--- a/static/styles/theme-light.css
+++ b/static/styles/theme-light.css
@@ -46,3 +46,24 @@
 
   --status-bar: #eeedee;
 }
+
+/*custom scrollbar for notebook cells and hint box*/
+div::-webkit-scrollbar, ul::-webkit-scrollbar {
+      width: 11px;
+      height: 11px;
+} 
+div::-webkit-scrollbar-track, ul::-webkit-scrollbar-track {
+      -webkit-box-shadow: inset 0 0 2px rgba(0,0,0,0.3);
+} 
+div::-webkit-scrollbar-thumb, ul::-webkit-scrollbar-thumb {
+      background-color: rgba(199,199,199, .4)
+}
+div::-webkit-scrollbar-thumb:hover, ul::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(199,199,199, .6)
+}
+div::-webkit-scrollbar-thumb:active, ul::-webkit-scrollbar-thumb:active {
+      background-color: rgba(199,199,199, .8)
+}
+div::-webkit-scrollbar-corner, ul::-webkit-scrollbar-corner {
+      background-color:transparent;
+}

--- a/static/styles/theme-nteract.css
+++ b/static/styles/theme-nteract.css
@@ -383,3 +383,24 @@ tr
 {
   transition: all 0.1s ease-in-out;
 }
+
+/*custom scrollbar for notebook cells and hint box*/
+div::-webkit-scrollbar, ul::-webkit-scrollbar {
+      width: 11px;
+      height: 11px;
+} 
+div::-webkit-scrollbar-track, ul::-webkit-scrollbar-track {
+      -webkit-box-shadow: inset 0 0 10px rgba(0,0,0,0.3);
+} 
+div::-webkit-scrollbar-thumb, ul::-webkit-scrollbar-thumb {
+      background-color: rgba(237, 243, 247, .6) 
+}
+div::-webkit-scrollbar-thumb:hover, ul::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(237, 243, 247, .7);
+}
+div::-webkit-scrollbar-thumb:active, ul::-webkit-scrollbar-thumb:active {
+      background-color: rgba(237, 243, 247, .9);
+}
+div::-webkit-scrollbar-corner, ul::-webkit-scrollbar-corner {
+      background-color:transparent;
+}


### PR DESCRIPTION
This address issue #771 and adds a custom style scroll bar to the light, dark, classic, and nteract themes.

I know this is a style and subjective so I'm open to any suggestions for changes. If no suggestions this should be an upgrade from the default chrome style scroll bars throughout the application.

It is a flat style, which shows a small track using css box-shadow. The scroll bar color is a translucent version of the --main-fg-color (for dark themes) or --cm-background (for light themes). The scrollbar styling only applies inside the Electron window, i.e. the "main" window itself keeps the default platform style. 

Here is a preview
![scrollbars](https://cloud.githubusercontent.com/assets/5368903/20273538/50d28ce8-aa57-11e6-9fee-e8d668b62a4b.png)
