### PR TITLE
chore(pkg): bump ansi-to-react

### DIFF
--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@nteract/transforms": "^1.0.7",
-    "ansi-to-react": "^1.1.0"
+    "ansi-to-react": "^1.1.1"
   },
   "peerDependencies": {
     "immutable": "^3.8.1",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "react-json-tree": "^0.10.1",
-    "ansi-to-react": "^1.1.0",
+    "ansi-to-react": "^1.1.1",
     "mathjax-electron": "^1.2.0",
     "commonmark": "^0.27.0",
     "commonmark-react-renderer": "^4.3.1"


### PR DESCRIPTION
Linkify is breaking the rendering of many notebooks, so I want to upgrade and turn it off for us for now.