### PR TITLE
feat(nbp): respect hide_input from jupyter-contrib

### DIFF
--- a/packages/notebook-preview/src/code-cell.js
+++ b/packages/notebook-preview/src/code-cell.js
@@ -35,7 +35,10 @@ class CodeCell extends React.PureComponent {
   }
 
   isInputHidden(): any {
-    return this.props.cell.getIn(["metadata", "inputHidden"]);
+    return (
+      this.props.cell.getIn(["metadata", "inputHidden"]) ||
+      this.props.cell.getIn(["metadata", "hide_input"])
+    );
   }
 
   isOutputExpanded() {


### PR DESCRIPTION
nteract desktop uses `inputHidden` while [hide input](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/hide_input) uses `hide_input`. We'll at least acknowledge it within notebook preview though we should likely align desktop and nbextensions where they make sense.

/cc @jcb91