### PR TITLE
test: mock fs

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -170,3 +170,9 @@ mock('spawnteract', {
     });
   },
 });
+
+mock('fs', {
+  unlinkSync: function(){},
+  unlink: function(){},
+  existsSync: function(){},
+});


### PR DESCRIPTION
I noticed when running the tests that 'filename' (literally) was being created
at the root while running tests. This forces our use of `fs` to be mocked within
tests.