### PR TITLE
bug(tooltip): stop tooltip from showing if introspection request is empty

### DIFF
--- a/packages/editor/src/wrapper.js
+++ b/packages/editor/src/wrapper.js
@@ -168,6 +168,9 @@ const CodeMirrorWrapper: CodeMirrorHOC = (
     if (tip) {
       tool(channels, editor).subscribe(resp => {
         const bundle = ImmutableMap(resp.dict);
+        if (bundle.size === 0) {
+          return;
+        }
         const mimetype = "text/plain";
         // $FlowFixMe: until transforms refactored for new export interface GH #1488
         const Transform = transforms.get(mimetype);


### PR DESCRIPTION
I noticed that even if the tooltip has nothing to show, a blank box is still created. This prevents that from happening.