### PR TITLE
Fake requirejs & JS transform specific to electron frontends

### DIFF
--- a/packages/transforms-electron/README.md
+++ b/packages/transforms-electron/README.md
@@ -1,0 +1,33 @@
+# nteract transforms for electron based frontends
+
+These are transforms specifically tailored for electron based frontends, targeting:
+
+* `application/javascript`
+* `text/html`
+
+## Installation
+
+```
+npm install @nteract/transforms-electron
+```
+
+## Usage
+
+### Adding New Transforms
+
+```js
+import {
+  richestMimetype,
+  registerTransform,
+  standardTransforms,
+  standardDisplayOrder,
+} from '@nteract/transforms'
+
+import { HTMLTransform, JavaScriptTransform } from '@nteract/transforms-electron'
+
+const transforms = standardTransforms
+  .set(HTMLTransform.MIMETYPE, HTMLTransform)
+  .set(JavaScriptTransform.MIMETYPE, JavaScriptTransform)
+
+let Transform = transforms.get(mimetype);
+```

--- a/packages/transforms-electron/__tests__/index.test.js
+++ b/packages/transforms-electron/__tests__/index.test.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+import React from "react";
+import { mount } from "enzyme";
+
+import { HTMLTransform } from "../src/";
+
+describe("HTMLTransform", () => {
+  it("renders direct HTML", () => {
+    const component = mount(<HTMLTransform data={"<b>woo</b>"} />);
+    expect(component.html()).toEqual("<div><b>woo</b></div>");
+  });
+  it("correctly chooses to update with data changing", () => {
+    const wrapper = mount(<HTMLTransform data={"<b>woo</b>"} />);
+
+    const component = wrapper.instance();
+    expect(component.shouldComponentUpdate({ data: "<b>woo</b>" })).toBeFalsy();
+    expect(
+      component.shouldComponentUpdate({ data: "<b>womp</b>" })
+    ).toBeTruthy();
+  });
+  it("updates the underlying HTML when data changes", () => {
+    const wrapper = mount(<HTMLTransform data={"<b>woo</b>"} />);
+    expect(wrapper.html()).toEqual("<div><b>woo</b></div>");
+
+    wrapper.setProps({ data: "<b>womp</b>" });
+
+    expect(wrapper.html()).toEqual("<div><b>womp</b></div>");
+  });
+});

--- a/packages/transforms-electron/package.json
+++ b/packages/transforms-electron/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@nteract/transforms-electron",
+  "version": "1.0.0",
+  "description": "nteract transforms for electron based jupyter frontends",
+  "main": "lib/index.js",
+  "scripts": {
+    "prepublish": "npm run build",
+    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "build:clean": "rimraf lib",
+    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nteract/nteract.git"
+  },
+  "keywords": [
+    "nteract",
+    "transforms",
+    "electron",
+    "notebook"
+  ],
+  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/nteract/nteract/issues"
+  },
+  "homepage": "https://github.com/nteract/nteract#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+  },
+  "peerDependencies": {
+    "immutable": "^3.8.1",
+    "react": "^15.5.4"
+  }
+}

