### PR TITLE
fix: pin codemirror 5.24.x, workaround scroll prob

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     ]
   },
   "dependencies": {
-    "codemirror": "^5.23.0",
+    "codemirror": "~5.24.0",
     "commonmark": "^0.27.0",
     "commonmark-react-renderer": "^4.3.1",
     "electron-context-menu": "^0.8.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@nteract/messaging": "^1.0.6",
-    "codemirror": "^5.23.0",
+    "codemirror": "~5.24.0",
     "react-codemirror": "^0.3.0",
     "rxjs": "^5.0.2"
   },

--- a/packages/notebook-preview-demo/package.json
+++ b/packages/notebook-preview-demo/package.json
@@ -12,7 +12,7 @@
     "@nteract/notebook-preview": "^1.0.7",
     "@nteract/transforms": "^1.0.8",
     "@nteract/transform-dataresource": "^1.0.1",
-    "codemirror": "^5.23.0",
+    "codemirror": "~5.24.0",
     "normalize.css": "^5.0.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -19,7 +19,7 @@
     "@nteract/display-area": "^1.1.0",
     "@nteract/editor": "^1.0.6",
     "@nteract/transforms": "^1.0.8",
-    "codemirror": "^5.23.0",
+    "codemirror": "~5.24.0",
     "commonmark": "^0.27.0",
     "commonmark-react-renderer": "^4.3.1",
     "mathjax-electron": "^1.2.0"


### PR DESCRIPTION
Pinning CodeMirror for now until we figure out what caused this, what we need to handle for codemirror 5.25.0.