### PR TITLE
feat(editor): add tooltip for introspection

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@ types
 
 [options]
 module.ignore_non_literal_requires=true
+suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 
 [ignore]
 node_modules/

--- a/package.json
+++ b/package.json
@@ -217,6 +217,8 @@
     "nyc": "^10.0.0",
     "prettier": "^0.22.0",
     "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.2",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "@nteract/messaging": "^1.0.8",
     "codemirror": "~5.24.0",
+    "@nteract/transforms": "1.0.6",
     "react-codemirror": "^0.3.0",
+    "react-dom": "^15.4.2",
     "rxjs": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/editor/src/tooltip.js
+++ b/packages/editor/src/tooltip.js
@@ -1,0 +1,43 @@
+import Rx from 'rxjs/Rx';
+
+import {
+  createMessage,
+} from '@nteract/messaging';
+
+export function tooltipObservable(channels, editor, message) {
+  const tip$ = channels.shell
+    .childOf(message)
+    .ofMessageType(['inspect_reply'])
+    .pluck('content')
+    .first()
+    .map(results => ({
+      dict: results.data,
+    }));
+  // On subscription, send the message
+  return Rx.Observable.create((observer) => {
+    const subscription = tip$.subscribe(observer);
+    channels.shell.next(message);
+    return subscription;
+  });
+}
+
+export const tooltipRequest = (code, cursorPos) =>
+  createMessage(
+    'inspect_request',
+    {
+      content: {
+        code,
+        cursor_pos: cursorPos,
+        detail_level: 0,
+      }
+    }
+  );
+
+export function tool(channels, editor) {
+  const cursor = editor.getCursor();
+  const cursorPos = editor.indexFromPos(cursor);
+  const code = editor.getValue();
+
+  const message = tooltipRequest(code, cursorPos);
+  return tooltipObservable(channels, editor, message);
+}

--- a/packages/notebook-preview/src/cell.js
+++ b/packages/notebook-preview/src/cell.js
@@ -13,6 +13,7 @@ export type CellProps = {
   id: string,
   language: string,
   theme: string,
+  tip: boolean,
   transforms: ImmutableMap<string, any>
 };
 
@@ -41,6 +42,7 @@ export class Cell extends React.PureComponent {
                   cell={cell}
                   id={this.props.id}
                   theme={this.props.theme}
+                  tip={this.props.tip}
                   language={this.props.language}
                   displayOrder={this.props.displayOrder}
                   transforms={this.props.transforms}

--- a/packages/notebook-preview/src/code-cell.js
+++ b/packages/notebook-preview/src/code-cell.js
@@ -15,6 +15,7 @@ type Props = {
   id: string,
   language: string,
   theme: string,
+  tip: boolean,
   transforms: ImmutableMap<string, any>,
   running: boolean,
   models: ImmutableMap<string, any>
@@ -56,6 +57,7 @@ class CodeCell extends React.PureComponent {
                 input={this.props.cell.get("source")}
                 language={this.props.language}
                 theme={this.props.theme}
+                tip={this.props.tip}
                 cellFocused={false}
                 onChange={() => {}}
                 onFocusChange={() => {}}
@@ -76,6 +78,7 @@ class CodeCell extends React.PureComponent {
               displayOrder={this.props.displayOrder}
               transforms={this.props.transforms}
               theme={this.props.theme}
+              tip={this.props.tip}
               expanded={this.isOutputExpanded()}
               isHidden={this.isOutputHidden()}
               models={this.props.models}

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -8,7 +8,8 @@ const Immutable = require("immutable");
 type Props = {
   notebook: Immutable.Map<string, any> | Object,
   displayOrder: Immutable.List<string>,
-  transforms: Immutable.Map<string, any>
+  transforms: Immutable.Map<string, any>,
+  tip: boolean
 };
 
 const NotebookPreview = (props: Props) => {
@@ -20,6 +21,7 @@ const NotebookPreview = (props: Props) => {
     <Notebook
       notebook={notebook}
       theme="light"
+      tip={props.tip}
       displayOrder={props.displayOrder}
       transforms={props.transforms}
     />

--- a/packages/notebook-preview/src/notebook.js
+++ b/packages/notebook-preview/src/notebook.js
@@ -11,7 +11,8 @@ type Props = {
   displayOrder: ImmutableList<any>,
   notebook: any,
   transforms: ImmutableMap<string, any>,
-  theme: string
+  theme: string,
+  tip: boolean
 };
 
 export function getLanguageMode(notebook: any): string {
@@ -55,6 +56,7 @@ export class Notebook extends React.PureComponent {
           key={id}
           id={id}
           cell={cell}
+          tip={this.props.tip}
           displayOrder={this.props.displayOrder}
           transforms={this.props.transforms}
           theme={this.props.theme}

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -57,6 +57,7 @@ class CodeCell extends React.PureComponent {
                 running={this.props.running}
               />
               <Editor
+                tip
                 completion
                 id={this.props.id}
                 input={this.props.cell.get("source")}

--- a/src/notebook/providers/editor.js
+++ b/src/notebook/providers/editor.js
@@ -12,6 +12,7 @@ type Props = {
   editorFocused: boolean,
   cellFocused: boolean,
   completion: boolean,
+  tip: boolean,
   focusAbove: () => void,
   focusBelow: () => void,
   theme: string,

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -599,3 +599,21 @@ li.CodeMirror-hint-active {
     background: var(--status-bar);
     z-index: 99;
 }
+
+/*Tooltip styling*/
+.bt {
+  float: right;
+  display: inline-block;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+}
+
+.tip {
+  padding: 20px 20px 50px 20px;
+  margin: 30px 20px 50px 20px;
+  box-shadow: 2px 2px 50px rgba(0,0,0,.2);
+  white-space: pre-wrap;
+  background-color: var(--main-bg-color);
+  z-index: 9999999;
+}


### PR DESCRIPTION
Closes #1254. 

Following discussion in #1254, I think the basic parts are here.

### Current Status
---
- I'm currently sending the request message and reply bundle (thanks for the help on the reply, John!) to the console to confirm that it's operating as expected.
- There's also the addWidget that prints the bundle in the cell (you have to press enter). Of course it doesn't display since it hasn't been transformed. See picture:

![screen shot 2017-02-18 at 5 08 56 pm](https://cloud.githubusercontent.com/assets/15242567/23097245/0954fe4a-f5fd-11e6-87c9-444612904ace.png)
---
### Next steps
- I'd like to transform bundle and display using the widget (putting aside the actual UI for the moment). I can see the basic usage of the transforms package for the bundle from the readme, but I don't quite know how to implement this and use react to display it

Thanks in advance!