### PR TITLE
chore(flow): fully type config.js

### DIFF
--- a/src/notebook/reducers/config.js
+++ b/src/notebook/reducers/config.js
@@ -1,14 +1,31 @@
-import { handleActions } from 'redux-actions';
+/* @flow */
 
-import * as constants from '../constants';
+import { Map } from 'immutable';
 
-export default handleActions({
-  [constants.SET_CONFIG_KEY]: function setConfigKey(state, action) {
-    const { key, value } = action;
-    return state.set(key, value);
-  },
-  [constants.MERGE_CONFIG]: function mergeConfig(state, action) {
-    const { config } = action;
-    return state.merge(config);
-  },
-}, {});
+type SetConfigAction = { type: 'SET_CONFIG_KEY', key: string, value: string };
+type MergeConfigAction = { type: 'MERGE_CONFIG', config: Map<any, any> };
+
+type ConfigAction = SetConfigAction | MergeConfigAction;
+
+type State = Map<any, any>;
+
+export function setConfigKey(state: State, action: SetConfigAction) {
+  const { key, value } = action;
+  return state.set(key, value);
+}
+
+export function mergeConfig(state: State, action: MergeConfigAction) {
+  const { config } = action;
+  return state.merge(config);
+}
+
+export default function handleConfig(state: State = Map(), action: ConfigAction) {
+  switch (action.type) {
+    case 'SET_CONFIG_KEY':
+      return setConfigKey(state, action);
+    case 'MERGE_CONFIG':
+      return mergeConfig(state, action);
+    default:
+      return state;
+  }
+}

--- a/src/notebook/reducers/config.js
+++ b/src/notebook/reducers/config.js
@@ -7,19 +7,19 @@ type MergeConfigAction = { type: 'MERGE_CONFIG', config: Map<any, any> };
 
 type ConfigAction = SetConfigAction | MergeConfigAction;
 
-type State = Map<any, any>;
+type ConfigState = Map<any, any>;
 
-export function setConfigKey(state: State, action: SetConfigAction) {
+export function setConfigKey(state: ConfigState, action: SetConfigAction) {
   const { key, value } = action;
   return state.set(key, value);
 }
 
-export function mergeConfig(state: State, action: MergeConfigAction) {
+export function mergeConfig(state: ConfigState, action: MergeConfigAction) {
   const { config } = action;
   return state.merge(config);
 }
 
-export default function handleConfig(state: State = Map(), action: ConfigAction) {
+export default function handleConfig(state: ConfigState = Map(), action: ConfigAction) {
   switch (action.type) {
     case 'SET_CONFIG_KEY':
       return setConfigKey(state, action);


### PR DESCRIPTION
In order to fully type the reducers (with full flow coverage) I noticed I had to do several things:

* Switch away from using constants
  * Good news though! Flow detects and ensures the type names are used.
* Break away from `handleActions` since it can't have the same flow based typing
  * We get some great typing benefits from this and this will end up cutting out a dependency that we were kind of treating like magic.