### PR TITLE
BREAKING CHANGE: Remove immutable from display-area and transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "electron-builder": "^18.2.2",
     "electron-mocha": "^3.2.0",
     "enzyme": "^2.7.1",
+    "enzyme-to-json": "^1.5.1",
     "esdoc": "^1.0.0-alpha.1",
     "eslint": "3.19.0",
     "eslint-config-prettier": "^2.1.1",

--- a/packages/display-area/README.md
+++ b/packages/display-area/README.md
@@ -1,4 +1,4 @@
-# Display Area 
+# Display Area
 Render Jupyter notebook outputs in a trim little React component.
 
 ## Installation
@@ -14,10 +14,10 @@ import Display from '@nteract/display-area`
 <Display outputs={outputs} />
 ```
 
-Here `outputs` is an Immutable.js structure with all the outputs of a cell. Note: this does require trim, clean editions of the multiline cells as is done in `@nteract/commutable`.
+Here `outputs` is an Object with all the outputs of a cell. Note: this does require trim, clean editions of the multiline cells as is done in `@nteract/commutable`.
 
 Used in context of a notebook, you will likely be extracting it from a cell:
 
 ```jsx
-<Display outputs={this.props.cell.get('outputs')} />
+<Display outputs={this.props.cell.outputs} />
 ```

--- a/packages/display-area/__tests__/display-spec.js
+++ b/packages/display-area/__tests__/display-spec.js
@@ -9,14 +9,14 @@ import { DEFAULT_SCROLL_HEIGHT } from "../src/display";
 
 describe("Display", () => {
   it("does not display when status is hidden", () => {
-    const outputs = Immutable.fromJS([
+    const outputs = [
       {
         output_type: "display_data",
         data: {
           "text/html": "Test content"
         }
       }
-    ]);
+    ];
     const component = shallow(
       <Display
         outputs={outputs}
@@ -29,14 +29,14 @@ describe("Display", () => {
     expect(component.find("div.cell_display")).toHaveLength(0);
   });
   it("displays status when it is not hidden", () => {
-    const outputs = Immutable.fromJS([
+    const outputs = [
       {
         output_type: "display_data",
         data: {
           "text/html": "Test content"
         }
       }
-    ]);
+    ];
     const component = shallow(
       <Display
         outputs={outputs}
@@ -49,14 +49,14 @@ describe("Display", () => {
     expect(component.find("div.cell_display")).toHaveLength(1);
   });
   it("sets expanded cell style correctly", () => {
-    const outputs = Immutable.fromJS([
+    const outputs = [
       {
         output_type: "display_data",
         data: {
           "text/html": "Test content"
         }
       }
-    ]);
+    ];
     const component = shallow(
       <Display
         outputs={outputs}
@@ -73,14 +73,14 @@ describe("Display", () => {
     expect(props.style.maxHeight).toEqual("100%");
   });
   it("sets non expanded cell style correctly", () => {
-    const outputs = Immutable.fromJS([
+    const outputs = [
       {
         output_type: "display_data",
         data: {
           "text/html": "Test content"
         }
       }
-    ]);
+    ];
     const component = shallow(
       <Display
         outputs={outputs}

--- a/packages/display-area/__tests__/output-spec.js
+++ b/packages/display-area/__tests__/output-spec.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { shallow } from "enzyme";
-import Immutable from "immutable";
 
 import Output from "../src/output";
 import RichestMime from "../src/richest-mime";
@@ -10,21 +9,21 @@ const Ansi = require("ansi-to-react");
 
 describe("Output", () => {
   it("handles display data", () => {
-    const output = Immutable.fromJS({
+    const output = {
       output_type: "display_data",
       data: {
         "text/html": "<h1>Multiple</h1>",
         "text/plain": "<IPython.core.display.HTML object>"
       },
       metadata: {}
-    });
+    };
 
     const component = shallow(<Output output={output} />);
     expect(component.type()).toEqual(RichestMime);
-    expect(component.first().props().bundle).toEqual(output.get("data"));
+    expect(component.first().props().bundle).toEqual(output.data);
   });
   it("handles execute_component", () => {
-    const output = Immutable.fromJS({
+    const output = {
       data: {
         "text/html": [
           '<img src="https://avatars2.githubusercontent.com/u/12401040?v=3&s=200"/>'
@@ -34,38 +33,38 @@ describe("Output", () => {
       execution_count: 7,
       metadata: {},
       output_type: "execute_result"
-    });
+    };
 
     const component = shallow(<Output output={output} />);
     expect(component.type()).toEqual(RichestMime);
-    expect(component.first().props().bundle).toEqual(output.get("data"));
+    expect(component.first().props().bundle).toEqual(output.data);
   });
   it("handles stream data", () => {
-    const output = Immutable.fromJS({
+    const output = {
       output_type: "stream",
       name: "stdout",
       text: "hey"
-    });
+    };
 
     const component = shallow(<Output output={output} />);
     expect(component.type()).toEqual(Ansi);
   });
   it("handles errors/tracebacks", () => {
-    const output = Immutable.fromJS({
+    const output = {
       output_type: "error",
       traceback: ["whoa there buckaroo!"],
       ename: "BuckarooException",
       evalue: "whoa!"
-    });
+    };
 
     const component = shallow(<Output output={output} />);
     expect(component.type()).toEqual(Ansi);
 
-    const outputNoTraceback = Immutable.fromJS({
+    const outputNoTraceback = {
       output_type: "error",
       ename: "BuckarooException",
       evalue: "whoa!"
-    });
+    };
 
     const component2 = shallow(<Output output={outputNoTraceback} />);
     expect(component2.type()).toEqual(Ansi);

--- a/packages/display-area/__tests__/richest-mime-spec.js
+++ b/packages/display-area/__tests__/richest-mime-spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Immutable from "immutable";
 
 import { shallow } from "enzyme";
 
@@ -8,13 +7,13 @@ import { RichestMime } from "../";
 
 describe("RichestMime", () => {
   it("renders a mimebundle", () => {
-    const models = Immutable.fromJS({});
+    const models = {};
     const rm = shallow(
       <RichestMime
         displayOrder={displayOrder}
         transforms={transforms}
-        bundle={Immutable.fromJS({ "text/plain": "THE DATA" })}
-        metadata={Immutable.fromJS({ "text/plain": "alright" })}
+        bundle={{ "text/plain": "THE DATA" }}
+        metadata={{ "text/plain": "alright" }}
         models={models}
       />
     );
@@ -32,7 +31,7 @@ describe("RichestMime", () => {
       <RichestMime
         displayOrder={displayOrder}
         transforms={transforms}
-        bundle={Immutable.fromJS({ "application/ipynb+json": "{}" })}
+        bundle={{ "application/ipynb+json": "{}" }}
       />
     );
 

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -28,7 +28,6 @@
     "ansi-to-react": "^1.4.2"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1",
     "react": "^15.5.4"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",

--- a/packages/display-area/src/display.js
+++ b/packages/display-area/src/display.js
@@ -1,19 +1,18 @@
 // @flow
 import React from "react";
-import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import { transforms, displayOrder } from "@nteract/transforms";
 
 import Output from "./output";
 
 type Props = {
-  displayOrder: ImmutableList<string>,
-  outputs: ImmutableList<any>,
-  transforms: ImmutableMap<string, any>,
+  displayOrder: Array<string>,
+  outputs: Array<any>,
+  transforms: Object,
   theme: string,
   expanded: boolean,
   isHidden: boolean,
-  models: ImmutableMap<string, any>
+  models: Object
 };
 
 export const DEFAULT_SCROLL_HEIGHT = 600;

--- a/packages/display-area/src/output.js
+++ b/packages/display-area/src/output.js
@@ -1,6 +1,5 @@
 // @flow
 import React from "react";
-import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 import Ansi from "ansi-to-react";
 
 import { transforms, displayOrder } from "@nteract/transforms";
@@ -9,29 +8,29 @@ import RichestMime from "./richest-mime";
 
 type Props = {
   expanded: boolean,
-  displayOrder: ImmutableList<string>,
+  displayOrder: Array<string>,
   output: any,
-  transforms: ImmutableMap<string, any>,
+  transforms: Object,
   theme: string,
-  models: ImmutableMap<string, any>
+  models: Object
 };
 
 const classPrefix = "nteract-display-area-";
 
 export default function Output(props: Props): ?React.Element<any> | null {
   const output = props.output;
-  const outputType = output.get("output_type");
+  const outputType = output.output_type;
   switch (outputType) {
     case "execute_result":
     // We can defer to display data here, the cell number will be handled
-    // separately. For reference, it is output.get('execution_count')
+    // separately. For reference, it is output.execution_count
     // The execution_count belongs in the component above if
     // this is a code cell
 
     // falls through
     case "display_data": {
-      const bundle = output.get("data");
-      const metadata = output.get("metadata");
+      const bundle = output.data;
+      const metadata = output.metadata;
       return (
         <RichestMime
           expanded={props.expanded}
@@ -45,8 +44,8 @@ export default function Output(props: Props): ?React.Element<any> | null {
       );
     }
     case "stream": {
-      const text = output.get("text");
-      const name = output.get("name");
+      const text = output.text;
+      const name = output.name;
       switch (name) {
         case "stdout":
         case "stderr":
@@ -56,12 +55,12 @@ export default function Output(props: Props): ?React.Element<any> | null {
       }
     }
     case "error": {
-      const traceback = output.get("traceback");
+      const traceback = output.traceback;
       if (!traceback) {
         return (
           <Ansi
             className={classPrefix + "traceback"}
-          >{`${output.get("ename")}: ${output.get("evalue")}`}</Ansi>
+          >{`${output.ename}: ${output.evalue}`}</Ansi>
         );
       }
       return (

--- a/packages/display-area/src/richest-mime.js
+++ b/packages/display-area/src/richest-mime.js
@@ -1,17 +1,16 @@
 // @flow
 import React from "react";
-import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import { richestMimetype, transforms, displayOrder } from "@nteract/transforms";
 
 type Props = {
   expanded: boolean,
-  displayOrder: ImmutableList<string>,
-  transforms: ImmutableMap<string, any>,
-  bundle: ImmutableMap<string, any>,
-  metadata: ImmutableMap<string, any>,
+  displayOrder: Array<string>,
+  transforms: Object,
+  bundle: Object,
+  metadata: Object,
   theme: string,
-  models?: ImmutableMap<string, any>
+  models?: Object
 };
 
 export default class RichestMime extends React.Component {
@@ -21,9 +20,9 @@ export default class RichestMime extends React.Component {
     transforms,
     displayOrder,
     theme: "light",
-    metadata: new ImmutableMap(),
-    bundle: new ImmutableMap(),
-    models: new ImmutableMap()
+    metadata: {},
+    bundle: {},
+    models: {}
   };
 
   shouldComponentUpdate(nextProps: Props): boolean {
@@ -52,9 +51,9 @@ export default class RichestMime extends React.Component {
       return null;
     }
 
-    const Transform = this.props.transforms.get(mimetype);
-    const data = this.props.bundle.get(mimetype);
-    const metadata = this.props.metadata.get(mimetype);
+    const Transform = this.props.transforms[mimetype];
+    const data = this.props.bundle[mimetype];
+    const metadata = this.props.metadata[mimetype];
     return (
       <Transform
         expanded={this.props.expanded}

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Notebook accepts an Immutable.List of cells 1`] = `
+<Notebook
+  displayOrder={
+    Array [
+      "application/json",
+      "application/javascript",
+      "text/html",
+      "text/markdown",
+      "text/latex",
+      "image/svg+xml",
+      "image/gif",
+      "image/png",
+      "image/jpeg",
+      "text/plain",
+    ]
+  }
+  notebook={
+    Immutable.Map {
+      cellOrder: Immutable.List [
+        4,
+        5,
+      ],
+      cellMap: Immutable.Map {
+        4: Immutable.Map {
+          cell_type: "markdown",
+          source: "## The Notable Nteract Notebook
+          
+          **It's a notebook!**
+          ",
+          metadata: Immutable.Map {
+          },
+        },
+        5: Immutable.Map {
+          cell_type: "code",
+          source: "import IPython
+          
+          from IPython.display import HTML
+          from IPython.display import Markdown
+          from IPython.display import display
+          
+          display(HTML('<h1>Multiple</h1>'))
+          display(HTML('<p>Display Elements</p>'))
+          display(Markdown('**awesome**'))
+          
+          print('hey')
+          42",
+          outputs: Immutable.List [
+            Immutable.Map {
+              output_type: "display_data",
+              data: Immutable.Map {
+                text/plain: "<IPython.core.display.HTML object>",
+              },
+              metadata: Immutable.Map {
+              },
+            },
+          ],
+          execution_count: 11,
+          metadata: Immutable.Map {
+            collapsed: false,
+          },
+        },
+      },
+      nbformat_minor: 0,
+      nbformat: 4,
+      metadata: Immutable.Map {
+        kernelspec: Immutable.Map {
+          display_name: "Python 3",
+          language: "python",
+          name: "python3",
+        },
+        language_info: Immutable.Map {
+          codemirror_mode: Immutable.Map {
+            name: "ipython",
+            version: 3,
+          },
+          file_extension: ".py",
+          mimetype: "text/x-python",
+          name: "python",
+          nbconvert_exporter: "python",
+          pygments_lexer: "ipython3",
+          version: "3.5.1",
+        },
+      },
+    }
+  }
+  theme="light"
+  tip={true}
+  transforms={
+    Object {
+      "application/javascript": [Function],
+      "application/json": [Function],
+      "image/gif": [Function],
+      "image/jpeg": [Function],
+      "image/png": [Function],
+      "image/svg+xml": [Function],
+      "text/html": [Function],
+      "text/latex": [Function],
+      "text/markdown": [Function],
+      "text/plain": [Function],
+    }
+  }
+/>
+`;
+
+exports[`Notebook accepts an Object of cells 1`] = `
+<Notebook
+  displayOrder={
+    Array [
+      "application/json",
+      "application/javascript",
+      "text/html",
+      "text/markdown",
+      "text/latex",
+      "image/svg+xml",
+      "image/gif",
+      "image/png",
+      "image/jpeg",
+      "text/plain",
+    ]
+  }
+  notebook={
+    Immutable.Map {
+      cellOrder: Immutable.List [
+        6,
+        7,
+      ],
+      cellMap: Immutable.Map {
+        6: Immutable.Map {
+          cell_type: "markdown",
+          source: "## The Notable Nteract Notebook
+          
+          **It's a notebook!**
+          ",
+          metadata: Immutable.Map {
+          },
+        },
+        7: Immutable.Map {
+          cell_type: "code",
+          source: "import IPython
+          
+          from IPython.display import HTML
+          from IPython.display import Markdown
+          from IPython.display import display
+          
+          display(HTML('<h1>Multiple</h1>'))
+          display(HTML('<p>Display Elements</p>'))
+          display(Markdown('**awesome**'))
+          
+          print('hey')
+          42",
+          outputs: Immutable.List [
+            Immutable.Map {
+              output_type: "display_data",
+              data: Immutable.Map {
+                text/plain: "<IPython.core.display.HTML object>",
+              },
+              metadata: Immutable.Map {
+              },
+            },
+          ],
+          execution_count: 11,
+          metadata: Immutable.Map {
+            collapsed: false,
+          },
+        },
+      },
+      nbformat_minor: 0,
+      nbformat: 4,
+      metadata: Immutable.Map {
+        kernelspec: Immutable.Map {
+          display_name: "Python 3",
+          language: "python",
+          name: "python3",
+        },
+        language_info: Immutable.Map {
+          codemirror_mode: Immutable.Map {
+            name: "ipython",
+            version: 3,
+          },
+          file_extension: ".py",
+          mimetype: "text/x-python",
+          name: "python",
+          nbconvert_exporter: "python",
+          pygments_lexer: "ipython3",
+          version: "3.5.1",
+        },
+      },
+    }
+  }
+  theme="light"
+  tip={true}
+  transforms={
+    Object {
+      "application/javascript": [Function],
+      "application/json": [Function],
+      "image/gif": [Function],
+      "image/jpeg": [Function],
+      "image/png": [Function],
+      "image/svg+xml": [Function],
+      "text/html": [Function],
+      "text/latex": [Function],
+      "text/markdown": [Function],
+      "text/plain": [Function],
+    }
+  }
+/>
+`;

