### PR TITLE
fix(editor): Shift+Tab de-indents selection by one unit

### DIFF
--- a/src/notebook/components/cell/codemirror/index.js
+++ b/src/notebook/components/cell/codemirror/index.js
@@ -151,6 +151,7 @@ const CodeMirrorWrapper: CodeMirrorHOC = (EditorView, customOptions = null) =>
         extraKeys: {
           'Ctrl-Space': 'autocomplete',
           Tab: this.executeTab,
+          'Shift-Tab': editor => editor.execCommand('indentLess'),
           Up: this.goLineUpOrEmit,
           Down: this.goLineDownOrEmit,
           'Cmd-/': 'toggleComment',


### PR DESCRIPTION
Fixes #1430 😎 