### PR TITLE
chore(lint): Remove no-unused-prop-types eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "comma-dangle": [0],
     "flowtype/define-flow-type": 2,
     "no-unused-expressions": [0, { allowTernary: true }],
+    "react/no-unused-prop-types": [0],
     "react/jsx-filename-extension": "off",
     "react/require-default-props": [0],
     "react/no-array-index-key": [0],

--- a/src/notebook/providers/draggable-cell.js
+++ b/src/notebook/providers/draggable-cell.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/no-unused-prop-types */
 import React from 'react';
 
 import { connect } from 'react-redux';

--- a/src/notebook/views/cell-creator.js
+++ b/src/notebook/views/cell-creator.js
@@ -1,6 +1,4 @@
 // @flow
-/* eslint-disable react/no-unused-prop-types */
-
 import React, { PureComponent } from 'react';
 import { throttle } from 'lodash';
 

--- a/src/notebook/views/draggable-cell.js
+++ b/src/notebook/views/draggable-cell.js
@@ -1,5 +1,4 @@
 // @flow
-/* eslint-disable react/no-unused-prop-types */
 import React from 'react';
 import { DragSource, DropTarget } from 'react-dnd';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';


### PR DESCRIPTION
The no-unused-prop-types rule throws false positives if you destructure your props in a component as I mentioned in #1335. We should turn it off until this issue is fixed.