### PR TITLE
chore(kernels): Store kernel specs on startup

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -15,9 +15,10 @@ import {
   launchNewNotebook,
 } from './launch';
 
-import { defaultMenu, loadFullMenu } from './menu';
+import { loadFullMenu } from './menu';
 
 import prepareEnv from './prepare-env';
+import saveKernelspecs from './kernel-specs';
 
 const log = require('electron-log');
 
@@ -90,7 +91,8 @@ const prepJupyterObservable = prepareEnv
 
 const kernelSpecsPromise = prepJupyterObservable
   .toPromise()
-  .then(() => kernelspecs.findAll());
+  .then(() => kernelspecs.findAll())
+  .then(kernelSpecs => saveKernelspecs(kernelSpecs));
 
 /**
  * Creates an Rx.Subscriber that will create a splash page onNext and close the
@@ -203,10 +205,8 @@ fullAppReady$
   .subscribe(() => {
     kernelSpecsPromise.then((kernelSpecs) => {
       if (Object.keys(kernelSpecs).length !== 0) {
-        // Get the default menu first
-        Menu.setApplicationMenu(defaultMenu);
-        // Let the kernels/languages come in after
-        loadFullMenu().then(menu => Menu.setApplicationMenu(menu));
+        const menu = loadFullMenu(kernelSpecs);
+        Menu.setApplicationMenu(menu);
       } else {
         dialog.showMessageBox({
           type: 'warning',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -91,9 +91,9 @@ const prepJupyterObservable = prepareEnv
 
 const kernelSpecsPromise = prepJupyterObservable
   .toPromise()
-  .then(() => kernelspecs.findAll())
-  .then(kernelSpecs => saveKernelspecs(kernelSpecs));
+  .then(() => kernelspecs.findAll());
 
+kernelSpecsPromise.then(saveKernelspecs);
 /**
  * Creates an Rx.Subscriber that will create a splash page onNext and close the
  * splash page onComplete.

--- a/src/main/kernel-specs.js
+++ b/src/main/kernel-specs.js
@@ -1,3 +1,11 @@
+import { ipcMain as ipc } from 'electron';
+
+const KERNEL_SPECS = {};
+
 export default function saveKernelspecs(kernelSpecs) {
-  global.KERNEL_SPECS = kernelSpecs;
+  Object.assign(KERNEL_SPECS, kernelSpecs);
 }
+
+ipc.on('kernel_specs_request', (event) => {
+  event.sender.send('kernel_specs_reply', KERNEL_SPECS);
+});

--- a/src/main/kernel-specs.js
+++ b/src/main/kernel-specs.js
@@ -1,0 +1,4 @@
+export default function saveKernelspecs(kernelSpecs) {
+  global.KERNEL_SPECS = kernelSpecs;
+  return kernelSpecs;
+}

--- a/src/main/kernel-specs.js
+++ b/src/main/kernel-specs.js
@@ -1,4 +1,3 @@
 export default function saveKernelspecs(kernelSpecs) {
   global.KERNEL_SPECS = kernelSpecs;
-  return kernelSpecs;
 }

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -4,8 +4,6 @@ import * as path from 'path';
 import { launch, launchNewNotebook } from './launch';
 import { installShellCommand } from './cli';
 
-const kernelspecs = require('kernelspecs');
-
 function getExampleNotebooksDir() {
   if (process.env.NODE_ENV === 'development') {
     return path.resolve(path.join(__dirname, '..', '..', 'example-notebooks'));
@@ -487,82 +485,80 @@ export function generateDefaultTemplate() {
 
 export const defaultMenu = Menu.buildFromTemplate(generateDefaultTemplate());
 
-export function loadFullMenu() {
-  return kernelspecs.findAll().then((kernelSpecs) => {
-    function generateSubMenu(kernelSpecName) {
-      return {
-        label: kernelSpecs[kernelSpecName].spec.display_name,
-        click: createSender('menu:new-kernel', kernelSpecs[kernelSpecName])
-      };
-    }
-
-    const kernelMenuItems = Object.keys(kernelSpecs).map(generateSubMenu);
-
-    const newNotebookItems = Object.keys(kernelSpecs)
-      .map(kernelSpecName => ({
-        label: kernelSpecs[kernelSpecName].spec.display_name,
-        click: () => launchNewNotebook(kernelSpecs[kernelSpecName]),
-      }));
-
-    const languageMenu = {
-      label: '&Language',
-      submenu: [
-        {
-          label: '&Kill Running Kernel',
-          click: createSender('menu:kill-kernel'),
-        },
-        {
-          label: '&Interrupt Running Kernel',
-          click: createSender('menu:interrupt-kernel'),
-        },
-        {
-          label: 'Restart Running Kernel',
-          click: createSender('menu:restart-kernel'),
-        },
-        {
-          label: 'Restart and Clear All Cells',
-          click: createSender('menu:restart-and-clear-all'),
-        },
-        {
-          type: 'separator',
-        },
-        // All the available kernels
-        ...kernelMenuItems,
-      ],
+export function loadFullMenu(kernelSpecs) {
+  function generateSubMenu(kernelSpecName) {
+    return {
+      label: kernelSpecs[kernelSpecName].spec.display_name,
+      click: createSender('menu:new-kernel', kernelSpecs[kernelSpecName])
     };
+  }
 
-    const template = [];
+  const kernelMenuItems = Object.keys(kernelSpecs).map(generateSubMenu);
 
-    if (process.platform === 'darwin') {
-      template.push(named);
-    }
+  const newNotebookItems = Object.keys(kernelSpecs)
+    .map(kernelSpecName => ({
+      label: kernelSpecs[kernelSpecName].spec.display_name,
+      click: () => launchNewNotebook(kernelSpecs[kernelSpecName]),
+    }));
 
-    const fileWithNew = {
-      label: '&File',
-      submenu: [
-        {
-          label: '&New',
-          submenu: newNotebookItems,
-        },
-        fileSubMenus.open,
-        fileSubMenus.openExampleNotebooks,
-        fileSubMenus.save,
-        fileSubMenus.saveAs,
-        fileSubMenus.publish,
-      ],
-    };
+  const languageMenu = {
+    label: '&Language',
+    submenu: [
+      {
+        label: '&Kill Running Kernel',
+        click: createSender('menu:kill-kernel'),
+      },
+      {
+        label: '&Interrupt Running Kernel',
+        click: createSender('menu:interrupt-kernel'),
+      },
+      {
+        label: 'Restart Running Kernel',
+        click: createSender('menu:restart-kernel'),
+      },
+      {
+        label: 'Restart and Clear All Cells',
+        click: createSender('menu:restart-and-clear-all'),
+      },
+      {
+        type: 'separator',
+      },
+      // All the available kernels
+      ...kernelMenuItems,
+    ],
+  };
 
-    template.push(fileWithNew);
-    template.push(edit);
-    template.push(cell);
-    template.push(view);
+  const template = [];
 
-    // Application specific functionality should go before window and help
-    template.push(languageMenu);
-    template.push(window);
-    template.push(help);
+  if (process.platform === 'darwin') {
+    template.push(named);
+  }
 
-    const menu = Menu.buildFromTemplate(template);
-    return menu;
-  });
+  const fileWithNew = {
+    label: '&File',
+    submenu: [
+      {
+        label: '&New',
+        submenu: newNotebookItems,
+      },
+      fileSubMenus.open,
+      fileSubMenus.openExampleNotebooks,
+      fileSubMenus.save,
+      fileSubMenus.saveAs,
+      fileSubMenus.publish,
+    ],
+  };
+
+  template.push(fileWithNew);
+  template.push(edit);
+  template.push(cell);
+  template.push(view);
+
+  // Application specific functionality should go before window and help
+  template.push(languageMenu);
+  template.push(window);
+  template.push(help);
+
+  const menu = Menu.buildFromTemplate(template);
+  return menu;
 }

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -126,11 +126,11 @@ export const watchExecutionStateEpic = action$ =>
   */
 export const kernelSpecsObservable =
   Rx.Observable.create((observer) => {
-    ipc.send('kernel_specs_request');
     ipc.on('kernel_specs_reply', (event, specs) => {
       observer.next(specs);
       observer.complete();
     });
+    ipc.send('kernel_specs_request');
   });
 
 /**

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -2,11 +2,10 @@ import Rx from 'rxjs/Rx';
 
 import { launchSpec } from 'spawnteract';
 
-import { find } from 'kernelspecs';
-
 import * as uuid from 'uuid';
 
 import {
+  remote,
   ipcRenderer as ipc,
 } from 'electron';
 
@@ -143,10 +142,11 @@ export const newKernelByNameEpic = action$ =>
         throw new Error('newKernelByNameEpic requires a kernel name');
       }
     })
-    .mergeMap(action =>
-      find(action.kernelSpecName)
-        .then(spec => newKernel(spec, action.cwd))
-    );
+    .mergeMap((action) => {
+      const spec = remote.getGlobal('KERNEL_SPECS')[action.kernelSpecName];
+      return Rx.Observable.of(newKernel(spec, action.cwd));
+    }
+  );
 
 /**
   * Launches a new kernel.

--- a/test/renderer/epics/kernel-launch-spec.js
+++ b/test/renderer/epics/kernel-launch-spec.js
@@ -160,7 +160,7 @@ describe('newKernelByNameEpic', () => {
   it('creates a LAUNCH_KERNEL action in response to a LAUNCH_KERNEL_BY_NAME action', (done) => {
     const input$ = Rx.Observable.of({
       type: constants.LAUNCH_KERNEL_BY_NAME,
-      kernelSpecName: 'python2.8',
+      kernelSpecName: 'python3',
       cwd: '~',
     });
     let actionBuffer = [];

--- a/test/setup.js
+++ b/test/setup.js
@@ -117,6 +117,14 @@ mock('electron', {
         'setDocumentEdited': function(){},
         'setRepresentedFilename': function() {},
       };
+    },
+    'getGlobal': function() {
+      return {
+        python3: {
+          name: 'python3',
+          spec: { argv: {}, display_name: 'Python 3', language: 'python' }
+        },
+      }
     }
   },
   'webFrame': {

--- a/test/setup.js
+++ b/test/setup.js
@@ -117,14 +117,6 @@ mock('electron', {
         'setDocumentEdited': function(){},
         'setRepresentedFilename': function() {},
       };
-    },
-    'getGlobal': function() {
-      return {
-        python3: {
-          name: 'python3',
-          spec: { argv: {}, display_name: 'Python 3', language: 'python' }
-        },
-      }
     }
   },
   'webFrame': {
@@ -132,7 +124,17 @@ mock('electron', {
     'getZoomLevel': function() { return 1; },
   },
   'ipcRenderer': {
-    'on': function() {},
+    'on': function(message, callback) {
+      if (message === 'kernel_specs_reply') {
+        const specs = {
+          python3: {
+            name: 'python3',
+            spec: { argv: {}, display_name: 'Python 3', language: 'python' }
+          },
+        };
+        callback(null, specs);
+      }
+    },
     'send': function(message, action) {}
   },
 });


### PR DESCRIPTION
Before `kernelspecs.find()` and `kernelspecs.findAll()` were called multiple times throughout the code base. Kernel specs are now stored on startup.

This makes it possible to very easily add additional kernel specs of bundled kernels in one central place.

And it slightly improves performance 😄 :
<img width="750" alt="bildschirmfoto 2017-01-15 um 14 36 45" src="https://cloud.githubusercontent.com/assets/13285808/21963078/c670b74c-db33-11e6-86a4-5a84f4eb45ad.png">

Fix #1324 