### PR TITLE
Use display_name in status bar and refactor kernel restart

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -55,7 +55,7 @@ type Props = {
   theme: string,
   cursorBlinkRate: number,
   lastSaved: Date,
-  kernelSpecName: string,
+  kernelSpecDisplayName: string,
   CellComponent: any,
   executionState: string,
 };
@@ -75,7 +75,7 @@ const mapStateToProps = (state: Object) => ({
   theme: state.config.get('theme'),
   cursorBlinkRate: state.config.get('cursorBlinkRate'),
   lastSaved: state.app.get('lastSaved'),
-  kernelSpecName: state.app.get('kernelSpecName'),
+  kernelSpecDisplayName: state.app.get('kernelSpecDisplayName'),
   notebook: state.document.get('notebook'),
   transient: state.document.get('transient'),
   cellPagers: state.document.get('cellPagers'),
@@ -249,7 +249,7 @@ export class Notebook extends React.PureComponent {
         <StatusBar
           notebook={this.props.notebook}
           lastSaved={this.props.lastSaved}
-          kernelSpecName={this.props.kernelSpecName}
+          kernelSpecDisplayName={this.props.kernelSpecDisplayName}
           executionState={this.props.executionState}
         />
         <link rel="stylesheet" href={`../static/styles/theme-${this.props.theme}.css`} />

--- a/src/notebook/components/status-bar.js
+++ b/src/notebook/components/status-bar.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 type Props = {
   notebook: any,
   lastSaved: Date,
-  kernelSpecName: string,
+  kernelSpecDisplayName: string,
   executionState: string,
 };
 
@@ -22,7 +22,7 @@ export default class StatusBar extends React.Component {
   }
 
   render(): ?React.Element<any> {
-    const name = this.props.kernelSpecName || 'Loading...';
+    const name = this.props.kernelSpecDisplayName || 'Loading...';
 
     return (
       <div className="status-bar">

--- a/src/notebook/menu.js
+++ b/src/notebook/menu.js
@@ -19,7 +19,6 @@ import {
   executeCell,
   clearOutputs,
   newKernel,
-  newKernelByName,
   killKernel,
   interruptKernel,
   copyCell,
@@ -82,11 +81,11 @@ export function dispatchRestartKernel(store) {
   }
 
   store.dispatch(killKernel);
-  store.dispatch(newKernelByName(state.app.kernelSpecName, cwd));
+  store.dispatch(newKernel(state.app.kernelSpec, cwd));
 
   notificationSystem.addNotification({
     title: 'Kernel Restarted',
-    message: `Kernel ${state.app.kernelSpecName} has been restarted.`,
+    message: `Kernel ${state.app.kernelSpecDisplayName} has been restarted.`,
     dismissible: true,
     position: 'tr',
     level: 'success',

--- a/src/notebook/records.js
+++ b/src/notebook/records.js
@@ -111,6 +111,8 @@ export const AppRecord = Immutable.Record({
   connectionFile: null,
   notificationSystem: null,
   kernelSpecName: null,
+  kernelSpecDisplayName: null,
+  kernelSpec: null,
   isSaving: false,
   lastSaved: null,
   configLastSaved: null,

--- a/src/notebook/reducers/app.js
+++ b/src/notebook/reducers/app.js
@@ -14,6 +14,8 @@ declare class AppState {
   spawn: ChildProcess,
   connectionFile: string,
   kernelSpecName: string,
+  kernelSpecDisplayName: string,
+  kernelSpec: Object,
   executionState: string,
   token: string,
   notificationSystem: Object,
@@ -35,6 +37,8 @@ function cleanupKernel(state: AppState): AppState {
       .set('spawn', null)
       .set('connectionFile', null)
       .set('kernelSpecName', null)
+      .set('kernelSpecDisplayName', null)
+      .set('kernelSpec', null)
       .set('executionState', 'not connected')
   );
 }
@@ -45,6 +49,7 @@ type NewKernelAction = {
   connectionFile: string,
   spawn: ChildProcess,
   kernelSpecName: string,
+  kernelSpec: Object,
 };
 
 function newKernel(state: AppState, action: NewKernelAction) {
@@ -54,6 +59,8 @@ function newKernel(state: AppState, action: NewKernelAction) {
         .set('connectionFile', action.connectionFile)
         .set('spawn', action.spawn)
         .set('kernelSpecName', action.kernelSpecName)
+        .set('kernelSpecDisplayName', action.kernelSpec.spec.display_name)
+        .set('kernelSpec', action.kernelSpec)
         .set('executionState', 'starting')
   );
 }

--- a/test/renderer/components/status-bar-spec.js
+++ b/test/renderer/components/status-bar-spec.js
@@ -13,13 +13,13 @@ import StatusBar from '../../../src/notebook/components/status-bar';
 describe('StatusBar', () => {
   it('can render on a dummyNotebook', () => {
     const lastSaved = new Date();
-    const kernelSpecName = 'python3';
-    
+    const kernelSpecDisplayName = 'python3';
+
     const component = shallow(
       <StatusBar
         notebook={dummyCommutable}
         lastSaved={lastSaved}
-        kernelSpecName={kernelSpecName}
+        kernelSpecDisplayName={kernelSpecDisplayName}
       />
     );
 
@@ -27,36 +27,36 @@ describe('StatusBar', () => {
   });
   it('no update if an irrelevant prop has changed', () => {
     const lastSaved = new Date();
-    const kernelSpecName = 'python3';
+    const kernelSpecDisplayName = 'python3';
     const shouldComponentUpdate = sinon.spy(StatusBar.prototype, 'shouldComponentUpdate');
-    
+
     const component = shallow(
       <StatusBar
         notebook={dummyCommutable}
         lastSaved={lastSaved}
-        kernelSpecName={kernelSpecName}
+        kernelSpecDisplayName={kernelSpecDisplayName}
       />
     );
 
-    component.setProps({lastSaved: lastSaved, kernelSpecName: 'javascript', notebook: dummyCommutable});
+    component.setProps({lastSaved: lastSaved, kernelSpecDisplayName: 'javascript', notebook: dummyCommutable});
     expect(shouldComponentUpdate).to.have.been.called;
     expect(shouldComponentUpdate).to.have.returned(false);
     shouldComponentUpdate.restore();
   });
   it('update if an irrelevant prop has changed', () => {
     const lastSaved = new Date();
-    const kernelSpecName = 'python3';
+    const kernelSpecDisplayName = 'python3';
     const shouldComponentUpdate = sinon.spy(StatusBar.prototype, 'shouldComponentUpdate');
-    
+
     const component = shallow(
       <StatusBar
         notebook={dummyCommutable}
         lastSaved={lastSaved}
-        kernelSpecName={kernelSpecName}
+        kernelSpecDisplayName={kernelSpecDisplayName}
       />
     );
 
-    component.setProps({lastSaved: new Date(), kernelSpecName: 'python3', notebook: dummyCommutable});
+    component.setProps({lastSaved: new Date(), kernelSpecDisplayName: 'python3', notebook: dummyCommutable});
     expect(shouldComponentUpdate).to.have.been.called;
     expect(shouldComponentUpdate).to.have.returned(true);
     shouldComponentUpdate.restore();

--- a/test/renderer/reducers/app-spec.js
+++ b/test/renderer/reducers/app-spec.js
@@ -210,12 +210,15 @@ describe('newKernel', () => {
       channels: 'test_channels',
       spawn: 'test_spawn',
       kernelSpecName: 'test_name',
+      kernelSpec: { spec: { display_name: 'Test Name' } },
       executionState: 'starting',
     };
 
     const state = reducers(originalState, action);
     expect(state.app.executionState).to.equal('starting');
     expect(state.app.kernelSpecName).to.equal('test_name');
+    expect(state.app.kernelSpec).to.deep.equal({ spec: { display_name: 'Test Name' } });
+    expect(state.app.kernelSpecDisplayName).to.equal('Test Name');
     expect(state.app.spawn).to.equal('test_spawn');
     expect(state.app.channels).to.equal('test_channels');
   });


### PR DESCRIPTION
Fix https://github.com/nteract/nteract/pull/1339#issuecomment-273545561

Additionally for restarting a kernel the stored kernel spec is used (one less ipc call).