### PR TITLE
Commuting commutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "rimraf": "^2.5.2",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
-    "source-map-support": "^0.4.6",
+    "source-map-support": "^0.4.10",
     "watch": "^1.0.0",
     "webpack": "^1.13.3"
   }

--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
     "rimraf": "^2.5.2",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
-    "source-map-support": "^0.4.10",
     "watch": "^1.0.0",
     "webpack": "^1.13.3"
   }

--- a/src/commutable/index.js
+++ b/src/commutable/index.js
@@ -50,6 +50,18 @@ export function fromJS(notebookJSON: Notebook): ImmutableNotebook {
   throw new TypeError('This notebook format is not supported');
 }
 
+export function toJS(immnb: ImmutableNotebook): v4Notebook {
+  if (immnb.get('nbformat') === 4 && immnb.get('nbformat_minor') >= 0) {
+    return v4.toJS(immnb);
+  }
+  throw new TypeError('Only notebook format 4 is supported');
+}
+
+// Expected usage is stringifyNotebook(toJS(immutableNotebook))
+export function stringifyNotebook(notebook: v4Notebook): string {
+  return JSON.stringify(notebook, null, 2);
+}
+
 export type {
   ImmutableNotebook,
 };

--- a/src/commutable/index.js
+++ b/src/commutable/index.js
@@ -1,0 +1,63 @@
+/* @flow */
+import * as v4 from './v4';
+
+import type { Notebook as v4Notebook } from './v4';
+
+import {
+  emptyNotebook,
+  emptyCodeCell,
+  emptyMarkdownCell,
+  appendCell,
+  monocellNotebook,
+} from './structures';
+
+import type {
+  ImmutableNotebook,
+  JSONType,
+} from './types';
+
+type PlaceholderNotebook = {
+  nbformat: number,
+  nbformat_minor: number,
+};
+
+export type Notebook = PlaceholderNotebook & v4Notebook;
+
+function freezeReviver(k: string, v: JSONType): JSONType {
+  return Object.freeze(v);
+}
+
+// Expected usage of below is
+// fromJS(parseNotebook(string|buffer))
+
+export function parseNotebook(notebookString: string): Notebook {
+  return JSON.parse(notebookString, freezeReviver);
+}
+
+export function fromJS(notebookJSON: Notebook): ImmutableNotebook {
+  if (notebookJSON.nbformat === 4 && notebookJSON.nbformat_minor >= 0) {
+    if (Array.isArray(notebookJSON.cells) && typeof notebookJSON.metadata === 'object') {
+      return v4.fromJS(notebookJSON);
+    }
+  }
+
+  if (notebookJSON.nbformat) {
+    throw new TypeError(
+      `nbformat v${notebookJSON.nbformat}.${notebookJSON.nbformat_minor} not recognized`
+    );
+  }
+
+  throw new TypeError('This notebook format is not supported');
+}
+
+export type {
+  ImmutableNotebook,
+};
+
+export {
+  emptyCodeCell,
+  emptyMarkdownCell,
+  emptyNotebook,
+  appendCell,
+  monocellNotebook,
+};

--- a/src/commutable/structures.js
+++ b/src/commutable/structures.js
@@ -1,0 +1,115 @@
+/* @flow */
+
+import * as Immutable from 'immutable';
+
+import { v4 as uuidv4 } from 'uuid';
+
+import type {
+  ImmutableOutput,
+  ImmutableCell,
+  ImmutableCodeCell,
+  ImmutableMarkdownCell,
+  ImmutableNotebook,
+  ImmutableCellOrder,
+  ImmutableCellMap,
+  ImmutableJSONType,
+  ExecutionCount,
+} from './types';
+
+// We're hardset to nbformat v4.4 for what we use in-memory
+export type Notebook = {|
+  nbformat: 4,
+  nbformat_minor: 4,
+  metadata: Immutable.Map<string, ImmutableJSONType>,
+  cellOrder: Immutable.List<string>,
+  cellMap: Immutable.Map<string, ImmutableCell>,
+|}
+
+export type CodeCell = {|
+  cell_type: 'code',
+  metadata: Immutable.Map<string, any>,
+  execution_count: ExecutionCount,
+  source: string,
+  outputs: Immutable.List<ImmutableOutput>,
+|}
+
+export type MarkdownCell = {|
+  cell_type: 'markdown',
+  source: string,
+  metadata: Immutable.Map<string, any>,
+|}
+
+const defaultCodeCell = Object.freeze({
+  cell_type: 'code',
+  execution_count: null,
+  metadata: Immutable.Map({
+    collapsed: false,
+  }),
+  source: '',
+  outputs: Immutable.List(),
+});
+
+const defaultMarkdownCell = Object.freeze({
+  cell_type: 'markdown',
+  metadata: Immutable.Map(),
+  source: '',
+});
+
+export function createCodeCell(cell: CodeCell = defaultCodeCell): ImmutableCodeCell { // eslint-disable-line max-len
+  return Immutable.Map(cell);
+}
+
+export function createMarkdownCell(cell: MarkdownCell = defaultMarkdownCell): ImmutableMarkdownCell { // eslint-disable-line max-len
+  return Immutable.Map(cell);
+}
+
+export const emptyCodeCell = createCodeCell();
+export const emptyMarkdownCell = createMarkdownCell();
+
+const defaultNotebook = Object.freeze({
+  nbformat: 4,
+  nbformat_minor: 4,
+  metadata: new Immutable.Map(),
+  cellOrder: new Immutable.List(),
+  cellMap: new Immutable.Map(),
+});
+
+export function createNotebook(notebook: Notebook = defaultNotebook): ImmutableNotebook {
+  return Immutable.Map(notebook);
+}
+
+export const emptyNotebook = createNotebook();
+
+export type CellStructure = {
+  cellOrder: ImmutableCellOrder,
+  cellMap: ImmutableCellMap,
+}
+
+// Intended to make it easy to use this with (temporary mutable cellOrder + cellMap)
+export function appendCell(
+  cellStructure: CellStructure,
+  immutableCell: ImmutableCell,
+  id: string = uuidv4()
+) {
+  return {
+    cellOrder: cellStructure.cellOrder.push(id),
+    cellMap: cellStructure.cellMap.set(id, immutableCell),
+  };
+}
+
+export function appendCellToNotebook(
+  immnb: ImmutableNotebook,
+  immCell: ImmutableCell)
+  : ImmutableNotebook {
+  return immnb.withMutations((nb) => {
+    const cellStructure = {
+      cellOrder: nb.get('cellOrder'),
+      cellMap: nb.get('cellMap'),
+    };
+    const { cellOrder, cellMap } = appendCell(cellStructure, immCell);
+    return nb.set('cellOrder', cellOrder)
+             .set('cellMap', cellMap);
+  });
+}
+
+export const monocellNotebook = appendCellToNotebook(emptyNotebook, emptyCodeCell);

