### PR TITLE
fix(pdf): hide undesired UI elements in pdf print

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -10,12 +10,19 @@
   * {
     box-shadow: none!important;
   }
-  .status-bar {
+  .status-bar{
     display: none!important;
   }
-  .cell-toolbar {
+  .notifications-wrapper {
     display: none!important;
   }
+  .cell-toolbar{
+    display: none!important;
+  }
+  .cell-creator{
+    display: none!important;
+  }
+
 }
 
 #app {


### PR DESCRIPTION
Fix to #1404 and some other related things I noticed.

- [x] hide notifications
- [x] hide cell-creator boxes
- [x] hide border around hovered cells. **wontfix/out-of-scoped:** This issue was a little deeper that some `@media print` css rules.

Is there a way to force the `@media` type in *View > Toggle Developer Tools*? Could be convenient.