--- a/packages/transforms-electron/package.json
+++ b/packages/transforms-electron/package.json
@@ -31,6 +31,8 @@
     "access": "public"
   },
   "dependencies": {
+    "d3": "^4.9.1",
+    "vega-embed": "^2.2.0"
   },
   "peerDependencies": {
     "immutable": "^3.8.1",

--- a/packages/transforms-electron/src/hacks/jupyter-vega.js
+++ b/packages/transforms-electron/src/hacks/jupyter-vega.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+var embed = require("vega-embed");
+
+export function vega(element: HTMLElement) {
+  return {
+    // Copied over from https://github.com/vega/ipyvega/blob/9de1958fa3341535f4e03989923415b5dafa48ee/src/index.js
+    // Then **heavily** trimmed and turned into a thunk
+    render: function(
+      selector: string, // ignored
+      spec: Object,
+      type: string,
+      output_area: any // ignored
+    ) {
+      var embedSpec = {
+        mode: type,
+        spec: spec
+      };
+
+      // HACK: we use the element from this scope to render vega.
+      // `selector` and `output_area` are ignored
+      embed(element, embedSpec, function(error, result) {});
+    }
+  };
+}

--- a/packages/transforms-electron/src/html.js
+++ b/packages/transforms-electron/src/html.js
@@ -1,0 +1,49 @@
+/* @flow */
+import React from "react";
+
+type Props = {
+  data: string
+};
+
+// Note: createRange and Range must be polyfilled on older browsers with
+//       https://github.com/timdown/rangy
+export function createFragment(html: string): Node {
+  // Create a range to ensure that scripts are invoked from within the HTML
+  const range = document.createRange();
+  const fragment = range.createContextualFragment(html);
+  return fragment;
+}
+
+class HTMLDisplay extends React.Component {
+  props: Props;
+  el: HTMLElement;
+
+  componentDidMount(): void {
+    this.el.appendChild(createFragment(this.props.data));
+  }
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return nextProps.data !== this.props.data;
+  }
+  componentDidUpdate(): void {
+    // clear out all DOM element children
+    while (this.el.firstChild) {
+      this.el.removeChild(this.el.firstChild);
+    }
+    this.el.appendChild(createFragment(this.props.data));
+  }
+
+  render(): ?React.Element<any> {
+    return (
+      <div
+        ref={el => {
+          this.el = el;
+        }}
+      />
+    );
+  }
+}
+
+HTMLDisplay.MIMETYPE = "text/html";
+
+export default HTMLDisplay;

--- a/packages/transforms-electron/src/html.js
+++ b/packages/transforms-electron/src/html.js
@@ -18,6 +18,8 @@ class HTMLDisplay extends React.Component {
   props: Props;
   el: HTMLElement;
 
+  static MIMETYPE = "text/html";
+
   componentDidMount(): void {
     this.el.appendChild(createFragment(this.props.data));
   }
@@ -43,7 +45,5 @@ class HTMLDisplay extends React.Component {
     );
   }
 }
-
-HTMLDisplay.MIMETYPE = "text/html";
 
 export default HTMLDisplay;

--- a/packages/transforms-electron/src/index.js
+++ b/packages/transforms-electron/src/index.js
@@ -1,0 +1,5 @@
+import HTML from "./html";
+import JS from "./javascript";
+
+export const JavaScriptTransform = JS;
+export const HTMLTransform = HTML;

--- a/packages/transforms-electron/src/javascript.js
+++ b/packages/transforms-electron/src/javascript.js
@@ -1,0 +1,77 @@
+/* @flow */
+import React from "react";
+
+const vm = require("vm");
+
+type Props = {
+  data: string
+};
+
+export function runCodeHere(el: HTMLElement, code: string): any {
+  // Compatibility with Jupyter/notebook JS evaluation.  Set element so
+  // the user has a handle on the context of the current output.
+  const element = el;
+
+  const sandbox = {
+    // TODO: until this is inside a webview or iframe, this escape hatch
+    // means we're **NOT** properly sandboxed
+    element,
+    document,
+
+    console: {
+      log: console.log.bind(console),
+      error: console.error.bind(console)
+    }
+  };
+
+  const ctxt = vm.createContext(sandbox);
+
+  try {
+    vm.runInContext(code, ctxt, {
+      filename: "kernel-output",
+      lineOffset: 0,
+      timeout: 2000,
+      displayErrors: false
+    });
+  } catch (err) {
+    const pre = document.createElement("pre");
+    if (err.stack) {
+      pre.textContent = err.stack;
+    } else {
+      pre.textContent = err;
+    }
+    element.appendChild(pre);
+    return err;
+  }
+}
+
+class JavaScriptDisplay extends React.Component {
+  props: Props;
+  el: HTMLElement;
+
+  componentDidMount(): void {
+    runCodeHere(this.el, this.props.data);
+  }
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return nextProps.data !== this.props.data;
+  }
+
+  componentDidUpdate(): void {
+    runCodeHere(this.el, this.props.data);
+  }
+
+  render(): ?React.Element<any> {
+    return (
+      <div
+        ref={el => {
+          this.el = el;
+        }}
+      />
+    );
+  }
+}
+
+JavaScriptDisplay.MIMETYPE = "application/javascript";
+
+export default JavaScriptDisplay;

