### PR TITLE
chore(flow): craft explicit flow types for notebook

### DIFF
--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -321,6 +321,7 @@ export function save(filename, notebook) {
     notebook
   };
 }
+
 export function saveAs(filename, notebook) {
   return {
     type: constants.SAVE_AS,

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -28,11 +28,11 @@ import {
 } from './records';
 
 const store = configureStore({
-  app: new AppRecord(),
-  metadata: new MetadataRecord(),
-  document: new DocumentRecord(),
-  comms: new CommsRecord(),
-  config: new ImmutableMap({
+  app: AppRecord(),
+  metadata: MetadataRecord(),
+  document: DocumentRecord(),
+  comms: CommsRecord(),
+  config: ImmutableMap({
     theme: 'light',
   }),
 }, reducers);

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -67,7 +67,32 @@ export type MarkdownCell = {
 
 export type Cell = MarkdownCell | CodeCell;
 
+export type KernelspecMetadata = {
+  name: string,
+  display_name: string,
+}
+
+export type LanguageInfoMetadata = {
+  name: string,
+  codemirror_mode?: string | ImmutableJSONMap,
+  file_extension?: string,
+  mimetype?: string,
+  pygments_lexer?: string,
+}
+
 export type NotebookMetadata = {
+  kernelspec: KernelspecMetadata,
+  language_info: LanguageInfoMetadata,
+  // We're not currently using orig_nbformat in nteract. Based on the comment
+  // in the schema, I'm not sure we should:
+  //
+  //   > Original notebook format (major number) before converting the notebook between versions. This should never be written to a file
+  //
+  //   from https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L58-L61
+  //
+  // It seems like an intermediate/in-memory representation that bled its way into the spec
+  //
+  // orig_nbformat?: number,
 }
 
 export type Notebook = {
@@ -91,6 +116,17 @@ export const AppRecord = Immutable.Record({
   configLastSaved: null,
   error: null,
 });
+
+export type Document = {
+  notebook: Notebook,
+  transient: Immutable.Map<string, any>,
+  cellPagers: any,
+  outputStatuses: Immutable.Map<string, any>,
+  stickyCells: Immutable.Set<any>,
+  editorFocused: any,
+  cellFocused: any,
+  copied: Immutable.Map<any, any>,
+}
 
 export const DocumentRecord = Immutable.Record({
   notebook: null,

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -1,6 +1,84 @@
-import Immutable from 'immutable';
+/* @flow */
 
-export const AppRecord = new Immutable.Record({
+const Immutable = require('immutable');
+
+/*
+
+This is the definition of JSON that Flow provides
+
+type JSON = | string | number | boolean | null | JSONObject | JSONArray;
+type JSONObject = { [key:string]: JSON };
+type JSONArray = Array<JSON>;
+
+Which we'll adapt for our use of Immutable.js
+
+*/
+
+export type ImmutableJSON = | string | number | boolean | null
+                            | ImmutableJSONMap | ImmutableJSONList; // eslint-disable-line no-use-before-define
+export type ImmutableJSONMap = Immutable.Map<string, ImmutableJSON>;
+export type ImmutableJSONList = Immutable.List<ImmutableJSON>;
+
+export type ExecutionCount = number | null;
+
+export type MimeBundle = Immutable.Map<string, ImmutableJSON>;
+
+export type ExecuteResult = {
+  output_type: 'execute_result',
+  execution_count: ExecutionCount,
+  data: MimeBundle,
+  metadata: ImmutableJSONMap,
+}
+
+export type DisplayData = {
+  output_type: 'display_data',
+  data: MimeBundle,
+  metadata: ImmutableJSONMap,
+}
+
+export type StreamOutput = {
+  output_type: 'stream',
+  name: 'stdout' | 'stderr',
+  text: string,
+}
+
+export type ErrorOutput = {
+  output_type: 'error',
+  ename: string,
+  evalue: string,
+  traceback: Immutable.List<string>,
+}
+
+export type Output = ExecuteResult | DisplayData | StreamOutput | ErrorOutput;
+
+export type CodeCell = {
+  cell_type: 'code',
+  metadata: ImmutableJSONMap,
+  execution_count: ExecutionCount,
+  source: string,
+  outputs: Immutable.List<Output>,
+}
+
+export type MarkdownCell = {
+  cell_type: 'markdown',
+  source: string,
+  metadata: ImmutableJSONMap,
+}
+
+export type Cell = MarkdownCell | CodeCell;
+
+export type NotebookMetadata = {
+}
+
+export type Notebook = {
+  cellMap: Immutable.Map<string, Cell>,
+  cellOrder: Immutable.List<string>,
+  nbformat: 4,
+  nbformat_minor: 0 | 1 | 2 | 3 | 4,
+  metadata: NotebookMetadata,
+}
+
+export const AppRecord = Immutable.Record({
   executionState: 'not connected',
   token: null,
   channels: null,
@@ -14,7 +92,7 @@ export const AppRecord = new Immutable.Record({
   error: null,
 });
 
-export const DocumentRecord = new Immutable.Record({
+export const DocumentRecord = Immutable.Record({
   notebook: null,
   transient: new Immutable.Map({
     keyPathsForDisplays: new Immutable.Map(),
@@ -27,12 +105,12 @@ export const DocumentRecord = new Immutable.Record({
   copied: new Immutable.Map(),
 });
 
-export const MetadataRecord = new Immutable.Record({
+export const MetadataRecord = Immutable.Record({
   past: new Immutable.List(),
   future: new Immutable.List(),
   filename: '',
 });
 
-export const CommsRecord = new Immutable.Record({
+export const CommsRecord = Immutable.Record({
   targets: new Immutable.Map(),
 });


### PR DESCRIPTION
I'm going to start getting our state to be a bit more exact to make typing of our reducers, actions, and epics much easier. This starts out by creating flow types for the overall notebook state.