### PR TITLE
chore(publish): Cleanup github code

### DIFF
--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -40,7 +40,6 @@ export function notifyUser(filename, gistID, notificationSystem) {
     },
   });
 }
-// give these module scope to allow overwriting of metadata
 
 /**
  * Callback function to be used in publishNotebookObservable such that the

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -17,6 +17,7 @@ const Observable = Rx.Observable;
 
 const Github = require('github');
 
+
 /**
  * Notify the notebook user that it has been published as a gist.
  * @param {string} filename - Filename of the notebook.
@@ -39,7 +40,9 @@ export function notifyUser(filename, gistID, notificationSystem) {
     },
   });
 }
-
+// give these module scope to allow overwriting of metadata
+let gistID;
+let gistURL;
 /**
  * Callback function to be used in publishNotebookObservable such that the
  * response from the github API can be used for user notification.
@@ -58,8 +61,8 @@ export function createGistCallback(observer, filename, notificationSystem) {
       observer.complete();
       return;
     }
-    const gistID = response.id;
-    const gistURL = response.html_url;
+    gistID = response.id;
+    gistURL = response.html_url;
 
     notifyUser(filename, gistID, notificationSystem);
   };
@@ -88,7 +91,7 @@ export function publishNotebookObservable(github, notebook, filepath,
       undefined,
       1);
 
-    const filename = filepath ?  path.parse(filepath).base : 'Untitled.ipynb';
+    const filename = filepath ? path.parse(filepath).base : 'Untitled.ipynb';
     const files = {};
     files[filename] = { content: notebookString };
 
@@ -122,9 +125,10 @@ export function publishNotebookObservable(github, notebook, filepath,
         files,
         public: false,
       };
+
       const resp = github.gists.create(gistRequest,
         createGistCallback(observer, filename, notificationSystem));
-      observer.next(overwriteMetadata('gist_id', resp.gistID));
+      observer.next(overwriteMetadata('gist_id', gistID));
       observer.complete();
     }
   });

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -60,7 +60,7 @@ export function createGistCallback(store, observer, filename, notificationSystem
       return;
     }
     const gistID = response.id;
-    store.dispatch(overwriteMetadata('gist_id', gistID));
+    observer.next(store.dispatch(overwriteMetadata('gist_id', gistID)));
     notifyUser(filename, gistID, notificationSystem);
   };
 }
@@ -107,13 +107,11 @@ export function publishNotebookObservable(github, notebook, filepath,
       message: 'Your notebook is being uploaded as a GitHub gist',
       level: 'info',
     });
-    console.log(notebook.hasIn(['metadata', 'gist_id']))
     // Already in a gist, update the gist
     const gistRequest = notebook.hasIn(['metadata', 'gist_id']) ?
       { files, id: notebook.getIn(['metadata', 'gist_id']), public: false } :
       { files, public: false };
     if (gistRequest.id) {
-      console.log(gistRequest)
       github.gists.edit(gistRequest,
         createGistCallback(store, observer, filename, notificationSystem));
     } else {

--- a/test/renderer/epics/github-publish-spec.js
+++ b/test/renderer/epics/github-publish-spec.js
@@ -82,7 +82,10 @@ describe('publishNotebookObservable', () => {
       const publishNotebookObs = publishNotebookObservable(github,
         notebook, './test.ipynb', notificationSystem);
       const edit = sinon.spy(github.gists, 'edit');
-      publishNotebookObs.subscribe( () => {
+      publishNotebookObs.subscribe(
+      (x) => { expect.fail() },
+      (err) => { expect.fail() },
+      () => {
         expect(edit).to.be.called;
         done();
       });

--- a/test/renderer/epics/github-publish-spec.js
+++ b/test/renderer/epics/github-publish-spec.js
@@ -83,7 +83,7 @@ describe('publishNotebookObservable', () => {
         notebook, './test.ipynb', notificationSystem);
       const edit = sinon.spy(github.gists, 'edit');
       publishNotebookObs.subscribe(
-      (x) => { expect.fail() },
+      (x) => { expect(x.type).to.deep.equal('OVERWRITE_METADATA_FIELD') },
       (err) => { expect.fail() },
       () => {
         expect(edit).to.be.called;

--- a/test/renderer/epics/github-publish-spec.js
+++ b/test/renderer/epics/github-publish-spec.js
@@ -47,58 +47,70 @@ describe('handleGistAction', () => {
 
 describe('publishNotebookObservable', () => {
     it('returns an observable', () => {
+        const store = dummyStore();
         const notificationSystem = NotificationSystem();
         const publishNotebookObs = publishNotebookObservable(new GitHub(),
-          dummyCommutable, './test.ipynb', notificationSystem);
+          dummyCommutable, './test.ipynb', notificationSystem, false, store);
         expect(publishNotebookObs.subscribe).to.not.be.null;
     });
 
     it('renders a notification popup', (done) => {
+      const store = dummyStore();
       const notificationSystem = NotificationSystem();
       const publishNotebookObs = publishNotebookObservable(new GitHub(),
-        dummyCommutable, './test.ipynb', notificationSystem);
+        dummyCommutable, './test.ipynb', notificationSystem, false, store);
       const addNotification = sinon.spy(notificationSystem, 'addNotification');
-      publishNotebookObs.subscribe( () => {
-        expect(addNotification).to.be.called;
-        done();
+      publishNotebookObs.subscribe(
+        (x) => { },
+        (err) => { expect.fail() },
+        () => {
+          expect(addNotification).to.be.called;
+          done();
       });
     });
 
     it('calls create gist', (done) => {
       const github = new GitHub();
+      const store = dummyStore();
       const notificationSystem = NotificationSystem();
       const publishNotebookObs = publishNotebookObservable(github,
-        dummyCommutable, './test.ipynb', notificationSystem);
+        dummyCommutable, './test.ipynb', notificationSystem, false,store);
       const create = sinon.spy(github.gists, 'create');
-      publishNotebookObs.subscribe( () => {
-        expect(create).to.be.called;
-        done();
+      publishNotebookObs.subscribe(
+        (x) => { },
+        (err) => { expect.fail() },
+        () => {
+          expect(create).to.be.called;
+          done();
       });
     });
     it('edits gist that is already made', (done) => {
       const github = new GitHub();
+      const store = dummyStore();
       const notebook = dummyCommutable.setIn(['metadata', 'gist_id'], 'ID123')
       const notificationSystem = NotificationSystem();
       const publishNotebookObs = publishNotebookObservable(github,
-        notebook, './test.ipynb', notificationSystem);
+        notebook, './test.ipynb', notificationSystem, false, store);
       const edit = sinon.spy(github.gists, 'edit');
+      const actionBuffer = [];
       publishNotebookObs.subscribe(
-      (x) => { expect(x.type).to.deep.equal('OVERWRITE_METADATA_FIELD') },
-      (err) => { expect.fail() },
-      () => {
-        expect(edit).to.be.called;
-        done();
+        (x) => { expect(x.type).to.equal('OVERWRITE_METADATA_FIELD') },
+        (err) => { expect.fail() },
+        () => {
+          expect(edit).to.be.called;
+          done();
       });
     });
 });
 
 describe('createGistCallback', () => {
   it('returns a function', () => {
+    const store = dummyStore();
     const github = new GitHub();
     const notificationSystem = NotificationSystem();
     const publishNotebookObs = publishNotebookObservable(github,
-      dummyCommutable, './test.ipynb', notificationSystem);
-    const callback = createGistCallback(true, publishNotebookObs,
+      dummyCommutable, './test.ipynb', notificationSystem, false, store);
+    const callback = createGistCallback(store, publishNotebookObs,
       './test.ipynb', notificationSystem);
     expect((typeof(callback))).to.equal('function');
   });


### PR DESCRIPTION
Posting this in an attempt to solicit help. Would like to be able to store the response of `createGistCallback` in `publishNotebookObservable`, but I have no idea to get the id and html_url from the response of `createGistCallback`. Please help me out if you have the time, thanks.