### PR TITLE
Show celltoolbar on hover in addition to focus.

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -111,6 +111,7 @@ export class Cell extends React.PureComponent {
     const cell = this.props.cell;
     const type = cell.get("cell_type");
     const cellFocused = this.props.cellFocused === this.props.id;
+    const hoverCell = this.state.hoverCell;
     const editorFocused = this.props.editorFocused === this.props.id;
     return (
       <div
@@ -123,7 +124,7 @@ export class Cell extends React.PureComponent {
           this.cellDiv = el;
         }}
       >
-        {cellFocused
+        {cellFocused || hoverCell
           ? <Toolbar type={type} cell={cell} id={this.props.id} />
           : null}
         {type === "markdown"


### PR DESCRIPTION
Make it easier to reach for an action of a cell with one less click.

One drawback is that with vertical toolbar with 1 line cells it's ugly
as toolbars overlap. Also the area where the cell is considered
"hovered" doe not include the area of the toolbar that overflow from the
bottom of the cell if the cell is less than 3 lines.

Also question, is it worth doing the focused/hover in react while it can
just be a css display option that could also have animations ?

--- 

Does that make some sens ? This was one of the reason for cell toolbar (at least in classic notebook) vs the global one at the top. You can reach things without having to "focus" your cell.