### PR TITLE
chore(lodash): Import lodash partials instead of whole library

### DIFF
--- a/src/notebook/components/transforms/vega.js
+++ b/src/notebook/components/transforms/vega.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React from 'react';
-import _ from 'lodash';
+import { merge } from 'lodash';
 
 const vegaEmbed = require('vega-embed');
 
@@ -25,7 +25,7 @@ function embed(el: HTMLElement, spec: Object, mode: string, cb: (err: any, resul
   };
 
   if (mode === 'vega-lite') {
-    embedSpec.spec.config = _.merge({
+    embedSpec.spec.config = merge({
       cell: {
         width: DEFAULT_WIDTH,
         height: DEFAULT_HEIGHT,

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -2,7 +2,7 @@ import Immutable from 'immutable';
 import { handleActions } from 'redux-actions';
 import * as uuid from 'uuid';
 import * as commutable from 'commutable';
-import _ from 'lodash';
+import { has } from 'lodash';
 
 import * as constants from '../constants';
 
@@ -75,7 +75,7 @@ export default handleActions({
     const output = action.output;
     const cellID = action.id;
 
-    if (output.output_type !== 'display_data' || !(_.has(output, 'transient.display_id'))) {
+    if (output.output_type !== 'display_data' || !(has(output, 'transient.display_id'))) {
       return state.updateIn(['notebook', 'cellMap', cellID, 'outputs'],
         outputs => reduceOutputs(outputs, output));
     }


### PR DESCRIPTION
This will enable us to take advantage of tree shaking when we eventually upgrade to Webpack 2. 🌳 

More info if you're curious: https://blog.engineyard.com/2016/tree-shaking