### PR TITLE
chore(pkgs): create a base babel config for pkgs

### DIFF
--- a/packages/.babelrc
+++ b/packages/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    "es2015",
+    "react"
+  ],
+  "plugins": [
+    "lodash",
+    "transform-class-properties",
+    "transform-flow-strip-types",
+    "transform-object-rest-spread"
+  ]
+}


### PR DESCRIPTION
New way of specifying a babel config for packages only while keeping our electron centric babel build. 😄 