### PR TITLE
feat(geojson): autodetect background to pick tiles

### DIFF
--- a/test/renderer/components/transforms/geojson-spec.js
+++ b/test/renderer/components/transforms/geojson-spec.js
@@ -89,7 +89,13 @@ describe('GeoJSONTransform', () => {
   it('picks an appropriate theme when unknown', () => {
     expect(getTheme('light')).to.equal('light');
     expect(getTheme('dark')).to.equal('dark');
-    expect(getTheme('nteract')).to.equal('light');
-    expect(getTheme()).to.equal('light');
+
+    const el = document.createElement('div');
+    el.style.backgroundColor = '#FFFFFF';
+    expect(getTheme('classic', el)).to.equal('light');
+
+    const darkEl = document.createElement('div');
+    darkEl.style.backgroundColor = '#000000';
+    expect(getTheme('classic', darkEl)).to.equal('dark');
   });
 });


### PR DESCRIPTION
Fixes #1093.

Relies on `window.getComputedStyle` to get the background color then computes the [Luma value](https://en.wikipedia.org/wiki/Luma_(video)).

While I was playing with this I also noticed I really like the `streets` map tileset from Mapbox.

/cc @gnestor