--- a/src/commutable/structures.js
+++ b/src/commutable/structures.js
@@ -44,6 +44,8 @@ const defaultCodeCell = Object.freeze({
   execution_count: null,
   metadata: Immutable.Map({
     collapsed: false,
+    outputHidden: false,
+    inputHidden: false,
   }),
   source: '',
   outputs: Immutable.List(),
@@ -110,6 +112,27 @@ export function appendCellToNotebook(
     return nb.set('cellOrder', cellOrder)
              .set('cellMap', cellMap);
   });
+}
+
+export function insertCellAt(
+  notebook: ImmutableNotebook,
+  cell: ImmutableCell,
+  cellID: string,
+  index: number)
+  : ImmutableNotebook {
+  return notebook.withMutations(nb =>
+    nb.setIn(['cellMap', cellID], cell)
+      .set('cellOrder', nb.get('cellOrder').insert(index, cellID))
+    );
+}
+
+export function insertCellAfter(
+  notebook: ImmutableNotebook,
+  cell: ImmutableCell,
+  cellID: string,
+  priorCellID: string)
+  : ImmutableNotebook {
+  return insertCellAt(notebook, cell, cellID, notebook.get('cellOrder').indexOf(priorCellID) + 1);
 }
 
 export const monocellNotebook = appendCellToNotebook(emptyNotebook, emptyCodeCell);

--- a/src/commutable/structures.js
+++ b/src/commutable/structures.js
@@ -135,4 +135,12 @@ export function insertCellAfter(
   return insertCellAt(notebook, cell, cellID, notebook.get('cellOrder').indexOf(priorCellID) + 1);
 }
 
+export function removeCell(notebook: ImmutableNotebook, cellID: string) {
+  return notebook
+    .removeIn(['cellMap', cellID])
+    .update('cellOrder',
+      (cellOrder: ImmutableCellOrder) => cellOrder.filterNot(id => id === cellID)
+    );
+}
+
 export const monocellNotebook = appendCellToNotebook(emptyNotebook, emptyCodeCell);

