### PR TITLE
chore(themes): porting css cleanup for cell border to notebook preview styles

### DIFF
--- a/packages/notebook-preview/styles/theme-classic.css
+++ b/packages/notebook-preview/styles/theme-classic.css
@@ -138,6 +138,15 @@
   box-shadow: -1px 1px 5px rgba(0,0,0,0.2);
 }
 
+/* -------------------- */
+/* Miscellaneous Styles */
+/* -------------------- */
+
+body
+{
+  line-height: 1.3 !important;
+}
+
 /*custom scrollbar for notebook cells and hint box*/
 div::-webkit-scrollbar, ul::-webkit-scrollbar {
       width: 11px;

--- a/packages/notebook-preview/styles/theme-dark.css
+++ b/packages/notebook-preview/styles/theme-dark.css
@@ -47,14 +47,23 @@
   --status-bar: #111;
 }
 
+/* -------------------- */
+/* Miscellaneous Styles */
+/* -------------------- */
+
+body
+{
+  line-height: 1.3 !important;
+}
+
 /*custom scrollbar for notebook cells and hint box*/
 div::-webkit-scrollbar, ul::-webkit-scrollbar {
       width: 11px;
       height: 11px;
-} 
+}
 div::-webkit-scrollbar-track, ul::-webkit-scrollbar-track {
       -webkit-box-shadow: inset 0 0 10px rgba(0,0,0,0.3);
-} 
+}
 div::-webkit-scrollbar-thumb, ul::-webkit-scrollbar-thumb {
       background-color: rgba(204,204,204, .6);
 }

--- a/packages/notebook-preview/styles/theme-light.css
+++ b/packages/notebook-preview/styles/theme-light.css
@@ -47,14 +47,23 @@
   --status-bar: #eeedee;
 }
 
+/* -------------------- */
+/* Miscellaneous Styles */
+/* -------------------- */
+
+body
+{
+  line-height: 1.3 !important;
+}
+
 /*custom scrollbar for notebook cells and hint box*/
 div::-webkit-scrollbar, ul::-webkit-scrollbar {
       width: 11px;
       height: 11px;
-} 
+}
 div::-webkit-scrollbar-track, ul::-webkit-scrollbar-track {
       -webkit-box-shadow: inset 0 0 2px rgba(0,0,0,0.3);
-} 
+}
 div::-webkit-scrollbar-thumb, ul::-webkit-scrollbar-thumb {
       background-color: rgba(199,199,199, .4)
 }


### PR DESCRIPTION
Copying css updates for bottom cell border from main themes to notebook preview themes as discussed in #1520.
