### PR TITLE
ux(app): Make celltoolbar transparent to see-through text.

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -177,6 +177,13 @@ body
 {
     display: inline-box;
     background-color: var(--toolbar-bg);
+    opacity: 0.4;
+    transition: opacity 0.4s;
+}
+
+.cell-toolbar:hover
+{
+    opacity: 1;
 }
 
 .cell-toolbar button


### PR DESCRIPTION
Unless hover'd in which case restaure 100% opacity.
Making it fully opaque hide text when editing markdown

![see-through](https://cloud.githubusercontent.com/assets/335567/24727096/9a111f9c-1a09-11e7-88b9-5a4bef3afc80.gif)

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
