### PR TITLE
transform-geojson: Accept `url_template` and `layer_options` metadata

### DIFF
--- a/packages/transform-geojson/__tests__/geojson.test.js
+++ b/packages/transform-geojson/__tests__/geojson.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+import { Map } from 'immutable';
 
 import { mount } from 'enzyme';
 
@@ -46,11 +47,14 @@ const geojson = deepFreeze({
   ],
 });
 
+const metadata = Map({ expanded: true });
+
 describe('GeoJSONTransform', () => {
   it('renders a map', () => {
     const geoComponent = mount(
       <GeoJSONTransform
         data={geojson}
+        metadata={metadata}
       />,
     );
 
@@ -65,6 +69,7 @@ describe('GeoJSONTransform', () => {
     const geoComponent = mount(
       <GeoJSONTransform
         data={geojson}
+        metadata={metadata}
       />,
     );
 
@@ -82,6 +87,7 @@ describe('GeoJSONTransform', () => {
       theme: 'dark',
     });
   });
+
   it('picks an appropriate theme when unknown', () => {
     expect(getTheme('light')).toEqual('light');
     expect(getTheme('dark')).toEqual('dark');

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -15,6 +15,7 @@
     "leaflet": "^1.0.1"
   },
   "peerDependencies": {
+    "immutable": "^3.8.1",
     "react": "^15.4.2"
   },
   "publishConfig": {

--- a/packages/transform-geojson/src/index.js
+++ b/packages/transform-geojson/src/index.js
@@ -83,13 +83,19 @@ export class GeoJSONTransform extends React.Component {
 
   getTileLayer(): TileLayer {
     const metadata = this.props.metadata.toJSON();
-    // const theme = getTheme(this.props.theme, this.el);
+    const theme = getTheme(this.props.theme, this.el);
+    // const urlTemplate = (metadata && metadata.url_template) ||
+    //   'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     const urlTemplate = (metadata && metadata.url_template) ||
-      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+      'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWlja3QiLCJhIjoiLXJIRS1NbyJ9.EfVT76g4A5dyuApW_zuIFQ';
+    // const layerOptions = (metadata && metadata.layer_options) || {
+    //   attribution: 'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+    //   minZoom: 0,
+    //   maxZoom: 18
+    // };
     const layerOptions = (metadata && metadata.layer_options) || {
-      attribution: 'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
-      minZoom: 0,
-      maxZoom: 18
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      id: `mapbox.${theme}`
     };
     return [urlTemplate, layerOptions];
   }

--- a/packages/transform-geojson/src/index.js
+++ b/packages/transform-geojson/src/index.js
@@ -9,8 +9,6 @@ type TileTheme = 'dark' | 'light';
 type TileLayer = [string, Object];
 
 const MIMETYPE = 'application/geo+json';
-const MAPBOX_ACCESS_TOKEN =
-  'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw';
 
 L.Icon.Default.imagePath = '../node_modules/leaflet/dist/images/';
 
@@ -85,14 +83,15 @@ export class GeoJSONTransform extends React.Component {
 
   getTileLayer(): TileLayer {
     const metadata = this.props.metadata.toJSON();
-    const theme = getTheme(this.props.theme, this.el);
-    return [
-      (metadata && metadata.url_template) || `https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=${MAPBOX_ACCESS_TOKEN}`,
-      (metadata && metadata.layer_options) || {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        id: `mapbox.${theme}`
-      }
-    ];
+    // const theme = getTheme(this.props.theme, this.el);
+    const urlTemplate = (metadata && metadata.url_template) ||
+      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    const layerOptions = (metadata && metadata.layer_options) || {
+      attribution: 'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+      minZoom: 0,
+      maxZoom: 18
+    };
+    return [urlTemplate, layerOptions];
   }
 
   render(): ?React.Element<any> {

--- a/packages/transform-geojson/src/index.js
+++ b/packages/transform-geojson/src/index.js
@@ -1,10 +1,14 @@
 /* @flow */
 /* eslint class-methods-use-this: 0 */
 import React from 'react';
+import L from 'leaflet';
+import { Map } from 'immutable';
 
-const L = require('leaflet');
-
-type Props = { data: Object, metadata: Object, theme: string };
+type Props = {
+  data: Object,
+  metadata: Map<string, any>,
+  theme: string
+};
 type TileTheme = 'dark' | 'light';
 type TileLayer = [string, Object];
 
@@ -47,7 +51,9 @@ export class GeoJSONTransform extends React.Component {
   geoJSONLayer: Object;
   tileLayer: Object;
 
-  static defaultProps = { theme: 'light' };
+  static defaultProps = {
+    theme: 'light'
+  };
   static MIMETYPE = MIMETYPE;
 
   componentDidMount(): void {
@@ -81,24 +87,23 @@ export class GeoJSONTransform extends React.Component {
     }
   }
 
-  getTileLayer(): TileLayer {
-    const metadata = this.props.metadata.toJSON();
+  getTileLayer = (): TileLayer => {
     const theme = getTheme(this.props.theme, this.el);
     // const urlTemplate = (metadata && metadata.url_template) ||
     //   'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-    const urlTemplate = (metadata && metadata.url_template) ||
+    const urlTemplate = this.props.metadata.get('url_template') ||
       'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWlja3QiLCJhIjoiLXJIRS1NbyJ9.EfVT76g4A5dyuApW_zuIFQ';
     // const layerOptions = (metadata && metadata.layer_options) || {
     //   attribution: 'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
     //   minZoom: 0,
     //   maxZoom: 18
     // };
-    const layerOptions = (metadata && metadata.layer_options) || {
+    const layerOptions = this.props.metadata.get('layer_options') || {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
       id: `mapbox.${theme}`
     };
     return [urlTemplate, layerOptions];
-  }
+  };
 
   render(): ?React.Element<any> {
     return (
@@ -111,7 +116,7 @@ export class GeoJSONTransform extends React.Component {
           ref={(el) => {
             this.el = el;
           }}
-          style={{ height: '600px', width: '100%' }}
+          style={{ height: 600, width: '100%' }}
         />
       </div>
     );


### PR DESCRIPTION
Closes: https://github.com/nteract/nteract/issues/1574

This currently depends on a pending PR on ipython: https://github.com/ipython/ipython/pull/10404

Usage:

```py
from IPython.display import GeoJSON

GeoJSON(data={
    "type": "Feature",
    "geometry": {
        "type": "Point",
        "coordinates": [11.8, -45.04]
    }
}, url_template="http://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/{basemap_id}/{z}/{x}/{y}.png", 
layer_options={
    "basemap_id": "mola-color",
    "attribution" : "NASA/MOLA",
    "tms": True,
    "minZoom" : 0,
    "maxZoom" : 6
})
```

![image](https://cloud.githubusercontent.com/assets/512354/24218020/fbcc1946-0efe-11e7-8efb-9f64e4323ad3.png)
