### PR TITLE
ux: Switched 'sticky' and 'delete' button

### DIFF
--- a/src/notebook/components/cell/toolbar.js
+++ b/src/notebook/components/cell/toolbar.js
@@ -97,11 +97,11 @@ export default class Toolbar extends React.PureComponent {
               <span className="octicon octicon-triangle-right" />
             </button>
           </span>}
-          <button onClick={this.removeCell} className="deleteButton" >
-            <span className="octicon octicon-trashcan" />
-          </button>
           <button onClick={this.toggleStickyCell} className="stickyButton" >
             <span className="octicon octicon-pin" />
+          </button>
+          <button onClick={this.removeCell} className="deleteButton" >
+            <span className="octicon octicon-trashcan" />
           </button>
           <Dropdown ref={(dropdown) => { this.dropdown = dropdown; }}>
             <DropdownTrigger>


### PR DESCRIPTION
Swapped "sticky" and "delete" buttons to reduce likelihood of people hitting "delete" instead of "run"