### PR TITLE
feat(cell): keep cell in edit mode + cell type shortcut

### DIFF
--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -29,7 +29,10 @@ type Props = {
 };
 
 class CodeCell extends React.PureComponent {
-  props: Props;
+
+  constructor(props: Props): void {
+    super(props);
+  }
 
   static defaultProps = {
     pagers: new ImmutableList(),

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -74,6 +74,9 @@ export default class MarkdownCell extends React.PureComponent {
   updateFocus(): void {
     if (this.state && this.state.view && this.props.cellFocused) {
       this.rendered.focus();
+      if (this.props.editorFocused) {
+        this.openEditor();
+      }
     }
   }
 


### PR DESCRIPTION
EDIT - This PR is now ready to be reviewed and merged.

I've removed all the keyboard shortcut functionality (see conversation below).
This commit will still place the markdown cell in edit mode from code cell and vice versa.

----------------
This commit addresses issue #1360
When a code cell is converted to a markdown cell (and there is content in the cell editor) the editor will be refocused and kept in edit mode.

The commit adds keyboard shortcuts for switching between code and markdown cells.
- When in a code cell "ALT+m" will switch to markdown.
- When in a markdown cell "ALT+c" will switch to a code cell.

Looking for feedback on where I should document the shortcut.
