### PR TITLE
[WIP] Base resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "react-dnd": "^2.4.0",
     "react-dnd-html5-backend": "^2.4.1",
     "react-dom": "^15.5.4",
+    "react-helmet": "^5.1.3",
     "react-json-tree": "^0.10.9",
     "react-notification-system": "^0.2.14",
     "react-redux": "^5.0.5",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -53,6 +53,9 @@ ipc.on("open-notebook", (event, filename) => {
 
 const electronReady$ = Rx.Observable.fromEvent(app, "ready");
 
+// TODO: Register our protocol here, rendering index.html accordingly
+// See https://github.com/nteract/nteract/pull/1720
+
 const fullAppReady$ = Rx.Observable.zip(electronReady$, prepareEnv).first();
 
 const jupyterConfigDir = path.join(app.getPath("home"), ".jupyter");
@@ -208,10 +211,11 @@ fullAppReady$.subscribe(() => {
             title: "No Kernels Installed",
             buttons: [],
             message: "No kernels are installed on your system.",
-            detail: "No kernels are installed on your system so you will not be " +
-              "able to execute code cells in any language. You can read about " +
-              "installing kernels at " +
-              "https://ipython.readthedocs.io/en/latest/install/kernel_install.html"
+            detail:
+              "No kernels are installed on your system so you will not be " +
+                "able to execute code cells in any language. You can read about " +
+                "installing kernels at " +
+                "https://ipython.readthedocs.io/en/latest/install/kernel_install.html"
           },
           index => {
             if (index === 0) {
@@ -228,11 +232,12 @@ fullAppReady$.subscribe(() => {
           title: "No Kernels Installed",
           buttons: [],
           message: "No kernels are installed on your system.",
-          detail: "No kernels are installed on your system so you will not be " +
-            "able to execute code cells in any language. You can read about " +
-            "installing kernels at " +
-            "https://ipython.readthedocs.io/en/latest/install/kernel_install.html" +
-            `\nFull error: ${err.message}`
+          detail:
+            "No kernels are installed on your system so you will not be " +
+              "able to execute code cells in any language. You can read about " +
+              "installing kernels at " +
+              "https://ipython.readthedocs.io/en/latest/install/kernel_install.html" +
+              `\nFull error: ${err.message}`
         },
         index => {
           if (index === 0) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,11 @@
-import { Menu, dialog, app, ipcMain as ipc, BrowserWindow } from "electron";
+import {
+  Menu,
+  dialog,
+  app,
+  ipcMain as ipc,
+  BrowserWindow,
+  protocol
+} from "electron";
 import { resolve, join } from "path";
 import { existsSync } from "fs";
 
@@ -13,6 +20,8 @@ import {
 import { launch, launchNewNotebook } from "./launch";
 
 import { loadFullMenu } from "./menu";
+
+import { registerProtocol } from "./protocol";
 
 import prepareEnv from "./prepare-env";
 import initializeKernelSpecs from "./kernel-specs";
@@ -55,6 +64,9 @@ const electronReady$ = Rx.Observable.fromEvent(app, "ready");
 
 // TODO: Register our protocol here, rendering index.html accordingly
 // See https://github.com/nteract/nteract/pull/1720
+electronReady$.subscribe(() => {
+  registerProtocol();
+});
 
 const fullAppReady$ = Rx.Observable.zip(electronReady$, prepareEnv).first();
 

--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -4,7 +4,12 @@ import { shell, BrowserWindow } from "electron";
 
 let launchIpynb;
 
+const URL = require("url");
+
 export function getPath(url) {
+  if (url.startsWith("file:///")) {
+    return URL.parse(url).pathname;
+  }
   const nUrl = url.substring(url.indexOf("static"), path.length);
   return path.join(__dirname, "..", "..", nUrl.replace("static/", ""));
 }

--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -15,6 +15,7 @@ export function getPath(url) {
 }
 
 export function deferURL(event, url) {
+  console.log("deferral");
   event.preventDefault();
   if (!url.startsWith("file:")) {
     shell.openExternal(url);

--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -14,6 +14,8 @@ export function deferURL(event, url) {
   if (!url.startsWith("file:")) {
     shell.openExternal(url);
   } else if (url.endsWith(".ipynb")) {
+    // TODO: Determine if `file://` already set up as if the user
+    //       has clicked a notebook link within another notebook
     launchIpynb(getPath(url));
   }
 }

--- a/src/main/protocol.js
+++ b/src/main/protocol.js
@@ -1,0 +1,129 @@
+import { protocol, BrowserWindow } from "electron";
+
+const path = require("path");
+const url = require("url");
+
+const baseAppDirectory = path.resolve(path.join(__dirname, "..", ".."));
+
+const node_modules = path.join(baseAppDirectory, "node_modules");
+
+console.log("NODE MODULES", node_modules);
+
+const template = `
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset="UTF-8">
+      <link rel="stylesheet" href="file://${node_modules}/normalize.css/normalize.css"/>
+      <link rel="stylesheet" href="file://${node_modules}/codemirror/lib/codemirror.css"/>
+      <link rel="stylesheet" href="file://${node_modules}/codemirror/addon/hint/show-hint.css"/>
+      <link rel="stylesheet" href="file://${node_modules}/codemirror/addon/dialog/dialog.css"/>
+      <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-sans-pro/source-sans-pro.css"/>
+      <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-code-pro/source-code-pro.css"/>
+      <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/octicons/octicons.css"/>
+      <script type="text/javascript" src="file://${node_modules}/mathjax-electron/resources/MathJax/MathJax.js?config=electron"></script>
+    </head>
+    <body>
+      <div id="app">
+        Loading...
+      </div>
+      <script>
+        window.onload = function deferredLoad() {
+          if (process.env.NODE_ENV === 'development') {
+              var rdev = require('electron-react-devtools');
+              rdev.install();
+          } else {
+              // Force production by default for the sake of packaging
+              process.env.NODE_ENV = 'production';
+          }
+          try {
+            require('${path.join(baseAppDirectory, "lib", "vendor")}')
+            require('${path.join(
+              baseAppDirectory,
+              "lib",
+              "webpacked-notebook"
+            )}')
+          } catch(err) {
+            const el = document.querySelector('body');
+            el.innerHTML = '';
+
+            const headerEl = document.createElement('h3');
+            const msgContainer = document.createElement('div');
+
+            headerEl.textContent = err.message;
+
+            switch(err.code) {
+              case 'MODULE_NOT_FOUND':
+                const msgEl = document.createElement('pre');
+                msgEl.textContent = 'Do you need to npm install any new packages?';
+                msgContainer.appendChild(msgEl);
+                break;
+              default:
+                if(/Module version mismatch/.test(err.message)) {
+                  msgContainer.innerHTML = '<p>the native modules mismatch, try running <a href="https://github.com/nteract/nteract#troubleshooting"><pre>npm install</pre></a> from the root of the git clone</p>';
+                }
+            }
+            el.appendChild(headerEl);
+            el.appendChild(msgContainer);
+            console.dir(err);
+          }
+        };
+      </script>
+    </body>
+  </html>
+  `;
+
+const SCHEME = "nteract";
+const SCHEME_PREFIX_LENGTH = SCHEME.length + "://".length;
+
+protocol.registerStandardSchemes(["nteract"]);
+
+/**
+ * Registers the nteract protocol
+ * NOTE: Protocols have to be registered after the `app` fires the 'ready' event.
+ */
+export function registerProtocol() {
+  protocol.registerBufferProtocol(
+    "nteract",
+    (request, callback) => {
+      console.warn("BUFFER BASED");
+      console.log(request);
+
+      const pathname = request.url.substr(SCHEME_PREFIX_LENGTH);
+      console.log(pathname);
+      const extension = path.extname(pathname);
+
+      if (extension === ".ipynb") {
+        // Custom render
+        callback({
+          mimeType: "text/html",
+          data: new Buffer(template)
+        });
+        return;
+      }
+
+      // Now we pass through to default read.
+      callback({ path: path.normalize(`${__dirname}/${pathname}`) });
+    },
+    error => {
+      if (error) console.error("Failed to register protocol");
+    }
+  );
+
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      webSecurity: false
+    }
+  });
+
+  mainWindow.loadURL(
+    url.format({
+      pathname: "someNotebook.ipynb",
+      protocol: "nteract:",
+      slashes: true
+    })
+  );
+}

--- a/src/main/protocol.js
+++ b/src/main/protocol.js
@@ -11,79 +11,79 @@ const node_modules = path.join(baseAppDirectory, "node_modules");
 
 const mime = require("mime");
 
-console.log("NODE MODULES", node_modules);
-
 const BASE_PATH = app.getAppPath();
 
-const template = `
-  <!DOCTYPE html>
-  <html>
-    <head>
-      <meta charset="UTF-8">
-      <link rel="stylesheet" href="file://${node_modules}/normalize.css/normalize.css"/>
-      <link rel="stylesheet" href="file://${node_modules}/codemirror/lib/codemirror.css"/>
-      <link rel="stylesheet" href="file://${node_modules}/codemirror/addon/hint/show-hint.css"/>
-      <link rel="stylesheet" href="file://${node_modules}/codemirror/addon/dialog/dialog.css"/>
-      <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-sans-pro/source-sans-pro.css"/>
-      <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-code-pro/source-code-pro.css"/>
-      <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/octicons/octicons.css"/>
-      <link rel="stylesheet" href="file://${BASE_PATH}/static/styles/main.css" />
-      <link rel="stylesheet" href="file://${BASE_PATH}/static/styles/theme-light.css" />
-      <script type="text/javascript" src="file://${node_modules}/mathjax-electron/resources/MathJax/MathJax.js?config=electron"></script>
-      <base href="file:///Users/kylek/" />
-    </head>
-    <body>
-      <div id="app">
-        Loading...
-      </div>
-      <script>
-        window.onload = function deferredLoad() {
-          if (process.env.NODE_ENV === 'development') {
-              var rdev = require('electron-react-devtools');
-              rdev.install();
-          } else {
-              // Force production by default for the sake of packaging
-              process.env.NODE_ENV = 'production';
-          }
-          try {
-            require('${path.join(baseAppDirectory, "lib", "vendor")}')
-            require('${path.join(
-              baseAppDirectory,
-              "lib",
-              "webpacked-notebook"
-            )}')
-          } catch(err) {
-            const el = document.querySelector('body');
-            el.innerHTML = '';
-
-            const headerEl = document.createElement('h3');
-            const msgContainer = document.createElement('div');
-
-            headerEl.textContent = err.message;
-
-            switch(err.code) {
-              case 'MODULE_NOT_FOUND':
-                const msgEl = document.createElement('pre');
-                msgEl.textContent = 'Do you need to npm install any new packages?';
-                msgContainer.appendChild(msgEl);
-                break;
-              default:
-                if(/Module version mismatch/.test(err.message)) {
-                  msgContainer.innerHTML = '<p>the native modules mismatch, try running <a href="https://github.com/nteract/nteract#troubleshooting"><pre>npm install</pre></a> from the root of the git clone</p>';
-                }
+function renderTemplate(dirpath) {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8">
+        <link rel="stylesheet" href="file://${node_modules}/normalize.css/normalize.css"/>
+        <link rel="stylesheet" href="file://${node_modules}/codemirror/lib/codemirror.css"/>
+        <link rel="stylesheet" href="file://${node_modules}/codemirror/addon/hint/show-hint.css"/>
+        <link rel="stylesheet" href="file://${node_modules}/codemirror/addon/dialog/dialog.css"/>
+        <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-sans-pro/source-sans-pro.css"/>
+        <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-code-pro/source-code-pro.css"/>
+        <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/octicons/octicons.css"/>
+        <link rel="stylesheet" href="file://${BASE_PATH}/static/styles/main.css" />
+        <link rel="stylesheet" href="file://${BASE_PATH}/static/styles/theme-light.css" />
+        <script type="text/javascript" src="file://${node_modules}/mathjax-electron/resources/MathJax/MathJax.js?config=electron"></script>
+        <base href="file://${dirpath}" />
+      </head>
+      <body>
+        <div id="app">
+          Loading...
+        </div>
+        <script>
+          window.onload = function deferredLoad() {
+            if (process.env.NODE_ENV === 'development') {
+                var rdev = require('electron-react-devtools');
+                rdev.install();
+            } else {
+                // Force production by default for the sake of packaging
+                process.env.NODE_ENV = 'production';
             }
-            el.appendChild(headerEl);
-            el.appendChild(msgContainer);
-            console.dir(err);
-          }
-        };
-      </script>
-    </body>
-  </html>
-  `;
+            try {
+              require('${path.join(baseAppDirectory, "lib", "vendor")}')
+              require('${path.join(
+                baseAppDirectory,
+                "lib",
+                "webpacked-notebook"
+              )}')
+            } catch(err) {
+              const el = document.querySelector('body');
+              el.innerHTML = '';
+
+              const headerEl = document.createElement('h3');
+              const msgContainer = document.createElement('div');
+
+              headerEl.textContent = err.message;
+
+              switch(err.code) {
+                case 'MODULE_NOT_FOUND':
+                  const msgEl = document.createElement('pre');
+                  msgEl.textContent = 'Do you need to npm install any new packages?';
+                  msgContainer.appendChild(msgEl);
+                  break;
+                default:
+                  if(/Module version mismatch/.test(err.message)) {
+                    msgContainer.innerHTML = '<p>the native modules mismatch, try running <a href="https://github.com/nteract/nteract#troubleshooting"><pre>npm install</pre></a> from the root of the git clone</p>';
+                  }
+              }
+              el.appendChild(headerEl);
+              el.appendChild(msgContainer);
+              console.dir(err);
+            }
+          };
+        </script>
+      </body>
+    </html>
+    `;
+}
 
 const SCHEME = "nteract";
-const SCHEME_PREFIX_LENGTH = SCHEME.length + "://".length;
+const SCHEME_PREFIX_LENGTH = SCHEME.length + ":/".length;
 
 protocol.registerStandardSchemes(["nteract"]);
 
@@ -92,22 +92,20 @@ protocol.registerStandardSchemes(["nteract"]);
  * NOTE: Protocols have to be registered after the `app` fires the 'ready' event.
  */
 export function registerProtocol() {
-  console.warn("REGISTERING PROTOCOL");
   protocol.registerBufferProtocol(
     "nteract",
     (request, callback) => {
-      console.warn("BUFFER BASED");
       console.log(request);
 
       const pathname = request.url.substr(SCHEME_PREFIX_LENGTH);
-      console.log("pathy", pathname);
+      console.log("PATHNAME ", pathname);
       const extension = path.extname(pathname);
 
       if (extension === ".ipynb") {
         // Custom render
         callback({
           mimeType: "text/html",
-          data: new Buffer(template)
+          data: new Buffer(renderTemplate(pathname))
         });
         return;
       }
@@ -123,22 +121,4 @@ export function registerProtocol() {
       if (error) console.error("Failed to register protocol");
     }
   );
-
-  /*
-  // Create the browser window.
-  const mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
-    webPreferences: {
-      webSecurity: false
-    }
-  });
-
-  mainWindow.loadURL(
-    url.format({
-      pathname: "someNotebook.ipynb",
-      protocol: "nteract:",
-      slashes: true
-    })
-  );*/
 }

--- a/src/main/protocol.js
+++ b/src/main/protocol.js
@@ -1,4 +1,4 @@
-import { protocol, BrowserWindow } from "electron";
+import { protocol, BrowserWindow, app } from "electron";
 
 const path = require("path");
 const url = require("url");
@@ -13,6 +13,8 @@ const mime = require("mime");
 
 console.log("NODE MODULES", node_modules);
 
+const BASE_PATH = app.getAppPath();
+
 const template = `
   <!DOCTYPE html>
   <html>
@@ -25,7 +27,10 @@ const template = `
       <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-sans-pro/source-sans-pro.css"/>
       <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/source-code-pro/source-code-pro.css"/>
       <link rel="stylesheet" href="file://${node_modules}/nteract-assets/fonts/octicons/octicons.css"/>
+      <link rel="stylesheet" href="file://${BASE_PATH}/static/styles/main.css" />
+      <link rel="stylesheet" href="file://${BASE_PATH}/static/styles/theme-light.css" />
       <script type="text/javascript" src="file://${node_modules}/mathjax-electron/resources/MathJax/MathJax.js?config=electron"></script>
+      <base href="file:///Users/kylek/" />
     </head>
     <body>
       <div id="app">

--- a/src/main/protocol.js
+++ b/src/main/protocol.js
@@ -3,9 +3,13 @@ import { protocol, BrowserWindow } from "electron";
 const path = require("path");
 const url = require("url");
 
+const fs = require("fs");
+
 const baseAppDirectory = path.resolve(path.join(__dirname, "..", ".."));
 
 const node_modules = path.join(baseAppDirectory, "node_modules");
+
+const mime = require("mime");
 
 console.log("NODE MODULES", node_modules);
 
@@ -83,6 +87,7 @@ protocol.registerStandardSchemes(["nteract"]);
  * NOTE: Protocols have to be registered after the `app` fires the 'ready' event.
  */
 export function registerProtocol() {
+  console.warn("REGISTERING PROTOCOL");
   protocol.registerBufferProtocol(
     "nteract",
     (request, callback) => {
@@ -90,7 +95,7 @@ export function registerProtocol() {
       console.log(request);
 
       const pathname = request.url.substr(SCHEME_PREFIX_LENGTH);
-      console.log(pathname);
+      console.log("pathy", pathname);
       const extension = path.extname(pathname);
 
       if (extension === ".ipynb") {
@@ -103,13 +108,18 @@ export function registerProtocol() {
       }
 
       // Now we pass through to default read.
-      callback({ path: path.normalize(`${__dirname}/${pathname}`) });
+      callback({
+        mimeType: mime.lookup(extension),
+        // TODO: Async yo
+        data: fs.readFileSync(pathname)
+      });
     },
     error => {
       if (error) console.error("Failed to register protocol");
     }
   );
 
+  /*
   // Create the browser window.
   const mainWindow = new BrowserWindow({
     width: 800,
@@ -125,5 +135,5 @@ export function registerProtocol() {
       protocol: "nteract:",
       slashes: true
     })
-  );
+  );*/
 }

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -104,7 +104,8 @@ export class Notebook extends React.PureComponent {
     if (this.stickyCellsPlaceholder) {
       // Make sure the document is vertically shifted so the top non-stickied
       // cell is always visible.
-      this.stickyCellsPlaceholder.style.height = `${this.stickyCellContainer.clientHeight}px`;
+      this.stickyCellsPlaceholder.style.height = `${this.stickyCellContainer
+        .clientHeight}px`;
     }
   }
 
@@ -246,10 +247,6 @@ export class Notebook extends React.PureComponent {
           lastSaved={this.props.lastSaved}
           kernelSpecDisplayName={this.props.kernelSpecDisplayName}
           executionState={this.props.executionState}
-        />
-        <link
-          rel="stylesheet"
-          href={`../static/styles/theme-${this.props.theme}.css`}
         />
       </div>
     );

--- a/src/notebook/head.js
+++ b/src/notebook/head.js
@@ -40,6 +40,11 @@ export class Head extends React.PureComponent {
   };
 
   render(): ?React.Element<any> {
+    if (true) {
+      // silly me
+      return null;
+    }
+
     return (
       <Helmet>
         <base href={this.props.dirname} />

--- a/src/notebook/head.js
+++ b/src/notebook/head.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-return-assign */
+/* @flow */
+import React from "react";
+import { connect } from "react-redux";
+import { Helmet } from "react-helmet";
+
+const remote = require("electron").remote;
+const BASE_PATH = remote.app.getAppPath();
+
+const path = require("path");
+const url = require("url");
+
+// TODO: Remove after provider refactor finished
+const PropTypes = require("prop-types");
+
+type Props = {
+  dirname: string,
+  theme: string
+};
+
+const mapStateToProps = (state: Object) => ({
+  dirname: url.format({
+    protocol: "file",
+    slashes: true,
+    pathname: path.resolve(state.metadata.get("filename"))
+  }),
+  theme: state.config.get("theme")
+});
+
+export class Head extends React.PureComponent {
+  props: Props;
+
+  static defaultProps = {
+    dirname: "",
+    theme: "light"
+  };
+
+  static contextTypes = {
+    store: PropTypes.object
+  };
+
+  render(): ?React.Element<any> {
+    return (
+      <Helmet>
+        <base href={this.props.dirname} />
+        <link
+          rel="stylesheet"
+          href={path.join(BASE_PATH, "static/styles/main.css")}
+        />
+        <link
+          rel="stylesheet"
+          href={path.join(
+            BASE_PATH,
+            `static/styles/theme-${this.props.theme}.css`
+          )}
+        />
+      </Helmet>
+    );
+  }
+}
+
+export default connect(mapStateToProps)(Head);

--- a/src/notebook/index.js
+++ b/src/notebook/index.js
@@ -11,6 +11,7 @@ import NotificationSystem from "react-notification-system";
 import configureStore from "./store";
 import { reducers } from "./reducers";
 import Notebook from "./components/notebook";
+import Head from "./head";
 
 import { setNotificationSystem } from "./actions";
 
@@ -24,6 +25,8 @@ import {
   MetadataRecord,
   CommsRecord
 } from "./records";
+
+const path = require("path");
 
 const store = configureStore(
   {
@@ -59,7 +62,7 @@ class App extends React.PureComponent {
     return (
       <Provider store={store}>
         <div>
-          <link rel="stylesheet" href="../static/styles/main.css" />
+          <Head />
           <Notebook />
           <NotificationSystem
             ref={notificationSystem => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -29,7 +29,8 @@ global.HTMLElement = global.window.HTMLElement;
 global.console.debug = () => {};
 
 global.navigator = {
-  userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) nteract/0.0.12 Chrome/50.0.2661.102 Electron/1.1.3 Safari/537.36",
+  userAgent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) nteract/0.0.12 Chrome/50.0.2661.102 Electron/1.1.3 Safari/537.36",
   platform: "MacIntel"
 };
 
@@ -96,7 +97,8 @@ mock("electron", {
           return "/home/home/on/the/range";
         }
         throw Error("not mocked");
-      }
+      },
+      getAppPath: () => "/"
     },
     dialog: {
       showSaveDialog: () => {}


### PR DESCRIPTION
This makes relative assets load properly on the page. At the same time, it's also made our elements destined for `<head />` go to one `<Head />` component, managed by [react-helmet](https://github.com/nfl/react-helmet).

I've only done some initial testing, and while images and links are displaying properly there are a few things to fix up:

* [x] Our main handler for launching notebooks doesn't handle `file://` links for notebooks right (they get processed in a really weird way...)
* [ ] All assets are shown right after the second React render of the element containing it. Basically, since the text hasn't changed in the source of the markdown, there's no reason to flush a new element out.

I might see if there's a better way to handle this where the literal URL for every notebook is what we load with `loadURL`.

At any rate, demo with a notebook from my desktop:

![screen shot 2017-05-29 at 11 50 44 am](https://cloud.githubusercontent.com/assets/836375/26559528/100190e4-4465-11e7-809c-549e9c0ff057.png)

The link text at the bottom is a result of me copying the link output and pasting the URL (success!).

When finished, this closes #349, #1242.