### PR TITLE
[WIP] feat: prototype a table component + mimetype for tabular data

### DIFF
--- a/example-notebooks/only-table.ipynb
+++ b/example-notebooks/only-table.ipynb
@@ -1,0 +1,352 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": true
+   },
+   "source": [
+    "display({\n",
+    "    'application/vnd.tableschema.v1+json': payload\n",
+    "}, raw=True)"
+   ],
+   "outputs": [
+    {
+     "metadata": {},
+     "data": {
+      "application/vnd.tableschema.v1+json": {
+       "schema": {
+        "fields": [
+         {
+          "type": "any",
+          "name": "Date"
+         },
+         {
+          "type": "number",
+          "name": "Open"
+         },
+         {
+          "type": "number",
+          "name": "High"
+         },
+         {
+          "type": "number",
+          "name": "Low"
+         },
+         {
+          "type": "number",
+          "name": "Close"
+         },
+         {
+          "type": "integer",
+          "name": "Volume"
+         },
+         {
+          "type": "number",
+          "name": "Adj Close"
+         }
+        ]
+       },
+       "data": [
+        {
+         "Low": 88.94,
+         "High": 94.09,
+         "Close": 90.81,
+         "Adj Close": 33.68,
+         "Volume": 106889800,
+         "Open": 89.62,
+         "Date": "2000-03-01"
+        },
+        {
+         "Low": 91.12,
+         "High": 95.37,
+         "Close": 93.37,
+         "Adj Close": 34.63,
+         "Volume": 106932600,
+         "Open": 91.81,
+         "Date": "2000-03-02"
+        },
+        {
+         "Low": 93.87,
+         "High": 98.87,
+         "Close": 96.12,
+         "Adj Close": 35.65,
+         "Volume": 101435200,
+         "Open": 94.75,
+         "Date": "2000-03-03"
+        },
+        {
+         "Low": 90.12,
+         "High": 97.37,
+         "Close": 90.62,
+         "Adj Close": 33.61,
+         "Volume": 93609400,
+         "Open": 96,
+         "Date": "2000-03-06"
+        },
+        {
+         "Low": 91.94,
+         "High": 97.5,
+         "Close": 92.87,
+         "Adj Close": 34.45,
+         "Volume": 135061000,
+         "Open": 96.12,
+         "Date": "2000-03-07"
+        },
+        {
+         "Low": 91,
+         "High": 96.19,
+         "Close": 95.56,
+         "Adj Close": 35.44,
+         "Volume": 94290000,
+         "Open": 93.81,
+         "Date": "2000-03-08"
+        },
+        {
+         "Low": 95,
+         "High": 100,
+         "Close": 100,
+         "Adj Close": 37.09,
+         "Volume": 88198800,
+         "Open": 95.31,
+         "Date": "2000-03-09"
+        },
+        {
+         "Low": 99.5,
+         "High": 102.5,
+         "Close": 101,
+         "Adj Close": 37.46,
+         "Volume": 85589000,
+         "Open": 99.56,
+         "Date": "2000-03-10"
+        },
+        {
+         "Low": 97.5,
+         "High": 100.25,
+         "Close": 98,
+         "Adj Close": 36.35,
+         "Volume": 61831800,
+         "Open": 97.62,
+         "Date": "2000-03-13"
+        },
+        {
+         "Low": 95.12,
+         "High": 99.25,
+         "Close": 95.12,
+         "Adj Close": 35.28,
+         "Volume": 73489200,
+         "Open": 98.62,
+         "Date": "2000-03-14"
+        },
+        {
+         "Low": 93.69,
+         "High": 96.62,
+         "Close": 95.37,
+         "Adj Close": 35.37,
+         "Volume": 53208000,
+         "Open": 94.56,
+         "Date": "2000-03-15"
+        },
+        {
+         "Low": 93.25,
+         "High": 96.69,
+         "Close": 95.37,
+         "Adj Close": 35.37,
+         "Volume": 77300800,
+         "Open": 95.94,
+         "Date": "2000-03-16"
+        },
+        {
+         "Low": 94.5,
+         "High": 99.5,
+         "Close": 99.37,
+         "Adj Close": 36.86,
+         "Volume": 81161600,
+         "Open": 95.25,
+         "Date": "2000-03-17"
+        },
+        {
+         "Low": 96.5,
+         "High": 99.75,
+         "Close": 97.37,
+         "Adj Close": 36.12,
+         "Volume": 47773000,
+         "Open": 98.75,
+         "Date": "2000-03-20"
+        },
+        {
+         "Low": 96.5,
+         "High": 103.12,
+         "Close": 102.75,
+         "Adj Close": 38.11,
+         "Volume": 81648800,
+         "Open": 96.75,
+         "Date": "2000-03-21"
+        },
+        {
+         "Low": 101.12,
+         "High": 105.62,
+         "Close": 103.25,
+         "Adj Close": 38.3,
+         "Volume": 93975800,
+         "Open": 102.81,
+         "Date": "2000-03-22"
+        },
+        {
+         "Low": 106.62,
+         "High": 112.87,
+         "Close": 111.87,
+         "Adj Close": 41.49,
+         "Volume": 148224000,
+         "Open": 106.81,
+         "Date": "2000-03-23"
+        },
+        {
+         "Low": 109.56,
+         "High": 115,
+         "Close": 111.69,
+         "Adj Close": 41.43,
+         "Volume": 112196800,
+         "Open": 112.62,
+         "Date": "2000-03-24"
+        },
+        {
+         "Low": 103.94,
+         "High": 108.25,
+         "Close": 104.06,
+         "Adj Close": 38.6,
+         "Volume": 111434000,
+         "Open": 107.77,
+         "Date": "2000-03-27"
+        },
+        {
+         "Low": 102.37,
+         "High": 107.44,
+         "Close": 104.31,
+         "Adj Close": 38.69,
+         "Volume": 81114400,
+         "Open": 103.62,
+         "Date": "2000-03-28"
+        }
+       ]
+      }
+     },
+     "output_type": "display_data",
+     "text": []
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [
+    "import IPython.display"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "IPython.display.JSON(filename=\"only-table.ipynb\")"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [],
+   "outputs": []
+  }
+ ],
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "language": "python",
+   "display_name": "Python 3"
+  },
+  "kernel_info": {
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "version": "3.5.2",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "codemirror_mode": {
+    "version": 3,
+    "name": "ipython"
+   }
+  }
+ }
+}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "electron-react-devtools": "^0.4.0",
     "enchannel": "^1.1.3",
     "enchannel-zmq-backend": "^2.6.0",
