### PR TITLE
feat(menu): add file-exit for win32

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -184,6 +184,17 @@ export const file = {
   ],
 };
 
+if (process.platform === 'win32') {
+  file.submenu.push({
+    type: 'separator',
+  },
+    {
+      label: 'Exit',
+      accelerator: 'Alt+F4',
+      role: 'close',
+    });
+}
+
 export const edit = {
   label: 'Edit',
   submenu: [
@@ -563,6 +574,17 @@ export function loadFullMenu(kernelSpecs) {
       fileSubMenus.exportPDF,
     ],
   };
+
+  if (process.platform === 'win32') {
+    fileWithNew.submenu.push({
+      type: 'separator',
+    },
+      {
+        label: 'Exit',
+        accelerator: 'Alt+F4',
+        role: 'close',
+      });
+  }
 
   template.push(fileWithNew);
   template.push(edit);


### PR DESCRIPTION
Addresses issue #1468
Adds File>Exit (ALT+F4) for win32 platforms.
