### PR TITLE
Resolve relative URLs in markdown cells to notebook directory

### DIFF
--- a/src/notebook/components/base.js
+++ b/src/notebook/components/base.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+import path from 'path';
+import url from 'url';
+
+function Base(props: Object, context: { store: Object }): ?React.Element<any> {
+  const state = context.store.getState();
+  const metadata = state.metadata.toJS();
+  const cwd = `${path.dirname(metadata.filename)}/`;
+  return React.cloneElement(props.children, { cwd });
+}
+
+Base.contextTypes = {
+  store: React.PropTypes.object,
+};
+
+export default Base;

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -5,6 +5,7 @@ import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
 import CodeCell from './code-cell';
 import MarkdownCell from './markdown-cell';
 import Toolbar from './toolbar';
+import Base from '../base';
 
 import {
   focusCell,
@@ -122,16 +123,18 @@ export class Cell extends React.PureComponent {
         }
         {
         type === 'markdown' ?
-          <MarkdownCell
-            focusAbove={this.focusAboveCell}
-            focusBelow={this.focusBelowCell}
-            focusEditor={this.focusCellEditor}
-            cellFocused={cellFocused}
-            editorFocused={editorFocused}
-            cell={cell}
-            id={this.props.id}
-            theme={this.props.theme}
-          /> :
+          <Base>
+            <MarkdownCell
+              focusAbove={this.focusAboveCell}
+              focusBelow={this.focusBelowCell}
+              focusEditor={this.focusCellEditor}
+              cellFocused={cellFocused}
+              editorFocused={editorFocused}
+              cell={cell}
+              id={this.props.id}
+              theme={this.props.theme}
+            />
+          </Base> :
           <CodeCell
             focusAbove={this.focusAboveCell}
             focusBelow={this.focusBelowCell}

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -17,6 +17,7 @@ type Props = {
   focusEditor: Function,
   cellFocused: boolean,
   editorFocused: boolean,
+  cwd: string
 };
 
 type State = {
@@ -118,8 +119,6 @@ export default class MarkdownCell extends React.PureComponent {
   }
 
   render(): ?React.Element<any> {
-    const { filename } = this.context.store.getState().metadata.toJS();
-    const cwd = `${path.dirname(filename)}/`;
     const parser = new CommonMark.Parser();
     const renderer = new MarkdownRenderer();
     const parsed = parser.parse(
@@ -132,7 +131,7 @@ export default class MarkdownCell extends React.PureComponent {
     while ((event = walker.next())) { // eslint-disable-line no-cond-assign
       const { node } = event;
       if (event.entering && node.type === 'link') {
-        node.destination = url.resolve(cwd, node.destination);
+        node.destination = url.resolve(this.props.cwd, node.destination);
       }
     }
     return (


### PR DESCRIPTION
Follow up from https://github.com/nteract/nteract/issues/349

To do:

* [ ] Use `<base>` html element: https://github.com/nteract/nteract/issues/349#issuecomment-278180910
* [ ] Fix broken paths to CSS/images
  * [ ] Webpack CSS/images