### PR TITLE
style: singular "Open Example Notebook"

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -85,7 +85,7 @@ export const fileSubMenus = {
     accelerator: 'CmdOrCtrl+O',
   },
   openExampleNotebooks: {
-    label: '&Open Example Notebooks',
+    label: '&Open Example Notebook',
     submenu: [
       {
         label: '&Intro',


### PR DESCRIPTION
Every time I describe "File -> Open Example Notebooks -> Intro" I want to say "File -> Open Example Notebook -> Intro". I've switched it over to singular here.