### PR TITLE
chore(lint): Fix slow linter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,5 @@ flow-typed/
 types/
 build/
 example-notebooks/
+packages/**/node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "spawn": "cross-env NODE_ENV=development electron .",
     "spawn:debug": "cross-env DEBUG=true NODE_ENV=development electron .",
     "clean": "rimraf lib dist",
-    "lint": "eslint .",
+    "lint": "eslint src/ test/",
     "lint:fix": "eslint . --fix",
     "prebuild": "rimraf lib",
     "build": "npm run build:renderer && npm run build:main",


### PR DESCRIPTION
Eslint has been really slow locally! 🐢 This PR fixes that by changing the linting script to only lint src & test.
