### PR TITLE
transform flow into comments rather than stripping

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,7 @@
     "plugins": [
       "lodash",
       "transform-class-properties",
-      "transform-flow-strip-types",
+      "babel-plugin-transform-flow-comments",
       "transform-object-rest-spread"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "babel-loader": "^6.2.8",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-class-properties": "^6.19.0",
+    "babel-plugin-transform-flow-comments": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015-node6": "^0.4.0",


### PR DESCRIPTION
To make our flow efforts more useful when consuming packages from the lerna package explosion, I've switched our configuration over to [transforming](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-comments) to [flow comments](https://flowtype.org/blog/2015/02/20/Flow-Comments.html) rather than stripping them.