### PR TITLE
ux(scroll-buffer): Add buffer div so user can scroll cell to top

### DIFF
--- a/src/notebook/components/scroll-buffer.js
+++ b/src/notebook/components/scroll-buffer.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-return-assign */
+/* @flow */
+import React from "react";
+
+type Props = {
+  lastCell: any
+};
+
+export default class ScrollBuffer extends React.Component {
+  props: Props;
+
+  render(): ?React.Element<any> {
+    let bufferStyle = {};
+
+    // If the last cell output is empty, let the user scroll that cell to the
+    // top of their screen
+    if (this.props.lastCell) {
+      if (this.props.lastCell.get("outputs").size == 0) {
+        bufferStyle = { height: "calc(100vh - 110px)" };
+      }
+    }
+
+    return <div style={bufferStyle} />;
+  }
+}

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -182,7 +182,7 @@ body
 }
 
 .notebook .cell-container:last-child {
-    padding-bottom: 200px;
+    padding-bottom: 20px;
 }
 
 /*

--- a/static/styles/theme-classic.css
+++ b/static/styles/theme-classic.css
@@ -77,13 +77,6 @@
   padding: 0px 0px 0px calc(var(--prompt-width) + 10px);
 }
 
-.draggable-cell {
-  padding: 0px !important;
-  border-top-width: 1px !important;
-  border-bottom-width: 1px !important;
-  margin-bottom: -1px;
-}
-
 .cell-toolbar {
   box-shadow: 0 1px 0.5px 0 rgba(0,0,0,.10);
   border-radius: 3px;


### PR DESCRIPTION
This commit addresses issue #1733

An empty div will be added below the last cell if the last cell has no output. It will allow the user to scroll to the last cell to the top of the screen.

Happy to get feedback on whether `calc(100vh - 120px)` is appropriate. I think this should work.
I've removed some CSS from the `classic` theme. I could not see it helping anything, but it changes the height of the cell compared to other themes.

Also I tried to run Flow but I had some issues, Flow is wonky on Windows.
