### PR TITLE
Fix(Toolbar): removed hardwired shouldComponentUpdate

### DIFF
--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -47,10 +47,6 @@ export default class Toolbar extends React.PureComponent {
     this.toggleOutputExpansion = this.toggleOutputExpansion.bind(this);
   }
 
-  shouldComponentUpdate(): boolean {
-    return false;
-  }
-
   toggleStickyCell(): void {
     this.context.store.dispatch(toggleStickyCell(this.props.id));
   }


### PR DESCRIPTION
Toolbar menu did not update when changing cell type. Is this the right way of fixing this or should we make `shouldComponentUpdate` smarter?

What kind of test could I add to prevent this from coming back in the future? The current test only checks that the correct action is being dispatched.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.