### PR TITLE
chore(docs): use aliased slack-in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![](https://img.shields.io/badge/version-stable-blue.svg)](https://github.com/nteract/nteract/releases)
 [![codecov.io](https://codecov.io/github/nteract/nteract/coverage.svg?branch=master)](https://codecov.io/github/nteract/nteract?branch=master)
 ![Documentation Coverage](https://doc.esdoc.org/github.com/nteract/nteract/badge.svg)
-[![slack in](https://slackin-egwcornswi.now.sh/badge.svg)](https://slackin-egwcornswi.now.sh/)
+[![slack in](https://slackin-nteract.now.sh/badge.svg)](https://slackin-nteract.now.sh)
 
 [**Users**](#installation---users) | [**Contributors and Development**](#installation---contributors-and-development) | [**Maintainers**](#for-maintainers-creating-a-release)
 


### PR DESCRIPTION
To make this easier on myself, I'm just going with a now alias for our slack in URL: https://slackin-nteract.now.sh

Please update other projects and correspondence to use https://slackin-nteract.now.sh as the canonical URL for our slack inviter!