### PR TITLE
feat: toggle the blinking of cursor editor

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -434,6 +434,14 @@ export const view = {
       label: 'Theme',
       submenu: theme_menu,
     },
+    {
+      label: 'No Blink Editor Cursor',
+      click: createSender('menu:set-blink-rate', 0),
+    },
+    {
+      label: 'Blink Editor Cursor',
+      click: createSender('menu:set-blink-rate', 100),
+    },
   ],
 };
 

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -357,6 +357,18 @@ const theme_menu = [
     click: createSender('menu:theme', 'nteract'),
   },
 ];
+const blink_menu = [
+  // TODO: replace the with one `type: 'checkbox'` item once we have state to
+  // know which way it should be set initially.
+  {
+    label: 'Do Not Blink Editor Cursor',
+    click: createSender('menu:set-blink-rate', 0),
+  },
+  {
+    label: 'Blink Editor Cursor',
+    click: createSender('menu:set-blink-rate', 530),
+  },
+];
 
 const today = new Date();
 const day = today.getDate();
@@ -434,13 +446,10 @@ export const view = {
       label: 'Theme',
       submenu: theme_menu,
     },
+
     {
-      label: 'No Blink Editor Cursor',
-      click: createSender('menu:set-blink-rate', 0),
-    },
-    {
-      label: 'Blink Editor Cursor',
-      click: createSender('menu:set-blink-rate', 100),
+      label: 'Editor options',
+      submenu: blink_menu,
     },
   ],
 };

--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -265,6 +265,10 @@ export function setTheme(theme) {
   return setConfigKey('theme', theme);
 }
 
+export function setCursorBlink(value) {
+  return setConfigKey('cursorBlinkRate', value);
+}
+
 export function toggleOutputExpansion(id) {
   return {
     type: constants.TOGGLE_OUTPUT_EXPANSION,

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -137,21 +137,21 @@ export class Cell extends React.Component {
             theme={this.props.theme}
             cursorBlinkRate={this.props.cursorBlinkRate}
           /> :
-          <CodeCell
-            focusAbove={this.focusAboveCell}
-            focusBelow={this.focusBelowCell}
-            cellFocused={cellFocused}
-            editorFocused={editorFocused}
-            cell={cell}
-            id={this.props.id}
-            theme={this.props.theme}
-            cursorBlinkRate={this.props.cursorBlinkRate}
-            language={this.props.language}
-            displayOrder={this.props.displayOrder}
-            transforms={this.props.transforms}
-            pagers={this.props.pagers}
-            running={this.props.running}
-          />
+            <CodeCell
+              focusAbove={this.focusAboveCell}
+              focusBelow={this.focusBelowCell}
+              cellFocused={cellFocused}
+              editorFocused={editorFocused}
+              cell={cell}
+              id={this.props.id}
+              theme={this.props.theme}
+              cursorBlinkRate={this.props.cursorBlinkRate}
+              language={this.props.language}
+              displayOrder={this.props.displayOrder}
+              transforms={this.props.transforms}
+              pagers={this.props.pagers}
+              running={this.props.running}
+            />
         }
       </div>
     );

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -137,21 +137,21 @@ export class Cell extends React.Component {
             theme={this.props.theme}
             cursorBlinkRate={this.props.cursorBlinkRate}
           /> :
-            <CodeCell
-              focusAbove={this.focusAboveCell}
-              focusBelow={this.focusBelowCell}
-              cellFocused={cellFocused}
-              editorFocused={editorFocused}
-              cell={cell}
-              id={this.props.id}
-              theme={this.props.theme}
-              cursorBlinkRate={this.props.cursorBlinkRate}
-              language={this.props.language}
-              displayOrder={this.props.displayOrder}
-              transforms={this.props.transforms}
-              pagers={this.props.pagers}
-              running={this.props.running}
-            />
+          <CodeCell
+            focusAbove={this.focusAboveCell}
+            focusBelow={this.focusBelowCell}
+            cellFocused={cellFocused}
+            editorFocused={editorFocused}
+            cell={cell}
+            id={this.props.id}
+            theme={this.props.theme}
+            cursorBlinkRate={this.props.cursorBlinkRate}
+            language={this.props.language}
+            displayOrder={this.props.displayOrder}
+            transforms={this.props.transforms}
+            pagers={this.props.pagers}
+            running={this.props.running}
+          />
         }
       </div>
     );

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -26,6 +26,7 @@ export type CellProps = {
   language: string,
   running: boolean,
   theme: string,
+  cursorBlinkRate: number,
   pagers: ImmutableList<any>,
   transforms: ImmutableMap<string, any>,
 };
