### PR TITLE
[WIP] Start faking requirejs

### DIFF
--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -34,7 +34,8 @@
     "commonmark": "^0.27.0",
     "commonmark-react-renderer": "^4.3.2",
     "mathjax-electron": "^2.0.1",
-    "react-json-tree": "^0.10.9"
+    "react-json-tree": "^0.10.9",
+    "requirejs": "^2.3.3"
   },
   "peerDependencies": {
     "immutable": "^3.8.1",

--- a/packages/transforms/src/hokey-require.js
+++ b/packages/transforms/src/hokey-require.js
@@ -1,0 +1,11 @@
+const requirejs = require("requirejs");
+
+// Copy over some of the require functions
+requirejs.resolve = require.resolve;
+requirejs.cache = require.cache;
+requirejs.extensions = require.extension;
+requirejs.main = require.main;
+
+// However, we'll overload particular nbextension names with our own polyfills
+
+module.exports = requirejs;


### PR DESCRIPTION
![now for something completely different](https://media.giphy.com/media/oWWfwpLj5l0XK/giphy.gif)

In a complete about-face, I'm going to try out providing requirejs within HTML and JS outputs. In addition, I want to fake some common `require(['someName'])` to provide direct support for certain modules:

* [ ] `require(['nbextensions/jupyter-vega/index'], cb)' - `cb` gets the vega object, particularly for calling `vega.render`
* [ ] some collection of the `require(['jupyter'])`, at least to provide an appropriate error message
* [ ] Plotly's

Any others?

We'll probably want to add in jQuery into the output areas as well.