### PR TITLE
chore(docs): Update link to Slack and Slack inviter.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@
 - [ ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
 - [ ] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.
 
-<!-- Questions? Feel free to ping us on https://slack.nteract.in -->
+<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To learn how to contribute, head to our [contributing guide](CONTRIBUTING.md).
 This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior to rgbkrk@gmail.com.
 
-Feel free to post issues or chat in [Slack](http://slack.nteract.in/) if you need help or have questions. If you have trouble creating an account on slack, either email rgbkrk@gmail.com or post an issue on GitHub.
+Feel free to post issues or chat in [Slack](https://nteract.slack.com/) ([request an invite](https://slackin-nteract.now.sh/)) if you need help or have questions. If you have trouble creating an account on Slack, either email rgbkrk@gmail.com or post an issue on GitHub.
 
 ### Development
 


### PR DESCRIPTION
I noticed the link to nteract's Slack was not resolving so I've updated it. Also added a link to the Slack inviter as mentioned in #1388.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

<!-- Questions? Feel free to ping us on https://slack.nteract.in -->