+    "fixed-data-table": "^0.6.3",
     "github": "^7.0.0",
     "immutable": "^3.7.6",
     "jupyter-paths": "^1.0.2",

--- a/src/notebook/components/transforms/index.js
+++ b/src/notebook/components/transforms/index.js
@@ -26,6 +26,8 @@ import {
   Vega,
 } from './vega';
 
+import TableTransform from './table';
+
 type StandardTransforms = ImmutableMap<string, any>
 type StandardDisplayOrder = ImmutableList<string>
 
@@ -61,14 +63,16 @@ const transforms = standardTransforms
   .set(PlotlyTransform.MIMETYPE, PlotlyTransform)
   .set(GeoJSONTransform.MIMETYPE, GeoJSONTransform)
   .set(VegaLite.MIMETYPE, VegaLite)
-  .set(Vega.MIMETYPE, Vega);
+  .set(Vega.MIMETYPE, Vega)
+  .set(TableTransform.MIMETYPE, TableTransform);
 
 // Register our custom transforms as the most rich (front of List)
 const displayOrder = standardDisplayOrder
   .insert(0, PlotlyTransform.MIMETYPE)
   .insert(0, VegaLite.MIMETYPE)
   .insert(0, Vega.MIMETYPE)
-  .insert(0, GeoJSONTransform.MIMETYPE);
+  .insert(0, GeoJSONTransform.MIMETYPE)
+  .insert(0, TableTransform.MIMETYPE);
 
 /**
  * Choose the richest mimetype available based on the displayOrder and transforms

--- a/src/notebook/components/transforms/table.js
+++ b/src/notebook/components/transforms/table.js
@@ -25,7 +25,7 @@ export class TableTransform extends React.Component {
     return (
       // fixed-data-table/dist/fixed-data-table.min.css
       // node_modules/fixed-data-table/dist/fixed-data-table.min.css
-      <table border="1" className="dataframe">
+      <table border="1" className="dataframe" width="100%">
         <thead>
           <tr style={{ textAlign: 'right' }}>
             {

--- a/src/notebook/components/transforms/table.js
+++ b/src/notebook/components/transforms/table.js
@@ -1,0 +1,65 @@
+/* @flow */
+/* eslint class-methods-use-this: 0 */
+import React, { PropTypes } from 'react';
+
+import { Map as ImmutableMap } from 'immutable';
+
+
+import { Table, Column, Cell } from 'fixed-data-table';
+
+type Props = {
+  data: ImmutableMap,
+};
+
+const MIMETYPE = 'application/vnd.tableschema.v1+json';
+
+export class TableTransform extends React.Component {
+  props: Props;
+
+  static MIMETYPE = MIMETYPE;
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return this.props.data !== nextProps.data;
+  }
+
+  render(): ?React.Element<any> {
+    const { data, schema } = this.props.data.toJS();
+
+    return (
+      // fixed-data-table/dist/fixed-data-table.min.css
+      // node_modules/fixed-data-table/dist/fixed-data-table.min.css
+      <div>
+        <link
+          rel="stylesheet"
+          href={'../node_modules/fixed-data-table/dist/fixed-data-table.min.css'}
+        />
+        <Table
+          rowHeight={50}
+          headerHeight={50}
+          rowsCount={data.length}
+          width={3000}
+          height={2000}
+          {...this.props}
+        >
+          {
+            schema.fields.map((field, idx) =>
+              <Column
+                header={<Cell>{field.name}</Cell>}
+                cell={(props) =>
+                  <Cell>{data[props.rowIndex][field.name]}</Cell>
+                }
+                width={300}
+                key={idx}
+                fixed={false}
+              />
+            )
+          }
+
+        </Table>
+      </div>
+    );
+  }
+
+}
+
+export default TableTransform;

