### PR TITLE
docs: fix links to ipython PRs for update display

### DIFF
--- a/example-notebooks/display-updates.ipynb
+++ b/example-notebooks/display-updates.ipynb
@@ -31,7 +31,7 @@
    "source": [
     "There was no simple way to make code in one cell to write output to another cell. Now there is!\n",
     "\n\n",
-    "This feature is so new that we need to patch `display` until nteract depends on an IPython release which includes [ipython/ipykernel#204](https://github.com/ipython/ipykernel/pulls/204) and [ipython/ipython#10048](https://github.com/ipython/ipyhton/pulls/10048). So as a temporary workaround, we will define `display_with_id` and its signature and behavior will be provided with `display` in future versions of IPython.\n",
+    "This feature is so new that we need to patch `display` until nteract depends on an IPython release which includes [ipython/ipykernel#204](https://github.com/ipython/ipykernel/pull/204) and [ipython/ipython#10048](https://github.com/ipython/ipython/pull/10048). So as a temporary workaround, we will define `display_with_id` and its signature and behavior will be provided with `display` in future versions of IPython.\n",
     "\n\n",
     "**You do not need to understand any of the code in the next cell**, just execute it so you can get to the fun stuff.\n"
    ]


### PR DESCRIPTION
Noticed these links were wrong, fixed 'em up.