### PR TITLE
fix(docs): correct typo in display-updates

### DIFF
--- a/example-notebooks/display-updates.ipynb
+++ b/example-notebooks/display-updates.ipynb
@@ -24,7 +24,7 @@
    "status": "idle",
    "cell_type": "code",
    "source": [
-    "print(\"typical ouput\")"
+    "print(\"typical output\")"
    ]
   },
   {


### PR DESCRIPTION
Fixed the typo found in issue #1200 

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

<!-- Questions? Feel free to ping us on https://slack.nteract.in -->

