### PR TITLE
Define packaging targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,13 +74,17 @@
       ]
     },
     "win": {
-      "target": "nsis"
+      "target": [
+        "nsis",
+        "zip"
+      ]
     },
     "linux": {
       "maintainer": "nteract contributors <jupyter@googlegroups.com>",
       "target": [
         "deb",
-        "AppImage"
+        "AppImage",
+        "tar.gz"
       ],
       "desktop": {
         "Comment": "Interactive literate coding notebook",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
       "name": "ipynb"
     },
     "mac": {
-      "category": "public.app-category.developer-tools"
+      "category": "public.app-category.developer-tools",
+      "target": [
+        "dmg",
+        "zip"
+      ]
     },
     "win": {
       "target": "nsis"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "linux": {
       "maintainer": "nteract contributors <jupyter@googlegroups.com>",
       "target": [
-        "deb"
+        "deb",
+        "AppImage"
       ],
       "desktop": {
         "Comment": "Interactive literate coding notebook",


### PR DESCRIPTION
Main changes:
- restores the AppImage build for linux
- compresses unpacked build folder into `zip` (Windows) or `tar.gz` (Linux) archive