### PR TITLE
fix(notebook): Removed auto scroll to maintain viewport when executing cells

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -72,36 +72,6 @@ export function getLanguageMode(notebook: any): string {
     'text')));
   return language;
 }
-/**
- * Provide the appropriate position to scroll to when given cell position and size
- * information.
- * @param  {HTMLElement} el - Element to be compared against window and body for
- * scrollTop value.
- * @return {Integer} - An integer for the new document scrollTop value.
- */
-export function scrollToElement(el: HTMLElement): number {
-  const viewportHeight = window.innerHeight;
-  const viewportOffset = document.body.scrollTop;
-
-  const cellTop = el.offsetTop;
-  const cellHeight = el.offsetHeight;
-
-  const belowFold = (cellTop + cellHeight) > (viewportOffset + viewportHeight);
-  const aboveFold = cellTop < viewportOffset;
-
-  if (aboveFold) {
-    return cellTop;
-  }
-
-  if (belowFold) {
-    if (cellHeight > viewportHeight) {
-      return cellTop;
-    }
-    const offset = viewportHeight - cellHeight;
-    return cellTop - offset;
-  }
-  return document.body.scrollTop;
-}
 
 const mapStateToProps = (state: Object) => ({
   theme: state.config.get('theme'),
@@ -150,12 +120,6 @@ export class Notebook extends React.Component {
 
   componentDidMount(): void {
     document.addEventListener('keydown', this.keyDown);
-  }
-
-  componentWillReceiveProps(nextProps: Props): void {
-    if (nextProps.cellFocused !== this.props.cellFocused) {
-      this.resolveScrollPosition(nextProps.cellFocused);
-    }
   }
 
   componentDidUpdate(): void {
@@ -208,13 +172,6 @@ export class Notebook extends React.Component {
           cell.get('source')
         )
       );
-    }
-  }
-
-  resolveScrollPosition(id: string): void {
-    const cellFocused = this.cellElements.get(id);
-    if (cellFocused) {
-      document.body.scrollTop = scrollToElement(cellFocused);
     }
   }
 

--- a/test/renderer/components/notebook-spec.js
+++ b/test/renderer/components/notebook-spec.js
@@ -177,35 +177,3 @@ describe('Notebook DnD', () => {
     // TODO: Write tests for cell drag and drop
   })
 })
-
-describe('scrollToElement', () => {
-  it('works for case aboveFold', () => {
-    let el = document.createElement('div');
-    el.offsetTop = 1111;
-    el.offsetHeight = 0;
-    window.innerHeight = 0;
-    document.body.scrollTop = 2000;
-    const scrollTop = scrollToElement(el);
-    expect(scrollTop).to.equal(1111);
-  });
-
-  it('works for belowFold and cellHeight greater than viewport', () => {
-    let el = document.createElement('div')
-    el.offsetTop = 100 //cellTop
-    el.offsetHeight = 100; //cellHeight
-    window.innerHeight = 99; //viewportHeight
-    document.body.scrollTop = 99; //viewportOffset
-    const scrollTop = scrollToElement(el);
-    expect(scrollTop).to.equal(100);
-  });
-
-  it('works for belowFold and cellHeight less than viewport', () => {
-    let el = document.createElement('div')
-    el.offsetTop = 100; //cellTop
-    el.offsetHeight = 100; //cellHeight
-    window.innerHeight = 100; //viewportHeight
-    document.body.scrollTop = 99; //viewportOffset
-    const scrollTop = scrollToElement(el);
-    expect(scrollTop).to.equal(100);
-  })
-})


### PR DESCRIPTION
Resolves #803 

After playing around in the Jupyter notebook, it seems like ripping out our current scroll behavior provides a more consistent user experience. One thing I would like to improve is the transition from scrolling at the top/bottom of the cell output to the notebook scroll - right now, it seems a little janky. Maybe throttling the notebook scroll slightly so it's closer to the speed of cell scroll would help? What do you think?