### PR TITLE
fix(text-transform): Disable linkify to fix performance issue

### DIFF
--- a/packages/transforms/src/text.js
+++ b/packages/transforms/src/text.js
@@ -15,6 +15,6 @@ export default class TextDisplay extends React.Component {
   }
 
   render(): ?React.Element<any> {
-    return <Ansi linkify>{this.props.data}</Ansi>;
+    return <Ansi>{this.props.data}</Ansi>;
   }
 }


### PR DESCRIPTION
Fixes rendering performance for large text as mentioned in https://github.com/nteract/hydrogen/issues/817

This disables the linkification until we figure out a performant way of doing this.