### PR TITLE
set nsis:perMachine to enable file associations

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,10 @@
         "zip"
       ]
     },
+    "nsis": {
+      "perMachine": true,
+      "oneClick": false
+    },
     "win": {
       "target": [
         "nsis",


### PR DESCRIPTION
fixes #1446
fixes #1060

I just ran the build with these options, I can also set `allowToChangeInstallationDirectory`
