### PR TITLE
fix(vega): Add version key to Vega MIMETYPE

### DIFF
--- a/example-notebooks/altair.ipynb
+++ b/example-notebooks/altair.ipynb
@@ -11,7 +11,7 @@
     "import IPython.display\n",
     "def vegify(spec):\n",
     "    IPython.display.display({\n",
-    "        'application/vnd.vegalite+json': spec.to_dict()\n",
+    "        'application/vnd.vegalite.v1+json': spec.to_dict()\n",
     "    }, raw=True)"
    ]
   },

--- a/packages/transform-vega/src/index.js
+++ b/packages/transform-vega/src/index.js
@@ -4,8 +4,8 @@ import React from "react";
 const merge = require("lodash").merge;
 const vegaEmbed = require("vega-embed");
 
-const MIMETYPE_VEGA = "application/vnd.vega+json";
-const MIMETYPE_VEGALITE = "application/vnd.vegalite+json";
+const MIMETYPE_VEGA = "application/vnd.vega.v2+json";
+const MIMETYPE_VEGALITE = "application/vnd.vegalite.v1+json";
 
 const DEFAULT_WIDTH = 500;
 const DEFAULT_HEIGHT = DEFAULT_WIDTH / 1.5;


### PR DESCRIPTION
The next version of altair will return JSON with MIMETYPES `application/vnd.vega.v2+json` and `application/vnd.vegalite.v1+json`:  https://github.com/altair-viz/altair/pull/216