@@ -134,6 +135,7 @@ export class Cell extends React.Component {
             cell={cell}
             id={this.props.id}
             theme={this.props.theme}
+            cursorBlinkRate={this.props.cursorBlinkRate}
           /> :
             <CodeCell
               focusAbove={this.focusAboveCell}
@@ -143,6 +145,7 @@ export class Cell extends React.Component {
               cell={cell}
               id={this.props.id}
               theme={this.props.theme}
+              cursorBlinkRate={this.props.cursorBlinkRate}
               language={this.props.language}
               displayOrder={this.props.displayOrder}
               transforms={this.props.transforms}

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -17,6 +17,7 @@ type Props = {
   id: string,
   language: string,
   theme: string,
+  cursorBlinkRate: number,
   transforms: ImmutableMap<string, any>,
   cellFocused: boolean,
   editorFocused: boolean,
@@ -72,6 +73,7 @@ class CodeCell extends React.Component {
               cellFocused={this.props.cellFocused}
               editorFocused={this.props.editorFocused}
               theme={this.props.theme}
+              cursorBlinkRate={this.props.cursorBlinkRate}
               focusAbove={this.props.focusAbove}
               focusBelow={this.props.focusBelow}
             />

--- a/src/notebook/components/cell/draggable-cell.js
+++ b/src/notebook/components/cell/draggable-cell.js
@@ -25,6 +25,7 @@ type Props = {
   language: string,
   running: boolean,
   theme: string,
+  cursorBlinkRate: number,
   pagers: ImmutableList<any>,
   moveCell: (source: string, dest: string, above: boolean) => Object,
 };
@@ -167,6 +168,7 @@ class DraggableCell extends React.Component {
             language={this.props.language}
             running={this.props.running}
             theme={this.props.theme}
+            cursorBlinkRate={this.props.cursorBlinkRate}
             pagers={this.props.pagers}
             transforms={this.props.transforms}
           />

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -229,12 +229,12 @@ export default class Editor extends React.Component {
       this.cursorBlinkRate = this.props.cursorBlinkRate;
       const cm = this.codemirror.getCodeMirror();
       cm.setOption('cursorBlinkRate', this.cursorBlinkRate);
-      if (this.props.editorFocused)  {
+      if (this.props.editorFocused) {
         // code mirror doesn't change the blink rate immediately, we have to
         // move the cursor, or unfocus and refocus the editor to get the blink
         // rate to update - so here we do that (unfocus and refocus)
         cm.getInputField().blur();
-        cm.focus()
+        cm.focus();
       }
     }
   }

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -162,7 +162,6 @@ export default class Editor extends React.Component {
 
   constructor(props: Props): void {
     super(props);
-
     this.state = {
       source: this.props.input,
     };

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -47,6 +47,7 @@ type Props = {
   editorFocused: boolean,
   focusAbove: Function,
   focusBelow: Function,
+  cursorBlinkRate: number,
 };
 
 type State = {
@@ -142,6 +143,7 @@ export default class Editor extends React.Component {
   onFocusChange: (focused: boolean) => void;
   hint: (editor: Object, cb: Function) => void;
   theme: string|null;
+  cursorBlinkRate: number;
   codemirror: CodeMirror;
   focus: () => void;
 
@@ -160,6 +162,7 @@ export default class Editor extends React.Component {
 
   constructor(props: Props): void {
     super(props);
+
     this.state = {
       source: this.props.input,
     };
@@ -223,6 +226,18 @@ export default class Editor extends React.Component {
       this.theme = this.props.theme;
       this.codemirror.getCodeMirror().refresh();
     }
+    if (this.cursorBlinkRate !== this.props.cursorBlinkRate) {
+      this.cursorBlinkRate = this.props.cursorBlinkRate;
+      const cm = this.codemirror.getCodeMirror();
+      cm.setOption('cursorBlinkRate', this.cursorBlinkRate);
+      if (this.props.editorFocused)  {
+        // code mirror doesn't change the blink rate immediately, we have to
+        // move the cursor, or unfocus and refocus the editor to get the blink
+        // rate to update - so here we do that (unfocus and refocus)
+        cm.getInputField().blur();
+        cm.focus()
+      }
+    }
   }
 
   onChange(text: string): void {
@@ -266,6 +281,7 @@ export default class Editor extends React.Component {
       lineWrapping: this.props.lineWrapping,
       matchBrackets: this.props.matchBrackets,
       theme: this.props.cmtheme,
+      cursorBlinkRate: this.props.cursorBlinkRate,
       autofocus: false,
       hintOptions: {
         hint: this.hint,

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -11,6 +11,7 @@ type Props = {
   cell: any,
   id: string,
   theme: string,
+  cursorBlinkRate: number,
   focusAbove: Function,
   focusBelow: Function,
   focusEditor: Function,
@@ -150,6 +151,7 @@ export default class MarkdownCell extends React.Component {
                lineWrapping
                input={this.state.source}
                theme={this.props.theme}
+               cursorBlinkRate={this.props.cursorBlinkRate}
                focusAbove={this.props.focusAbove}
                focusBelow={this.props.focusBelow}
                cellFocused={this.props.cellFocused}

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -54,6 +54,7 @@ type Props = {
   cellFocused: string,
   editorFocused: string,
   theme: string,
+  cursorBlinkRate: number,
   lastSaved: Date,
   kernelSpecName: string,
   CellComponent: any,
@@ -103,6 +104,7 @@ export function scrollToElement(el: HTMLElement): number {
 
 const mapStateToProps = (state: Object) => ({
   theme: state.config.get('theme'),
+  cursorBlinkRate: state.config.get('cursorBlinkRate'),
   lastSaved: state.app.get('lastSaved'),
   kernelSpecName: state.app.get('kernelSpecName'),
   notebook: state.document.get('notebook'),
@@ -231,6 +233,7 @@ export class Notebook extends React.Component {
       // Theme is passed through to let the Editor component know when to
       // tell CodeMirror to remeasure
       theme: this.props.theme,
+      cursorBlinkRate: this.props.cursorBlinkRate,
     };
   }
 

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -37,6 +37,7 @@ import {
   setGithubToken,
   changeInputVisibility,
   setTheme,
+  setCursorBlink,
   save,
   saveAs,
 } from './actions';
@@ -266,6 +267,10 @@ export function dispatchSetTheme(store, evt, theme) {
   store.dispatch(setTheme(theme));
 }
 
+export function dispatchSetCursorBlink(store, evt, value) {
+  store.dispatch(setCursorBlink(value));
+}
+
 export function dispatchCopyCell(store) {
   const state = store.getState();
   const focused = state.document.get('cellFocused');
@@ -329,6 +334,7 @@ export function initMenuHandlers(store) {
   ipc.on('menu:zoom-out', dispatchZoomOut.bind(null, store));
   ipc.on('menu:zoom-reset', dispatchZoomReset.bind(null, store));
   ipc.on('menu:theme', dispatchSetTheme.bind(null, store));
+  ipc.on('menu:set-blink-rate', dispatchSetCursorBlink.bind(null, store));
   ipc.on('menu:github:auth', dispatchPublishUserGist.bind(null, store));
   // OCD: This is more like the registration of main -> renderer thread
   ipc.on('main:load', dispatchLoad.bind(null, store));

--- a/test/renderer/components/cell/editor-spec.js
+++ b/test/renderer/components/cell/editor-spec.js
@@ -99,6 +99,18 @@ describe('Editor', () => {
     expect(completer).to.have.not.been.called;
     completer.restore();
   });
+  it('handles cursor blinkery changes', () => {
+	const editorWrapper = mount(
+	  <Editor
+	  cursorBlinkRate={530}
+		/>,
+	);
+	const instance = editorWrapper.instance();
+	const cm = instance.codemirror.getCodeMirror()
+	expect(cm.options.cursorBlinkRate).to.equal(530);
+	editorWrapper.setProps({cursorBlinkRate: 0})
+	expect(cm.options.cursorBlinkRate).to.equal(0);
+  });
 });
 
 describe('complete', () => {

--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -102,6 +102,20 @@ describe('menu', () => {
       });
     });
   });
+  describe('dispatchSetCursorBlink', () => {
+    it('dispatches a SET_CONFIG_KEY action', () => {
+      const store = dummyStore();
+      store.dispatch = sinon.spy();
+
+      menu.dispatchSetCursorBlink(store, {}, 42);
+
+      expect(store.dispatch.firstCall).to.be.calledWith({
+        type: constants.SET_CONFIG_KEY,
+        key: 'cursorBlinkRate',
+        value: 42,
+      });
+    });
+  });
 
   describe('dispatchLoadConfig', () => {
     it('dispatches a LOAD_CONFIG action', () => {
@@ -366,6 +380,7 @@ describe('menu', () => {
         'menu:zoom-in',
         'menu:zoom-out',
         'menu:theme',
+        'menu:set-blink-rate',
         'main:load',
         'main:new',
       ].forEach(name => {


### PR DESCRIPTION
We will want to refactor this so passing around CodeMirror editors is less painful in the future. 

It would also be nice for the menu items to have access to state, so we could have a checkbox reflecting which theme is used, and whether or not the cursor blinking is enabled.