### PR TITLE
Kernel error notification

### DIFF
--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -83,37 +83,37 @@ export function newKernelObservable(kernelSpec: KernelInfo, cwd: string) {
   const spec = kernelSpec.spec;
 
   return Rx.Observable.create((observer) => {
-      launchSpec(spec, { cwd })
-        .then((c) => {
-          const { config, spawn, connectionFile } = c;
-          const kernelSpecName = kernelSpec.name;
+    launchSpec(spec, { cwd })
+      .then((c) => {
+        const { config, spawn, connectionFile } = c;
+        const kernelSpecName = kernelSpec.name;
 
-          const identity = uuid.v4();
-          // TODO: I'm realizing that we could trigger on when the underlying sockets
-          //       are ready with these subjects to let us know when the kernels
-          //       are *really* ready
-          const channels = {
-            shell: createShellSubject(identity, config),
-            iopub: createIOPubSubject(identity, config),
-            control: createControlSubject(identity, config),
-            stdin: createStdinSubject(identity, config),
-          };
-          observer.next(setNotebookKernelInfo(kernelSpec));
+        const identity = uuid.v4();
+        // TODO: I'm realizing that we could trigger on when the underlying sockets
+        //       are ready with these subjects to let us know when the kernels
+        //       are *really* ready
+        const channels = {
+          shell: createShellSubject(identity, config),
+          iopub: createIOPubSubject(identity, config),
+          control: createControlSubject(identity, config),
+          stdin: createStdinSubject(identity, config),
+        };
+        observer.next(setNotebookKernelInfo(kernelSpec));
 
-          observer.next({
-            type: NEW_KERNEL,
-            channels,
-            connectionFile,
-            spawn,
-            kernelSpecName,
-            kernelSpec,
-          });
-
-          spawn.on('error', (error) => {
-            observer.error({ type: 'ERROR', payload: error, err: true })
-            observer.complete();
-          })
+        observer.next({
+          type: NEW_KERNEL,
+          channels,
+          connectionFile,
+          spawn,
+          kernelSpecName,
+          kernelSpec,
         });
+
+        spawn.on('error', (error) => {
+          observer.error({ type: 'ERROR', payload: error, err: true });
+          observer.complete();
+        });
+      });
   });
 }
 
@@ -130,7 +130,7 @@ export const watchExecutionStateEpic = (action$: ActionsObservable) =>
           .filter(msg => msg.header.msg_type === 'status')
           .map(msg => setExecutionState(msg.content.execution_state)),
         Rx.Observable.of(setExecutionState('idle'))
-      );
+      )
   );
 /**
   * Get kernel specs from main process

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -113,6 +113,12 @@ export function newKernelObservable(kernelSpec: KernelInfo, cwd: string) {
           observer.error({ type: 'ERROR', payload: error, err: true });
           observer.complete();
         });
+        spawn.on('exit', () => {
+          observer.complete();
+        });
+        spawn.on('disconnect', () => {
+          observer.complete();
+        });
       });
   });
 }

--- a/src/notebook/epics/kernel-launch.js
+++ b/src/notebook/epics/kernel-launch.js
@@ -83,33 +83,37 @@ export function newKernelObservable(kernelSpec: KernelInfo, cwd: string) {
   const spec = kernelSpec.spec;
 
   return Rx.Observable.create((observer) => {
-    launchSpec(spec, { cwd })
-      .then((c) => {
-        const { config, spawn, connectionFile } = c;
-        const kernelSpecName = kernelSpec.name;
+      launchSpec(spec, { cwd })
+        .then((c) => {
+          const { config, spawn, connectionFile } = c;
+          const kernelSpecName = kernelSpec.name;
 
-        const identity = uuid.v4();
-        // TODO: I'm realizing that we could trigger on when the underlying sockets
-        //       are ready with these subjects to let us know when the kernels
-        //       are *really* ready
-        const channels = {
-          shell: createShellSubject(identity, config),
-          iopub: createIOPubSubject(identity, config),
-          control: createControlSubject(identity, config),
-          stdin: createStdinSubject(identity, config),
-        };
-        observer.next(setNotebookKernelInfo(kernelSpec));
+          const identity = uuid.v4();
+          // TODO: I'm realizing that we could trigger on when the underlying sockets
+          //       are ready with these subjects to let us know when the kernels
+          //       are *really* ready
+          const channels = {
+            shell: createShellSubject(identity, config),
+            iopub: createIOPubSubject(identity, config),
+            control: createControlSubject(identity, config),
+            stdin: createStdinSubject(identity, config),
+          };
+          observer.next(setNotebookKernelInfo(kernelSpec));
 
-        observer.next({
-          type: NEW_KERNEL,
-          channels,
-          connectionFile,
-          spawn,
-          kernelSpecName,
-          kernelSpec,
+          observer.next({
+            type: NEW_KERNEL,
+            channels,
+            connectionFile,
+            spawn,
+            kernelSpecName,
+            kernelSpec,
+          });
+
+          spawn.on('error', (error) => {
+            observer.error({ type: 'ERROR', payload: error, err: true })
+            observer.complete();
+          })
         });
-        observer.complete();
-      });
   });
 }
 
@@ -126,9 +130,8 @@ export const watchExecutionStateEpic = (action$: ActionsObservable) =>
           .filter(msg => msg.header.msg_type === 'status')
           .map(msg => setExecutionState(msg.content.execution_state)),
         Rx.Observable.of(setExecutionState('idle'))
-      )
-    );
-
+      );
+  );
 /**
   * Get kernel specs from main process
   *

--- a/test/renderer/epics/kernel-launch-spec.js
+++ b/test/renderer/epics/kernel-launch-spec.js
@@ -139,11 +139,16 @@ describe('newKernelEpic', () => {
     const action$ = new ActionsObservable(input$);
     const obs = newKernelEpic(action$);
     obs.subscribe(
-      (x) => actionBuffer.push(x.type),
+      (x) => {
+        actionBuffer.push(x.type);
+        if (actionBuffer.length === 2) {
+          expect(actionBuffer).to.deep.equal([constants.SET_KERNEL_INFO, constants.NEW_KERNEL]);
+          done();
+        }
+      },
       (err) => expect.fail(err, null),
       () => {
-        expect(actionBuffer).to.deep.equal([constants.SET_KERNEL_INFO, constants.NEW_KERNEL]);
-        done();
+        expect.fail();
       },
     );
   });

--- a/test/setup.js
+++ b/test/setup.js
@@ -170,7 +170,7 @@ mock('spawnteract', {
     }
     return writeConnectionFile('config').then((c) => {
       return {
-        spawn: 'runningKernel',
+        spawn: { on: () => {} },
         connectionFile: c.connectionFile,
         config: c.config,
         kernelSpec: kernelSpec.name,


### PR DESCRIPTION
Changed:
- New Kernel Observable does not complete unless there is an error
- Tests finish after both actions are pushed
- Emit an error that is caught by the notification system when spawning fails.

Issue:
When Spawnteract's child process spawning of a kernel fails, it fails asynchronously. `Child_process.spawn` in spawnteract emits an error, on this error we should emit an error action that is caught by the middleware. To test, change the path of a kernel in your kernelspec's kernel.json folder. This should help expose issues for new users. 