### PR TITLE
chore(pkg): upgrade react and react-dom

### DIFF
--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-preview-demo/package.json
+++ b/packages/notebook-preview-demo/package.json
@@ -14,8 +14,8 @@
     "@nteract/transform-dataresource": "^1.0.2",
     "codemirror": "~5.24.0",
     "normalize.css": "^6.0.0",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^15.5.3",
+    "react-dom": "^15.5.3",
     "react-router": "^4.0.0-beta.5",
     "react-router-dom": "^4.0.0-beta.5",
     "react-virtualized": "^9.2.1"

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "license": "BSD-3-Clause",
   "dependencies": {

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "license": "BSD-3-Clause"
 }

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -20,7 +20,7 @@
     "plotly.js": "^1.19.2"
   },
   "peerDependencies": {
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "license": "BSD-3-Clause"
 }

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -22,7 +22,7 @@
     "vega-lite": "^1.3.1"
   },
   "peerDependencies": {
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "license": "BSD-3-Clause"
 }

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   },
   "dependencies": {
     "@nteract/transform-geojson": "^1.1.1",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -38,6 +38,6 @@
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
-    "react": "^15.4.2"
+    "react": "^15.5.3"
   }
 }


### PR DESCRIPTION
There are deprecation warnings to handle here, especially for our tests. 

```
    console.error node_modules/fbjs/lib/warning.js:36
      Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.
    console.error node_modules/fbjs/lib/warning.js:36
      Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
    console.error node_modules/fbjs/lib/warning.js:36
      Warning: A Component: React.createClass is deprecated and will be removed in version 16. Use plain JavaScript classes instead. If you're not yet ready to migrate, create-react-class is available on npm as a drop-in replacement.
```

Basically, all the transform tests that run through jest currently have some soon-to-be-outdated stuff. I probably won't be able to fix these up until tomorrow.

---------

Separately, I just noticed some sinon deprecations:

```
  unlinkObservable
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
```