### PR TITLE
Update Rx links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ You'll need knowledge of JavaScript (ES6), React, RxJS, Redux, and Flow to help 
 with this project. That's a whole lot of cool stuff! But don't worry, we've
 got some resources to help you out.
 * [Building a voting app with Redux and React](http://teropa.info/blog/2015/09/10/full-stack-redux-tutorial.html)
-* [The RxJS Tutorial](https://xgrommx.github.io/rx-book/index.html)
+* [Introduction to Reactive Programming](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754)
+* [Examples, Explanations, and Resources for RxJS 5](https://github.com/btroncone/learn-rxjs)
 * [Adding Flow to React Components](https://flowtype.org/docs/react.html#defining-components-as-reactcomponent-subclasses)
 
 ### Jupyter and ZeroMQ (Optional)


### PR DESCRIPTION
Noticed we had a link to an RxJS 4 guide, updated it to link to RxJS 5 and a generic reactive tutorial.