### PR TITLE
fix(epics): pass source observable through catch

### DIFF
--- a/src/notebook/components/transforms/geojson.js
+++ b/src/notebook/components/transforms/geojson.js
@@ -40,12 +40,6 @@ export class GeoJSONTransform extends React.Component {
   static MIMETYPE = MIMETYPE;
 
   componentDidMount(): void {
-    // HACK: Work around for testing Leaflet in JSDOM
-    // see: https://github.com/Leaflet/Leaflet/issues/4823
-    if (!this.el.clientWidth && !this.el.clientHeight) {
-      this.el.clientHeight = 600;
-      this.el.clientWidth = 1000;
-    }
     this.map = L.map(this.el);
     this.map.scrollWheelZoom.disable();
 

--- a/src/notebook/epics/comm.js
+++ b/src/notebook/epics/comm.js
@@ -118,7 +118,7 @@ export function commActionObservable(newKernelAction) {
   return Rx.Observable.merge(
     commOpenAction$,
     commMessageAction$
-  );
+  ).retry();
 }
 
 /**
@@ -130,5 +130,4 @@ export function commActionObservable(newKernelAction) {
 export const commListenEpic = action$ =>
   action$.ofType(NEW_KERNEL)
     // We have a new channel
-    .switchMap(commActionObservable)
-    .catch(createCommErrorAction);
+    .switchMap(commActionObservable);

--- a/src/notebook/epics/config.js
+++ b/src/notebook/epics/config.js
@@ -26,10 +26,6 @@ const HOME = remote.app.getPath('home');
 
 export const CONFIG_FILE_PATH = path.join(HOME, '.jupyter', 'nteract.json');
 
-export function retryAndEmitError(err, source) {
-  return source.startWith({ type: 'ERROR', payload: err, error: true });
-}
-
 /**
   * An epic that loads the configuration.
   *
@@ -42,8 +38,7 @@ export const loadConfigEpic = actions =>
       readFileObservable(CONFIG_FILE_PATH)
         .map(JSON.parse)
         .map(configLoaded)
-    )
-    .catch(retryAndEmitError);
+    );
 
 /**
   * An epic that saves the configuration if it has been changed.
@@ -67,5 +62,4 @@ export const saveConfigEpic = (actions, store) =>
     .mergeMap(() =>
       writeFileObservable(CONFIG_FILE_PATH, JSON.stringify(store.getState().config.toJS()))
       .map(doneSavingConfig)
-    )
-    .catch(retryAndEmitError);
+    );

--- a/src/notebook/epics/execute.js
+++ b/src/notebook/epics/execute.js
@@ -265,7 +265,12 @@ export function executeCellEpic(action$, store) {
     )
     // Bring back all the inner Observables into one stream
     .mergeAll()
-    .catch(createErrorActionObservable(ERROR_EXECUTING));
+    .catch((err, source) =>
+      Rx.Observable.merge(
+        createErrorActionObservable(ERROR_EXECUTING)(err),
+        source
+      )
+    );
 }
 
 

--- a/src/notebook/epics/index.js
+++ b/src/notebook/epics/index.js
@@ -39,9 +39,7 @@ export function retryAndEmitError(err, source) {
 }
 
 export const wrapEpic = epic => (...args) =>
-  epic(...args).catch((error, source) =>
-    source.startWith({ type: 'ERROR', payload: error, error: true })
-  );
+  epic(...args).catch(retryAndEmitError);
 
 const epics = [
   commListenEpic,

--- a/src/notebook/epics/index.js
+++ b/src/notebook/epics/index.js
@@ -34,6 +34,15 @@ import {
   saveConfigOnChangeEpic,
 } from './config';
 
+export function retryAndEmitError(err, source) {
+  return source.startWith({ type: 'ERROR', payload: err, error: true });
+}
+
+export const wrapEpic = epic => (...args) =>
+  epic(...args).catch((error, source) =>
+    source.startWith({ type: 'ERROR', payload: error, error: true })
+  );
+
 const epics = [
   commListenEpic,
   publishEpic,
@@ -50,6 +59,6 @@ const epics = [
   loadConfigEpic,
   saveConfigEpic,
   saveConfigOnChangeEpic,
-];
+].map(wrapEpic);
 
 export default epics;

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -188,8 +188,11 @@ export const newKernelEpic = (action$: ActionsObservable) =>
     .mergeMap(action =>
       newKernelObservable(action.kernelSpec, action.cwd)
     )
-    .catch(error => Rx.Observable.of({
-      type: ERROR_KERNEL_LAUNCH_FAILED,
-      payload: error,
-      error: true,
-    }));
+    .catch((error, source) => Rx.Observable.merge(
+        Rx.Observable.of({
+          type: ERROR_KERNEL_LAUNCH_FAILED,
+          payload: error,
+          error: true,
+        }),
+        source,
+    ));

--- a/test/renderer/epics/config-spec.js
+++ b/test/renderer/epics/config-spec.js
@@ -1,37 +1,13 @@
-import chai, { expect } from 'chai';
+import { expect } from 'chai';
 import { ActionsObservable } from 'redux-observable';
 
 import {
-  LOAD_CONFIG,
-  loadConfigEpic,
   saveConfigOnChangeEpic,
-  retryAndEmitError,
 } from '../../../src/notebook/epics/config';
-
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
-
-chai.use(sinonChai);
 
 const Rx = require('rxjs/Rx');
 
 const Observable = Rx.Observable;
-
-describe('loadConfigEpic', () => {
-  it('errors on a bad read', (done) => {
-    const input$ = Observable.of({ type: LOAD_CONFIG }).share();
-    const action$ = new ActionsObservable(input$);
-    const responseActions = loadConfigEpic(action$);
-    responseActions.subscribe(
-      (x) => {
-        expect(x.type).to.equal('ERROR');
-        done();
-      },
-      expect.fail,
-      expect.fail,
-    );
-  });
-});
 
 describe('saveConfigOnChangeEpic', () => {
   it('invokes a SAVE when the SET_CONFIG_KEY action happens', (done) => {
@@ -46,25 +22,5 @@ describe('saveConfigOnChangeEpic', () => {
       expect.fail,
       expect.fail,
     );
-  });
-});
-
-describe('retryAndEmitError', () => {
-  it('returns the source observable, emitting an error action first', () => {
-    const source = {
-      startWith: sinon.stub(),
-    };
-    source.startWith.returns(source);
-    const err = new Error('Oh no!');
-    const newSource = retryAndEmitError(err, source);
-
-    expect(source.startWith.calledOnce).to.equal(true);
-    expect(source.startWith).to.have.been.calledWith({
-      payload: err,
-      error: true,
-      type: 'ERROR',
-    });
-
-    expect(newSource).to.equal(source);
   });
 });

--- a/test/renderer/epics/execute-spec.js
+++ b/test/renderer/epics/execute-spec.js
@@ -289,19 +289,21 @@ describe('executeCellEpic', () => {
     },
   };
   it('Errors on a bad action', (done) => {
-    const badInput$ = Observable.of({ type: EXECUTE_CELL });
+    // Make one hot action
+    const badInput$ = Observable.of({ type: EXECUTE_CELL }).share();
     const badAction$ = new ActionsObservable(badInput$);
-    const actionBuffer = [];
     const responseActions = executeCellEpic(badAction$, store).catch(error => {
       expect(error.message).to.equal('execute cell needs an id');
     });
     responseActions.subscribe(
       // Every action that goes through should get stuck on an array
-      (x) => actionBuffer.push(x.type),
+      (x) => {
+        expect(x.type).to.equal(ERROR_EXECUTING);
+        done();
+      },
       (err) => expect.fail(err, null), // It should not error in the stream
       () => {
-        expect(actionBuffer).to.deep.equal([ERROR_EXECUTING]);
-        done();
+        expect.fail('It should not complete');
       },
     );
   });

--- a/test/renderer/epics/index-spec.js
+++ b/test/renderer/epics/index-spec.js
@@ -1,8 +1,14 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 
 import { ActionsObservable } from 'redux-observable';
 
-import epics from '../../../src/notebook/epics';
+import epics, { retryAndEmitError } from '../../../src/notebook/epics';
+
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
 
 describe('epics', () => {
   it('is an array of epics', () => {
@@ -10,5 +16,25 @@ describe('epics', () => {
 
     const action$ = new ActionsObservable();
     epics.map(epic => epic(action$));
+  });
+});
+
+describe('retryAndEmitError', () => {
+  it('returns the source observable, emitting an error action first', () => {
+    const source = {
+      startWith: sinon.stub(),
+    };
+    source.startWith.returns(source);
+    const err = new Error('Oh no!');
+    const newSource = retryAndEmitError(err, source);
+
+    expect(source.startWith.calledOnce).to.equal(true);
+    expect(source.startWith).to.have.been.calledWith({
+      payload: err,
+      error: true,
+      type: 'ERROR',
+    });
+
+    expect(newSource).to.equal(source);
   });
 });

--- a/test/renderer/epics/kernel-launch-spec.js
+++ b/test/renderer/epics/kernel-launch-spec.js
@@ -113,16 +113,19 @@ describe('newKernelEpic', () => {
   it('throws an error if given a bad action', (done) => {
     const input$ = Rx.Observable.of({
       type: constants.LAUNCH_KERNEL,
-    });
+    }).share();
     const actionBuffer = [];
     const action$ = new ActionsObservable(input$);
     const obs = newKernelEpic(action$);
     obs.subscribe(
-      (x) => actionBuffer.push(x.type),
+      (x) => {
+        expect(x.type).to.equal(constants.ERROR_KERNEL_LAUNCH_FAILED);
+        actionBuffer.push(x.type);
+        done();
+      },
       (err) => expect.fail(err, null),
       () => {
-        expect(actionBuffer).to.deep.equal([constants.ERROR_KERNEL_LAUNCH_FAILED]);
-        done();
+        expect.fail('Should not complete');
       },
     );
   });


### PR DESCRIPTION
Wow I'm about to fix a pile of our "strange" bugs... The originating observable is available to the callback used with the [`catch` operator](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-catch). Returning it will "restart" the observable.

Ref #1177.

I feel a bit sheepish in admitting I didn't notice this before, even with people commenting about it in `redux-observable`. Too much scanning from me.