### PR TITLE
fix(flow): richestMimetype can return undefined

### DIFF
--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -79,7 +79,7 @@ export function richestMimetype(
   bundle: ImmutableMap<string, any>,
   order: ImmutableList<string> = standardDisplayOrder,
   tf: ImmutableMap<string, any> = standardTransforms
-): string {
+): ?string {
   return (
     bundle
       .keySeq()


### PR DESCRIPTION
`richestMimetype` can return `undefined`. This can lead to nasty React errors.

See https://github.com/nteract/hydrogen/pull/746