--- a/src/notebook/components/transforms/table.js
+++ b/src/notebook/components/transforms/table.js
@@ -4,9 +4,6 @@ import React, { PropTypes } from 'react';
 
 import { Map as ImmutableMap } from 'immutable';
 
-
-import { Table, Column, Cell } from 'fixed-data-table';
-
 type Props = {
   data: ImmutableMap,
 };
@@ -28,35 +25,30 @@ export class TableTransform extends React.Component {
     return (
       // fixed-data-table/dist/fixed-data-table.min.css
       // node_modules/fixed-data-table/dist/fixed-data-table.min.css
-      <div>
-        <link
-          rel="stylesheet"
-          href={'../node_modules/fixed-data-table/dist/fixed-data-table.min.css'}
-        />
-        <Table
-          rowHeight={50}
-          headerHeight={50}
-          rowsCount={data.length}
-          width={3000}
-          height={2000}
-          {...this.props}
-        >
+      <table border="1" className="dataframe">
+        <thead>
+          <tr style={{ textAlign: 'right' }}>
+            {
+              schema.fields.map((field, idx) => (
+                <th key={idx}>{field.name}</th>
+              ))
+            }
+          </tr>
+        </thead>
+        <tbody>
           {
-            schema.fields.map((field, idx) =>
-              <Column
-                header={<Cell>{field.name}</Cell>}
-                cell={(props) =>
-                  <Cell>{data[props.rowIndex][field.name]}</Cell>
+            data.map((row, rowIndex) =>
+              <tr key={rowIndex}>
+                {
+                  schema.fields.map((field, idx) => (
+                    <td>{row[field.name]}</td>
+                  ))
                 }
-                width={300}
-                key={idx}
-                fixed={false}
-              />
+              </tr>
             )
           }
-
-        </Table>
-      </div>
+        </tbody>
+      </table>
     );
   }
 


### PR DESCRIPTION
A transform for [JSON Table Schema](http://specs.frictionlessdata.io/json-table-schema/) + data (record oriented). The nteract side of https://github.com/pandas-dev/pandas/issues/14386. 

Takes an overall structure like:

```json
{
  "schema": {
    "fields": [
      {
        "type": "any",
        "name": "Date"
      },
      {
        "type": "number",
        "name": "Open"
      },
      {
        "type": "number",
        "name": "High"
      },
      {
        "type": "number",
        "name": "Low"
      },
      {
        "type": "number",
        "name": "Close"
      },
      {
        "type": "integer",
        "name": "Volume"
      },
      {
        "type": "number",
        "name": "Adj Close"
      }
    ]
  },
  "data": [
    {
      "Date": "2000-03-01",
      "Adj Close": 33.68,
      "Open": 89.62,
      "Low": 88.94,
      "Volume": 106889800,
      "High": 94.09,
      "Close": 90.81
    },
    {
      "Date": "2000-03-02",
      "Adj Close": 34.63,
      "Open": 91.81,
      "Low": 91.12,
      "Volume": 106932600,
      "High": 95.37,
      "Close": 93.37
    }
  ]
}
```

and creates a table.

![screen shot 2016-12-12 at 5 29 22 pm](https://cloud.githubusercontent.com/assets/836375/21124227/7650fddc-c092-11e6-94f4-aeaa32d4d52e.png)

Definitely a prototype, only putting this up to promote discussion. We have enough information here to align columns according to types, format tables accordingly, etc.

We should be able to map from `schema, data` to a reasonable table after iterating on this.
