### PR TITLE
fix(package): Use @nteract/plotly to reduce package size

### DIFF
--- a/packages/transform-plotly/__tests__/plotly.test.js
+++ b/packages/transform-plotly/__tests__/plotly.test.js
@@ -5,8 +5,8 @@ import { mount } from "enzyme";
 
 import PlotlyTransform from "../src";
 
-jest.mock("plotly.js/dist/plotly");
-const plotly = require("plotly.js/dist/plotly");
+jest.mock("@nteract/plotly");
+const plotly = require("@nteract/plotly");
 
 plotly.newPlot.mockImplementation(() => {});
 plotly.redraw.mockImplementation(() => {});

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -16,8 +16,8 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
-    "plotly.js": "^1.19.2"
+    "@nteract/plotly": "^1.0.0",
+    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "react": "^15.5.3"

--- a/packages/transform-plotly/src/index.js
+++ b/packages/transform-plotly/src/index.js
@@ -13,7 +13,7 @@ declare class PlotlyHTMLElement extends HTMLElement {
   layout: Object
 }
 
-const Plotly = require("plotly.js/dist/plotly");
+const Plotly = require("@nteract/plotly");
 
 const MIMETYPE = "application/vnd.plotly.v1+json";
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -67,7 +67,7 @@ mock("electron-json-storage", {
   }
 });
 
-mock("plotly.js/dist/plotly", {
+mock("@nteract/plotly", {
   newPlot: () => {},
   redraw: () => {}
 });


### PR DESCRIPTION
Use the new [`@nteract/plotly`](https://github.com/nteract/minimal-plotly) package.

This will reduce the repo size of a full dev install by 90MB.