### PR TITLE
chore(publish): Enable multi platform build

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ And then opening `docs/index.html` in your favorite browser.
 
 > I want to debug redux actions and state changes.
 
--  Enable [redux-logger](https://github.com/evgenyrodionov/redux-logger) by spawning the application with `npm run spawn:debug`. 
+-  Enable [redux-logger](https://github.com/evgenyrodionov/redux-logger) by spawning the application with `npm run spawn:debug`.
 
 ## For maintainers: Creating a release
 
@@ -122,12 +122,16 @@ npm publish
 
 It is recommended to run `npm run reinstall` before packaging a release.
 
-To package a release run:
+To package a release for your current platform run:
 ```
 npm run dist
 ```
 
-This needs to be done on every platform we like to ship.
+To package a release for all platforms run:
+```
+npm run dist:all
+```
+Make sure you have the [required dependencies](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build) for a multi platform build installed.
 
 The OS X release has to be signed with an Apple developer key. Currently only
 Kyle (@rgbkrk) has this set up.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "coverage": "nyc report --reporter=text-lcov > coverage/lcov.info",
     "pack": "npm install && npm run clean && npm run build && build --dir",
     "dist": "npm install && npm run clean && npm run build && build",
+    "dist:all": "npm run dist -- -mlw",
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js"
   },
@@ -150,7 +151,7 @@
     "chai-immutable": "^1.6.0",
     "cross-env": "^3.1.3",
     "electron": "1.4.12",
-    "electron-builder": "^10.2.0",
+    "electron-builder": "^10.9.2",
     "electron-mocha": "^3.2.0",
     "enzyme": "^2.6.0",
     "esdoc": "^0.4.8",


### PR DESCRIPTION
We can now build all nteract releases on one platform if the [required dependencies](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build) for a multi platform build are installed!

I didn't test windows but the linux release built on mac works great.