### PR TITLE
chore(deps): bump vega to 3.0.0-beta.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "spawn-rx": "^2.0.3",
     "spawnteract": "^2.2.0",
     "uuid": "^3.0.0",
-    "vega": "^2.6.3",
+    "vega": "^3.0.0-beta.10",
     "vega-embed": "^2.2.0",
     "vega-lite": "^1.3.1",
     "yargs": "^6.4.0"


### PR DESCRIPTION
In an attempt to escape the whole `canvas` requirement, I bumped `vega` to the 3.0.0 beta. _However_, [vega-scenegraph](https://github.com/vega/vega-scenegraph) relies on canvas still so it's still a bit of a headache since we're both in node.js and don't actually need canvas.