### PR TITLE
fix(markdown): Fixed bug with pressing shift+enter in markdown cells in view mode

### DIFF
--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -243,8 +243,6 @@ export default class Editor extends React.Component {
       if (!cellFocused) {
         this.context.store.dispatch(focusCell(this.props.id));
       }
-    } else {
-      this.context.store.dispatch(focusCellEditor(null));
     }
   }
 

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -194,7 +194,7 @@ export class Notebook extends React.Component {
 
     if (e.shiftKey) {
       this.context.store.dispatch(focusNextCell(this.props.cellFocused, true));
-      this.context.store.dispatch(focusNextCellEditor(this.props.editorFocused));
+      this.context.store.dispatch(focusNextCellEditor(id));
     }
 
     if (cell.get('cell_type') === 'code') {


### PR DESCRIPTION
Bug squashed! 🐛 Now you should be able to shift+enter through a notebook with ease, no matter what type of cells it contains!

To test:
- Open up the Pandas/GeoJSON example & shift+enter through the notebook. The cells should focus properly (highlight MD cells in view mode, focus editor on code cells)
- You can also create a new notebook with MD cell (view mode) - code cell - MD cell (view mode) - code cell - MD cell (view mode). You should also be able to shift+enter through this notebook properly despite what type of cell you start at

Sorry these notes were not super coherent, see you at PLOTCON!! @rgbkrk 