### PR TITLE
feat(prettier): Added commit hook to autoformat with git add

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "dist": "npm install && npm run clean && npm run build && build",
     "dist:all": "npm run dist -- -mlw",
     "flow": "flow",
-    "diagnostics": "scripts/kernelspecs-diagnostics.js"
+    "diagnostics": "scripts/kernelspecs-diagnostics.js",
+    "precommit": "lint-staged"
   },
   "build": {
     "electronVersion": "1.6.2",
@@ -131,6 +132,12 @@
       "./scripts/mockument"
     ]
   },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
+  },
   "dependencies": {
     "codemirror": "~5.24.0",
     "commonmark": "^0.27.0",
@@ -196,11 +203,13 @@
     "eslint-plugin-prettier": "^2.0.1",
     "flow-bin": "^0.40.0",
     "flow-copy-source": "^1.1.0",
+    "husky": "^0.13.3",
     "jest": "^19.0.0",
     "jsdom": "^9.10.0",
     "json-loader": "^0.5.4",
     "jsonschema": "^1.1.0",
     "lerna": "2.0.0-beta.38",
+    "lint-staged": "^3.4.0",
     "lodash-webpack-plugin": "^0.11.0",
     "mocha": "^3.2.0",
     "mock-require": "^2.0.0",

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -1,28 +1,24 @@
 /* eslint-disable no-return-assign */
 /* @flow */
-import React from 'react';
-import { DragDropContext as dragDropContext } from 'react-dnd';
-import HTML5Backend from 'react-dnd-html5-backend';
-import { connect } from 'react-redux';
+import React from "react";
+import { DragDropContext as dragDropContext } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
+import { connect } from "react-redux";
+import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
-import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+import { displayOrder, transforms } from "../../../packages/transforms-full";
 
-import {
-  displayOrder,
-  transforms,
-} from '../../../packages/transforms-full';
-
-import Cell from './cell/cell';
-import DraggableCell from '../providers/draggable-cell';
-import CellCreator from '../providers/cell-creator';
-import StatusBar from './status-bar';
+import Cell from "./cell/cell";
+import DraggableCell from "../providers/draggable-cell";
+import CellCreator from "../providers/cell-creator";
+import StatusBar from "./status-bar";
 import {
   focusNextCell,
   focusNextCellEditor,
   moveCell,
-  executeCell,
-} from '../actions';
-import type { CellProps } from './cell/cell';
+  executeCell
+} from "../actions";
+import type { CellProps } from "./cell/cell";
 
 type Props = {
   displayOrder: ImmutableList<any>,
@@ -38,32 +34,34 @@ type Props = {
   kernelSpecDisplayName: string,
   CellComponent: any,
   executionState: string,
-  models: ImmutableMap<string, any>,
+  models: ImmutableMap<string, any>
 };
 
 export function getLanguageMode(notebook: any): string {
   // The syntax highlighting language should be set in the language info
   // object.  First try codemirror_mode, then name, and fallback on 'null'.
-  const language =
-    notebook.getIn(['metadata', 'language_info', 'codemirror_mode', 'name'],
-    notebook.getIn(['metadata', 'language_info', 'codemirror_mode'],
-    notebook.getIn(['metadata', 'language_info', 'name'],
-    'text')));
+  const language = notebook.getIn(
+    ["metadata", "language_info", "codemirror_mode", "name"],
+    notebook.getIn(
+      ["metadata", "language_info", "codemirror_mode"],
+      notebook.getIn(["metadata", "language_info", "name"], "text")
+    )
+  );
   return language;
 }
 
 const mapStateToProps = (state: Object) => ({
-  theme: state.config.get('theme'),
-  lastSaved: state.app.get('lastSaved'),
-  kernelSpecDisplayName: state.app.get('kernelSpecDisplayName'),
-  notebook: state.document.get('notebook'),
-  transient: state.document.get('transient'),
-  cellPagers: state.document.get('cellPagers'),
-  cellFocused: state.document.get('cellFocused'),
-  editorFocused: state.document.get('editorFocused'),
-  stickyCells: state.document.get('stickyCells'),
-  executionState: state.app.get('executionState'),
-  models: state.comms.get('models'),
+  theme: state.config.get("theme"),
+  lastSaved: state.app.get("lastSaved"),
+  kernelSpecDisplayName: state.app.get("kernelSpecDisplayName"),
+  notebook: state.document.get("notebook"),
+  transient: state.document.get("transient"),
+  cellPagers: state.document.get("cellPagers"),
+  cellFocused: state.document.get("cellFocused"),
+  editorFocused: state.document.get("editorFocused"),
+  stickyCells: state.document.get("stickyCells"),
+  executionState: state.app.get("executionState"),
+  models: state.comms.get("models")
 });
 
 export class Notebook extends React.PureComponent {
@@ -79,11 +77,11 @@ export class Notebook extends React.PureComponent {
   static defaultProps = {
     displayOrder,
     transforms,
-    CellComponent: DraggableCell,
+    CellComponent: DraggableCell
   };
 
   static contextTypes = {
-    store: React.PropTypes.object,
+    store: React.PropTypes.object
   };
 
   constructor(): void {
@@ -96,20 +94,19 @@ export class Notebook extends React.PureComponent {
   }
 
   componentDidMount(): void {
-    document.addEventListener('keydown', this.keyDown);
+    document.addEventListener("keydown", this.keyDown);
   }
 
   componentDidUpdate(): void {
     if (this.stickyCellsPlaceholder) {
       // Make sure the document is vertically shifted so the top non-stickied
       // cell is always visible.
-      this.stickyCellsPlaceholder.style.height =
-        `${this.stickyCellContainer.clientHeight}px`;
+      this.stickyCellsPlaceholder.style.height = `${this.stickyCellContainer.clientHeight}px`;
     }
   }
 
   componentWillUnmount(): void {
-    document.removeEventListener('keydown', this.keyDown);
+    document.removeEventListener("keydown", this.keyDown);
   }
 
   moveCell(sourceId: string, destinationId: string, above: boolean): void {
@@ -124,11 +121,12 @@ export class Notebook extends React.PureComponent {
 
     let ctrlKeyPressed = e.ctrlKey;
     // Allow cmd + enter (macOS) to operate like ctrl + enter
-    if (process.platform === 'darwin') {
+    if (process.platform === "darwin") {
       ctrlKeyPressed = (e.metaKey || e.ctrlKey) && !(e.metaKey && e.ctrlKey);
     }
 
-    const shiftXORctrl = (e.shiftKey || ctrlKeyPressed) && !(e.shiftKey && ctrlKeyPressed);
+    const shiftXORctrl = (e.shiftKey || ctrlKeyPressed) &&
+      !(e.shiftKey && ctrlKeyPressed);
     if (!shiftXORctrl) {
       return;
     }
@@ -139,7 +137,7 @@ export class Notebook extends React.PureComponent {
 
     e.preventDefault();
 
-    const cellMap = this.props.notebook.get('cellMap');
+    const cellMap = this.props.notebook.get("cellMap");
     const id = this.props.cellFocused;
     const cell = cellMap.get(id);
 
@@ -148,13 +146,8 @@ export class Notebook extends React.PureComponent {
       this.context.store.dispatch(focusNextCellEditor(id));
     }
 
-    if (cell.get('cell_type') === 'code') {
-      this.context.store.dispatch(
-        executeCell(
-          id,
-          cell.get('source')
-        )
-      );
+    if (cell.get("cell_type") === "code") {
+      this.context.store.dispatch(executeCell(id, cell.get("source")));
     }
   }
 
@@ -164,14 +157,16 @@ export class Notebook extends React.PureComponent {
       cell,
       language: getLanguageMode(this.props.notebook),
       key: id,
-      ref: (el) => { this.cellElements = this.cellElements.set(id, el); },
+      ref: el => {
+        this.cellElements = this.cellElements.set(id, el);
+      },
       displayOrder: this.props.displayOrder,
       transforms: this.props.transforms,
       moveCell: this.moveCell,
       pagers: this.props.cellPagers.get(id),
       cellFocused: this.props.cellFocused,
       editorFocused: this.props.editorFocused,
-      running: transient.get('status') === 'busy',
+      running: transient.get("status") === "busy",
       // Theme is passed through to let the Editor component know when to
       // tell CodeMirror to remeasure
       theme: this.props.theme,
@@ -180,51 +175,61 @@ export class Notebook extends React.PureComponent {
   }
 
   createCellElement(id: string): ?React.Element<any> {
-    const cellMap = this.props.notebook.get('cellMap');
+    const cellMap = this.props.notebook.get("cellMap");
     const cell = cellMap.get(id);
-    const transient = this.props.transient.getIn(['cellMap', id], new ImmutableMap());
+    const transient = this.props.transient.getIn(
+      ["cellMap", id],
+      new ImmutableMap()
+    );
     const isStickied = this.props.stickyCells.get(id);
 
     const CellComponent = this.props.CellComponent;
 
     return (
       <div className="cell-container" key={`cell-container-${id}`}>
-        {isStickied ?
-          <div className="cell-placeholder">
-            <span className="octicon octicon-link-external" />
-          </div> :
-          <CellComponent {...this.createCellProps(id, cell, transient)} />}
+        {isStickied
+          ? <div className="cell-placeholder">
+              <span className="octicon octicon-link-external" />
+            </div>
+          : <CellComponent {...this.createCellProps(id, cell, transient)} />}
         <CellCreator key={`creator-${id}`} id={id} above={false} />
-      </div>);
+      </div>
+    );
   }
 
   createStickyCellElement(id: string): ?React.Element<any> {
-    const cellMap = this.props.notebook.get('cellMap');
-    const transient = this.props.transient.getIn(['cellMap', id], new ImmutableMap());
+    const cellMap = this.props.notebook.get("cellMap");
+    const transient = this.props.transient.getIn(
+      ["cellMap", id],
+      new ImmutableMap()
+    );
     const cell = cellMap.get(id);
     return (
       <div key={`cell-container-${id}`}>
         <Cell {...this.createCellProps(id, cell, transient)} />
-      </div>);
+      </div>
+    );
   }
 
   render(): ?React.Element<any> {
     if (!this.props.notebook) {
-      return (
-        <div className="notebook" />
-      );
+      return <div className="notebook" />;
     }
-    const cellOrder = this.props.notebook.get('cellOrder');
+    const cellOrder = this.props.notebook.get("cellOrder");
     return (
       <div>
         <div className="notebook">
           <div
             className="sticky-cells-placeholder"
-            ref={(ref) => { this.stickyCellsPlaceholder = ref; }}
+            ref={ref => {
+              this.stickyCellsPlaceholder = ref;
+            }}
           />
           <div
             className="sticky-cell-container"
-            ref={(ref) => { this.stickyCellContainer = ref; }}
+            ref={ref => {
+              this.stickyCellContainer = ref;
+            }}
           >
             {cellOrder
               .filter(id => this.props.stickyCells.get(id))
@@ -239,7 +244,10 @@ export class Notebook extends React.PureComponent {
           kernelSpecDisplayName={this.props.kernelSpecDisplayName}
           executionState={this.props.executionState}
         />
-        <link rel="stylesheet" href={`../static/styles/theme-${this.props.theme}.css`} />
+        <link
+          rel="stylesheet"
+          href={`../static/styles/theme-${this.props.theme}.css`}
+        />
       </div>
     );
   }


### PR DESCRIPTION
With this PR, `prettier` will automatically format all JS files added to staging via a precommit hook. Just tested it and it works great! 🎉

Here's what it looks like in the terminal:
```
[Node v7.5.0] nteract git/prettier-commit-hook*
❯ git commit -m "feat(prettier): Added commit hook to autoformat with git add"

> husky - npm run -s precommit

 ✔ Running tasks for *.js
[prettier-commit-hook efd3a15] feat(prettier): Added commit hook to autoformat with git add
 2 files changed, 88 insertions(+), 71 deletions(-)

[Node v7.5.0] nteract git/prettier-commit-hook
❯
```
