### PR TITLE
chore(statusBar): shifts status bar back to center

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -578,6 +578,7 @@ li.CodeMirror-hint-active {
 .status-bar {
     position: fixed;
     bottom: 0;
+    left: 0;
     width: 100%;
     font-size: 12px;
     line-height: 0.5em;


### PR DESCRIPTION
I noticed that on master right now, the status bar is pulled to the right:
<img width="802" alt="screen shot 2017-03-31 at 11 18 10 am" src="https://cloud.githubusercontent.com/assets/15242567/24556897/e08c680a-1603-11e7-89d8-edbe742087c9.png">

This moves it back to the center:
<img width="801" alt="screen shot 2017-03-31 at 11 19 33 am" src="https://cloud.githubusercontent.com/assets/15242567/24556940/fe4d1380-1603-11e7-9b2b-68d4363f8570.png">
