### PR TITLE
docs(README): add set debug=true environment variable note

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ And then opening `docs/index.html` in your favorite browser.
 
 - Try `npm run reinstall`
 
+> I want to debug redux actions and state changes.
+
+-  Enable [redux-logger](https://github.com/evgenyrodionov/redux-logger) by spawning the application with `npm run spawn:debug`. 
+
 ## For maintainers: Creating a release
 
 ### Bump the version

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prestart": "npm run build",
     "start": "npm run spawn",
     "spawn": "cross-env NODE_ENV=development electron .",
+    "spawn:debug": "cross-env DEBUG=true NODE_ENV=development electron .",
     "clean": "rimraf lib dist",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",


### PR DESCRIPTION
This commit adds a short note in troubleshooting section on how to enable the process.env.DEBUG environment variable which will enable the redux-logger functionality