### PR TITLE
chore(lerna): Only hoist rxjs and immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prebuild": "rimraf lib",
-    "lerna": "lerna bootstrap --hoist",
+    "lerna": "lerna bootstrap --hoist rxjs",
     "install": "npm run lerna && npm run build",
     "build": "npm run build:renderer && npm run build:main",
     "build:renderer": "webpack --progress --colors",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prebuild": "rimraf lib",
-    "lerna": "lerna bootstrap --hoist rxjs",
+    "lerna": "lerna bootstrap --hoist rxjs --hoist immutable",
     "install": "npm run lerna && npm run build",
     "build": "npm run build:renderer && npm run build:main",
     "build:renderer": "webpack --progress --colors",


### PR DESCRIPTION
This will make bootstrapping **a lot** faster 🚀 

I looks like all packages must use the same `rxjs`. I suppose this makes sure that `@nteract/messaging` uses `node_modules/rxjs` instead of `packages/node_modules/rxjs`.