--- a/src/commutable/types.js
+++ b/src/commutable/types.js
@@ -1,0 +1,33 @@
+// @flow
+
+import type { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
+type PrimitiveImmutable = | string | number | boolean | null
+
+export type JSONType = PrimitiveImmutable | JSONObject | JSONArray; // eslint-disable-line no-use-before-define
+export type JSONObject = { [key:string]: JSONType };
+export type JSONArray = Array<JSONType>;
+
+export type ImmutableJSONType = PrimitiveImmutable |
+  ImmutableMap<string, ImmutableJSONType> |
+  ImmutableList<ImmutableJSONType>;
+
+export type ExecutionCount = number | null;
+
+export type MimeBundle = JSONObject;
+
+export type CellType = 'markdown' | 'code';
+export type CellID = string;
+
+// These are very unserious types, since Records are not quite typable
+export type ImmutableNotebook = ImmutableMap<string, any>;
+export type ImmutableCodeCell = ImmutableMap<string, any>;
+export type ImmutableMarkdownCell = ImmutableMap<string, any>;
+export type ImmutableCell = ImmutableCodeCell | ImmutableMarkdownCell;
+export type ImmutableOutput = ImmutableMap<string, any>;
+export type ImmutableOutputs = ImmutableList<ImmutableOutput>;
+
+export type ImmutableMimeBundle = ImmutableMap<string, any>;
+
+export type ImmutableCellOrder = ImmutableList<CellID>;
+export type ImmutableCellMap = ImmutableMap<CellID, ImmutableCell>;

--- a/src/commutable/types.js
+++ b/src/commutable/types.js
@@ -23,6 +23,7 @@ export type CellID = string;
 export type ImmutableNotebook = ImmutableMap<string, any>;
 export type ImmutableCodeCell = ImmutableMap<string, any>;
 export type ImmutableMarkdownCell = ImmutableMap<string, any>;
+export type ImmutableRawCell = ImmutableMap<string, any>;
 export type ImmutableCell = ImmutableCodeCell | ImmutableMarkdownCell;
 export type ImmutableOutput = ImmutableMap<string, any>;
 export type ImmutableOutputs = ImmutableList<ImmutableOutput>;

--- a/src/commutable/v4.js
+++ b/src/commutable/v4.js
@@ -23,6 +23,7 @@ import type {
   ImmutableNotebook,
   ImmutableCodeCell,
   ImmutableMarkdownCell,
+  ImmutableRawCell,
   ImmutableCell,
   ImmutableOutput,
   ImmutableMimeBundle,
@@ -99,8 +100,14 @@ export type MarkdownCell = {|
   source: MultiLineString,
 |};
 
+export type RawCell = {|
+  cell_type: 'raw',
+  metadata: JSONObject,
+  source: MultiLineString,
+|};
+
 // TODO: RawCell
-export type Cell = CodeCell | MarkdownCell;
+export type Cell = CodeCell | MarkdownCell | RawCell;
 
 export type Notebook = {|
   cells: Array<Cell>,
@@ -186,6 +193,14 @@ function createImmutableOutput(output: Output): ImmutableOutput {
   }
 }
 
+function createImmutableRawCell(cell: RawCell): ImmutableRawCell {
+  return new Immutable.Map({
+    cell_type: cell.cell_type,
+    source: demultiline(cell.source),
+    metadata: Immutable.fromJS(cell.metadata),
+  });
+}
+
 function createImmutableMarkdownCell(cell: MarkdownCell): ImmutableMarkdownCell {
   return new Immutable.Map({
     cell_type: cell.cell_type,
@@ -210,6 +225,8 @@ function createImmutableCell(cell: Cell): ImmutableCell {
       return createImmutableMarkdownCell(cell);
     case 'code':
       return createImmutableCodeCell(cell);
+    case 'raw':
+      return createImmutableRawCell(cell);
     default:
       throw new TypeError(`Cell type ${cell.cell_type} unknown`);
   }

--- a/src/commutable/v4.js
+++ b/src/commutable/v4.js
@@ -135,9 +135,13 @@ function remultiline(s: string | Array<string>): Array<string> {
   return s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== '');
 }
 
+function isJSONKey(key) {
+  return /^application\/(.*\+)?json$/.test(key);
+}
+
 function cleanMimeData(key: string, data: string | Array<string> | Object) {
   // See https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L368
-  if (/^application\/(.*\+)?json$/.test(key)) {
+  if (isJSONKey(key)) {
     // Data stays as is for JSON types
     return data;
   }
@@ -295,7 +299,7 @@ function mimeBundleToJS(immMimeBundle: ImmutableMimeBundle): MimeBundle {
   const bundle = immMimeBundle.toObject();
 
   Object.keys(bundle).map((key) => {
-    if (/^application\/(.*\\+)?json$/.test(key)) {
+    if (isJSONKey(key)) {
       if (Immutable.Map.isMap(bundle[key])) {
         bundle[key] = bundle[key].toJS();
       }

--- a/src/commutable/v4.js
+++ b/src/commutable/v4.js
@@ -1,0 +1,245 @@
+/* @flow */
+
+/*
+ * Functions in this module are provided for converting from Jupyter Notebook
+ * Format v4 to nteract's in-memory format, affectionately referred to as
+ * commutable.
+ *
+ * See: https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json
+ *
+ * The main goal here is consistency and compliance with the v4 spec. The types
+ * contained in here (non Immutable ones) are constrained to the disk based
+ * notebook format.
+ *
+ * To assist in the developer experience, types are included through the use of
+ * flow.
+ *
+ */
+
+import * as Immutable from 'immutable';
+
+import type {
+  JSONObject,
+  ImmutableNotebook,
+  ImmutableCodeCell,
+  ImmutableMarkdownCell,
+  ImmutableCell,
+  ImmutableOutput,
+  ImmutableMimeBundle,
+} from './types';
+
+import type {
+  CellStructure,
+} from './structures';
+
+import { appendCell } from './structures';
+
+export type ExecutionCount = number | null;
+
+//
+// MimeBundle example (disk format)
+//
+// {
+//   "application/json": {"a": 3, "b": 2},
+//   "text/html": ["<p>\n", "Hey\n", "</p>"],
+//   "text/plain": "Hey"
+// }
+//
+export type MimeBundle = { [key:string]: string | Array<string> | Object };
+
+// On disk multi-line strings are used to accomodate line-by-line diffs in tools
+// like git and GitHub. They get converted to strings for the in-memory format.
+export type MultiLineString = string | Array<string>;
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                             Output Types
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+export type ExecuteResult = {|
+  output_type: 'execute_result',
+  execution_count: ExecutionCount,
+  data: MimeBundle,
+  metadata: JSONObject,
+|}
+
+export type DisplayData = {|
+  output_type: 'display_data',
+  data: MimeBundle,
+  metadata: JSONObject,
+|}
+
+export type StreamOutput = {|
+  output_type: 'stream',
+  name: 'stdout' | 'stderr',
+  text: MultiLineString,
+|}
+
+export type ErrorOutput = {|
+  output_type: 'error',
+  ename: string,
+  evalue: string,
+  traceback: Array<string>,
+|}
+
+export type Output = ExecuteResult | DisplayData | StreamOutput | ErrorOutput;
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *                              Cell Types
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+export type CodeCell = {|
+  cell_type: 'code',
+  metadata: JSONObject,
+  execution_count: ExecutionCount,
+  source: string,
+  outputs: Array<Output>,
+|};
+
+export type MarkdownCell = {|
+  cell_type: 'markdown',
+  metadata: JSONObject,
+  source: MultiLineString,
+|};
+
+// TODO: RawCell
+export type Cell = CodeCell | MarkdownCell;
+
+export type Notebook = {|
+  cells: Array<Cell>,
+  metadata: Object,
+  nbformat: 4,
+  nbformat_minor: number,
+|};
+
+function demultiline(s: string | Array<string>) {
+  if (Array.isArray(s)) {
+    return s.join('');
+  }
+  return s;
+}
+
+function cleanMimeData(key: string, data: string | Array<string> | Object) {
+  // See https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L368
+  if (/^application\/(.*\\+)?json$/.test(key)) {
+    // Data stays as is for JSON types
+    return data;
+  }
+
+  if (typeof data === 'string' || Array.isArray(data)) {
+    return demultiline(data);
+  }
+
+  throw new TypeError(`Data for ${key} is expected to be a string or an Array of strings`);
+}
+
+function cleanMimeAtKey(mimeBundle: MimeBundle, previous: ImmutableMimeBundle, key: string) {
+  return previous.set(key, cleanMimeData(key, mimeBundle[key]));
+}
+
+export function createImmutableMimeBundle(mimeBundle: MimeBundle): ImmutableMimeBundle {
+  // Map over all the mimetypes, turning them into our in-memory format
+  //
+  // {
+  //   "application/json": {"a": 3, "b": 2},
+  //   "text/html": ["<p>\n", "Hey\n", "</p>"],
+  //   "text/plain": "Hey"
+  // }
+  //
+  // to
+  //
+  // {
+  //   "application/json": {"a": 3, "b": 2},
+  //   "text/html": "<p>\nHey\n</p>",
+  //   "text/plain": "Hey"
+  // }
+  //
+  return Object.keys(mimeBundle)
+      .reduce(cleanMimeAtKey.bind(null, mimeBundle), Immutable.Map());
+}
+
+
+function createImmutableOutput(output: Output): ImmutableOutput {
+  switch (output.output_type) {
+    case 'execute_result':
+      return Immutable.Map({
+        output_type: output.output_type,
+        execution_count: output.execution_count,
+        data: createImmutableMimeBundle(output.data),
+        metadata: Immutable.fromJS(output.metadata), // TODO: Determine if this should be Immutable or just frozen
+      });
+    case 'display_data':
+      return Immutable.Map({
+        output_type: output.output_type,
+        data: createImmutableMimeBundle(output.data),
+        metadata: Immutable.fromJS(output.metadata), // TODO: Determine if this should be Immutable or just frozen
+      });
+    case 'stream':
+      return Immutable.Map({
+        output_type: output.output_type,
+        name: output.name,
+        text: demultiline(output.text),
+      });
+    case 'error':
+      // Note: this is one of the cases where the Array of strings (for traceback)
+      // is part of the format, not a multiline string
+      return Immutable.fromJS(output);
+    default:
+      throw new TypeError(`Output type ${output.output_type} not recognized`);
+  }
+}
+
+function createImmutableMarkdownCell(cell: MarkdownCell): ImmutableMarkdownCell {
+  return new Immutable.Map({
+    cell_type: cell.cell_type,
+    source: demultiline(cell.source),
+    metadata: Immutable.fromJS(cell.metadata), // TODO: Determine if this should be Immutable or just frozen
+  });
+}
+
+function createImmutableCodeCell(cell: CodeCell): ImmutableCodeCell {
+  return new Immutable.Map({
+    cell_type: cell.cell_type,
+    source: demultiline(cell.source),
+    outputs: new Immutable.List(cell.outputs.map(createImmutableOutput)),
+    execution_count: cell.execution_count,
+    metadata: Immutable.fromJS(cell.metadata), // TODO: Determine if this should be Immutable or just frozen
+  });
+}
+
+function createImmutableCell(cell: Cell): ImmutableCell {
+  switch (cell.cell_type) {
+    case 'markdown':
+      return createImmutableMarkdownCell(cell);
+    case 'code':
+      return createImmutableCodeCell(cell);
+    default:
+      throw new TypeError(`Cell type ${cell.cell_type} unknown`);
+  }
+}
+
+export function fromJS(notebook: Notebook): ImmutableNotebook {
+  if (notebook.nbformat !== 4 || notebook.nbformat_minor < 0) {
+    throw new TypeError(
+      `Notebook is not a valid v4 notebook. v4 notebooks must be of form 4.x
+       It lists nbformat v${notebook.nbformat}.${notebook.nbformat_minor}`
+     );
+  }
+
+  // Since we're doing N cell operations all at once, switch to mutable then
+  // switch back after.
+  const starterCellStructure = {
+    cellOrder: Immutable.List().asMutable(),
+    cellMap: Immutable.Map().asMutable(),
+  };
+
+  const cellStructure = notebook.cells.reduce(
+    (cellStruct: CellStructure, cell: Cell) =>
+      appendCell(cellStruct, createImmutableCell(cell)),
+    starterCellStructure);
+
+  return Immutable.Map({
+    cellOrder: cellStructure.cellOrder.asImmutable(),
+    cellMap: cellStructure.cellMap.asImmutable(),
+    nbformat_minor: notebook.nbformat_minor,
+    nbformat: 4,
+    metadata: Immutable.fromJS(notebook.metadata), // TODO: Determine if this should be Immutable or just frozen
+  });
+}

--- a/src/notebook/actions.js
+++ b/src/notebook/actions.js
@@ -180,14 +180,6 @@ export function toggleStickyCell(id) {
   };
 }
 
-export function splitCell(id, position) {
-  return {
-    type: constants.SPLIT_CELL,
-    id,
-    position,
-  };
-}
-
 export function overwriteMetadata(field, value) {
   return {
     type: constants.OVERWRITE_METADATA_FIELD,

--- a/src/notebook/components/transforms/geojson.js
+++ b/src/notebook/components/transforms/geojson.js
@@ -56,7 +56,7 @@ export class GeoJSONTransform extends React.Component {
       id: `mapbox.${theme}`,
     }).addTo(this.map);
 
-    const geoJSON = this.props.data.toJS();
+    const geoJSON = this.props.data;
 
     this.geoJSONLayer = L.geoJson(geoJSON).addTo(this.map);
     this.map.fitBounds(this.geoJSONLayer.getBounds());
@@ -81,7 +81,7 @@ export class GeoJSONTransform extends React.Component {
     }
 
     if (prevProps.data !== this.props.data) {
-      const geoJSON = this.props.data.toJS();
+      const geoJSON = this.props.data;
 
       this.map.removeLayer(this.geoJSONLayer);
       this.geoJSONLayer = L.geoJson(geoJSON).addTo(this.map);

--- a/src/notebook/components/transforms/plotly.js
+++ b/src/notebook/components/transforms/plotly.js
@@ -2,6 +2,8 @@
 /* eslint class-methods-use-this: 0 */
 import React from 'react';
 
+import _ from 'lodash';
+
 type Props = {
   data: string|Object,
 };
@@ -49,8 +51,13 @@ export class PlotlyTransform extends React.Component {
     if (typeof figure === 'string') {
       return JSON.parse(figure);
     }
-    // assume immutable.js
-    return figure.toJS();
+
+    // The Plotly API *mutates* the figure to include a UID, which means
+    // they won't take our frozen objects
+    if (Object.isFrozen(figure)) {
+      return _.cloneDeep(figure);
+    }
+    return figure;
   }
 
   render(): ?React.Element<any> {

--- a/src/notebook/components/transforms/vega.js
+++ b/src/notebook/components/transforms/vega.js
@@ -21,7 +21,7 @@ const defaultCallback = (): any => {};
 function embed(el: HTMLElement, spec: Object, mode: string, cb: (err: any, result: any) => any) {
   const embedSpec = {
     mode,
-    spec,
+    spec: Object.assign({}, spec),
   };
 
   if (mode === 'vega-lite') {
@@ -46,7 +46,7 @@ export class VegaEmbed extends React.Component {
   }
 
   componentDidMount(): void {
-    embed(this.el, this.props.data.toJS(), this.props.embedMode, this.props.renderedCallback);
+    embed(this.el, this.props.data, this.props.embedMode, this.props.renderedCallback);
   }
 
   shouldComponentUpdate(nextProps: EmbedProps): boolean {
@@ -54,7 +54,7 @@ export class VegaEmbed extends React.Component {
   }
 
   componentDidUpdate(): void {
-    embed(this.el, this.props.data.toJS(), this.props.embedMode, this.props.renderedCallback);
+    embed(this.el, this.props.data, this.props.embedMode, this.props.renderedCallback);
   }
 
   render(): ?React.Element<any> {

--- a/src/notebook/constants.js
+++ b/src/notebook/constants.js
@@ -32,7 +32,6 @@ export const NEW_CELL_BEFORE = 'NEW_CELL_BEFORE';
 export const NEW_CELL_APPEND = 'NEW_CELL_APPEND';
 
 export const MERGE_CELL_AFTER = 'MERGE_CELL_AFTER';
-export const SPLIT_CELL = 'SPLIT_CELL';
 
 export const ABORT_EXECUTION = 'ABORT_EXECUTION';
 

--- a/src/notebook/epics/github-publish.js
+++ b/src/notebook/epics/github-publish.js
@@ -9,7 +9,11 @@ import {
   deleteMetadata,
 } from '../actions';
 
-const commutable = require('commutable');
+import {
+  toJS,
+  stringifyNotebook,
+} from '../../commutable';
+
 const path = require('path');
 
 const Rx = require('rxjs/Rx');
@@ -80,15 +84,7 @@ export function createGistCallback(observer, filename, notificationSystem) {
 export function publishNotebookObservable(github, notebook, filepath,
   notificationSystem, publishAsUser) {
   return Rx.Observable.create((observer) => {
-    const notebookString = JSON.stringify(
-      commutable.toJS(notebook.update('cellMap', cells =>
-        cells.map(value =>
-          value
-            .deleteIn(['metadata', 'inputHidden'])
-            .deleteIn(['metadata', 'outputHidden'])
-            .delete(['metadata', 'status'])))),
-      undefined,
-      1);
+    const notebookString = stringifyNotebook(toJS(notebook));
 
     const filename = filepath ? path.parse(filepath).base : 'Untitled.ipynb';
     const files = {};

--- a/src/notebook/epics/saving.js
+++ b/src/notebook/epics/saving.js
@@ -13,8 +13,12 @@ import {
   doneSaving,
 } from '../actions';
 
+import {
+  toJS,
+  stringifyNotebook,
+} from '../../commutable';
+
 const Rx = require('rxjs/Rx');
-const commutable = require('commutable');
 
 const Observable = Rx.Observable;
 
@@ -32,16 +36,7 @@ export function saveEpic(action$: ActionsObservable) {
       }
     })
     .mergeMap(action =>
-      writeFileObservable(action.filename,
-        JSON.stringify(
-          commutable.toJS(
-            action.notebook.update('cellMap', cells =>
-              cells.map(value =>
-                value.deleteIn(['metadata', 'inputHidden'])
-                  .deleteIn(['metadata', 'outputHidden'])
-                  .deleteIn(['metadata', 'status'])))),
-          null,
-          1))
+      writeFileObservable(action.filename, stringifyNotebook(toJS(action.notebook)))
         .catch((error: Error) =>
           Observable.of({
             type: 'ERROR_SAVING',

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -2,7 +2,6 @@
 
 import * as Immutable from 'immutable';
 import * as uuid from 'uuid';
-import * as commutable from 'commutable';
 
 import * as constants from '../constants';
 
@@ -21,6 +20,7 @@ import {
 import {
   insertCellAt,
   insertCellAfter,
+  removeCell,
 } from '../../commutable/structures';
 
 import type {
@@ -299,11 +299,11 @@ function moveCell(state: DocumentState, action: MoveCellAction) {
 }
 
 type RemoveCellAction = { type: 'REMOVE_CELL', id: CellID };
-function removeCell(state: DocumentState, action: RemoveCellAction) {
+function removeCellFromState(state: DocumentState, action: RemoveCellAction) {
   const { id } = action;
   return cleanCellTransient(
     state.update('notebook',
-      notebook => commutable.removeCell(notebook, id)
+      (notebook: ImmutableNotebook) => removeCell(notebook, id)
     ),
     id
   );
@@ -353,7 +353,7 @@ function mergeCellAfter(state: DocumentState, action: MergeCellAfterAction) {
   const source = firstSource.concat('\n', '\n', secondSource);
 
   return state.update('notebook',
-    (notebook: ImmutableNotebook) => commutable.removeCell(
+    (notebook: ImmutableNotebook) => removeCell(
       notebook.setIn(['cellMap', id, 'source'], source),
       nextId)
   );
@@ -451,7 +451,7 @@ function cutCell(state: DocumentState, action: CutCellAction) {
   const cell : ImmutableCell = cellMap.get(id);
   return state
     .set('copied', new Immutable.Map({ id, cell }))
-    .update('notebook', notebook => commutable.removeCell(notebook, id));
+    .update('notebook', (notebook: ImmutableNotebook) => removeCell(notebook, id));
 }
 
 type PasteCellAction = { type: 'PASTE_CELL' };
@@ -543,7 +543,7 @@ function handleDocument(state: DocumentState = defaultDocument, action: Document
     case constants.MOVE_CELL:
       return moveCell(state, action);
     case constants.REMOVE_CELL:
-      return removeCell(state, action);
+      return removeCellFromState(state, action);
     case constants.NEW_CELL_AFTER:
       return newCellAfter(state, action);
     case constants.NEW_CELL_BEFORE:

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -385,20 +385,6 @@ function updateSource(state: DocumentState, action: UpdateSourceAction) {
   return state.setIn(['notebook', 'cellMap', id, 'source'], source);
 }
 
-type SplitCellAction = { type: 'SPLIT_CELL', id: CellID, position: number }
-// Note: position is line number in the source of the cell and we
-//       don't have any UI for this action yet.
-function splitCell(state: DocumentState, action: SplitCellAction) {
-  const { id, position } = action;
-  const index = state.getIn(['notebook', 'cellOrder'], Immutable.List()).indexOf(id);
-  const updatedState = state.update('notebook',
-      notebook => commutable.splitCell(notebook, id, position));
-  const newCell = updatedState.getIn(['notebook', 'cellOrder', index + 1]);
-  return updatedState
-    .setIn(['notebook', 'cellMap', newCell, 'metadata', 'outputHidden'], false)
-    .setIn(['notebook', 'cellMap', newCell, 'metadata', 'inputHidden'], false);
-}
-
 type ChangeOutputVisibilityAction = { type: 'CHANGE_OUTPUT_VISIBILITY', id: CellID }
 function changeOutputVisibility(state: DocumentState, action: ChangeOutputVisibilityAction) {
   const { id } = action;
@@ -525,7 +511,7 @@ type DocumentAction =
   ClearOutputsAction | AppendOutputAction | UpdateDisplayAction |
   UpdateExecutionCountAction | MoveCellAction | RemoveCellAction |
   NewCellAfterAction | NewCellBeforeAction | NewCellAppendAction |
-  MergeCellAfterAction | UpdateSourceAction | SplitCellAction |
+  MergeCellAfterAction | UpdateSourceAction |
   ChangeOutputVisibilityAction | ChangeInputVisibilityAction | UpdateCellPagersAction |
   UpdateCellStatusAction | SetLanguageInfoAction | SetKernelInfoAction |
   OverwriteMetadataFieldAction | DeleteMetadataFieldAction | CopyCellAction |
@@ -574,8 +560,6 @@ function handleDocument(state: DocumentState = defaultDocument, action: Document
       return newCellAppend(state, action);
     case constants.UPDATE_CELL_SOURCE:
       return updateSource(state, action);
-    case constants.SPLIT_CELL:
-      return splitCell(state, action);
     case constants.CHANGE_OUTPUT_VISIBILITY:
       return changeOutputVisibility(state, action);
     case constants.CHANGE_INPUT_VISIBILITY:

--- a/test/renderer/actions-spec.js
+++ b/test/renderer/actions-spec.js
@@ -281,16 +281,6 @@ describe('setBackwardCheckpoint', () => {
   });
 });
 
-describe('splitCell', () => {
-  it('creates a SPLIT_CELL action', () => {
-    expect(actions.splitCell('235', 0)).to.deep.equal({
-      type: constants.SPLIT_CELL,
-      id: '235',
-      position: 0,
-    });
-  });
-});
-
 describe('copyCell', () => {
   it('creates a COPY_CELL action', () => {
     expect(actions.copyCell('235')).to.deep.equal({

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -11,7 +11,12 @@ import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
 import { Cell } from '../../../../src/notebook/components/cell/cell';
-import * as commutable from 'commutable';
+
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+} from '../../../../src/commutable';
+
 import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 const sharedProps = { displayOrder, transforms };
@@ -19,7 +24,7 @@ describe('Cell', () => {
   it('should be able to render a markdown cell', () => {
     const store = dummyStore();
     const cell = mount(
-      <Cell cell={commutable.emptyMarkdownCell} {...sharedProps} />,
+      <Cell cell={emptyMarkdownCell} {...sharedProps} />,
       {
         context: { store }
       }
@@ -30,7 +35,7 @@ describe('Cell', () => {
   it('should be able to render a code cell', () => {
     const store = dummyStore();
     const cell = mount(
-      <Cell cell={commutable.emptyCodeCell} {...sharedProps}
+      <Cell cell={emptyCodeCell} {...sharedProps}
       cellStatus={Immutable.Map({'outputHidden': false, 'inputHidden': false})}/>,
       {
         context: { store }
@@ -42,7 +47,7 @@ describe('Cell', () => {
   it('dispatches cell actions', () => {
     const store = dummyStore();
     const cell = mount(
-      <Cell cell={commutable.emptyMarkdownCell} {...sharedProps} />,
+      <Cell cell={emptyMarkdownCell} {...sharedProps} />,
       {
         context: { store }
       }

--- a/test/renderer/components/cell/code-cell-spec.js
+++ b/test/renderer/components/cell/code-cell-spec.js
@@ -5,14 +5,19 @@ import Immutable from 'immutable';
 import {expect} from 'chai';
 
 import CodeCell from '../../../../src/notebook/components/cell/code-cell';
-import * as commutable from 'commutable';
+
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+} from '../../../../src/commutable';
+
 import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 const sharedProps = { displayOrder, transforms };
 describe('CodeCell', () => {
   it('can be rendered', () => {
     const cell = shallow(
-      <CodeCell cell={commutable.emptyCodeCell} {...sharedProps}
+      <CodeCell cell={emptyCodeCell} {...sharedProps}
       cellStatus={
         Immutable.Map({
           'outputHidden': false,
@@ -25,7 +30,7 @@ describe('CodeCell', () => {
   });
   it('creates an editor', () => {
     const cell = mount(
-      <CodeCell cell={commutable.emptyCodeCell} {...sharedProps}
+      <CodeCell cell={emptyCodeCell} {...sharedProps}
       cellStatus={
         Immutable.Map({
           'outputHidden': false,
@@ -38,7 +43,7 @@ describe('CodeCell', () => {
   });
   it('creates a pager', () => {
     const cell = mount(
-      <CodeCell cell={commutable.emptyCodeCell} {...sharedProps}
+      <CodeCell cell={emptyCodeCell} {...sharedProps}
       cellStatus={
         Immutable.Map({
           'outputHidden': false,

--- a/test/renderer/components/cell/display-area/richest-mime-spec.js
+++ b/test/renderer/components/cell/display-area/richest-mime-spec.js
@@ -10,7 +10,6 @@ import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
 import RichestMime from '../../../../../src/notebook/components/cell/display-area/richest-mime'
-import * as commutable from 'commutable';
 import { displayOrder, transforms } from '../../../../../src/notebook/components/transforms';
 
 describe('RichestMime', () => {

--- a/test/renderer/components/cell/markdown-cell-spec.js
+++ b/test/renderer/components/cell/markdown-cell-spec.js
@@ -14,7 +14,11 @@ import {
   focusNextCell,
 } from '../../../../src/notebook/actions';
 
-import * as commutable from 'commutable';
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+} from '../../../../src/commutable';
+
 import { displayOrder, transforms } from '../../../../src/notebook/components/transforms';
 
 import { dummyStore } from '../../../utils';
@@ -22,7 +26,7 @@ import { dummyStore } from '../../../utils';
 describe('MarkdownCell', () => {
   it('can be rendered', () => {
     const cell = shallow(
-      <MarkdownCell cell={commutable.emptyMarkdownCell} {...{ displayOrder, transforms }}/>
+      <MarkdownCell cell={emptyMarkdownCell} {...{ displayOrder, transforms }}/>
     );
     expect(cell).to.not.be.null;
   });
@@ -34,7 +38,7 @@ describe('MarkdownCell', () => {
     const cell = mount(
       <MarkdownCell
       id='1234'
-      cell={commutable.emptyMarkdownCell}
+      cell={emptyMarkdownCell}
       focusEditor={() => store.dispatch(focusCellEditor('1234'))}
       {...{ displayOrder, transforms }} />,
       { context: { store } }
@@ -61,10 +65,10 @@ describe('MarkdownCell', () => {
 
   it('sets the state of the text based on cell source', () => {
     const cell = mount(
-      <MarkdownCell cell={commutable.emptyMarkdownCell} {...{ displayOrder, transforms }}/>,
+      <MarkdownCell cell={emptyMarkdownCell} {...{ displayOrder, transforms }}/>,
     );
 
-    cell.setProps({'cell': commutable.emptyMarkdownCell.set('source', 'test')});
+    cell.setProps({'cell': emptyMarkdownCell.set('source', 'test')});
     expect(cell.state('source')).to.equal('test');
   });
 
@@ -75,7 +79,7 @@ describe('MarkdownCell', () => {
     const cell = shallow(
       <MarkdownCell
         id='1234'
-        cell={commutable.emptyMarkdownCell}
+        cell={emptyMarkdownCell}
         focusAbove={() => store.dispatch(focusPreviousCell('1234'))}
         {...{displayOrder, transforms }}/>,
       { context: { store } }
@@ -96,7 +100,7 @@ describe('MarkdownCell', () => {
     const cell = shallow(
       <MarkdownCell
         id='1234'
-        cell={commutable.emptyMarkdownCell}
+        cell={emptyMarkdownCell}
         focusBelow={() => store.dispatch(focusNextCell('1234', true))}
         {...{displayOrder, transforms }}/>,
       { context: { store } }

--- a/test/renderer/components/cell/toolbar-spec.js
+++ b/test/renderer/components/cell/toolbar-spec.js
@@ -9,7 +9,11 @@ const sinonChai = require("sinon-chai");
 chai.use(sinonChai);
 const expect = chai.expect;
 
-import * as commutable from 'commutable';
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+} from '../../../../src/commutable';
+
 import { dummyStore } from '../../../utils';
 
 import Toolbar from '../../../../src/notebook/components/cell/toolbar';
@@ -54,7 +58,7 @@ describe('Toolbar', () => {
 
 describe('Toolbar.executeCell', () => {
   it('dispatches an executeCell action', () => {
-    const cell = commutable.emptyCodeCell.set('source', 'print("sup")')
+    const cell = emptyCodeCell.set('source', 'print("sup")')
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -78,7 +82,7 @@ describe('Toolbar.executeCell', () => {
 
 describe('Toolbar.removeCell', () => {
   it('dispatches a REMOVE_CELL action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -101,7 +105,7 @@ describe('Toolbar.removeCell', () => {
 
 describe('Toolbar.toggleStickyCell', () => {
   it('dispatches TOGGLE_STICKY_CELL action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -124,7 +128,7 @@ describe('Toolbar.toggleStickyCell', () => {
 
 describe('Toolbar.clearOutputs', () => {
   it('dispatches CLEAR_OUTPUTS action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -147,7 +151,7 @@ describe('Toolbar.clearOutputs', () => {
 
 describe('Toolbar.changeInputVisibility', () => {
   it('dispatches CHANGE_INPUT_VISIBILITY action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -170,7 +174,7 @@ describe('Toolbar.changeInputVisibility', () => {
 
 describe('Toolbar.changeOutputVisibility', () => {
   it('dispatches CHANGE_OUTPUT_VISIBILITY action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -193,7 +197,7 @@ describe('Toolbar.changeOutputVisibility', () => {
 
 describe('Toolbar.changeCellType', () => {
   it('dispatches CHANGE_CELL_TYPE action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 
@@ -217,7 +221,7 @@ describe('Toolbar.changeCellType', () => {
 
 describe('Toolbar.toggleOutputExpansion', () => {
   it('dispatches a TOGGLE_OUTPUT_EXPANSION action', () => {
-    const cell = commutable.emptyCodeCell;
+    const cell = emptyCodeCell;
     const store = dummyStore();
     store.dispatch = sinon.spy();
 

--- a/test/renderer/components/transforms/geojson-spec.js
+++ b/test/renderer/components/transforms/geojson-spec.js
@@ -7,11 +7,30 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
+import _ from 'lodash';
+
 chai.use(sinonChai);
+
+function deepFreeze(obj) {
+  // Retrieve the property names defined on obj
+  var propNames = Object.getOwnPropertyNames(obj);
+
+  // Freeze properties before freezing self
+  propNames.forEach(function(name) {
+    var prop = obj[name];
+
+    // Freeze prop if it is an object
+    if (typeof prop == 'object' && prop !== null)
+      deepFreeze(prop);
+  });
+
+  // Freeze self (no-op if already frozen)
+  return Object.freeze(obj);
+}
 
 import GeoJSONTransform, { getTheme } from '../../../../src/notebook/components/transforms/geojson';
 
-const geojson = Immutable.fromJS({
+const geojson = deepFreeze({
   "type": "FeatureCollection",
   "features": [
       {
@@ -68,7 +87,7 @@ describe('GeoJSONTransform', () => {
     expect(geoComponent.find('.leaflet-container')).to.have.length(1);
 
     geoComponent.setProps({
-      data: geojson.setIn(["features", 0, "properties", "popupContent"], "somewhere"),
+      data: _.set(_.cloneDeep(geojson), ["features", 0, "properties", "popupContent"], "somewhere"),
       theme: 'dark',
     })
 

--- a/test/renderer/components/transforms/plotly-spec.js
+++ b/test/renderer/components/transforms/plotly-spec.js
@@ -7,13 +7,32 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
+import _ from 'lodash';
+
 chai.use(sinonChai);
 
 const plotly = require('plotly.js/dist/plotly');
 
 import PlotlyTransform from '../../../../src/notebook/components/transforms/plotly';
 
-const immutableFigure = Immutable.fromJS({
+function deepFreeze(obj) {
+  // Retrieve the property names defined on obj
+  var propNames = Object.getOwnPropertyNames(obj);
+
+  // Freeze properties before freezing self
+  propNames.forEach(function(name) {
+    var prop = obj[name];
+
+    // Freeze prop if it is an object
+    if (typeof prop == 'object' && prop !== null)
+      deepFreeze(prop);
+  });
+
+  // Freeze self (no-op if already frozen)
+  return Object.freeze(obj);
+}
+
+const figure = deepFreeze({
   data: [
     {'x': [1999, 2000, 2001, 2002], 'y': [10, 15, 13, 17], 'type': 'scatter'},
     {'x': [1999, 2000, 2001, 2002], 'y': [16, 5, 11, 9], 'type': 'scatter'},
@@ -32,7 +51,7 @@ describe('PlotlyTransform', () => {
 
     const plotComponent = mount(
       <PlotlyTransform
-        data={immutableFigure}
+        data={figure}
       />
     );
 
@@ -62,7 +81,7 @@ describe('PlotlyTransform', () => {
 
     const plotComponent = mount(
       <PlotlyTransform
-        data={JSON.stringify(immutableFigure.toJS())}
+        data={JSON.stringify(figure)}
       />
     );
 
@@ -92,14 +111,14 @@ describe('PlotlyTransform', () => {
 
     const wrapper = mount(
       <PlotlyTransform
-        data={immutableFigure}
+        data={figure}
       />
     );
 
     const instance = wrapper.instance();
 
     wrapper.setProps({
-      data: immutableFigure.setIn(['data', 0, 'type'], 'bar'),
+      data: _.set(_.cloneDeep(figure), ['data', 0, 'type'], 'bar'),
     });
 
     expect(instance.el.data[0].type).to.equal('bar');

--- a/test/renderer/dummy-nb.js
+++ b/test/renderer/dummy-nb.js
@@ -1,4 +1,4 @@
-import * as commutable from 'commutable';
+import { fromJS } from '../../src/commutable';
 
 export const dummy = '{"cells":[{"cell_type":"markdown","metadata":{},\
 "source":["## The Notable Nteract Notebook\\n","\\n","**It\'s a notebook!**\\n"]},\
@@ -16,4 +16,4 @@ export const dummy = '{"cells":[{"cell_type":"markdown","metadata":{},\
 
 export const dummyJSON = JSON.parse(dummy);
 
-export const dummyCommutable = commutable.fromJS(dummyJSON);
+export const dummyCommutable = fromJS(dummyJSON);

--- a/test/renderer/reducers/document-spec.js
+++ b/test/renderer/reducers/document-spec.js
@@ -593,25 +593,6 @@ describe('deleteMetadata', () => {
   })
 })
 
-describe('splitCell', () => {
-  it('splits a notebook cell into two', () => {
-    const originalState = {
-      document: monocellDocument,
-    };
-
-    const id = originalState.document.getIn(['notebook', 'cellOrder']).first();
-
-    const action = {
-      type: constants.SPLIT_CELL,
-      id: id,
-      position: 0,
-    };
-
-    const state = reducers(originalState, action);
-    expect(state.document.getIn(['notebook', 'cellOrder']).size).to.equal(4);
-  });
-});
-
 describe('changeOutputVisibility', () => {
   it('changes the visibility on a single cell', () => {
     const originalState = {

--- a/test/renderer/reducers/document-spec.js
+++ b/test/renderer/reducers/document-spec.js
@@ -1,7 +1,18 @@
 import { expect } from 'chai';
 
-import * as commutable from 'commutable';
 import * as constants from '../../../src/notebook/constants';
+
+
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+  fromJS,
+} from '../../../src/commutable';
+
+import {
+  appendCellToNotebook,
+} from '../../../src/commutable/structures';
+
 
 import { DocumentRecord, MetadataRecord } from '../../../src/notebook/records';
 
@@ -15,10 +26,6 @@ import {
 } from '../dummy-nb';
 
 import {
-  fromJS,
-} from 'commutable';
-
-import {
   List,
   Map,
   Set,
@@ -28,7 +35,7 @@ const Immutable = require('immutable');
 
 const initialDocument = new Map();
 const monocellDocument = initialDocument
-  .set('notebook', commutable.appendCell(dummyCommutable, commutable.emptyCodeCell))
+  .set('notebook', appendCellToNotebook(dummyCommutable, emptyCodeCell))
   .set('transient', new Immutable.Map({ keyPathsForDisplays: new Immutable.Map() }));
 
 describe('reduceOutputs', () => {
@@ -414,8 +421,8 @@ describe('clearOutputs', () => {
   it('should clear outputs list', () => {
     const originalState = {
       document: initialDocument.set('notebook',
-        commutable.appendCell(dummyCommutable,
-          commutable.emptyCodeCell.set('outputs', ['dummy outputs']))
+        appendCellToNotebook(dummyCommutable,
+          emptyCodeCell.set('outputs', ['dummy outputs']))
         )
         .set('transient', new Immutable.Map({ keyPathsForDisplays: new Immutable.Map() })),
     };
@@ -434,8 +441,8 @@ describe('clearOutputs', () => {
   it('doesn\'t clear outputs on markdown cells', () => {
     const originalState = {
       document: initialDocument.set('notebook',
-        commutable.appendCell(dummyCommutable,
-          commutable.emptyMarkdownCell
+        appendCellToNotebook(dummyCommutable,
+          emptyMarkdownCell
         )
       )
     };

--- a/test/renderer/reducers/metadata-spec.js
+++ b/test/renderer/reducers/metadata-spec.js
@@ -3,7 +3,17 @@ import { expect } from 'chai';
 import * as constants from '../../../src/notebook/constants';
 
 import { MetadataRecord } from '../../../src/notebook/records';
-import * as commutable from 'commutable';
+
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+  fromJS,
+} from '../../../src/commutable';
+
+import {
+  appendCellToNotebook,
+} from '../../../src/commutable/structures';
+
 import { dummyCommutable } from '../dummy-nb';
 import { List } from 'immutable';
 
@@ -11,7 +21,7 @@ import reducers from '../../../src/notebook/reducers';
 
 const initialDocument = new Map();
 const monocellDocument = initialDocument.set('notebook',
-    commutable.appendCell(dummyCommutable, commutable.emptyCell));
+    appendCellToNotebook(dummyCommutable, emptyCodeCell));
 
 describe('changeFilename', () => {
   it('returns the same originalState if filename is undefined', () => {
@@ -34,7 +44,7 @@ describe('changeFilename', () => {
         filename: 'original.ipynb',
       })
     };
-    
+
     const action = {
       type: constants.CHANGE_FILENAME,
       filename: 'test.ipynb',

--- a/test/renderer/views/draggable-cell-spec.js
+++ b/test/renderer/views/draggable-cell-spec.js
@@ -4,7 +4,11 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
 import DraggableCell from '../../../src/notebook/views/draggable-cell';
-import * as commutable from 'commutable';
+
+import {
+  emptyMarkdownCell,
+} from '../../../src/commutable';
+
 import { displayOrder, transforms } from '../../../src/notebook/components/transforms';
 
 // Spoof DND manager for tests.
@@ -24,7 +28,7 @@ const sharedProps = { displayOrder, transforms };
 describe('DraggableCell', () => {
   it('can be rendered', () => {
     const cell = shallow(
-      <DraggableCell cell={commutable.emptyMarkdownCell} {...sharedProps}/>
+      <DraggableCell cell={emptyMarkdownCell} {...sharedProps}/>
     , {
       context: { dragDropManager }
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,10 +1,14 @@
 import { expect } from 'chai';
 import Immutable from 'immutable';
+
 import {
-  emptyNotebook,
+  monocellNotebook,
   emptyCodeCell,
-  appendCell,
-} from 'commutable';
+} from '../src/commutable';
+
+import {
+  appendCellToNotebook,
+} from '../src/commutable/structures';
 
 import { shutdownKernel } from '../src/notebook/kernel/shutdown';
 import * as actions from '../src/notebook/actions';
@@ -32,7 +36,7 @@ const sinon = require('sinon');
  * Created using the config object passed in.
  */
 function buildDummyNotebook(config) {
-  let notebook = appendCell(emptyNotebook, emptyCodeCell).setIn([
+  let notebook = monocellNotebook.setIn([
     'metadata', 'kernelspec', 'name',
   ], 'python2');
 
@@ -40,13 +44,13 @@ function buildDummyNotebook(config) {
 
     if (config.codeCellCount) {
       for (let i=1; i < config.codeCellCount; i++) {
-        notebook = appendCell(notebook, emptyCodeCell);
+        notebook = appendCellToNotebook(notebook, emptyCodeCell);
       }
     }
 
     if (config.markdownCellCount){
       for (let i=0; i < config.markdownCellCount; i++) {
-        notebook = appendCell(notebook, emptyCodeCell.set('cell_type', 'markdown'));
+        notebook = appendCellToNotebook(notebook, emptyCodeCell.set('cell_type', 'markdown'));
       }
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,5 +29,8 @@ module.exports = {
   plugins: [
     new LodashModuleReplacementPlugin(),
     new webpack.IgnorePlugin(/\.(css|less)$/),
+    new webpack.BannerPlugin('require("source-map-support").install();',
+                         { raw: true, entryOnly: false })
   ],
+  devtool: 'source-map'
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,8 +29,5 @@ module.exports = {
   plugins: [
     new LodashModuleReplacementPlugin(),
     new webpack.IgnorePlugin(/\.(css|less)$/),
-    new webpack.BannerPlugin('require("source-map-support").install();',
-                         { raw: true, entryOnly: false })
   ],
-  devtool: 'source-map'
 };


### PR DESCRIPTION
As a follow on to the other flow and state PRs I've been making, I've been working on refactoring commutable and organizing flow types. Not finished, not ready to merge.

## Remaining Items

* [x] Make it work with current structure of commutable usage, including passing an Immutable Notebook as a payload for an action
* [x] Convert `commutable.insertCellAt`
* [x] Convert `commutable.removeCell`
* [x] Convert `commutable.updateSource` (replaced with direct usage)
* [x] Convert `commutable.splitCell` (deleted for now)
* [x] Include the Raw Cell type
* [x] Put Metadata back as `fromJS`ed for now... 😢  No problem though, we can adapt it later!
* [x] Create `commutable.toJS`
* [x] Run through all notebooks for conformance testing

## Cleanup:

* [x] Tear out the source map support I injected
* [x] Rebase PR for cleaner commit history
* [ ] Increase coverage across the entire patch set