### PR TITLE
feat(document): persist cell type on down arrow

### DIFF
--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -215,6 +215,7 @@ type FocusNextCellAction = { type: 'FOCUS_NEXT_CELL', id: CellID, createCellIfUn
 function focusNextCell(state: DocumentState, action: FocusNextCellAction) {
   const cellOrder = state.getIn(['notebook', 'cellOrder'], Immutable.List());
   const curIndex = cellOrder.findIndex((id: CellID) => id === action.id);
+  const curCellType = state.getIn(['notebook', 'cellMap', action.id, 'cell_type']);
 
   const nextIndex = curIndex + 1;
 
@@ -225,7 +226,7 @@ function focusNextCell(state: DocumentState, action: FocusNextCellAction) {
     }
 
     const cellID: string = uuid.v4();
-    const cell = emptyCodeCell;
+    const cell = curCellType === 'code' ? emptyCodeCell : emptyMarkdownCell;
 
     const notebook: ImmutableNotebook = state.get('notebook');
 

--- a/test/renderer/reducers/document-spec.js
+++ b/test/renderer/reducers/document-spec.js
@@ -171,9 +171,9 @@ describe('focusNextCell', () => {
     expect(state.document.get('cellFocused')).to.not.be.null;
     expect(state.document.getIn(['notebook', 'cellOrder']).size).to.equal(3);
   });
-  it('should create and focus a new cell if last cell', () => {
+  it('should create and focus a new code cell if last cell and last cell is code cell', () => {
     const originalState = {
-      document: monocellDocument,
+      document: monocellDocument.set('notebook', appendCellToNotebook(dummyCommutable, emptyCodeCell)),
     };
 
     const id = originalState.document.getIn(['notebook', 'cellOrder']).last();
@@ -185,8 +185,33 @@ describe('focusNextCell', () => {
     };
 
     const state = reducers(originalState, action);
+    const newCellId = state.document.getIn(['notebook', 'cellOrder']).last();
+    const newCellType = state.document.getIn(['notebook', 'cellMap', newCellId, 'cell_type']);
+
     expect(state.document.cellFocused).to.not.be.null;
     expect(state.document.getIn(['notebook', 'cellOrder']).size).to.equal(4);
+    expect(newCellType).to.equal('code');
+  });
+  it('should create and focus a new markdown cell if last cell and last cell is markdown cell', () => {
+    const originalState = {
+      document: monocellDocument.set('notebook', appendCellToNotebook(dummyCommutable, emptyMarkdownCell)),
+    };
+
+    const id = originalState.document.getIn(['notebook', 'cellOrder']).last();
+
+    const action = {
+      type: constants.FOCUS_NEXT_CELL,
+      id,
+      createCellIfUndefined: true,
+    };
+
+    const state = reducers(originalState, action);
+    const newCellId = state.document.getIn(['notebook', 'cellOrder']).last();
+    const newCellType = state.document.getIn(['notebook', 'cellMap', newCellId, 'cell_type']);
+
+    expect(state.document.cellFocused).to.not.be.null;
+    expect(state.document.getIn(['notebook', 'cellOrder']).size).to.equal(4);
+    expect(newCellType).to.equal('markdown');
   });
 });
 


### PR DESCRIPTION
This addresses issue #1410.  This commit persists the cell type when it is created with the down arrow.

- When a code cell is the last cell down arrow will create a new code cell
- When a markdown cell is the last cell down arrow will create a new markdown cell

*Note this will persist the cell type with an execute + create new cell (shift+enter). If we want to only persist on down arrow I will refactor this.*