--- a/packages/transforms-electron/src/javascript.js
+++ b/packages/transforms-electron/src/javascript.js
@@ -3,6 +3,8 @@ import React from "react";
 
 const vm = require("vm");
 
+const requirejs = require("requirejs");
+
 type Props = {
   data: string
 };
@@ -60,17 +62,18 @@ function createSandbox(element: HTMLElement) {
     return;
   }
 
-  const sandbox = {
-    // TODO: until this is inside a webview or iframe, this escape hatch
-    // means we're **NOT** properly sandboxed
-    element,
+  const sandbox = Object.assign(
+    {},
+    global,
+    {
+      // TODO: until this is inside a webview or iframe, this escape hatch
+      // means we're **NOT** properly sandboxed
+      element,
+      require: pretendRequire,
+      define: pretendDefine
+    }
     // HACK: Give them global access anyways
-    document,
-    window,
-    require: pretendRequire,
-    define: pretendDefine,
-    console: console
-  };
+  );
 
   return sandbox;
 }

--- a/packages/transforms-electron/src/javascript.js
+++ b/packages/transforms-electron/src/javascript.js
@@ -10,11 +10,13 @@ type Props = {
 // In a complete about-face, we're going to support a variety of notebook
 // extensions that are used within display data in Jupyter.
 //
-// Primary targets:
+// Primary module support, since we already include them as part of our app:
 //   * vega
 //   * d3
+//   * plotly
+//   * underscore / lodash (we'll provide lodash)
 
-function createSandbox(element) {
+function createSandbox(element: HTMLElement) {
   function pretendRequire(modules: Array<string> | string, cb?: Function) {
     if (typeof modules === "string") {
       // Assume CommonJS, though we'll only support specific modules
@@ -62,7 +64,9 @@ function createSandbox(element) {
     // TODO: until this is inside a webview or iframe, this escape hatch
     // means we're **NOT** properly sandboxed
     element,
+    // HACK: Give them global access anyways
     document,
+    window,
     require: pretendRequire,
     define: pretendDefine,
     console: console

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -7,6 +7,10 @@ import { connect } from "react-redux";
 import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import { displayOrder, transforms } from "../../../packages/transforms-full";
+import {
+  HTMLTransform,
+  JavaScriptTransform
+} from "../../../packages/transforms-electron";
 
 import Cell from "./cell/cell";
 import DraggableCell from "../providers/draggable-cell";
@@ -79,7 +83,9 @@ export class Notebook extends React.PureComponent {
 
   static defaultProps = {
     displayOrder,
-    transforms,
+    transforms: transforms
+      .set(HTMLTransform.MIMETYPE, HTMLTransform)
+      .set(JavaScriptTransform.MIMETYPE, JavaScriptTransform),
     CellComponent: DraggableCell
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,7 +1745,7 @@ command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
 
-commander@2.9.0, commander@2.9.x, commander@^2.8.1, commander@^2.9.0, commander@~2.9.0:
+commander@2, commander@2.9.0, commander@2.9.x, commander@^2.8.1, commander@^2.9.0, commander@~2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2308,29 +2308,122 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+d3-array@1, d3-array@1.2.0, d3-array@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.0.tgz#147d269720e174c4057a7f42be8b0f3f2ba53108"
+
+d3-axis@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.7.tgz#048433d307061f62d1d248e2930c01d7b6738cd8"
+
+d3-brush@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.4.tgz#00c2f238019f24f6c0a194a26d41a1530ffe7bc4"
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-chord@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.4.tgz#7dec4f0ba886f713fe111c45f763414f6f74ca2c"
+  dependencies:
+    d3-array "1"
+    d3-path "1"
+
 d3-cloud@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/d3-cloud/-/d3-cloud-1.2.4.tgz#3e169403adab74fdb0c867638d7f0bb8e6ae71ff"
   dependencies:
     d3-dispatch "1"
 
-d3-dispatch@1:
+d3-collection@1, d3-collection@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.3.tgz#00bdea94fbc1628d435abbae2f4dc2164e37dd34"
+
+d3-color@1, d3-color@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
+
+d3-dispatch@1, d3-dispatch@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.3.tgz#46e1491eaa9b58c358fce5be4e8bed626e7871f8"
+
+d3-drag@1, d3-drag@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.1.0.tgz#4a49b4d77a42e9e3d5a0ef3b492b14aaa2e5a733"
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
 
 d3-dsv@0.1:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-0.1.14.tgz#9833cd61a5a3e81e03263a1ce78f74de56a1dbb8"
 
+d3-dsv@1, d3-dsv@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.5.tgz#419f7db47f628789fc3fdb636e678449d0821136"
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1, d3-ease@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
+
+d3-force@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.0.6.tgz#ea7e1b7730e2664cd314f594d6718c57cc132b79"
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
+
 d3-format@0.4:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-0.4.2.tgz#aa759c1e5aae5fa8dabc9ab7819c502fc6b56875"
+
+d3-format@1, d3-format@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
 
 d3-geo-projection@0.2, d3-geo-projection@^0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/d3-geo-projection/-/d3-geo-projection-0.2.16.tgz#4994ecd1033ddb1533b6c4c5528a1c81dcc29427"
   dependencies:
     brfs "^1.3.0"
+
+d3-geo@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.6.4.tgz#f20e1e461cb1845f5a8be55ab6f876542a7e3199"
+  dependencies:
+    d3-array "1"
+
+d3-hierarchy@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.4.tgz#96c3942f3f21cf997a11b4edf00dde2a77b4c6d0"
+
+d3-interpolate@1, d3-interpolate@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.5.tgz#69e099ff39214716e563c9aec3ea9d1ea4b8a79f"
+  dependencies:
+    d3-color "1"
+
+d3-path@1, d3-path@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
+
+d3-polygon@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.3.tgz#16888e9026460933f2b179652ad378224d382c62"
+
+d3-quadtree@1, d3-quadtree@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.3.tgz#ac7987e3e23fe805a990f28e1b50d38fcb822438"
 
 d3-queue@1:
   version "1.2.3"
@@ -2340,11 +2433,56 @@ d3-queue@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-2.0.3.tgz#07fbda3acae5358a9c5299aaf880adf0953ed2c2"
 
+d3-queue@3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-3.0.7.tgz#c93a2e54b417c0959129d7d73f6cf7d4292e7618"
+
+d3-random@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.0.tgz#6642e506c6fa3a648595d2b2469788a8d12529d3"
+
+d3-request@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-request/-/d3-request-1.0.5.tgz#4daae946d1dd0d57dfe01f022956354958d51f23"
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-dsv "1"
+    xmlhttprequest "1"
+
+d3-scale@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-selection@1, d3-selection@1.1.0, d3-selection@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.1.0.tgz#1998684896488f839ca0372123da34f1d318809c"
+
+d3-shape@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.1.1.tgz#50a1037e48a79f5b8fd9d58cde52799aeb1f7723"
+  dependencies:
+    d3-path "1"
+
 d3-time-format@0.2:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-0.2.1.tgz#846e39eb7f22676692d86040c48e9fa54fd8bf18"
   dependencies:
     d3-time "~0.1.1"
+
+d3-time-format@2, d3-time-format@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.5.tgz#9d7780204f7c9119c9170b1a56db4de9a8af972e"
+  dependencies:
+    d3-time "1"
 
 d3-time-format@^0.3.2:
   version "0.3.2"
@@ -2356,13 +2494,81 @@ d3-time@0.1, d3-time@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-0.1.1.tgz#38ce2a7bb47a4031613823dde4688e58e892ae5b"
 
+d3-time@1, d3-time@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.6.tgz#a55b13d7d15d3a160ae91708232e0835f1d5e945"
+
 d3-time@~0.2.0:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-0.2.6.tgz#587553e9ea9e055462d419c7aa94e9477be15cb0"
 
+d3-timer@1, d3-timer@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.5.tgz#b266d476c71b0d269e7ac5f352b410a3b6fe6ef0"
+
+d3-transition@1, d3-transition@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.0.tgz#cfc85c74e5239324290546623572990560c3966f"
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-voronoi@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
+
+d3-zoom@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.2.0.tgz#b3231f4f9386241475defe1c557bfd3fde1065fb"
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
 d3@3, d3@^3.5.6, d3@^3.5.9:
   version "3.5.17"
   resolved "https://registry.yarnpkg.com/d3/-/d3-3.5.17.tgz#bc46748004378b21a360c9fc7cf5231790762fb8"
+
+d3@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-4.9.1.tgz#f860be9252261a3c14eea64b1d2590d14f4db838"
+  dependencies:
+    d3-array "1.2.0"
+    d3-axis "1.0.7"
+    d3-brush "1.0.4"
+    d3-chord "1.0.4"
+    d3-collection "1.0.3"
+    d3-color "1.0.3"
+    d3-dispatch "1.0.3"
+    d3-drag "1.1.0"
+    d3-dsv "1.0.5"
+    d3-ease "1.0.3"
+    d3-force "1.0.6"
+    d3-format "1.2.0"
+    d3-geo "1.6.4"
+    d3-hierarchy "1.1.4"
+    d3-interpolate "1.1.5"
+    d3-path "1.0.5"
+    d3-polygon "1.0.3"
+    d3-quadtree "1.0.3"
+    d3-queue "3.0.7"
+    d3-random "1.1.0"
+    d3-request "1.0.5"
+    d3-scale "1.0.6"
+    d3-selection "1.1.0"
+    d3-shape "1.1.1"
+    d3-time "1.0.6"
+    d3-time-format "2.0.5"
+    d3-timer "1.0.5"
+    d3-transition "1.1.0"
+    d3-voronoi "1.1.2"
+    d3-zoom "1.2.0"
 
 d@1:
   version "1.0.0"
@@ -4302,7 +4508,7 @@ iconv-lite@0.2:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.2.11.tgz#1ce60a3a57864a292d1321ff4609ca4bb965adc8"
 
-iconv-lite@0.4.13, iconv-lite@~0.4.13:
+iconv-lite@0.4, iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
@@ -9229,6 +9435,10 @@ xmlbuilder@8.2.2:
 xmldom@0.1.x:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+
+xmlhttprequest@1:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
 xss-filters@^1.2.6:
   version "1.2.7"


### PR DESCRIPTION
This is the beginning of custom transforms for electron based frontends to handle "Jupyter-style" JS and HTML in a secure and friendly way. Secure because we could lock it down. Friendly because we'll try to match some invariants:

* Access to a partially limited requirejs as `require` -- will likely use the `vm` module for js runtime
  * We'll provide some faked access to more common `require` paths, including vega and others since we already support vega
* All the output from a single execution request (cell) should get rendered in the same webview

There's no code here yet, figured I should post where I'm headed with it.

After this PR I'm going to make a version that is web specific that will use the requirejs helper code.

Libraries to support

* [x] `nbextensions/jupyter-vega/index`
* [x] `d3`

Libraries definitely not going to be supported as part of this:

* ipywidgets
* pythreejs (relies on widgets)
* the jupyter and ipython js APIs from the classic notebook
* `plotly` - we already handle the plotly mimetype, we won't support the `text/html` version from them
* holoviews
* bokeh

Related PR: https://github.com/nteract/nteract/pull/1709