### PR TITLE
feat(editor): Allow cmd+enter as option to run cell on macOS

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -122,7 +122,13 @@ export class Notebook extends React.PureComponent {
       return;
     }
 
-    const shiftXORctrl = (e.shiftKey || e.ctrlKey) && !(e.shiftKey && e.ctrlKey);
+    let ctrlKeyPressed = e.ctrlKey;
+    // Allow cmd + enter (macOS) to operate like ctrl + enter
+    if (process.platform === 'darwin') {
+      ctrlKeyPressed = (e.metaKey || e.ctrlKey) && !(e.metaKey && e.ctrlKey);
+    }
+
+    const shiftXORctrl = (e.shiftKey || ctrlKeyPressed) && !(e.shiftKey && ctrlKeyPressed);
     if (!shiftXORctrl) {
       return;
     }


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

Was playing around with a notebook on macOS, kept trying to run a code cell via `cmd + enter` rather than `ctrl + enter`, so I thought I'd open a PR for that.