### PR TITLE
chore(lerna): Add watch command for lerna packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build:renderer": "webpack --progress --colors",
     "build:renderer:watch": "npm run build:renderer -- --watch",
     "build:packages": "lerna run build --ignore @nteract/notebook-preview-demo",
+    "build:packages:watch": "lerna run build:lib:watch --stream",
     "build:main": "babel src/main --out-dir ./lib/main && babel src/utils --out-dir ./lib/utils",
     "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
     "build:docs": "esdoc -c esdoc.json",

--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "echo \"We need tests here\""
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "keywords": [
     "nteract",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "dependencies": {
     "rxjs": "^5.0.2",

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -8,7 +8,8 @@
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
-    "build:lib": "babel -d lib src --ignore '**/__tests__/**'"
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "dependencies": {
     "leaflet": "^1.0.1"

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "author": "",
   "publishConfig": {

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "author": "",
   "publishConfig": {

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "author": "",
   "publishConfig": {

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -8,7 +8,8 @@
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
-    "build:lib": "babel -d lib src --ignore '**/__tests__/**'"
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -9,7 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Yet another lerna PR 😄 

Watching for all packages still doesn't work reliably with this command, but it can be used to watch a single package which is enough for most cases:
```bash
npm run build:packages:watch -- --scope @nteract/transforms
```