### PR TITLE
[WIP][discuss] feature(notebook): Added key binding for esc to notebook

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -197,7 +197,13 @@ export class Notebook extends React.Component {
         e.preventDefault();
 
         const shiftXORctrl = (shiftKey || ctrlKey) && !(shiftKey && ctrlKey);
-        if (!shiftXORctrl) return;
+
+        if (!shiftXORctrl) {
+          if (!editorFocused) {
+            store.dispatch(focusCellEditor(id))
+          }
+          break;
+        }
 
         if (shiftKey) {
           store.dispatch(focusNextCell(id, true));

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -213,7 +213,7 @@ export class Notebook extends React.Component {
       }
       case 'ArrowDown': {
         if (!editorFocused) {
-          store.dispatch(focusNextCell(id, false));
+          store.dispatch(focusNextCell(id, true));
         }
         break;
       }


### PR DESCRIPTION
This PR is to address the issue that @jkornblum brought up in Slack.

Here's the user experience in the Jupyter notebook:
1. User presses the Esc key in a cell with the editor focused
2. The cell's editor loses focus while the cell's focus is maintained
3. User presses up/down arrow keys to navigate 
4. The cell's editor never focuses - in Esc mode, only the cell is focused
5. At the end of the notebook, a new cell is not created

I recreated this experience by creating key bindings at the notebook level to handle Esc, Up & Down. This is problematic because we currently handle Up & Down at the cell level so we can navigate through the notebook while maintaining focus on the editor as described by @rgbkrk's user intents in #1065.

Please check out the branch and let me know what you think. One caveat - right now, you can't move between rendered MD cells and code cells without focusing the cell's editor because of how it's handled here: https://github.com/nteract/nteract/blob/master/src/notebook/components/cell/markdown-cell.js#L110-L124

It's going to get messy splitting that out so I wanted to get feedback before proceeding.