### PR TITLE
fix(CI): Don't update yarn.lock a second time

### DIFF
--- a/scripts/yarn.sh
+++ b/scripts/yarn.sh
@@ -17,7 +17,7 @@ echo "Switching to branch $TRAVIS_PULL_REQUEST_BRANCH"
 git checkout $TRAVIS_PULL_REQUEST_BRANCH
 
 # See if commit message includes "update"
-git log --name-status HEAD^..HEAD | grep "update" || exit 0
+git log --name-status HEAD^..HEAD | grep "chore(package): update" || exit 0
 
 echo "(Creat/updat)ing lockfile"
 yarn


### PR DESCRIPTION
This should prevent repeated updates as happening in #1721 by being more explicit.