### PR TITLE
fix(reducers): Move cell status from notebook to transient

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -51,6 +51,7 @@ type Props = {
   transforms: ImmutableMap<string, any>,
   cellPagers: ImmutableMap<string, any>,
   stickyCells: ImmutableMap<string, any>,
+  transient: ImmutableMap<string, any>,
   cellFocused: string,
   editorFocused: string,
   theme: string,
@@ -108,6 +109,7 @@ const mapStateToProps = (state: Object) => ({
   lastSaved: state.app.get('lastSaved'),
   kernelSpecName: state.app.get('kernelSpecName'),
   notebook: state.document.get('notebook'),
+  transient: state.document.get('transient'),
   cellPagers: state.document.get('cellPagers'),
   cellFocused: state.document.get('cellFocused'),
   editorFocused: state.document.get('editorFocused'),
@@ -216,7 +218,7 @@ export class Notebook extends React.Component {
     }
   }
 
-  createCellProps(id: string, cell: any): CellProps {
+  createCellProps(id: string, cell: any, transient: any): CellProps {
     return {
       id,
       cell,
@@ -229,7 +231,7 @@ export class Notebook extends React.Component {
       pagers: this.props.cellPagers.get(id),
       cellFocused: this.props.cellFocused,
       editorFocused: this.props.editorFocused,
-      running: cell.get('status') === 'busy',
+      running: transient.get('status') === 'busy',
       // Theme is passed through to let the Editor component know when to
       // tell CodeMirror to remeasure
       theme: this.props.theme,
@@ -240,6 +242,7 @@ export class Notebook extends React.Component {
   createCellElement(id: string): ?React.Element<any> {
     const cellMap = this.props.notebook.get('cellMap');
     const cell = cellMap.get(id);
+    const transient = this.props.transient.getIn(['cellMap', id], new ImmutableMap());
     const isStickied = this.props.stickyCells.get(id);
 
     const CellComponent = this.props.CellComponent;
@@ -250,17 +253,18 @@ export class Notebook extends React.Component {
           <div className="cell-placeholder">
             <span className="octicon octicon-link-external" />
           </div> :
-          <CellComponent {...this.createCellProps(id, cell)} />}
+          <CellComponent {...this.createCellProps(id, cell, transient)} />}
         <CellCreator key={`creator-${id}`} id={id} above={false} />
       </div>);
   }
 
   createStickyCellElement(id: string): ?React.Element<any> {
     const cellMap = this.props.notebook.get('cellMap');
+    const transient = this.props.transient.getIn(['cellMap', id], new ImmutableMap());
     const cell = cellMap.get(id);
     return (
       <div key={`cell-container-${id}`}>
-        <Cell {...this.createCellProps(id, cell)} />
+        <Cell {...this.createCellProps(id, cell, transient)} />
       </div>);
   }
 

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -45,7 +45,7 @@ export function cleanCellTransient(state, id) {
     kpfd.map(keyPaths =>
       keyPaths.filter(keyPath => keyPath.get(2) !== id)
     )
-  );
+  ).setIn(['transient', 'cellMap'], new Immutable.Map());
 }
 
 export default handleActions({
@@ -55,11 +55,11 @@ export default handleActions({
         cells.map((value) =>
           value.setIn(['metadata', 'inputHidden'], false)
                 .setIn(['metadata', 'outputHidden'], false)
-                .setIn(['metadata', 'outputExpanded'], false)
-                .set('status', '')));
+                .setIn(['metadata', 'outputExpanded'], false)));
 
     return state.set('notebook', notebook)
-      .set('cellFocused', notebook.getIn(['cellOrder', 0]));
+      .set('cellFocused', notebook.getIn(['cellOrder', 0]))
+      .setIn(['transient', 'cellMap'], new Immutable.Map());
   },
   [constants.FOCUS_CELL]: function focusCell(state, action) {
     return state.set('cellFocused', action.id);
@@ -293,7 +293,7 @@ export default handleActions({
   },
   [constants.UPDATE_CELL_STATUS]: function updateCellStatus(state, action) {
     const { id, status } = action;
-    return state.setIn(['notebook', 'cellMap', id, 'status'], status);
+    return state.setIn(['transient', 'cellMap', id, 'status'], status);
   },
   [constants.SET_LANGUAGE_INFO]: function setLanguageInfo(state, action) {
     const langInfo = Immutable.fromJS(action.langInfo);

--- a/test/renderer/components/notebook-spec.js
+++ b/test/renderer/components/notebook-spec.js
@@ -37,6 +37,7 @@ describe('Notebook', () => {
     const component = shallow(
       <Notebook
         notebook={dummyCommutable}
+        transient={new Immutable.Map({cellMap: new Immutable.Map()})}
         cellPagers={new Immutable.Map()}
         cellStatuses={new Immutable.Map()}
         stickyCells={(new Immutable.Map())
@@ -53,6 +54,7 @@ describe('Notebook', () => {
     const component = mount(
       <Notebook
         notebook={dummyCommutable}
+        transient={new Immutable.Map({cellMap: new Immutable.Map()})}
         cellPagers={new Immutable.Map()}
         cellStatuses={dummyCellStatuses}
         stickyCells={new Immutable.Map()}
@@ -96,6 +98,7 @@ describe('Notebook', () => {
       const component = shallow(
         <Notebook
           notebook={dummyCommutable}
+          transient={new Immutable.Map({cellMap: new Immutable.Map()})}
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}
           stickyCells={(new Immutable.Map())}
@@ -129,6 +132,7 @@ describe('Notebook', () => {
       const component = shallow(
         <Notebook
           notebook={dummyCommutable}
+          transient={new Immutable.Map({cellMap: new Immutable.Map()})}
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}
           stickyCells={(new Immutable.Map())}
@@ -160,6 +164,7 @@ describe('Notebook DnD', () => {
     const component = mount(
       <TestNotebook
         notebook={dummyCommutable}
+        transient={new Immutable.Map({cellMap: new Immutable.Map()})}
         cellPagers={new Immutable.Map()}
         cellStatuses={dummyCellStatuses}
         stickyCells={(new Immutable.Map())}

--- a/test/renderer/reducers/document-spec.js
+++ b/test/renderer/reducers/document-spec.js
@@ -601,7 +601,7 @@ describe('updateCellStatus', () => {
     };
 
     const state = reducers(originalState, action);
-    expect(state.document.getIn(['notebook', 'cellMap', id, 'status'])).to.equal("test status");
+    expect(state.document.getIn(['transient', 'cellMap', id, 'status'])).to.equal("test status");
   });
 });
 


### PR DESCRIPTION
Introduces the transient state subtree to hold state which go away without a kernel session.
Paired with @rgbkrk 

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

