### PR TITLE
Downgrade Electron to 1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "diagnostics": "scripts/kernelspecs-diagnostics.js"
   },
   "build": {
-    "electronVersion": "1.4.9",
+    "electronVersion": "1.4.8",
     "appId": "io.nteract.nteract",
     "fileAssociations": {
       "ext": "ipynb",
@@ -149,7 +149,7 @@
     "colors": "^1.1.2",
     "command-exists": "^1.0.2",
     "cross-env": "^3.1.3",
-    "electron": "1.4.9",
+    "electron": "1.4.8",
     "electron-builder": "^8.5.2",
     "electron-mocha": "^3.2.0",
     "enzyme": "^2.6.0",


### PR DESCRIPTION
Version 1.4.9 was unpublished and isn't available anymore.

This is why the build in #1243 fails