### PR TITLE
fix(editor): Use spaces for tabs when indentWithTabs is false

### DIFF
--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -272,6 +272,15 @@ export default class Editor extends React.Component {
       .subscribe(callback);
   }
 
+  tabToSpaces(editor: Object) {
+    if (editor.somethingSelected()) {
+      editor.indentSelection('add');
+    } else {
+      editor.replaceSelection(editor.getOption('indentWithTabs') ? '\t' :
+        Array(editor.getOption('indentUnit') + 1).join(' '), 'end', '+input');
+    }
+  }
+
   render(): ?React.Element<any> {
     const options = {
       autoCloseBrackets: this.props.autoCloseBrackets,
@@ -291,6 +300,7 @@ export default class Editor extends React.Component {
       },
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
+        'Tab': this.tabToSpaces,
       },
       indentUnit: this.props.tabSize,
       tabSize: this.props.tabSize,

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -272,12 +272,12 @@ export default class Editor extends React.Component {
       .subscribe(callback);
   }
 
-  static tabToSpaces(editor: Object) {
+  tabToSpaces(editor: Object): void {
     if (editor.somethingSelected()) {
       editor.indentSelection('add');
     } else {
       editor.replaceSelection(editor.getOption('indentWithTabs') ? '\t' :
-        Array(editor.getOption('indentUnit') + 1).join(' '), 'end', '+input');
+        Array(this.props.tabSize + 1).join(' '), 'end', '+input');
     }
   }
 

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -272,7 +272,7 @@ export default class Editor extends React.Component {
       .subscribe(callback);
   }
 
-  tabToSpaces(editor: Object) {
+  static tabToSpaces(editor: Object) {
     if (editor.somethingSelected()) {
       editor.indentSelection('add');
     } else {
@@ -300,7 +300,7 @@ export default class Editor extends React.Component {
       },
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
-        'Tab': this.tabToSpaces,
+        Tab: this.tabToSpaces,
       },
       indentUnit: this.props.tabSize,
       tabSize: this.props.tabSize,


### PR DESCRIPTION
Closes #1238.

![nteract-indent](https://cloud.githubusercontent.com/assets/1857993/20849459/6abc2d6e-b89c-11e6-9bbc-23f9b0f7d801.gif)

