### PR TITLE
style(nbp): no overflow on notebook preview

### DIFF
--- a/packages/notebook-preview/src/code-cell.js
+++ b/packages/notebook-preview/src/code-cell.js
@@ -17,7 +17,7 @@ type Props = {
   theme: string,
   transforms: ImmutableMap<string, any>,
   running: boolean,
-  models: ImmutableMap<string, any>,
+  models: ImmutableMap<string, any>
 };
 
 class CodeCell extends React.PureComponent {
@@ -26,7 +26,7 @@ class CodeCell extends React.PureComponent {
   static defaultProps = {
     running: false,
     tabSize: 4,
-    models: new ImmutableMap(),
+    models: new ImmutableMap()
   };
 
   isOutputHidden(): any {
@@ -38,14 +38,14 @@ class CodeCell extends React.PureComponent {
   }
 
   isOutputExpanded() {
-    return this.props.cell.getIn(['metadata', 'outputExpanded']);
+    return this.props.cell.getIn(['metadata', 'outputExpanded'], true);
   }
 
   render(): ?React.Element<any> {
-    return (<div className={this.props && this.props.running ? 'cell-running' : ''} >
-      {
-        !this.isInputHidden() ?
-          <div className="input-container">
+    return (
+      <div className={this.props && this.props.running ? 'cell-running' : ''}>
+        {!this.isInputHidden()
+          ? <div className="input-container">
             <Inputs
               executionCount={this.props.cell.get('execution_count')}
               running={this.props.running}
@@ -66,23 +66,24 @@ class CodeCell extends React.PureComponent {
               focusAbove={() => {}}
               focusBelow={() => {}}
             />
-          </div> : <div className="input-container invisible" />
-      }
-      <LatexRenderer>
-        <div className="outputs">
-          <Display
-            className="outputs-display"
-            outputs={this.props.cell.get('outputs')}
-            displayOrder={this.props.displayOrder}
-            transforms={this.props.transforms}
-            theme={this.props.theme}
-            expanded={this.isOutputExpanded()}
-            isHidden={this.isOutputHidden()}
-            models={this.props.models}
-          />
-        </div>
-      </LatexRenderer>
-    </div>);
+          </div>
+          : <div className="input-container invisible" />}
+        <LatexRenderer>
+          <div className="outputs">
+            <Display
+              className="outputs-display"
+              outputs={this.props.cell.get('outputs')}
+              displayOrder={this.props.displayOrder}
+              transforms={this.props.transforms}
+              theme={this.props.theme}
+              expanded={this.isOutputExpanded()}
+              isHidden={this.isOutputHidden()}
+              models={this.props.models}
+            />
+          </div>
+        </LatexRenderer>
+      </div>
+    );
   }
 }
 

--- a/packages/notebook-preview/styles/main.css
+++ b/packages/notebook-preview/styles/main.css
@@ -202,37 +202,10 @@ body
     opacity: var(--cell-placeholder-opacity);
 }
 
-.sticky-cell-container {
-    background: var(--main-bg-color);
-    box-shadow: 0 1px 2px 0 rgba(0,0,0,.50);
-
-    top: 0px;
-    position: fixed;
-    z-index: 300;
-    width: 100%;
-    max-height: 50%;
-
-    padding-bottom: 10px;
-    padding-top: 20px;
-    overflow: auto;
-}
-
-.sticky-cell-container:empty {
-    display: none;
-}
-
-.pagers
-{
-    padding: 10px var(--prompt-width) 10px var(--prompt-width);
-    background-color: var(--pager-bg);
-    word-wrap: break-word;
-}
-
 .outputs>div
 {
     word-wrap: break-word;
     padding: 10px 10px 10px calc(var(--prompt-width) + 10px);
-    overflow-y: auto;
 }
 
 .outputs>div:empty


### PR DESCRIPTION
On the version of commuter that @cabhishek and I have been deploying internally at Netflix, people have remarked that they want the full outputs not collapsed.