### PR TITLE
chore(build): Fix lerna warnings:

### DIFF
--- a/packages/notebook-preview-demo/package.json
+++ b/packages/notebook-preview-demo/package.json
@@ -14,7 +14,7 @@
     "@nteract/transform-plotly": "^1.2.0",
     "@nteract/transforms": "^1.0.11",
     "codemirror": "~5.24.0",
-    "normalize.css": "^6.0.0",
+    "normalize.css": "^7.0.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-router": "^4.0.0-beta.5",

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -9,8 +9,7 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch",
-    "test": "jest"
+    "build:lib:watch": "npm run build:lib -- --watch"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "publishConfig": {
@@ -25,11 +24,5 @@
     "jsontableschema": "^0.2.2",
     "lodash.sortby": "^4.7.0",
     "react-virtualized": "^9.7.3"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "flow-copy-source": "^1.1.0",
-    "jest": "^19.0.2",
-    "rimraf": "^2.6.1"
   }
 }


### PR DESCRIPTION
* remove unnecessary devDependencies
* upgrade normalize.css to match root version

Get rid of the following warnings:
```
lerna WARN EHOIST_ROOT_VERSION The repository root depends on jest@^20.0.0, which differs from the more common jest@^19.0.2.
lerna WARN EHOIST_PKG_VERSION "@nteract/transform-dataresource" package depends on jest@^19.0.2, which differs from the hoisted jest@^20.0.0.
lerna WARN EHOIST_ROOT_VERSION The repository root depends on normalize.css@^7.0.0, which differs from the more common normalize.css@^6.0.0.
lerna WARN EHOIST_PKG_VERSION "@nteract/notebook-preview-demo" package depends on normalize.css@^6.0.0, which differs from the hoisted normalize.css@^7.0.0.
```