### PR TITLE
fix: delete code keys from converted markdown cells

### DIFF
--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -350,8 +350,8 @@ export default handleActions({
     }
 
     return cleanCellTransient(state.setIn(['notebook', 'cellMap', id, 'cell_type'], to)
-      .delete(['notebook', 'cellMap', id, 'execution_count'])
-      .delete(['notebook', 'cellMap', id, 'outputs']),
+      .deleteIn(['notebook', 'cellMap', id, 'execution_count'])
+      .deleteIn(['notebook', 'cellMap', id, 'outputs']),
       id);
   },
   [constants.TOGGLE_OUTPUT_EXPANSION]: function toggleOutputExpansion(state, action) {


### PR DESCRIPTION
Doing the cleanup that I noticed in #1232. I'm thinking the change cell type op should use an empty code or markdown cell so it ensures all the metadata is cleaned out. Not real sure what's best here or if we want to carry some metadata over. ¯\\\_(ツ)\_/¯