### PR TITLE
feat(markdown-cell):  keep markdown cell in editing mode

### DIFF
--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -74,6 +74,9 @@ export default class MarkdownCell extends React.PureComponent {
   updateFocus(): void {
     if (this.state && this.state.view && this.props.cellFocused) {
       this.rendered.focus();
+      if (this.props.editorFocused) {
+        this.openEditor();
+      }
     }
   }
 


### PR DESCRIPTION
Addresses part of  #1360. This commit will keep the cell focused and in editing mode when changing from code cell type to markdown cell type. Previously the cell would come out of editing mode.

This is a cleaned up redo of PR #1406.