### PR TITLE
refactor: Remove PureRenderMixin (deprecated), extend from PureComponent #1287

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "nteract-assets": "^2.1.0",
     "plotly.js": "^1.19.2",
     "react": "^15.3.2",
-    "react-addons-pure-render-mixin": "^15.3.2",
     "react-codemirror": "^0.3.0",
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",

--- a/src/notebook/components/cell/cell-creator-buttons.js
+++ b/src/notebook/components/cell/cell-creator-buttons.js
@@ -1,7 +1,6 @@
 /* eslint class-methods-use-this: 0 */
 // @flow
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { connect } from 'react-redux';
 
 import {
@@ -16,9 +15,8 @@ type Props = {
   id: string,
 };
 
-export class CellCreatorButtons extends React.Component {
+export class CellCreatorButtons extends React.PureComponent {
   props: Props;
-  shouldComponentUpdate: (p: Props, s: any) => boolean;
   createCodeCell: (type: string) => void;
   createTextCell: (type: string) => void;
   createCell: (type: string) => void;
@@ -30,7 +28,6 @@ export class CellCreatorButtons extends React.Component {
 
   constructor(): void {
     super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.createCodeCell = this.createCell.bind(this, 'code');
     this.createTextCell = this.createCell.bind(this, 'markdown');
     this.createCell = this.createCell.bind(this);

--- a/src/notebook/components/cell/cell-creator.js
+++ b/src/notebook/components/cell/cell-creator.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import CellCreatorButtons from './cell-creator-buttons';
 
@@ -13,17 +12,15 @@ type State = {
     show: boolean,
 };
 
-export default class CellCreator extends React.Component {
+export default class CellCreator extends React.PureComponent {
   props: Props;
   state: State;
-  shouldComponentUpdate: (p: Props, s: State) => boolean;
   setHoverElement: (el: HTMLElement) => void;
   updateVisibility: (mouseEvent: MouseEvent) => void;
   hoverElement: Object;
 
   constructor(): void {
     super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.setHoverElement = this.setHoverElement.bind(this);
     this.updateVisibility = this.updateVisibility.bind(this);
   }

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -1,6 +1,5 @@
 /* @flow */
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import CodeCell from './code-cell';
@@ -34,10 +33,9 @@ type State = {
   hoverCell: boolean,
 }
 
-export class Cell extends React.Component {
+export class Cell extends React.PureComponent {
   props: CellProps;
   state: State;
-  shouldComponentUpdate: (p: CellProps, s: State) => boolean;
   selectCell: () => void;
   focusAboveCell: () => void;
   focusBelowCell: () => void;
@@ -51,7 +49,6 @@ export class Cell extends React.Component {
 
   constructor(): void {
     super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.selectCell = this.selectCell.bind(this);
     this.focusCellEditor = this.focusCellEditor.bind(this);
     this.focusAboveCell = this.focusAboveCell.bind(this);

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 
 import Inputs from './inputs';
@@ -28,20 +27,14 @@ type Props = {
   tabSize: number,
 };
 
-class CodeCell extends React.Component {
+class CodeCell extends React.PureComponent {
   props: Props;
-  shouldComponentUpdate: (p: Props, s: any) => boolean;
 
   static defaultProps = {
     pagers: new ImmutableList(),
     running: false,
     tabSize: 4,
   };
-
-  constructor(): void {
-    super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
-  }
 
   isOutputHidden(): any {
     return this.props.cell.getIn(['metadata', 'outputHidden']);

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -1,9 +1,6 @@
 // @flow
 import React from 'react';
-
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
-
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import { transforms, displayOrder } from '../../transforms';
 
@@ -20,9 +17,8 @@ type Props = {
 
 const DEFAULT_SCROLL_HEIGHT = 600;
 
-export default class Display extends React.Component {
+export default class Display extends React.PureComponent {
   props: Props;
-  shouldComponentUpdate: (p: Props, s: any) => boolean;
   recomputeStyle: () => void;
   el: HTMLElement;
 
@@ -36,7 +32,6 @@ export default class Display extends React.Component {
   constructor() {
     super();
     this.recomputeStyle = this.recomputeStyle.bind(this);
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
   }
 
   componentDidMount() {

--- a/src/notebook/components/cell/draggable-cell.js
+++ b/src/notebook/components/cell/draggable-cell.js
@@ -1,7 +1,6 @@
 // @flow
 /* eslint-disable react/no-unused-prop-types */
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { DragSource, DropTarget } from 'react-dnd';
 
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
@@ -82,10 +81,9 @@ function collectTarget(connect: Object, monitor: Object): Object {
   };
 }
 
-class DraggableCell extends React.Component {
+class DraggableCell extends React.PureComponent {
   props: Props;
   state: State;
-  shouldComponentUpdate: (p: Props, s: State) => boolean;
   selectCell: () => void;
   el: HTMLElement;
 
@@ -95,7 +93,6 @@ class DraggableCell extends React.Component {
 
   constructor(): void {
     super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.selectCell = this.selectCell.bind(this);
   }
 

--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import CodeMirror from 'react-codemirror';
 import CM from 'codemirror';
@@ -136,9 +135,8 @@ CM.keyMap.basic.Down = 'goLineDownOrEmit';
 CM.commands.goLineUpOrEmit = goLineUpOrEmit;
 CM.commands.goLineDownOrEmit = goLineDownOrEmit;
 
-export default class Editor extends React.Component {
+export default class Editor extends React.PureComponent {
   state: State;
-  shouldComponentUpdate: (p: Props, s: State) => boolean;
   onChange: (text: string) => void;
   onFocusChange: (focused: boolean) => void;
   hint: (editor: Object, cb: Function) => void;
@@ -167,7 +165,6 @@ export default class Editor extends React.Component {
     };
     this.onChange = this.onChange.bind(this);
     this.onFocusChange = this.onFocusChange.bind(this);
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.hint = this.completions.bind(this);
     this.hint.async = true;
 

--- a/src/notebook/components/cell/inputs.js
+++ b/src/notebook/components/cell/inputs.js
@@ -1,20 +1,13 @@
 // @flow
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 type Props = {
   executionCount: any,
   running: boolean,
 };
 
-export default class Inputs extends React.Component {
-  props: Props
-  shouldComponentUpdate: (p: Props, s: void) => boolean;
-
-  constructor(): void {
-    super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
-  }
+export default class Inputs extends React.PureComponent {
+  props: Props;
 
   render(): ?React.Element<any> {
     const { executionCount, running } = this.props;

--- a/src/notebook/components/cell/inputs.js
+++ b/src/notebook/components/cell/inputs.js
@@ -6,17 +6,14 @@ type Props = {
   running: boolean,
 };
 
-export default class Inputs extends React.PureComponent {
-  props: Props;
+export default function Inputs(props: Props): ?React.Element<any> {
+  const { executionCount, running } = props;
+  const count = !executionCount ? ' ' : executionCount;
+  const input = running ? '*' : count;
 
-  render(): ?React.Element<any> {
-    const { executionCount, running } = this.props;
-    const count = !executionCount ? ' ' : executionCount;
-    const input = running ? '*' : count;
-    return (
-      <div className="prompt">
-        [{input}]
-      </div>
-    );
-  }
+  return (
+    <div className="prompt">
+      [{input}]
+    </div>
+  );
 }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import CommonMark from 'commonmark';
 import MarkdownRenderer from 'commonmark-react-renderer';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import Editor from './editor';
 import LatexRenderer from '../latex';
@@ -31,12 +30,11 @@ const renderer = new MarkdownRenderer();
 
 const mdRender: MDRender = input => renderer.render(parser.parse(input));
 
-export default class MarkdownCell extends React.Component {
+export default class MarkdownCell extends React.PureComponent {
   state: State;
   openEditor: () => void;
   editorKeyDown: (e: Object) => void;
   renderedKeyDown: (e: Object) => boolean;
-  shouldComponentUpdate: (p: Props, s: State) => boolean;
   rendered: HTMLElement;
 
   static contextTypes = {
@@ -49,7 +47,6 @@ export default class MarkdownCell extends React.Component {
 
   constructor(props: Props): void {
     super(props);
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.state = {
       view: true,
       // HACK: We'll need to handle props and state change better here

--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -1,7 +1,6 @@
 /* eslint class-methods-use-this: 0 */
 // @flow
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdown';
 
 import {
@@ -21,8 +20,7 @@ type Props = {
   type: string,
 }
 
-export default class Toolbar extends React.Component {
-  shouldComponentUpdate: (p: Props, s: any) => boolean;
+export default class Toolbar extends React.PureComponent {
   removeCell: () => void;
   executeCell: () => void;
   clearOutputs: () => void;
@@ -39,7 +37,6 @@ export default class Toolbar extends React.Component {
 
   constructor(props: Props): void {
     super(props);
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.removeCell = this.removeCell.bind(this);
     this.executeCell = this.executeCell.bind(this);
     this.clearOutputs = this.clearOutputs.bind(this);

--- a/src/notebook/components/latex.js
+++ b/src/notebook/components/latex.js
@@ -1,6 +1,5 @@
 /* @flow */
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { typesetMath } from 'mathjax-electron';
 
 type Props = {
@@ -15,15 +14,9 @@ function isMathJaxOkYet(): boolean {
                                 && window.MathJax.Hub.Queue;
 }
 
-export default class LatexRenderer extends React.Component {
+export default class LatexRenderer extends React.PureComponent {
   props: Props;
-  shouldComponentUpdate: (p: Props, s: any) => boolean;
   rendered: HTMLElement;
-
-  constructor(): void {
-    super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
-  }
 
   componentDidMount(): void {
     if (isMathJaxOkYet()) typesetMath(this.rendered);

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-return-assign */
 /* @flow */
 import React from 'react';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 import { DragDropContext as dragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
@@ -86,9 +85,8 @@ const mapStateToProps = (state: Object) => ({
   executionState: state.app.get('executionState'),
 });
 
-export class Notebook extends React.Component {
+export class Notebook extends React.PureComponent {
   props: Props;
-  shouldComponentUpdate: (p: Props, s: any) => boolean;
   createCellElement: (s: string) => ?React.Element<any>;
   createStickyCellElement: (s: string) => ?React.Element<any>;
   keyDown: (e: KeyboardEvent) => void;
@@ -109,7 +107,6 @@ export class Notebook extends React.Component {
 
   constructor(): void {
     super();
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
     this.createCellElement = this.createCellElement.bind(this);
     this.createStickyCellElement = this.createStickyCellElement.bind(this);
     this.keyDown = this.keyDown.bind(this);

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shouldComponentUpdate } from 'react-addons-pure-render-mixin';
 
 import { Provider } from 'react-redux';
 
@@ -45,19 +44,15 @@ initNativeHandlers(store);
 initMenuHandlers(store);
 initGlobalHandlers(store);
 
-class App extends React.Component {
-  props: Object
-  state: Object
+class App extends React.PureComponent {
+  props: Object;
+  state: Object;
   notificationSystem: NotificationSystem;
-  shouldComponentUpdate: (p: Object, s: Object) => boolean
 
-  constructor(props): void {
-    super(props);
-    this.shouldComponentUpdate = shouldComponentUpdate.bind(this);
-  }
   componentDidMount(): void {
     store.dispatch(setNotificationSystem(this.notificationSystem));
   }
+
   render(): ?React.Element<any> { // eslint-disable-line class-methods-use-this
     return (
       <Provider store={store}>


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

<!-- Questions? Feel free to ping us on https://slack.nteract.in -->

Removed all references to the 'react-addons-pure-render-mixin' and extend the following components from React.PureComponent:

- CodeCell 
- Cell 
- CellCreator 
- CellCreatorButtons 
- Display 
- DraggableCell 
- Editor 
- Inputs 
- MarkdownCell 
- Toolbar 
- LatexRenderer 
- Notebook 
- App 

Also refactored the Inputs component to be a stateless function.