### PR TITLE
all our packages should use the same babel config

### DIFF
--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -15,6 +15,18 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract/tree/master/packages/commutable"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "keywords": [
     "commutable",
     "nteract",

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -15,6 +15,18 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract/tree/master/packages/display-area"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "keywords": [
     "nteract",
     "display",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -11,6 +11,18 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "test": "jest"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "keywords": [
     "nteract",
     "editor",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -17,6 +17,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "flow-copy-source": "^1.1.0",

--- a/packages/notebook-preview-demo/package.json
+++ b/packages/notebook-preview-demo/package.json
@@ -7,6 +7,18 @@
   "devDependencies": {
     "react-scripts": "0.8.5"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "dependencies": {
     "@nteract/commutable": "^1.0.5",
     "@nteract/notebook-preview": "^1.0.3",

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -14,6 +14,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "dependencies": {
     "@nteract/commutable": "^1.0.5",
     "@nteract/display-area": "^1.0.3",

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -11,6 +11,18 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "test": "jest"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "flow-copy-source": "^1.1.0",

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -15,6 +15,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "peerDependencies": {
     "react": "^15.4.2"
   },

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -15,6 +15,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "dependencies": {
     "plotly.js": "^1.19.2"
   },

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -15,6 +15,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "dependencies": {
     "vega": "^2.6.3",
     "vega-embed": "^2.2.0",

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -15,6 +15,18 @@
     "type": "git",
     "url": "git+https://github.com/nteract/nteract.git"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "keywords": [
     "nteract",
     "transforms",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -15,6 +15,18 @@
     "type": "git",
     "url": "git+https://github.com/nteract/nteract.git"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash",
+      "transform-class-properties",
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
+  },
   "keywords": [
     "nteract",
     "transforms",


### PR DESCRIPTION
Spreading babel config everywhere. 🤔  I wonder if I could just place a `.babelrc` inside of `packages/`. Let me try that, don't merge me.