### PR TITLE
Models 

### DIFF
--- a/example-notebooks/model-debug.ipynb
+++ b/example-notebooks/model-debug.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [
+    "import IPython"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [
+    "import ipykernel"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [
+    "IPython.display.display({\n",
+    "    'application/x-nteract-model-debug+json': 'asdfasf'\n",
+    "},\n",
+    "raw=True)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "application/x-nteract-model-debug+json": [
+       "asdfasf"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [
+    "c = ipykernel.comm.Comm(target_name='setIn', target_module='reducers')"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [
+    "import time\n",
+    "import random\n",
+    "\n",
+    "for ii in range(25) :\n",
+    "  time.sleep(0.1)\n",
+    "  c.send({'path': ['b', 'c'], 'value': random.random()})"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "outputExpanded": false
+   },
+   "source": [],
+   "outputs": []
+  }
+ ],
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "language": "python",
+   "display_name": "Python 3"
+  },
+  "kernel_info": {
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.6.0",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  }
+ }
+}

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -27,6 +27,7 @@ export type CellProps = {
   cursorBlinkRate: number,
   pagers: ImmutableList<any>,
   transforms: ImmutableMap<string, any>,
+  models: ImmutableMap<string, any>,
 };
 
 type State = {
@@ -147,6 +148,7 @@ export class Cell extends React.PureComponent {
             transforms={this.props.transforms}
             pagers={this.props.pagers}
             running={this.props.running}
+            models={this.props.models}
           />
         }
       </div>

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -25,6 +25,7 @@ type Props = {
   focusAbove: Function,
   focusBelow: Function,
   tabSize: number,
+  models: ImmutableMap<string, any>,
 };
 
 class CodeCell extends React.PureComponent {
@@ -99,6 +100,7 @@ class CodeCell extends React.PureComponent {
             theme={this.props.theme}
             expanded={this.isOutputExpanded()}
             isHidden={this.isOutputHidden()}
+            models={this.props.models}
           />
         </div>
       </LatexRenderer>

--- a/src/notebook/components/cell/display-area/display.js
+++ b/src/notebook/components/cell/display-area/display.js
@@ -13,6 +13,7 @@ type Props = {
   theme: string,
   expanded: boolean,
   isHidden: boolean,
+  models: ImmutableMap<string, any>,
 }
 
 const DEFAULT_SCROLL_HEIGHT = 600;
@@ -71,6 +72,7 @@ export default class Display extends React.PureComponent {
                 displayOrder={order}
                 transforms={tf}
                 theme={this.props.theme}
+                models={this.props.models}
               />
             )
           }

--- a/src/notebook/components/cell/display-area/output.js
+++ b/src/notebook/components/cell/display-area/output.js
@@ -12,6 +12,7 @@ type Props = {
   output: any,
   transforms: ImmutableMap<string, any>,
   theme: string,
+  models: ImmutableMap<string, any>,
 }
 
 export default function Output(props: Props): ?React.Element<any>|null {
@@ -35,6 +36,7 @@ export default function Output(props: Props): ?React.Element<any>|null {
           displayOrder={props.displayOrder}
           transforms={props.transforms}
           theme={props.theme}
+          models={props.models}
         />);
     }
     case 'stream': {

--- a/src/notebook/components/cell/display-area/richest-mime.js
+++ b/src/notebook/components/cell/display-area/richest-mime.js
@@ -10,6 +10,7 @@ type Props = {
   bundle: ImmutableMap<string, any>,
   metadata: ImmutableMap<string, any>,
   theme: string,
+  models?: ImmutableMap<string, any>,
 };
 
 export default class RichestMime extends React.Component {
@@ -21,6 +22,7 @@ export default class RichestMime extends React.Component {
     theme: 'light',
     metadata: new ImmutableMap(),
     bundle: new ImmutableMap(),
+    models: new ImmutableMap(),
   };
 
   shouldComponentUpdate(nextProps: Props): boolean {  // eslint-disable-line class-methods-use-this
@@ -46,6 +48,13 @@ export default class RichestMime extends React.Component {
     const Transform = this.props.transforms.get(mimetype);
     const data = this.props.bundle.get(mimetype);
     const metadata = this.props.metadata.get(mimetype);
-    return <Transform data={data} metadata={metadata} theme={this.props.theme} />;
+    return (
+      <Transform
+        data={data}
+        metadata={metadata}
+        theme={this.props.theme}
+        models={this.props.models}
+      />
+    );
   }
 }

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -58,6 +58,7 @@ type Props = {
   kernelSpecDisplayName: string,
   CellComponent: any,
   executionState: string,
+  models: ImmutableMap<string, any>,
 };
 
 export function getLanguageMode(notebook: any): string {
@@ -83,6 +84,7 @@ const mapStateToProps = (state: Object) => ({
   editorFocused: state.document.get('editorFocused'),
   stickyCells: state.document.get('stickyCells'),
   executionState: state.app.get('executionState'),
+  models: state.comms.get('models'),
 });
 
 export class Notebook extends React.PureComponent {
@@ -189,6 +191,7 @@ export class Notebook extends React.PureComponent {
       // tell CodeMirror to remeasure
       theme: this.props.theme,
       cursorBlinkRate: this.props.cursorBlinkRate,
+      models: this.props.models,
     };
   }
 

--- a/src/notebook/components/transforms/index.js
+++ b/src/notebook/components/transforms/index.js
@@ -22,6 +22,8 @@ import {
 import PlotlyTransform from './plotly';
 import GeoJSONTransform from './geojson';
 
+import ModelDebug from './model-debug';
+
 import {
   VegaLite,
   Vega,
@@ -58,20 +60,28 @@ export const standardDisplayOrder: StandardDisplayOrder = new ImmutableList([
   'text/plain',
 ]);
 
+function registerTransform({ transforms, displayOrder }, transform) {
+  return {
+    transforms: transforms.set(transform.MIMETYPE, transform),
+    displayOrder: displayOrder.insert(0, transform.MIMETYPE)
+  };
+}
 
-// Register custom transforms
-const transforms = standardTransforms
-  .set(PlotlyTransform.MIMETYPE, PlotlyTransform)
-  .set(GeoJSONTransform.MIMETYPE, GeoJSONTransform)
-  .set(VegaLite.MIMETYPE, VegaLite)
-  .set(Vega.MIMETYPE, Vega);
+const additionalTransforms = [
+  ModelDebug,
+  PlotlyTransform,
+  GeoJSONTransform,
+  VegaLite,
+  Vega,
+];
 
-// Register our custom transforms as the most rich (front of List)
-const displayOrder = standardDisplayOrder
-  .insert(0, PlotlyTransform.MIMETYPE)
-  .insert(0, VegaLite.MIMETYPE)
-  .insert(0, Vega.MIMETYPE)
-  .insert(0, GeoJSONTransform.MIMETYPE);
+const {
+  transforms,
+  displayOrder,
+} = additionalTransforms.reduce(registerTransform, {
+  transforms: standardTransforms,
+  displayOrder: standardDisplayOrder,
+});
 
 /**
  * Choose the richest mimetype available based on the displayOrder and transforms

--- a/src/notebook/components/transforms/model-debug.js
+++ b/src/notebook/components/transforms/model-debug.js
@@ -1,0 +1,40 @@
+/* @flow */
+import React from 'react';
+
+const Immutable = require('immutable');
+
+type Props = {
+  data: string,
+  models: Immutable.Map<string, any>,
+  modelID: string,
+}
+
+class ModelDebug extends React.Component {
+  props: Props;
+  static MIMETYPE = 'application/x-nteract-model-debug+json';
+
+  shouldComponentUpdate(): boolean {
+    return true;
+  }
+
+  render(): ?React.Element<any> {
+    const { models, data, modelID } = this.props;
+    // TODO: Provide model IDs on transient field
+    // For now, if modelID is not provided (or model does not exist),
+    // show all the models
+    const model = models.get(modelID, models);
+    return (
+      <div>
+        <h1>{JSON.stringify(data, null, 2)}</h1>
+        <pre>
+          {
+            model ? JSON.stringify(model, null, 2) : null
+          }
+        </pre>
+      </div>
+    );
+  }
+}
+
+
+export default ModelDebug;

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -167,6 +167,8 @@ export const MetadataRecord = Immutable.Record({
 
 export const CommsRecord = Immutable.Record({
   targets: new Immutable.Map(),
+  info: new Immutable.Map(),
+  models: new Immutable.Map(),
 });
 
 export type AppState = {

--- a/src/notebook/reducers/comms.js
+++ b/src/notebook/reducers/comms.js
@@ -5,6 +5,8 @@ type CommState = Immutable.Map<string, any>;
 
 const defaultCommState : CommState = Immutable.Map({
   targets: Immutable.Map(),
+  models: Immutable.Map(),
+  info: Immutable.Map(),
 });
 
 type RegisterCommTargetAction = { type: 'REGISTER_COMM_TARGET', name: string, handler: string };
@@ -12,12 +14,62 @@ function registerCommTarget(state: CommState, action: RegisterCommTargetAction):
   return state.setIn(['targets', action.name], action.handler);
 }
 
-type CommAction = RegisterCommTargetAction;
+type CommOpenAction = {
+  type: 'COMM_OPEN',
+  target_name: string,
+  target_module: string,
+  data: any,
+  comm_id: string
+};
+
+function processCommOpen(state: CommState, action: CommOpenAction): CommState {
+  const {
+    target_name,
+    target_module,
+    data,
+    comm_id,
+  } = action;
+
+  const commInfo = {
+    target_module,
+    target_name,
+  };
+
+  return state.setIn(['info', comm_id], Immutable.fromJS(commInfo))
+              .setIn(['models', comm_id], Immutable.fromJS(data));
+}
+
+type CommMessageAction = { type: 'COMM_MESSAGE', data: any, comm_id: string };
+function processCommMessage(state: CommState, action: CommMessageAction): CommState {
+  const {
+    data,
+    comm_id,
+  } = action;
+
+  const commInfo = state.getIn(['info', comm_id]);
+  if (commInfo && commInfo.get('target_module') === 'reducers' &&
+     commInfo.get('target_name') === 'setIn') {
+    const path : Array<string|number> = data.path;
+    const value = Immutable.fromJS(data.value);
+
+    // set `value` into `path` of the model data
+    return state.setIn(['models', comm_id].concat(path), value);
+  }
+
+  // Default to overwrite / replace for now
+  return state.setIn(['models', comm_id], Immutable.fromJS(data));
+}
+
+type CommAction = RegisterCommTargetAction | CommMessageAction | CommOpenAction;
 
 export default function (state: CommState = defaultCommState, action: CommAction) {
   switch (action.type) {
     case 'REGISTER_COMM_TARGET':
       return registerCommTarget(state, action);
+    case 'COMM_OPEN':
+      return processCommOpen(state, action);
+    case 'COMM_MESSAGE':
+      return processCommMessage(state, action);
     default:
       return state;
   }

--- a/src/notebook/views/draggable-cell.js
+++ b/src/notebook/views/draggable-cell.js
@@ -24,6 +24,7 @@ type Props = {|
   cursorBlinkRate: number,
   pagers: ImmutableList<any>,
   moveCell: (source: string, dest: string, above: boolean) => Object,
+  models: ImmutableMap<string, any>,
 |};
 
 type State = {|
@@ -153,6 +154,7 @@ class DraggableCellView extends React.PureComponent {
             cursorBlinkRate={this.props.cursorBlinkRate}
             pagers={this.props.pagers}
             transforms={this.props.transforms}
+            models={this.props.models}
           />
         </div>
       </div>

--- a/test/renderer/components/cell/display-area/richest-mime-spec.js
+++ b/test/renderer/components/cell/display-area/richest-mime-spec.js
@@ -14,17 +14,25 @@ import { displayOrder, transforms } from '../../../../../src/notebook/components
 
 describe('RichestMime', () => {
   it('renders a mimebundle', () => {
+
+    const models = Immutable.fromJS({});
     const rm = shallow(
       <RichestMime
         displayOrder={displayOrder}
         transforms={transforms}
         bundle={Immutable.fromJS({"text/plain": "THE DATA"})}
         metadata={Immutable.fromJS({"text/plain": "alright"})}
+        models={models}
       />
     );
 
     expect(rm.instance().shouldComponentUpdate()).to.be.true;
-    expect(rm.first().props()).to.deep.equal({data: 'THE DATA', theme: 'light', metadata: 'alright'});
+    expect(rm.first().props()).to.deep.equal({
+      data: 'THE DATA',
+      theme: 'light',
+      metadata: 'alright',
+      models,
+    });
   })
   it('does not render unknown mimetypes', () => {
     const rm = shallow(

--- a/test/renderer/components/transforms/model-debug-spec.js
+++ b/test/renderer/components/transforms/model-debug-spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Immutable from 'immutable';
+
+import { mount } from 'enzyme';
+import chai, { expect } from 'chai';
+
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+
+import ModelDebug from '../../../../src/notebook/components/transforms/model-debug';
+
+describe('ModelDebug', () => {
+  it('renders all models when no modelID set', () => {
+    const modelDebugWrapper = mount(
+      <ModelDebug
+        data={"hey"}
+        models={Immutable.fromJS({ "1": { "fun": true } })}
+      />
+    );
+
+    const instance = modelDebugWrapper.instance();
+    expect(instance.shouldComponentUpdate()).to.be.true;
+
+    expect(
+      modelDebugWrapper.contains(
+        <pre>{JSON.stringify({"1": {"fun": true}}, null, 2)}</pre>
+      )
+    ).to.equal(true);
+  });
+});

--- a/test/renderer/reducers/comms-spec.js
+++ b/test/renderer/reducers/comms-spec.js
@@ -19,3 +19,63 @@ describe('registerCommTarget', () => {
     expect(nextState).to.deep.equal(state.setIn(['targets', 'steve'], '?????'))
   })
 })
+
+describe('comm reducers', () => {
+  it('process comm_open and comm_message actions', () => {
+    const state = new CommsRecord();
+    const action = {
+      type: 'COMM_OPEN',
+      target_module: 'reducers',
+      target_name: 'setIn',
+      data: { a: 2 },
+      comm_id: 100,
+    };
+
+    const nextState = commsReducer(state, action);
+    expect(nextState.getIn(['info', 100]).toJS()).to.deep.equal({
+      target_module: 'reducers',
+      target_name: 'setIn',
+    })
+
+    expect(nextState.getIn(['models', 100]).toJS()).to.deep.equal({
+      a: 2,
+    })
+
+    const actionMessage = {
+      type: 'COMM_MESSAGE',
+      data: {
+        path: ['a'],
+        value: 3
+      },
+      comm_id: 100,
+    }
+
+    const afterMessageState = commsReducer(nextState, actionMessage);
+
+    expect(afterMessageState.getIn(['models', 100]).toJS()).to.deep.equal({
+      a: 3,
+    })
+  })
+  it('does a straight replacement for unknown comm messages', () => {
+    const state = new CommsRecord();
+
+    // Note that we're not starting with a COMM_OPEN in order to process
+    // a COMM_MESSAGE that hasn't been "opened"
+    const action = {
+      type: 'COMM_MESSAGE',
+      data: {
+        x: 5113,
+        bagels: true,
+      },
+      comm_id: 101,
+    }
+
+    const nextState = commsReducer(state, action);
+
+    expect(nextState.getIn(['models', 101]).toJS()).to.deep.equal({
+      bagels: true,
+      x: 5113,
+    })
+
+  })
+})


### PR DESCRIPTION
At the end of the day Friday I spent time with @ivanov and @ian-r-rose to explore simple mechanics for modifying a model structure reliant on comms that are implementable in a variety of languages. The base concept for these models over the comms is that we employ the use of a function to go from `oldModel` to `newModel` based on a payload.

```js
model = reducer(model, data)
```

We experimented (on a whiteboard) with a few different reducers as a baseline:

* deepMerge
* replace
* shallowMerge
* setIn

After exploring these, we ended up thinking that `setIn` covered many of the uses of the merge operations while also encapsulating `replace` entirely\*. The payload for updating a model via `setIn` includes the `path` and the `value` (which can be arbitrary JSON).

\* caveat: `setIn` is overkill for single primitive values for a model

## Model change example

Starting model

```js
model = {
  fruits: [
    { color: 'red', name: 'apple' },
    { color: 'green', name: 'banana' }
  ]
}
```

```js
> setIn(model, ['fruits', 1, 'color'], 'yellow')
{
  fruits: [
    { color: 'red', name: 'apple' },
    { color: 'yellow', name: 'banana' }
  ]
}
```

## Displaying a model

This implementation expects that a transform/renderer accepts the `models` as well as a `modelID` to display a representation of a model.

Example component usage:

```js
<ModelDebugTransform
  data={data}
  models={models}
  modelID={modelID}
/>
```

This is similar in usage to the other transforms for html, images, plotly, vega, etc. with the addition of having access to all the models as an immutable Map as well as a particular model ID. The intent with the model ID is for this output to have an associated field in `transient`.

Example payload for `display_data`:

```js
content = {
  data: {
    'application/x-nteract-model-debug+json': 'pretend-data',
  }
  transient: {
    model_id: '1'
  },
}
```

This matches the format of the update display spec with the use of transient for something that is intended to match the lifetime of the kernel.