### PR TITLE
fix(display-area): fix scrollbar still visible after expansion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "javascript.validate.enable": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "javascript.validate.enable": false
-}

--- a/packages/display-area/__tests__/display-spec.js
+++ b/packages/display-area/__tests__/display-spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import Immutable from "immutable";
 
 import { displayOrder, transforms } from "@nteract/transforms";
@@ -19,13 +19,13 @@ describe("Display", () => {
     const component = shallow(
       <Display
         outputs={outputs}
-        isHidden
+        isHidden={true}
         theme={"light"}
         displayOrder={displayOrder}
         transforms={transforms}
       />
     );
-    expect(component.contains(<div className="cell_display" />)).toEqual(false);
+    expect(component.find("div.cell_display")).toHaveLength(0);
   });
   it("displays status when it is not hidden", () => {
     const outputs = Immutable.fromJS([
@@ -45,6 +45,6 @@ describe("Display", () => {
         transforms={transforms}
       />
     );
-    expect(component.contains(<div className="cell_display" />)).toEqual(false);
+    expect(component.find("div.cell_display")).toHaveLength(1);
   });
 });

--- a/packages/display-area/__tests__/display-spec.js
+++ b/packages/display-area/__tests__/display-spec.js
@@ -5,6 +5,7 @@ import Immutable from "immutable";
 
 import { displayOrder, transforms } from "@nteract/transforms";
 import { Display } from "../";
+import { DEFAULT_SCROLL_HEIGHT } from "../src/display";
 
 describe("Display", () => {
   it("does not display when status is hidden", () => {
@@ -46,5 +47,85 @@ describe("Display", () => {
       />
     );
     expect(component.find("div.cell_display")).toHaveLength(1);
+  });
+  it("sets expanded cell style correctly", () => {
+    const outputs = Immutable.fromJS([
+      {
+        output_type: "display_data",
+        data: {
+          "text/html": "Test content"
+        }
+      }
+    ]);
+    const component = shallow(
+      <Display
+        outputs={outputs}
+        isHidden={false}
+        theme={"light"}
+        displayOrder={displayOrder}
+        transforms={transforms}
+        expanded={true}
+      />
+    );
+
+    let ci = component.instance();
+
+    // Cannot new an HTMLElement without global document reference
+    ci.el = { scrollHeight: 100, style: {} };
+    ci.recomputeStyle();
+    expect(ci.el.style.overflowY).toEqual("auto");
+    expect(ci.el.style.height).toEqual("auto");
+
+    // Simulate scrollHeight changing
+    ci.el.scrollHeight = DEFAULT_SCROLL_HEIGHT + 1;
+    ci.recomputeStyle();
+    expect(ci.el.style.overflowY).toEqual("auto");
+    expect(ci.el.style.height).toEqual("auto");
+
+    // Simulate scrollHeight changing.
+    ci.el.scrollHeight = DEFAULT_SCROLL_HEIGHT;
+    ci.recomputeStyle();
+    expect(ci.el.style.overflowY).toEqual("auto");
+    expect(ci.el.style.height).toEqual("auto");
+  });
+  it("sets non expanded cell style correctly", () => {
+    const outputs = Immutable.fromJS([
+      {
+        output_type: "display_data",
+        data: {
+          "text/html": "Test content"
+        }
+      }
+    ]);
+    const component = shallow(
+      <Display
+        outputs={outputs}
+        isHidden={false}
+        theme={"light"}
+        displayOrder={displayOrder}
+        transforms={transforms}
+        expanded={false}
+      />
+    );
+
+    let ci = component.instance();
+
+    //Cannot new an HTMLElement without global document reference
+    ci.el = { scrollHeight: 100, style: {} };
+    ci.recomputeStyle();
+    expect(ci.el.style.overflowY).toEqual("auto");
+    expect(ci.el.style.height).toEqual("auto");
+
+    //Simulate scrollHeight changing
+    ci.el.scrollHeight = DEFAULT_SCROLL_HEIGHT + 1;
+    ci.recomputeStyle();
+    expect(ci.el.style.overflowY).toEqual("scroll");
+    expect(ci.el.style.height).toEqual(`${DEFAULT_SCROLL_HEIGHT}px`);
+
+    // Simulate scrollHeight changing.
+    ci.el.scrollHeight = DEFAULT_SCROLL_HEIGHT;
+    ci.recomputeStyle();
+    expect(ci.el.style.overflowY).toEqual("auto");
+    expect(ci.el.style.height).toEqual("auto");
   });
 });

--- a/packages/display-area/src/display.js
+++ b/packages/display-area/src/display.js
@@ -16,12 +16,12 @@ type Props = {
   models: ImmutableMap<string, any>
 };
 
-const DEFAULT_SCROLL_HEIGHT = 600;
+export const DEFAULT_SCROLL_HEIGHT = 600;
 
 export default class Display extends React.PureComponent {
   props: Props;
-  recomputeStyle: () => void;
   el: HTMLElement;
+  recomputeStyle: () => void;
 
   static defaultProps = {
     transforms,
@@ -47,6 +47,7 @@ export default class Display extends React.PureComponent {
     if (!this.el) {
       return;
     }
+
     if (!this.props.expanded && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT) {
       this.el.style.height = `${DEFAULT_SCROLL_HEIGHT}px`;
       this.el.style.overflowY = "scroll";
@@ -54,7 +55,7 @@ export default class Display extends React.PureComponent {
     }
 
     this.el.style.height = "auto";
-    this.el.style.overflowY = "overflow";
+    this.el.style.overflowY = "auto";
   }
 
   render() {


### PR DESCRIPTION
There was an issue when you expanded a cell output and the `overflowY` property was previously set to scroll that it wouldn't change the `overflowY` property correctly to remove the scrollbar.

This PR adds unit tests to verify the `overflowY` and `height` style change logic.

This PR fixes two existing unit tests in `display-spec.js` which were previously false passes.