### PR TITLE
feat(menu) add run cells below functionality

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -326,6 +326,10 @@ export const cell = {
       click: createSender('menu:run-all'),
     },
     {
+      label: 'Run All Below',
+      click: createSender('menu:run-all-below'),
+    },
+    {
       label: 'Clear All',
       click: createSender('menu:clear-all'),
     },

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -172,6 +172,31 @@ export function dispatchPublishUserGist(store, event, githubToken) {
   store.dispatch({ type: 'PUBLISH_USER_GIST' });
 }
 
+/**
+ * Redux dispatch function to run the focused cell and all cells below it.
+ * It obtains the focused cell cell id and all code cell cell ids below.
+ * It dispatches the {@link executeCell} action on all of those retrieved cells.
+ *
+ * @exports
+ * @param {Object} store - The Redux store
+ */
+export function dispatchRunAllBelow(store) {
+  const state = store.getState();
+  const focusedCellId = state.document.get('cellFocused');
+  const notebook = state.document.get('notebook');
+  const indexOfFocusedCell = notebook.get('cellOrder').indexOf(focusedCellId);
+  const cellsBelowFocusedId = notebook.get('cellOrder').skip(indexOfFocusedCell);
+  const cells = notebook.get('cellMap');
+
+  cellsBelowFocusedId.filter((cellID) =>
+    cells.getIn([cellID, 'cell_type']) === 'code')
+      .map((cellID) => store.dispatch(
+        executeCell(
+          cellID,
+          cells.getIn([cellID, 'source'])
+        )
+  ));
+}
 
 export function dispatchRunAll(store) {
   const state = store.getState();
@@ -285,6 +310,7 @@ export function dispatchLoadConfig(store) {
 export function initMenuHandlers(store) {
   ipc.on('menu:new-kernel', dispatchNewKernel.bind(null, store));
   ipc.on('menu:run-all', dispatchRunAll.bind(null, store));
+  ipc.on('menu:run-all-below', dispatchRunAllBelow.bind(null, store));
   ipc.on('menu:clear-all', dispatchClearAll.bind(null, store));
   ipc.on('menu:unhide-all', dispatchUnhideAll.bind(null, store));
   ipc.on('menu:save', dispatchSave.bind(null, store));

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -203,6 +203,26 @@ describe('menu', () => {
     });
   });
 
+  describe('dispatchRunAllBelow', () => {
+    it('runs all code cells below the focused cell', () => {
+      const store = dummyStore({codeCellCount: 4, markdownCellCount: 4});
+      const markdownCells = store.getState().document.getIn(['notebook', 'cellMap'])
+                                                     .filter(cell => cell.get('cell_type') === 'markdown');
+      store.dispatch = sinon.spy();
+      
+      menu.dispatchRunAllBelow(store);
+
+      expect(store.dispatch.calledThrice).to.equal(true);    
+      for (let cellId of markdownCells.keys()) {
+          expect(store.dispatch.neverCalledWith({
+            type: 'EXECUTE_CELL',
+            id: cellId,
+            source: '',
+          })).to.equal(true);
+      }
+    });    
+  });
+
   describe('dispatchRunAll', () => {
     const store = dummyStore();
     store.dispatch = sinon.spy();

--- a/test/utils.js
+++ b/test/utils.js
@@ -21,6 +21,43 @@ import {
 
 const sinon = require('sinon');
 
+/**
+ * Creates a dummy notebook for Redux state for testing.
+ * 
+ * @param {object} config - Configuration options for notebook
+ * config.codeCellCount (number) - Number of empty code cells to be in notebook.
+ * config.markdownCellCount (number) - Number of empty markdown cells to be in notebook.
+ * config.hideAll (boolean) - Hide all cells in notebook
+ * @returns {object} - A notebook for {@link DocumentRecord} for Redux store. 
+ * Created using the config object passed in.
+ */
+function buildDummyNotebook(config) {
+  let notebook = appendCell(emptyNotebook, emptyCodeCell).setIn([
+    'metadata', 'kernelspec', 'name',
+  ], 'python2');
+
+  if (config) {
+
+    if (config.codeCellCount) {
+      for (let i=1; i < config.codeCellCount; i++) {
+        notebook = appendCell(notebook, emptyCodeCell);
+      }
+    }
+
+    if (config.markdownCellCount){
+      for (let i=0; i < config.markdownCellCount; i++) {
+        notebook = appendCell(notebook, emptyCodeCell.set('cell_type', 'markdown'));
+      }
+    }
+
+    if (config.hideAll) {
+      notebook = hideCells(notebook)
+    }
+  }
+
+  return notebook;
+}
+
 function hideCells(notebook) {
   return notebook
     .update('cellMap', (cells) => notebook
@@ -29,15 +66,15 @@ function hideCells(notebook) {
 }
 
 export function dummyStore(config) {
-  const notebook = appendCell(emptyNotebook, emptyCodeCell).setIn([
-    'metadata', 'kernelspec', 'name',
-  ], 'python2');
+  const dummyNotebook = buildDummyNotebook(config);
+
   return createStore({
     document: DocumentRecord({
-      notebook: (config && config.hideAll) ? hideCells(notebook) : notebook,
+      notebook: dummyNotebook,
       cellPagers: new Immutable.Map(),
       stickyCells: new Immutable.Map(),
       outputStatuses: new Immutable.Map(),
+      cellFocused: (config && config.codeCellCount > 1) ? dummyNotebook.get('cellOrder').get(1) : null,
     }),
     app: AppRecord({
       executionState: 'not connected',
@@ -54,6 +91,6 @@ export function dummyStore(config) {
     }),
     config: new Immutable.Map({
       theme: 'light',
-    }),
+    })
   }, reducers);
 }


### PR DESCRIPTION
Adds Menu > Run Cells Below to the menu.
This functionality runs the currently focused cell and all cells below it.
I use this functionality quite frequently in Jupyter notebooks and have added it to nteract now.

Commit also Enhances ./test/utils.js to add more configuration for building dummy notebooks for test

All comments welcome, thanks!