### PR TITLE
chore(README): Clean up badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # nteract <img src="https://cloud.githubusercontent.com/assets/836375/15271096/98e4c102-19fe-11e6-999a-a74ffe6e2000.gif" alt="nteract animated logo" height="80px" align="right" />
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/nteract/nteract.svg)](https://greenkeeper.io/)
-
 [![](https://img.shields.io/badge/version-latest-blue.svg)](https://github.com/nteract/nteract)
 [![Build Status](https://travis-ci.org/nteract/nteract.svg?branch=master)](https://travis-ci.org/nteract/nteract) [![Build status](https://ci.appveyor.com/api/projects/status/odxx4hrkcxh1oilx/branch/master?svg=true)](https://ci.appveyor.com/project/nteract/nteract/branch/master)
 [![](https://img.shields.io/badge/version-stable-blue.svg)](https://github.com/nteract/nteract/releases)
 [![codecov.io](https://codecov.io/github/nteract/nteract/coverage.svg?branch=master)](https://codecov.io/github/nteract/nteract?branch=master)
-![Documentation Coverage](https://doc.esdoc.org/github.com/nteract/nteract/badge.svg)
 [![slack in](https://slackin-nteract.now.sh/badge.svg)](https://slackin-nteract.now.sh)
+[![Greenkeeper badge](https://badges.greenkeeper.io/nteract/nteract.svg)](https://greenkeeper.io/)
+
 
 [**Users**](#installation---users) | [**Contributors and Development**](#installation---contributors-and-development) | [**Maintainers**](#for-maintainers-creating-a-release)
 


### PR DESCRIPTION
Removed the documentation coverage badge since it's not always rendering and there isn't a movement to progress that documentation. We've also gone a bit different direction since we've been doing flow so deeply and are about to export many many packages.