### PR TITLE
fix(editor): Indenting with tab no longer focuses the next cell

### DIFF
--- a/src/notebook/components/cell/editor/index.js
+++ b/src/notebook/components/cell/editor/index.js
@@ -139,6 +139,7 @@ export default class Editor extends React.PureComponent {
   state: State;
   onChange: (text: string) => void;
   onFocusChange: (focused: boolean) => void;
+  tabToSpaces: (editor: Object) => void;
   hint: (editor: Object, cb: Function) => void;
   theme: string|null;
   cursorBlinkRate: number;
@@ -165,6 +166,7 @@ export default class Editor extends React.PureComponent {
     };
     this.onChange = this.onChange.bind(this);
     this.onFocusChange = this.onFocusChange.bind(this);
+    this.tabToSpaces = this.tabToSpaces.bind(this);
     this.hint = this.completions.bind(this);
     this.hint.async = true;
 


### PR DESCRIPTION
Fixes #1301 

There's a slight issue with deleting - we need to write a spacesToTab function to convert the spaces back to tabs so you only have to press delete once to get rid of the tab. Right now, you have to press delete for as many spaces make up a tab.