--- a/packages/notebook-preview/__tests__/index.test.js
+++ b/packages/notebook-preview/__tests__/index.test.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { shallow } from "enzyme";
+import toJson from "enzyme-to-json";
+
+import { displayOrder, transforms } from "@nteract/transforms";
+
+import NotebookPreview from "./../src";
+
+import { dummyCommutable, dummyJSON } from "./../../../test/renderer/dummy-nb";
+
+// In order to get reproducable snapshots we nee to mock the uuid package
+jest.mock("uuid", () => {
+  let uuid = 1;
+  return {
+    v4: jest.fn(() => uuid++)
+  };
+});
+
+describe("Notebook", () => {
+  it("accepts an Immutable.List of cells", () => {
+    const component = shallow(
+      <NotebookPreview
+        notebook={dummyCommutable}
+        theme="light"
+        tip
+        displayOrder={displayOrder}
+        transforms={transforms}
+      />
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("accepts an Object of cells", () => {
+    const component = shallow(
+      <NotebookPreview
+        notebook={dummyJSON}
+        theme="light"
+        tip
+        displayOrder={displayOrder}
+        transforms={transforms}
+      />
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+});

--- a/packages/notebook-preview/src/cell.js
+++ b/packages/notebook-preview/src/cell.js
@@ -9,7 +9,7 @@ import RawCell from "./raw-cell";
 
 export type CellProps = {
   cell: any,
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   id: string,
   language: string,
   theme: string,

--- a/packages/notebook-preview/src/code-cell.js
+++ b/packages/notebook-preview/src/code-cell.js
@@ -11,12 +11,12 @@ import LatexRenderer from "./latex";
 
 type Props = {
   cell: ImmutableMap<string, any>,
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   id: string,
   language: string,
   theme: string,
   tip: boolean,
-  transforms: ImmutableMap<string, any>,
+  transforms: Object,
   running: boolean,
   models: ImmutableMap<string, any>
 };
@@ -77,14 +77,14 @@ class CodeCell extends React.PureComponent {
           <div className="outputs">
             <Display
               className="outputs-display"
-              outputs={this.props.cell.get("outputs")}
+              outputs={this.props.cell.get("outputs").toJS()}
               displayOrder={this.props.displayOrder}
               transforms={this.props.transforms}
               theme={this.props.theme}
               tip={this.props.tip}
               expanded={this.isOutputExpanded()}
               isHidden={this.isOutputHidden()}
-              models={this.props.models}
+              models={this.props.models.toJS()}
             />
           </div>
         </LatexRenderer>

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -7,8 +7,8 @@ const Immutable = require("immutable");
 
 type Props = {
   notebook: Immutable.Map<string, any> | Object,
-  displayOrder: Immutable.List<string>,
-  transforms: Immutable.Map<string, any>,
+  displayOrder: Array<string>,
+  transforms: Object,
   tip: boolean
 };
 

--- a/packages/notebook-preview/src/notebook.js
+++ b/packages/notebook-preview/src/notebook.js
@@ -11,9 +11,9 @@ import Cell from "./cell";
 const PropTypes = require("prop-types");
 
 type Props = {
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   notebook: any,
-  transforms: ImmutableMap<string, any>,
+  transforms: Object,
   theme: string,
   tip: boolean
 };

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -16,7 +16,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1",
     "react": "^15.5.4"
   },
   "license": "BSD-3-Clause",

--- a/packages/transform-geojson/__tests__/geojson.test.js
+++ b/packages/transform-geojson/__tests__/geojson.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import _ from "lodash";
-import { Map } from "immutable";
 
 import { mount } from "enzyme";
 
@@ -50,7 +49,7 @@ const geojson = deepFreeze({
   ]
 });
 
-const metadata = Map({ expanded: true });
+const metadata = { expanded: true };
 
 describe("GeoJSONTransform", () => {
   it("renders a map", () => {

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -15,7 +15,6 @@
     "leaflet": "^1.0.3"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1",
     "react": "^15.5.4"
   },
   "publishConfig": {

--- a/packages/transform-geojson/src/index.js
+++ b/packages/transform-geojson/src/index.js
@@ -2,11 +2,10 @@
 /* eslint class-methods-use-this: 0 */
 import React from "react";
 import L from "leaflet";
-import { Map } from "immutable";
 
 type Props = {
   data: Object,
-  metadata: Map<string, any>,
+  metadata: Object,
   theme: string
 };
 type TileTheme = "dark" | "light";
@@ -93,19 +92,17 @@ export class GeoJSONTransform extends React.Component {
     // const urlTemplate = (metadata && metadata.url_template) ||
     //   'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     const urlTemplate =
-      this.props.metadata.get("url_template") ||
+      this.props.metadata.url_template ||
       "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWlja3QiLCJhIjoiLXJIRS1NbyJ9.EfVT76g4A5dyuApW_zuIFQ";
     // const layerOptions = (metadata && metadata.layer_options) || {
     //   attribution: 'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
     //   minZoom: 0,
     //   maxZoom: 18
     // };
-    const layerOptions = this.props.metadata.get("layer_options")
-      ? this.props.metadata.get("layer_options").toJS()
-      : {
-          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-          id: `mapbox.${theme}`
-        };
+    const layerOptions = this.props.metadata.layer_options || {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      id: `mapbox.${theme}`
+    };
     return [urlTemplate, layerOptions];
   };
 

--- a/packages/transform-model-debug/__tests__/model-debug.test.js
+++ b/packages/transform-model-debug/__tests__/model-debug.test.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Immutable from "immutable";
 
 import { mount } from "enzyme";
 
@@ -8,10 +7,7 @@ import ModelDebug from "../src";
 describe("ModelDebug", () => {
   it("renders all models when no modelID set", () => {
     const modelDebugWrapper = mount(
-      <ModelDebug
-        data={"hey"}
-        models={Immutable.fromJS({ 1: { fun: true } })}
-      />
+      <ModelDebug data={"hey"} models={{ 1: { fun: true } }} />
     );
 
     const instance = modelDebugWrapper.instance();

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -16,7 +16,6 @@
     "access": "public"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1",
     "react": "^15.5.4"
   },
   "license": "BSD-3-Clause"

--- a/packages/transform-model-debug/src/index.js
+++ b/packages/transform-model-debug/src/index.js
@@ -1,11 +1,9 @@
 /* @flow */
 import React from "react";
 
-const Immutable = require("immutable");
-
 type Props = {
   data: string,
-  models: Immutable.Map<string, any>,
+  models: Object,
   modelID: string
 };
 
@@ -22,7 +20,7 @@ class ModelDebug extends React.Component {
     // TODO: Provide model IDs on transient field
     // For now, if modelID is not provided (or model does not exist),
     // show all the models
-    const model = models.get(modelID, models);
+    const model = models.modelID || models;
     return (
       <div>
         <h1>{JSON.stringify(data, null, 2)}</h1>

--- a/packages/transforms-full/README.md
+++ b/packages/transforms-full/README.md
@@ -18,7 +18,7 @@ release of the display area (:soon:).
 npm install @nteract/transforms-full
 ```
 
-Note: React and Immutable are peer dependencies you'll have to install yourself.
+Note: React is a peer dependencies you'll have to install yourself.
 
 ## Usage
 
@@ -31,22 +31,20 @@ import {
   displayOrder,
 } from '@nteract/transforms-full'
 
-import Immutable from 'immutable'
-
 // Jupyter style MIME bundle
-const bundle = new Immutable.Map({
+const bundle = {
   'text/plain': 'This is great',
   'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-})
+}
 
 // Find out which mimetype is the richest
 const mimetype = richestMimetype(bundle, transforms)
 
 // Get the matching React.Component for that mimetype
-let Transform = transforms.get(mimetype)
+let Transform = transforms[mimetype]
 
 // Create a React element
-return <Transform data={bundle.get(mimetype)} />
+return <Transform data={bundle[mimetype]} />
 ```
 
 ### Adding New Transforms
@@ -67,5 +65,5 @@ registry = registerTransform(registry, someCustomTransform);
 
 ...
 
-let Transform = registry.transforms.get(mimetype);
+const Transform = registry.transforms[mimetype];
 ```

--- a/packages/transforms/README.md
+++ b/packages/transforms/README.md
@@ -11,7 +11,7 @@ release of the display area (:soon:).
 npm install @nteract/transforms
 ```
 
-Note: React and Immutable are peer dependencies you'll have to install yourself.
+Note: React is a peer dependencies you'll have to install yourself.
 
 ## Usage
 
@@ -24,22 +24,20 @@ import {
   standardTransforms,
 } from '@nteract/transforms'
 
-import Immutable from 'immutable'
-
 // Jupyter style MIME bundle
-const bundle = new Immutable.Map({
+const bundle = {
   'text/plain': 'This is great',
   'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-})
+}
 
 // Find out which mimetype is the richest
 const mimetype = richestMimetype(bundle, standardDisplayOrder, standardTransforms)
 
 // Get the matching React.Component for that mimetype
-let Transform = standardTransforms.get(mimetype)
+let Transform = standardTransforms[mimetype]
 
 // Create a React element
-return <Transform data={bundle.get(mimetype)} />
+return <Transform data={bundle[mimetype]} />
 ```
 
 ### Adding New Transforms
@@ -64,5 +62,5 @@ const {
 
 ...
 
-let Transform = transforms.get(mimetype);
+const Transform = transforms[mimetype];
 ```

--- a/packages/transforms/__tests__/index-spec.js
+++ b/packages/transforms/__tests__/index-spec.js
@@ -1,34 +1,25 @@
-import { List, Map } from "immutable";
-
 import TextDisplay from "../src/text";
 
 import { richestMimetype, transforms } from "../src";
 
 describe("richestMimetype", () => {
   it("picks the richest of the mimetypes from a bundle with defaults", () => {
-    const mimeBundle = new Map({
-      "text/plain": "Hello World"
-    });
+    const mimeBundle = { "text/plain": "Hello World" };
 
     expect(richestMimetype(mimeBundle)).toEqual("text/plain");
 
     expect(
-      richestMimetype(
-        new Map({
-          "text/plain": "Hello World",
-          "image/png": "imageData"
-        })
-      )
+      richestMimetype({ "text/plain": "Hello World", "image/png": "imageData" })
     ).toEqual("image/png");
   });
   it("falls back to a simpler mimetype if a transform is not available", () => {
-    const mimeBundle = new Map({
+    const mimeBundle = {
       "text/plain": "Hello World",
       "text/html": "<b>NIY</b>"
-    });
+    };
 
-    const order = new List(["text/html", "text/plain"]);
-    const myTransforms = new Map({ "text/plain": TextDisplay });
+    const order = ["text/html", "text/plain"];
+    const myTransforms = { "text/plain": TextDisplay };
 
     const mimetype = richestMimetype(mimeBundle, order, myTransforms);
     expect(mimetype).toEqual("text/plain");
@@ -37,13 +28,13 @@ describe("richestMimetype", () => {
 
 describe("transforms", () => {
   it("is a collection of default transforms that provide React components", () => {
-    const mimeBundle = new Map({
+    const mimeBundle = {
       "text/plain": "Hello World",
       "text/html": "<b>NIY</b>"
-    });
+    };
 
-    const mimetype = richestMimetype(mimeBundle, new List(["text/plain"]));
-    const Element = transforms.get(mimetype);
+    const mimetype = richestMimetype(mimeBundle, ["text/plain"]);
+    const Element = transforms[mimetype];
 
     expect(Element).toEqual(TextDisplay);
   });

--- a/packages/transforms/__tests__/index-spec.js
+++ b/packages/transforms/__tests__/index-spec.js
@@ -4,13 +4,18 @@ import { richestMimetype, transforms } from "../src";
 
 describe("richestMimetype", () => {
   it("picks the richest of the mimetypes from a bundle with defaults", () => {
-    const mimeBundle = { "text/plain": "Hello World" };
+    const singleMimeBundle = { "text/plain": "Hello World" };
+    const mimeBundle = {
+      "text/plain": "Hello World",
+      "image/png": "imageData"
+    };
 
-    expect(richestMimetype(mimeBundle)).toEqual("text/plain");
+    expect(richestMimetype(singleMimeBundle)).toEqual("text/plain");
+    expect(richestMimetype(Object.freeze(singleMimeBundle))).toEqual(
+      "text/plain"
+    );
 
-    expect(
-      richestMimetype({ "text/plain": "Hello World", "image/png": "imageData" })
-    ).toEqual("image/png");
+    expect(richestMimetype(Object.freeze(mimeBundle))).toEqual("image/png");
   });
   it("falls back to a simpler mimetype if a transform is not available", () => {
     const mimeBundle = {

--- a/packages/transforms/__tests__/json-spec.js
+++ b/packages/transforms/__tests__/json-spec.js
@@ -1,12 +1,11 @@
 import React from "react";
-import Immutable from "immutable";
 import JSONTree from "react-json-tree";
 
 import { shallow } from "enzyme";
 
 import JsonDisplay from "../src/json";
 
-const baseData = Immutable.fromJS({ name: "Octocat" });
+const baseData = { name: "Octocat" };
 
 describe("JsonDisplay", () => {
   it("renders a <JSONTree /> component", () => {
@@ -21,7 +20,7 @@ describe("JsonDisplay", () => {
   });
 
   it("should expand json tree if expanded metadata is true", () => {
-    const metadata = Immutable.fromJS({ expanded: true });
+    const metadata = { expanded: true };
     const component = shallow(
       <JsonDisplay data={baseData} theme="light" metadata={metadata} />
     );

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -37,7 +37,6 @@
     "react-json-tree": "^0.10.9"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1",
     "react": "^15.5.4"
   }
 }

--- a/packages/transforms/src/html.js
+++ b/packages/transforms/src/html.js
@@ -17,6 +17,7 @@ export function createFragment(html: string): Node {
 export default class HTMLDisplay extends React.Component {
   props: Props;
   el: HTMLElement;
+  static MIMETYPE = "text/html";
 
   componentDidMount(): void {
     this.el.appendChild(createFragment(this.props.data));

--- a/packages/transforms/src/image.js
+++ b/packages/transforms/src/image.js
@@ -25,14 +25,26 @@ export default function ImageDisplay(props: TopProps): ?React.Element<any> {
   );
 }
 
-export function PNGDisplay(props: ImageProps): ?React.Element<any> {
-  return <ImageDisplay mimetype="image/png" {...props} />;
+export class PNGDisplay extends React.Component {
+  props: ImageProps;
+  static MIMETYPE = "image/png";
+  render() {
+    return <ImageDisplay mimetype="image/png" {...this.props} />;
+  }
 }
 
-export function JPEGDisplay(props: ImageProps): ?React.Element<any> {
-  return <ImageDisplay mimetype="image/jpeg" {...props} />;
+export class JPEGDisplay extends React.Component {
+  props: ImageProps;
+  static MIMETYPE = "image/jpeg";
+  render() {
+    return <ImageDisplay mimetype="image/jpeg" {...this.props} />;
+  }
 }
 
-export function GIFDisplay(props: ImageProps): ?React.Element<any> {
-  return <ImageDisplay mimetype="image/gif" {...props} />;
+export class GIFDisplay extends React.Component {
+  props: ImageProps;
+  static MIMETYPE = "image/gif";
+  render() {
+    return <ImageDisplay mimetype="image/gif" {...this.props} />;
+  }
 }

--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -1,5 +1,4 @@
 /* @flow */
-import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 // Needed for flow
 /* eslint-disable no-unused-vars */
@@ -12,82 +11,76 @@ import JavaScriptDisplay from "./javascript";
 import HTMLDisplay from "./html";
 import MarkdownDisplay from "./markdown";
 import LaTeXDisplay from "./latex";
-
 import SVGDisplay from "./svg";
-
 import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image";
 
 declare class Transform extends React.Component {
   MIMETYPE: string
 }
 
-type Transforms = ImmutableMap<string, Transform>;
-type DisplayOrder = ImmutableList<string>;
+type Transforms = { [string]: Transform };
+type DisplayOrder = Array<string>;
 
 export type TransformRegister = {
   transforms: Transforms,
   displayOrder: DisplayOrder
 };
 
-export const standardTransforms: Transforms = new ImmutableMap({
-  "text/plain": TextDisplay,
-  "image/png": PNGDisplay,
-  "image/jpeg": JPEGDisplay,
-  "image/gif": GIFDisplay,
-  "image/svg+xml": SVGDisplay,
-  "text/html": HTMLDisplay,
-  "text/markdown": MarkdownDisplay,
-  "text/latex": LaTeXDisplay,
-  "application/json": JsonDisplay,
-  "application/javascript": JavaScriptDisplay
+const tfs = [
+  JsonDisplay,
+  JavaScriptDisplay,
+  HTMLDisplay,
+  MarkdownDisplay,
+  LaTeXDisplay,
+  SVGDisplay,
+  GIFDisplay,
+  PNGDisplay,
+  JPEGDisplay,
+  TextDisplay
+];
+
+export const standardTransforms: Transforms = {};
+
+tfs.forEach(transform => {
+  standardTransforms[transform.MIMETYPE] = transform;
 });
 
-export const standardDisplayOrder: DisplayOrder = new ImmutableList([
-  "application/json",
-  "application/javascript",
-  "text/html",
-  "image/svg+xml",
-  "text/markdown",
-  "text/latex",
-  "image/svg+xml",
-  "image/gif",
-  "image/png",
-  "image/jpeg",
-  "application/pdf",
-  "text/plain"
-]);
+export const standardDisplayOrder: DisplayOrder = tfs.map(
+  transform => transform.MIMETYPE
+);
 
 export function registerTransform(
   { transforms, displayOrder }: TransformRegister,
   transform: Transform
 ) {
   return {
-    transforms: transforms.set(transform.MIMETYPE, transform),
-    displayOrder: displayOrder.insert(0, transform.MIMETYPE)
+    transforms: {
+      ...transforms,
+      [transform.MIMETYPE]: transform
+    },
+    displayOrder: [transform.MIMETYPE, ...displayOrder]
   };
 }
 
 /**
  * Choose the richest mimetype available based on the displayOrder and transforms
- * @param  {ImmutableMap}   bundle - Map({mimetype1: data1, mimetype2: data2, ...})
- * @param  {ImmutableList}  ordered list of mimetypes - List(['text/html', 'text/plain'])
- * @param  {ImmutableMap}   mimetype -> React Component - Map({'text/plain': TextTransform})
+ * @param  {Map}   bundle - Map({mimetype1: data1, mimetype2: data2, ...})
+ * @param  {Array} ordered list of mimetypes - ['text/html', 'text/plain']
+ * @param  {Map}   mimetype -> React Component - Map({'text/plain': TextTransform})
  * @return {string}          Richest mimetype
  */
 
 export function richestMimetype(
-  bundle: ImmutableMap<string, any>,
-  order: ImmutableList<string> = standardDisplayOrder,
-  tf: ImmutableMap<string, any> = standardTransforms
+  bundle: Object,
+  order: DisplayOrder = standardDisplayOrder,
+  tf: Transforms = standardTransforms
 ): ?string {
   return (
-    bundle
-      .keySeq()
+    [...Object.keys(bundle)]
       // we can only use those we have a transform for
-      .filter(mimetype => tf.has(mimetype) && order.includes(mimetype))
+      .filter(mimetype => tf[mimetype] && order.includes(mimetype))
       // the richest is based on the order in displayOrder
-      .sortBy(mimetype => order.indexOf(mimetype))
-      .first()
+      .sort(mimetype => order.indexOf(mimetype))[0]
   );
 }
 export const transforms = standardTransforms;

--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -1,10 +1,5 @@
 /* @flow */
 
-// Needed for flow
-/* eslint-disable no-unused-vars */
-import React from "react";
-/* eslint-enable no-unused-vars */
-
 import TextDisplay from "./text";
 import JsonDisplay from "./json";
 import JavaScriptDisplay from "./javascript";
@@ -14,9 +9,9 @@ import LaTeXDisplay from "./latex";
 import SVGDisplay from "./svg";
 import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image";
 
-declare class Transform extends React.Component {
+type Transform = {
   MIMETYPE: string
-}
+};
 
 type Transforms = { [string]: Transform };
 type DisplayOrder = Array<string>;

--- a/packages/transforms/src/javascript.js
+++ b/packages/transforms/src/javascript.js
@@ -26,6 +26,7 @@ export function runCodeHere(el: HTMLElement, code: string): any {
 export default class JavaScript extends React.Component {
   props: Props;
   el: HTMLElement;
+  static MIMETYPE = "application/javascript";
 
   componentDidMount(): void {
     runCodeHere(this.el, this.props.data);

--- a/packages/transforms/src/json.js
+++ b/packages/transforms/src/json.js
@@ -52,6 +52,7 @@ type Props = {
 export default class JsonDisplay extends React.Component {
   props: Props;
   shouldExpandNode: () => boolean;
+  static MIMETYPE = "application/json";
 
   constructor(): void {
     super();
@@ -69,7 +70,7 @@ export default class JsonDisplay extends React.Component {
   }
 
   shouldExpandNode(): boolean {
-    if (this.props.metadata && this.props.metadata.get("expanded")) {
+    if (this.props.metadata && this.props.metadata.expanded) {
       return true;
     }
     return false;

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -9,6 +9,7 @@ type Props = {
 export default class LaTeXDisplay extends React.Component {
   props: Props;
   el: HTMLElement;
+  static MIMETYPE = "text/latex";
 
   componentDidMount(): void {
     this.el.innerHTML = this.props.data;

--- a/packages/transforms/src/markdown.js
+++ b/packages/transforms/src/markdown.js
@@ -16,6 +16,7 @@ const mdRender: MDRender = input => renderer.render(parser.parse(input));
 
 export class MarkdownDisplay extends React.Component {
   props: Props;
+  static MIMETYPE = "text/markdown";
 
   shouldComponentUpdate(nextProps: Props): boolean {
     return nextProps.data !== this.props.data;

--- a/packages/transforms/src/svg.js
+++ b/packages/transforms/src/svg.js
@@ -8,6 +8,7 @@ type Props = {
 export default class SVGDisplay extends React.Component {
   props: Props;
   el: HTMLElement;
+  static MIMETYPE = "image/svg+xml";
 
   componentDidMount(): void {
     this.el.insertAdjacentHTML("beforeend", this.props.data);

--- a/packages/transforms/src/text.js
+++ b/packages/transforms/src/text.js
@@ -9,6 +9,7 @@ type Props = {
 
 export default class TextDisplay extends React.Component {
   props: Props;
+  static MIMETYPE = "text/plain";
 
   shouldComponentUpdate(): boolean {
     return true;

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -24,7 +24,7 @@ const PropTypes = require("prop-types");
 
 export type CellProps = {
   cell: any,
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   id: string,
   cellFocused: string,
   editorFocused: string,
@@ -32,7 +32,7 @@ export type CellProps = {
   running: boolean,
   theme: string,
   pagers: ImmutableList<any>,
-  transforms: ImmutableMap<string, any>,
+  transforms: Object,
   models: ImmutableMap<string, any>
 };
 

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -4,7 +4,6 @@ import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import Inputs from "./inputs";
 import { Display } from "../../../../packages/display-area";
-import { outputToJS } from "../../../../packages/commutable";
 
 import Editor from "../../providers/editor";
 import LatexRenderer from "../latex";

--- a/src/notebook/components/cell/code-cell.js
+++ b/src/notebook/components/cell/code-cell.js
@@ -4,6 +4,7 @@ import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import Inputs from "./inputs";
 import { Display } from "../../../../packages/display-area";
+import { outputToJS } from "../../../../packages/commutable";
 
 import Editor from "../../providers/editor";
 import LatexRenderer from "../latex";
@@ -12,11 +13,11 @@ import Pager from "./pager";
 
 type Props = {
   cell: ImmutableMap<string, any>,
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   id: string,
   language: string,
   theme: string,
-  transforms: ImmutableMap<string, any>,
+  transforms: Object,
   cellFocused: boolean,
   editorFocused: boolean,
   pagers: ImmutableList<any>,
@@ -89,13 +90,13 @@ class CodeCell extends React.PureComponent {
           <div className="outputs">
             <Display
               className="outputs-display"
-              outputs={this.props.cell.get("outputs")}
+              outputs={this.props.cell.get("outputs").toJS()}
               displayOrder={this.props.displayOrder}
               transforms={this.props.transforms}
               theme={this.props.theme}
               expanded={this.isOutputExpanded()}
               isHidden={this.isOutputHidden()}
-              models={this.props.models}
+              models={this.props.models.toJS()}
             />
           </div>
         </LatexRenderer>

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -24,9 +24,9 @@ import type { CellProps } from "./cell/cell";
 const PropTypes = require("prop-types");
 
 type Props = {
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   notebook: any,
-  transforms: ImmutableMap<string, any>,
+  transforms: Object,
   cellPagers: ImmutableMap<string, any>,
   stickyCells: ImmutableMap<string, any>,
   transient: ImmutableMap<string, any>,

--- a/src/notebook/views/draggable-cell.js
+++ b/src/notebook/views/draggable-cell.js
@@ -10,7 +10,7 @@ import Cell from "../components/cell/cell";
 
 type Props = {|
   cell: ImmutableMap<string, any>,
-  displayOrder: ImmutableList<any>,
+  displayOrder: Array<string>,
   connectDragPreview: (img: Image) => void,
   connectDragSource: (el: ?React.Element<any>) => void,
   connectDropTarget: (el: ?React.Element<any>) => void,

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -35,6 +35,7 @@ describe("Cell", () => {
         cell={emptyCodeCell}
         {...sharedProps}
         cellStatus={Immutable.Map({ outputHidden: false, inputHidden: false })}
+        models={new Immutable.Map({})}
       />,
       {
         context: { store }

--- a/test/renderer/components/cell/code-cell-spec.js
+++ b/test/renderer/components/cell/code-cell-spec.js
@@ -22,6 +22,7 @@ describe("CodeCell", () => {
           inputHidden: false,
           outputExpanded: false
         })}
+        models={new Immutable.Map({})}
       />
     );
     expect(cell).to.not.be.null;
@@ -39,6 +40,7 @@ describe("CodeCell", () => {
             inputHidden: false,
             outputExpanded: false
           })}
+          models={new Immutable.Map({})}
         />
       </Provider>
     );
@@ -58,6 +60,7 @@ describe("CodeCell", () => {
             outputExpanded: false
           })}
           pagers={Immutable.fromJS([{ data: { "text/plain": "one" } }])}
+          models={new Immutable.Map({})}
         />
       </Provider>
     );

--- a/test/renderer/components/notebook-spec.js
+++ b/test/renderer/components/notebook-spec.js
@@ -58,9 +58,10 @@ describe("Notebook", () => {
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}
           stickyCells={new Immutable.Map()}
-          displayOrder={displayOrder.delete("text/html")}
-          transforms={transforms.delete("text/html")}
+          displayOrder={displayOrder}
+          transforms={transforms}
           CellComponent={Cell}
+          models={new Immutable.Map({})}
         />
       </Provider>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,8 +1497,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000676"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000676.tgz#82ea578237637c8ff34a28acaade373b624c4ea8"
+  version "1.0.30000677"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000677.tgz#13f421d40ae1434702103c494d2c4d716e2a8fcb"
 
 caniuse-lite@^1.0.30000669, caniuse-lite@^1.0.30000670:
   version "1.0.30000670"
@@ -2982,6 +2982,18 @@ entities@^1.1.1, "entities@~ 1.1.1", entities@~1.1.1:
 env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
+
+enzyme-to-json@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.5.1.tgz#e34f4d126bb3f4696ce3800b51f9ed83df708799"
+  dependencies:
+    lodash.filter "^4.6.0"
+    lodash.isnil "^4.0.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.omitby "^4.5.0"
+    lodash.range "^3.2.0"
+    object-values "^1.0.0"
+    object.entries "^1.0.3"
 
 enzyme@^2.7.1:
   version "2.8.2"
@@ -5540,7 +5552,7 @@ lodash.defaults@^4.0.1, lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.filter@^4.4.0:
+lodash.filter@^4.4.0, lodash.filter@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
 
@@ -5563,6 +5575,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isnil@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -5588,9 +5604,17 @@ lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.omitby@^4.5.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
+
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
 
 lodash.reduce@^4.4.0:
   version "4.6.0"
@@ -6222,6 +6246,10 @@ object-keys@^1.0.10, object-keys@^1.0.6, object-keys@^1.0.8:
 object-keys@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
+
+object-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/object-values/-/object-values-1.0.0.tgz#72af839630119e5b98c3b02bb8c27e3237158105"
 
 object.assign@^4.0.4:
   version "4.0.4"
@@ -8694,8 +8722,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
 uglify-js@3.0.x:
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.13.tgz#1871d736aa1e550c728d7e5a6556579e70925d68"
+  version "3.0.15"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.15.tgz#aacb323a846b234602270dead8a32441a8806f42"
   dependencies:
     commander "~2.9.0"
     source-map "~0.5.1"


### PR DESCRIPTION
As mentioned in https://github.com/nteract/hydrogen/pull/772#issuecomment-301544392 it would be really cool for Hydrogen and other frontends not using Redux/Immutable.js if our packages would  use plain objects instead of immutable.js datastructures.

It would also help extremely with proper typings since it's very hard to properly type Immutable.js objects.

I totally understand if we don't accept this PR but I figured I should give it a try anyway 😄

**TODO:**
- [x] Fix flow error in `transforms`
- [x] Document changes in README