### PR TITLE
fix(bracketMatcher): Don't obstruct cursor

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -415,7 +415,7 @@ code {
 .cm-s-composition span.cm-operator { color: var(--cm-operator); }
 .cm-s-composition span.cm-def { color: var(--cm-def); }
 .cm-s-composition .CodeMirror-activeline-background { background: var(--cm-activeline-bg); }
-.cm-s-composition .CodeMirror-matchingbracket { outline:1px solid var(--cm-matchingbracket-outline); color: var(--cm-matchingbracket-color) !important; }
+.cm-s-composition .CodeMirror-matchingbracket { border-bottom: 1px solid var(--cm-matchingbracket-outline); color: var(--cm-matchingbracket-color) !important; }
 
 /* Overwrite some of the hint Styling */
 


### PR DESCRIPTION
master:
<img width="152" alt="bildschirmfoto 2016-11-17 um 00 18 45" src="https://cloud.githubusercontent.com/assets/13285808/20377228/ad541274-ac5b-11e6-9b82-b056f2890a0e.png">
PR:
<img width="149" alt="bildschirmfoto 2016-11-17 um 00 18 18" src="https://cloud.githubusercontent.com/assets/13285808/20377230/b44d6b0c-ac5b-11e6-84e3-54f29ff8cab1.png">


