### PR TITLE
Overwrite codemirror scroll behavior

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -356,8 +356,8 @@ code {
 
 .CodeMirror-scroll
 {
-    overflow-x: auto;
-    overflow-y: hidden;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
 }
 
 .CodeMirror-lines


### PR DESCRIPTION
`overflow: scroll` doesn't work well if scroll bars are hidden on OS X (default). There should be a better way of doing this or it's a bug in Codemirror related to https://github.com/codemirror/CodeMirror/commit/c818907c32203331f00f1415e0402fd2e0f08fdc.

For now this fixes #1223 