### PR TITLE
feat(menu): expand collapsed cells on export PDF

### DIFF
--- a/test/renderer/menu-spec.js
+++ b/test/renderer/menu-spec.js
@@ -447,10 +447,11 @@ describe("menu", () => {
 
   describe("exportPDF", () => {
     it("it notifies a user upon successful write", () => {
+      const store = dummyStore();
       const notificationSystem = NotificationSystem();
       const addNotification = sinon.spy(notificationSystem, "addNotification");
       const filename = "thisisafilename.ipynb";
-      menu.exportPDF(filename, notificationSystem);
+      menu.exportPDF(store, filename, notificationSystem);
       expect(addNotification).to.have.been.calledWithMatch({
         title: "PDF exported",
         message: `Notebook ${filename} has been exported as a pdf.`,


### PR DESCRIPTION
Opening new PR, git branch on the last one #1636 blew up.

Addresses issue #1610.

It will expand collapsed (default state) cells before export to PDF via modifying CSS. After export is
complete it will restore the cells to as before the export PDF.

Print to PDF still respects if you have the output hidden.
