### PR TITLE
chore(flow): Started adding Redux types, enabled typing on provider

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [libs]
-flow-typed/
+flow-typed
+types
 
 [options]
 module.ignore_non_literal_requires=true

--- a/src/notebook/providers/cell-creator.js
+++ b/src/notebook/providers/cell-creator.js
@@ -1,3 +1,4 @@
+// @flow
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -9,14 +10,16 @@ import {
 } from '../actions';
 import CellCreatorView from '../views/cell-creator';
 
-type Props = {
+type Props = {|
   above: boolean,
-  dispatch: Dispatch,
+  dispatch: Dispatch<*>,
   id: string|null,
-}
+|}
 
 class CellCreator extends Component {
   props: Props;
+  createCell: (type: string) => void;
+  mergeCell: () => void;
 
   constructor(): void {
     super();
@@ -42,7 +45,7 @@ class CellCreator extends Component {
   }
 
   render(): React.Element<any> {
-    const props: CellCreatorProps = {
+    const props = {
       ...this.props,
       createCell: this.createCell,
       mergeCell: this.mergeCell,

--- a/src/notebook/views/cell-creator.js
+++ b/src/notebook/views/cell-creator.js
@@ -1,19 +1,21 @@
 // @flow
+/* eslint-disable react/no-unused-prop-types */
+
 import React, { PureComponent } from 'react';
 import { throttle } from 'lodash';
 
-declare type CellCreatorProps = {|
+type Props = {
   above: boolean,
   id: string|null,
   createCell: (type: string) => void,
   mergeCell: () => void,
-|};
+};
 
 type State = {|
   show: boolean,
 |};
 
-const renderActionButtons = ({ above, createCell, mergeCell }: CellCreatorProps) => (
+const renderActionButtons = ({ above, createCell, mergeCell }: Props) => (
   <div className="cell-creator">
     <button
       onClick={() => createCell('markdown')}
@@ -33,7 +35,7 @@ const renderActionButtons = ({ above, createCell, mergeCell }: CellCreatorProps)
 );
 
 export default class CellCreator extends PureComponent {
-  props: CellCreatorProps;
+  props: Props;
   state: State;
   updateVisibility: (mouseEvent: MouseEvent) => void;
   hoverElement: HTMLElement;

--- a/types/redux.js
+++ b/types/redux.js
@@ -1,0 +1,8 @@
+// @flow
+/* eslint-disable no-undef */
+
+declare type Action = {
+  type: string
+}
+
+declare type Dispatch<A: Action> = (action: A) => A


### PR DESCRIPTION
- Enabled Flow on the cell creator provider
- Added types lib for global types (@rgbkrk we can possibly put our generated model files here if we end up going that route)

We should consider dropping the eslint-plugin-react no-unused-prop-types rule. [It throws a false positive](https://github.com/yannickcr/eslint-plugin-react/issues/816) if you destructure your props in your component. 