### PR TITLE
fix(splash): Hide scrollbars

### DIFF
--- a/static/splash.html
+++ b/static/splash.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
   </head>
-  <body>
+  <body style="margin: 0px; overflow: hidden;">
     <video autoplay="autoplay" loop="loop" width="565" height="233">
       <source src="loading.mp4" type="video/mp4" />
     </video>


### PR DESCRIPTION
Most platforms (all except macOS) don't hide scrollbars per default.