### PR TITLE
[WIP] feat: detect the default python setup

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -22,9 +22,10 @@ import initializeKernelSpecs from './kernel-specs';
 
 const log = require('electron-log');
 
-const kernelspecs = require('kernelspecs');
 const jupyterPaths = require('jupyter-paths');
 const path = require('path');
+
+const kernels = require('./kernels');
 
 const argv = require('yargs')
   .version()
@@ -91,7 +92,7 @@ const prepJupyterObservable = prepareEnv
 
 const kernelSpecsPromise = prepJupyterObservable
   .toPromise()
-  .then(() => kernelspecs.findAll())
+  .then(() => kernels.findAll().toPromise())
   .then(specs => initializeKernelSpecs(specs));
 
 /**
@@ -171,8 +172,8 @@ openFile$
 
         if (argv.kernel in specs) {
           kernel = argv.kernel;
-        } else if ('python2' in specs) {
-          kernel = 'python2';
+        } else if ('python' in specs) {
+          kernel = 'python';
         } else {
           const specList = Object.keys(specs);
           specList.sort();


### PR DESCRIPTION
I don't think I'll be able to finish this the way I really want to, which involves refactoring how we do our initial kernel detection.

Changes I wish I could make:

* [ ] Rely on `jupyter` if the user has it installed, to pick up the default kernel. @minrk already made changes in `jupyter-paths` to do this, we never propagated it up through `kernelspecs`.
* [ ] Only inject the default kernel as is done here if not detected by one of the others (assume an overwrite in the `reduce` on the observable stream
* [ ] Organize our kernel / language menus with a separate subsection for conda environments
* [ ] Type annotate all of this, in hopes of simplifying how our kernelspec structures are laid out

As it stands, this _does_ detect if the user has `ipykernel` installed in the default `python`. I was certainly able to use my local Python.