### PR TITLE
chore(kernels): Add help menu item

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -407,6 +407,10 @@ const helpDraft = {
     {
       label: 'Learn More',
       click: () => { shell.openExternal('http://github.com/nteract/nteract'); }
+    },
+    {
+      label: 'Install Additional Kernels',
+      click: () => { shell.openExternal('https://ipython.readthedocs.io/en/latest/install/kernel_install.html'); }
     }
   ]
 };


### PR DESCRIPTION
~~Since we now have our first bundled Node.js kernel, nteract can be used without user installed kernels.~~

This PR ~~refactors the error handling if no kernel specs are detected and~~ adds a menu item to provide more informations about installing additional kernels.