### PR TITLE
[WIP] Allow execute result

### DIFF
--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -76,7 +76,11 @@ export default handleActions({
     const output = action.output;
     const cellID = action.id;
 
-    if (output.output_type !== 'display_data' || !(_.has(output, 'transient.display_id'))) {
+    if ((output.output_type === 'display_data' || output.output_type === 'execute_result')
+        && _.has(output, 'transient.display_id')
+      ) {
+        // continue
+    } else {
       return state.updateIn(['notebook', 'cellMap', cellID, 'outputs'],
         (outputs) => reduceOutputs(outputs, output));
     }

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -124,7 +124,11 @@ export default handleActions({
     const keyPaths = state
       .getIn(
         ['transient', 'keyPathsForDisplays', displayID], new Immutable.List());
-    return keyPaths.reduce((currState, kp) => currState.setIn(kp, output), state);
+    return keyPaths.reduce(
+      (currState, kp) => currState.updateIn(kp,
+        oldOutput =>
+          output.set('output_type', oldOutput.get('output_type'))
+    ), state);
   },
   [constants.FOCUS_NEXT_CELL]: function focusNextCell(state, action) {
     const cellOrder = state.getIn(['notebook', 'cellOrder']);

--- a/test/renderer/reducers/document-spec.js
+++ b/test/renderer/reducers/document-spec.js
@@ -784,6 +784,15 @@ describe('updateDisplay', () => {
         }
       },
       {
+        type: constants.APPEND_OUTPUT,
+        id: id,
+        output: {
+          output_type: 'execute_result',
+          data: { 'text/plain': 'WOO' },
+          transient: { display_id: '1234' },
+        }
+      },
+      {
         type: constants.UPDATE_DISPLAY,
         output: {
           output_type: 'display_data',
@@ -798,6 +807,11 @@ describe('updateDisplay', () => {
       [
         {
           output_type: 'display_data',
+          data: { 'text/html': '<marquee>WOO</marquee>' },
+          transient: { display_id: '1234' },
+        },
+        {
+          output_type: 'execute_result',
           data: { 'text/html': '<marquee>WOO</marquee>' },
           transient: { display_id: '1234' },
         },


### PR DESCRIPTION
Update display data can also target `execute_result`. There's more to do here, as evidenced by the test I put in that fails (on purpose).