### PR TITLE
remove Travis caching to get around npm ls issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_install:
 before_script:
 - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
 - greenkeeper-lockfile-update
+install:
+- npm install
 script: npm run test:$GROUP
 after_script: greenkeeper-lockfile-upload
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
   - GROUP=flow
   - GROUP=conformance
 
+cache:
+  directories:
+    - $HOME/.npm
+    - node_modules
+
 before_install:
 - npm install -g npm@5
 - npm install -g greenkeeper-lockfile@1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ env:
   - GROUP=flow
   - GROUP=conformance
 
-cache:
-  directories:
-    - $HOME/.npm
-    - node_modules
-
 before_install:
 - npm install -g npm@5
 - npm install -g greenkeeper-lockfile@1

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,6 +244,12 @@
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
 			"integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
 		},
+		"archy": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+			"dev": true
+		},
 		"are-we-there-yet": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
@@ -1724,6 +1730,30 @@
 			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
 			"dev": true
 		},
+		"caching-transform": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+			"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+			"dev": true,
+			"requires": {
+				"md5-hex": "1.3.0",
+				"mkdirp": "0.5.1",
+				"write-file-atomic": "1.3.4"
+			},
+			"dependencies": {
+				"write-file-atomic": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"imurmurhash": "0.1.4",
+						"slide": "1.1.6"
+					}
+				}
+			}
+		},
 		"caller-id": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
@@ -1768,6 +1798,17 @@
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000697.tgz",
 			"integrity": "sha1-El+wBgS2P7sYjblqZnziki3NbN0=",
 			"dev": true
+		},
+		"canvas": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.5.tgz",
+			"integrity": "sha1-VX+ZiPXSyV/cJHxhpe5D3lL2cXw=",
+			"optional": true,
+			"requires": {
+				"nan": "2.6.2",
+				"parse-css-font": "2.0.2",
+				"units-css": "0.4.0"
+			}
 		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
@@ -2504,6 +2545,45 @@
 			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 			"dev": true
 		},
+		"css-font-size-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+			"integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
+			"optional": true
+		},
+		"css-font-stretch-keywords": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+			"integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
+			"optional": true
+		},
+		"css-font-style-keywords": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+			"integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
+			"optional": true
+		},
+		"css-font-weight-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+			"integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
+			"optional": true
+		},
+		"css-global-keywords": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+			"integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
+			"optional": true
+		},
+		"css-list-helpers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
+			"integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
+			"optional": true,
+			"requires": {
+				"tcomb": "2.7.0"
+			}
+		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -2515,6 +2595,12 @@
 				"domutils": "1.5.1",
 				"nth-check": "1.0.1"
 			}
+		},
+		"css-system-font-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+			"integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
+			"optional": true
 		},
 		"css-what": {
 			"version": "2.1.0",
@@ -2707,6 +2793,12 @@
 			"requires": {
 				"ms": "2.0.0"
 			}
+		},
+		"debug-log": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+			"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+			"dev": true
 		},
 		"decamelize": {
 			"version": "1.2.0",
@@ -4330,6 +4422,16 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
 			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
+		"foreground-child": {
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+			"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "4.0.2",
+				"signal-exit": "3.0.2"
+			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -6556,6 +6658,12 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
+		"isnumeric": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
+			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
+			"optional": true
+		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -8287,6 +8395,21 @@
 			"resolved": "https://registry.npmjs.org/mathjax-electron/-/mathjax-electron-2.0.1.tgz",
 			"integrity": "sha1-2gRKC/n/9HDgHA+zGXS8eYbnMj0="
 		},
+		"md5-hex": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+			"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+			"dev": true,
+			"requires": {
+				"md5-o-matic": "0.1.1"
+			}
+		},
+		"md5-o-matic": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+			"dev": true
+		},
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -8333,6 +8456,23 @@
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
 			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
 			"dev": true
+		},
+		"merge-source-map": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+			"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+			"dev": true,
+			"requires": {
+				"source-map": "0.5.6"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+					"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+					"dev": true
+				}
+			}
 		},
 		"micromatch": {
 			"version": "2.3.11",
@@ -8775,472 +8915,64 @@
 			"integrity": "sha1-DCi8ZpqFFiFwm/eghQMDS+44ErY=",
 			"dev": true,
 			"requires": {
-				"archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-				"arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-				"caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-				"convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-				"debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-				"default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-				"find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-				"find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-				"foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+				"archy": "1.0.0",
+				"arrify": "1.0.1",
+				"caching-transform": "1.0.1",
+				"convert-source-map": "1.5.0",
+				"debug-log": "1.0.1",
+				"default-require-extensions": "1.0.0",
+				"find-cache-dir": "0.1.1",
+				"find-up": "2.1.0",
+				"foreground-child": "1.5.6",
 				"glob": "7.1.2",
 				"istanbul-lib-coverage": "1.1.1",
 				"istanbul-lib-hook": "1.0.7",
-				"istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
+				"istanbul-lib-instrument": "1.7.3",
 				"istanbul-lib-report": "1.1.1",
 				"istanbul-lib-source-maps": "1.2.1",
 				"istanbul-reports": "1.1.1",
-				"md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-				"merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-				"micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-				"resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-				"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+				"md5-hex": "1.3.0",
+				"merge-source-map": "1.0.4",
+				"micromatch": "2.3.11",
+				"mkdirp": "0.5.1",
+				"resolve-from": "2.0.0",
+				"rimraf": "2.6.1",
+				"signal-exit": "3.0.2",
 				"spawn-wrap": "1.3.7",
 				"test-exclude": "4.1.1",
-				"yargs": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-				"yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+				"yargs": "8.0.2",
+				"yargs-parser": "5.0.0"
 			},
 			"dependencies": {
-				"align-text": {
-					"version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-					"dev": true,
-					"requires": {
-						"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-						"longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-						"repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-					}
-				},
-				"amdefine": {
-					"version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-					"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"append-transform": {
-					"version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-					"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-					"dev": true,
-					"requires": {
-						"default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
-					}
-				},
-				"archy": {
-					"version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-					"dev": true
-				},
-				"arr-diff": {
-					"version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
-					}
-				},
-				"arr-flatten": {
-					"version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-					"integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"arrify": {
-					"version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-					"dev": true
-				},
-				"async": {
-					"version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"dev": true
-				},
-				"babel-code-frame": {
-					"version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-					"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-					"dev": true,
-					"requires": {
-						"chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-						"esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-						"js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-					}
-				},
-				"babel-generator": {
-					"version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-					"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-					"dev": true,
-					"requires": {
-						"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-						"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-						"detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-						"jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-						"trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-					}
-				},
-				"babel-messages": {
-					"version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-					"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-					"dev": true,
-					"requires": {
-						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-					}
-				},
-				"babel-runtime": {
-					"version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-					"integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-					"dev": true,
-					"requires": {
-						"core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-						"regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-					}
-				},
-				"babel-template": {
-					"version": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-					"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-					"dev": true,
-					"requires": {
-						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-						"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-						"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-						"babylon": "6.17.4",
-						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-					}
-				},
-				"babel-traverse": {
-					"version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-					"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-					"dev": true,
-					"requires": {
-						"babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-						"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-						"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-						"babylon": "6.17.4",
-						"debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-						"globals": "9.18.0",
-						"invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-					}
-				},
-				"babel-types": {
-					"version": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-					"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-					"dev": true,
-					"requires": {
-						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-						"esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-						"to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-					}
-				},
 				"babylon": {
 					"version": "6.17.4",
 					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-					"integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
-					"dev": true
-				},
-				"balanced-match": {
-					"version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-					"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-					"dev": true,
-					"requires": {
-						"balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-						"concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-					}
-				},
-				"braces": {
-					"version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-						"preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-						"repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-					}
-				},
-				"builtin-modules": {
-					"version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-					"dev": true
-				},
-				"caching-transform": {
-					"version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-					"integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-					"dev": true,
-					"requires": {
-						"md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-						"write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
-					}
+					"integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo="
 				},
 				"camelcase": {
-					"version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-					"dev": true,
-					"optional": true
-				},
-				"center-align": {
-					"version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-					"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-						"lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-					}
-				},
-				"chalk": {
-					"version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-						"escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-						"has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-						"supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-					}
-				},
-				"cliui": {
-					"version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-						"right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-						"wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-					},
-					"dependencies": {
-						"wordwrap": {
-							"version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-							"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"code-point-at": {
-					"version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
 					"dev": true
-				},
-				"commondir": {
-					"version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-					"dev": true
-				},
-				"concat-map": {
-					"version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true
-				},
-				"convert-source-map": {
-					"version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-					"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
-					"dev": true
-				},
-				"core-js": {
-					"version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "4.1.1",
-						"which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-					}
-				},
-				"debug": {
-					"version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-					"dev": true,
-					"requires": {
-						"ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-					}
-				},
-				"debug-log": {
-					"version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-					"integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-					"dev": true
-				},
-				"decamelize": {
-					"version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-					"dev": true
-				},
-				"default-require-extensions": {
-					"version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-					"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-					"dev": true,
-					"requires": {
-						"strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-					}
-				},
-				"detect-indent": {
-					"version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-					"dev": true,
-					"requires": {
-						"repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-					}
-				},
-				"error-ex": {
-					"version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-					"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-					"dev": true,
-					"requires": {
-						"is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
-				},
-				"esutils": {
-					"version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-					"dev": true
-				},
-				"execa": {
-					"version": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-					"integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-						"get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-						"is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-						"npm-run-path": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-						"p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-						"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-						"strip-eof": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
-					}
-				},
-				"expand-brackets": {
-					"version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-					}
-				},
-				"expand-range": {
-					"version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-					"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-					"dev": true,
-					"requires": {
-						"fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-					}
-				},
-				"extglob": {
-					"version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-					}
-				},
-				"filename-regex": {
-					"version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-					"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-					"dev": true
-				},
-				"fill-range": {
-					"version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-					"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-					"dev": true,
-					"requires": {
-						"is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-						"isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-						"randomatic": "1.1.7",
-						"repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-						"repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-					}
 				},
 				"find-cache-dir": {
-					"version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
 					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
 					"dev": true,
 					"requires": {
-						"commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-						"pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
 					}
 				},
 				"find-up": {
-					"version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
-					}
-				},
-				"for-in": {
-					"version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-					"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-					"dev": true
-				},
-				"for-own": {
-					"version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-					"dev": true,
-					"requires": {
-						"for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-					}
-				},
-				"foreground-child": {
-					"version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-					"integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-						"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-					}
-				},
-				"fs.realpath": {
-					"version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-					"dev": true
-				},
-				"get-caller-file": {
-					"version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-					"dev": true
-				},
-				"get-stream": {
-					"version": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-					"dev": true,
-					"requires": {
-						"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-						"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+						"locate-path": "2.0.0"
 					}
 				},
 				"glob": {
@@ -9249,223 +8981,24 @@
 					"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-						"inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
 						"minimatch": "3.0.4",
-						"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-						"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-					}
-				},
-				"glob-base": {
-					"version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-					"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-					"dev": true,
-					"requires": {
-						"glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-						"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-					}
-				},
-				"glob-parent": {
-					"version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
-					"requires": {
-						"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"globals": {
 					"version": "9.18.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
-					"dev": true
-				},
-				"graceful-fs": {
-					"version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-					"dev": true
-				},
-				"handlebars": {
-					"version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-					"integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-					"dev": true,
-					"requires": {
-						"async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-						"optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-						"uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-							"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-							"dev": true,
-							"requires": {
-								"amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-							}
-						}
-					}
-				},
-				"has-ansi": {
-					"version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-					}
+					"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
 				},
 				"has-flag": {
-					"version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
 					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
 					"dev": true
-				},
-				"hosted-git-info": {
-					"version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-					"integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
-					"dev": true
-				},
-				"imurmurhash": {
-					"version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-					"dev": true
-				},
-				"inflight": {
-					"version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true,
-					"requires": {
-						"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-						"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-					}
-				},
-				"inherits": {
-					"version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true
-				},
-				"invariant": {
-					"version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-					"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-					"dev": true,
-					"requires": {
-						"loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
-					}
-				},
-				"invert-kv": {
-					"version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-					"dev": true
-				},
-				"is-arrayish": {
-					"version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-					"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-					"dev": true
-				},
-				"is-buffer": {
-					"version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-					"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-					"dev": true
-				},
-				"is-builtin-module": {
-					"version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-					"dev": true,
-					"requires": {
-						"builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-					}
-				},
-				"is-dotfile": {
-					"version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-					"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-					"dev": true
-				},
-				"is-equal-shallow": {
-					"version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-					"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-					"dev": true,
-					"requires": {
-						"is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-					}
-				},
-				"is-extendable": {
-					"version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-					"dev": true
-				},
-				"is-extglob": {
-					"version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-finite": {
-					"version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-					"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-					}
-				},
-				"is-glob": {
-					"version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-					}
-				},
-				"is-number": {
-					"version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
-					"requires": {
-						"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-					}
-				},
-				"is-posix-bracket": {
-					"version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-					"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-					"dev": true
-				},
-				"is-primitive": {
-					"version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-					"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-					"dev": true
-				},
-				"is-stream": {
-					"version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-					"dev": true
-				},
-				"is-utf8": {
-					"version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-					"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-					"dev": true
-				},
-				"isarray": {
-					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"isexe": {
-					"version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-					"dev": true
-				},
-				"isobject": {
-					"version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
-					"requires": {
-						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-					}
 				},
 				"istanbul-lib-coverage": {
 					"version": "1.1.1",
@@ -9479,21 +9012,7 @@
 					"integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
 					"dev": true,
 					"requires": {
-						"append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
-					}
-				},
-				"istanbul-lib-instrument": {
-					"version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-					"integrity": "sha1-klsjkWPqvdaMxASPUsL6T4mez6c=",
-					"dev": true,
-					"requires": {
-						"babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-						"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-						"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-						"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-						"babylon": "6.17.4",
-						"istanbul-lib-coverage": "1.1.1",
-						"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+						"append-transform": "0.4.0"
 					}
 				},
 				"istanbul-lib-report": {
@@ -9503,19 +9022,9 @@
 					"dev": true,
 					"requires": {
 						"istanbul-lib-coverage": "1.1.1",
-						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-						"path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-						"supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-							"dev": true,
-							"requires": {
-								"has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-							}
-						}
+						"mkdirp": "0.5.1",
+						"path-parse": "1.0.5",
+						"supports-color": "3.2.3"
 					}
 				},
 				"istanbul-lib-source-maps": {
@@ -9524,11 +9033,11 @@
 					"integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
 					"dev": true,
 					"requires": {
-						"debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+						"debug": "2.6.8",
 						"istanbul-lib-coverage": "1.1.1",
-						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1",
+						"source-map": "0.5.6"
 					}
 				},
 				"istanbul-reports": {
@@ -9537,150 +9046,17 @@
 					"integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
 					"dev": true,
 					"requires": {
-						"handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
-					}
-				},
-				"js-tokens": {
-					"version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-					"integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-					"dev": true
-				},
-				"jsesc": {
-					"version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
-				},
-				"kind-of": {
-					"version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-					}
-				},
-				"lazy-cache": {
-					"version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-					"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-					"dev": true,
-					"optional": true
-				},
-				"lcid": {
-					"version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"dev": true,
-					"requires": {
-						"invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-					}
-				},
-				"load-json-file": {
-					"version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-						"parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-						"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-						"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-						"strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-					}
-				},
-				"locate-path": {
-					"version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-						"path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
-					},
-					"dependencies": {
-						"path-exists": {
-							"version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-							"dev": true
-						}
-					}
-				},
-				"lodash": {
-					"version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-					"dev": true
-				},
-				"longest": {
-					"version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-					"dev": true
-				},
-				"loose-envify": {
-					"version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-					"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-					"dev": true,
-					"requires": {
-						"js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+						"handlebars": "4.0.10"
 					}
 				},
 				"lru-cache": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 					"integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-					"dev": true,
 					"requires": {
-						"pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-						"yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+						"pseudomap": "1.0.2",
+						"yallist": "2.1.2"
 					}
-				},
-				"md5-hex": {
-					"version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-					"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-					"dev": true,
-					"requires": {
-						"md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-					}
-				},
-				"md5-o-matic": {
-					"version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-					"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-					"dev": true
-				},
-				"mem": {
-					"version": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
-					}
-				},
-				"merge-source-map": {
-					"version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-					"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-					"dev": true,
-					"requires": {
-						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-					}
-				},
-				"micromatch": {
-					"version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"dev": true,
-					"requires": {
-						"arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-						"array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-						"braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-						"expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-						"extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-						"filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-						"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-						"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-						"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-						"normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-						"object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-						"parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-						"regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-					}
-				},
-				"mimic-fn": {
-					"version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
@@ -9688,381 +9064,53 @@
 					"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
-					}
-				},
-				"minimist": {
-					"version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true,
-					"requires": {
-						"minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-					}
-				},
-				"ms": {
-					"version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-					"integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-						"is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-						"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-						"validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-					}
-				},
-				"normalize-path": {
-					"version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-					}
-				},
-				"npm-run-path": {
-					"version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-					"dev": true,
-					"requires": {
-						"path-key": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
-					}
-				},
-				"number-is-nan": {
-					"version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true
-				},
-				"object-assign": {
-					"version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-					"dev": true
-				},
-				"object.omit": {
-					"version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-					"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-					"dev": true,
-					"requires": {
-						"for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-						"is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-					}
-				},
-				"once": {
-					"version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true,
-					"requires": {
-						"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-					}
-				},
-				"optimist": {
-					"version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-					"dev": true,
-					"requires": {
-						"minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-						"wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-					}
-				},
-				"os-homedir": {
-					"version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-					"dev": true
-				},
-				"os-locale": {
-					"version": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-					"integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
-					"dev": true,
-					"requires": {
-						"execa": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-						"lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-						"mem": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
-					}
-				},
-				"p-finally": {
-					"version": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-					"dev": true
-				},
-				"p-locate": {
-					"version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
-					}
-				},
-				"parse-glob": {
-					"version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-					"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-					"dev": true,
-					"requires": {
-						"glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-						"is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-						"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-						"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-					}
-				},
-				"parse-json": {
-					"version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-					"dev": true,
-					"requires": {
-						"error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+						"brace-expansion": "1.1.8"
 					}
 				},
 				"path-exists": {
-					"version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-					}
-				},
-				"path-is-absolute": {
-					"version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-					"dev": true
-				},
-				"path-key": {
-					"version": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-					"dev": true
-				},
-				"path-parse": {
-					"version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-					"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-					"dev": true
-				},
-				"path-type": {
-					"version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-						"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-						"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-					}
-				},
-				"pify": {
-					"version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				},
-				"pinkie": {
-					"version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-					"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-					"dev": true
-				},
-				"pinkie-promise": {
-					"version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-					"dev": true,
-					"requires": {
-						"pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pkg-dir": {
-					"version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
 					"requires": {
-						"find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+						"find-up": "1.1.2"
 					},
 					"dependencies": {
 						"find-up": {
-							"version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+							"version": "1.1.2",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 							"dev": true,
 							"requires": {
-								"path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-								"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+								"path-exists": "2.1.0",
+								"pinkie-promise": "2.0.1"
 							}
 						}
 					}
-				},
-				"preserve": {
-					"version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-					"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-					"dev": true
-				},
-				"pseudomap": {
-					"version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-					"dev": true
 				},
 				"randomatic": {
 					"version": "1.1.7",
 					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-					"integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
-					"dev": true,
-					"requires": {
-						"is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-						"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
-					},
-					"dependencies": {
-						"is-number": {
-							"version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-							"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-							"dev": true,
-							"requires": {
-								"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-							},
-							"dependencies": {
-								"kind-of": {
-									"version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-									"dev": true,
-									"requires": {
-										"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-									}
-								}
-							}
-						},
-						"kind-of": {
-							"version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-							"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-							}
-						}
-					}
-				},
-				"read-pkg": {
-					"version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-						"normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-						"path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-					}
-				},
-				"read-pkg-up": {
-					"version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-					"dev": true,
-					"requires": {
-						"find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-						"read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-							"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-							"dev": true,
-							"requires": {
-								"path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-								"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-							}
-						}
-					}
-				},
-				"regenerator-runtime": {
-					"version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-					"dev": true
-				},
-				"regex-cache": {
-					"version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-					"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-					"dev": true,
-					"requires": {
-						"is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-						"is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-					}
-				},
-				"remove-trailing-separator": {
-					"version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-					"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-					"dev": true
-				},
-				"repeat-element": {
-					"version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-					"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-					"dev": true
-				},
-				"repeat-string": {
-					"version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-					"dev": true
-				},
-				"repeating": {
-					"version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-					"dev": true,
-					"requires": {
-						"is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-					}
-				},
-				"require-directory": {
-					"version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-					"dev": true
-				},
-				"require-main-filename": {
-					"version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-					"dev": true
+					"integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w="
 				},
 				"resolve-from": {
-					"version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
 					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
 					"dev": true
 				},
-				"right-align": {
-					"version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-					"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-					}
-				},
-				"rimraf": {
-					"version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-					"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-					"dev": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"semver": {
-					"version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-					"dev": true
-				},
-				"set-blocking": {
-					"version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-					"dev": true
-				},
-				"slide": {
-					"version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-					"dev": true
-				},
 				"source-map": {
-					"version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
 					"dev": true
 				},
@@ -10072,73 +9120,22 @@
 					"integrity": "sha1-vri/RCbWSysGhx4Nfe4mQ/H40bw=",
 					"dev": true,
 					"requires": {
-						"foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-						"os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-						"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-						"which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+						"foreground-child": "1.5.6",
+						"mkdirp": "0.5.1",
+						"os-homedir": "1.0.2",
+						"rimraf": "2.6.1",
+						"signal-exit": "3.0.2",
+						"which": "1.2.14"
 					}
-				},
-				"spdx-correct": {
-					"version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-					"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-					"dev": true,
-					"requires": {
-						"spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-					}
-				},
-				"spdx-expression-parse": {
-					"version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-					"integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-					"dev": true
-				},
-				"spdx-license-ids": {
-					"version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-					"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-					"integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-					},
-					"dependencies": {
-						"is-fullwidth-code-point": {
-							"version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
-						}
-					}
-				},
-				"strip-ansi": {
-					"version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-					}
-				},
-				"strip-bom": {
-					"version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"dev": true,
-					"requires": {
-						"is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-					}
-				},
-				"strip-eof": {
-					"version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-					"dev": true
 				},
 				"supports-color": {
-					"version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "1.0.0"
+					}
 				},
 				"test-exclude": {
 					"version": "4.1.1",
@@ -10146,246 +9143,20 @@
 					"integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
 					"dev": true,
 					"requires": {
-						"arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-						"micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-						"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-						"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-						"require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-					}
-				},
-				"to-fast-properties": {
-					"version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-					"dev": true
-				},
-				"trim-right": {
-					"version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-					"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-					"dev": true
-				},
-				"uglify-js": {
-					"version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-						"uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-						"yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-					},
-					"dependencies": {
-						"yargs": {
-							"version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-								"cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-								"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-								"window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-							}
-						}
-					}
-				},
-				"uglify-to-browserify": {
-					"version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-					"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-					"dev": true,
-					"optional": true
-				},
-				"validate-npm-package-license": {
-					"version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-					"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-					"dev": true,
-					"requires": {
-						"spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-						"spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-					}
-				},
-				"which": {
-					"version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-					"integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-					"dev": true,
-					"requires": {
-						"isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-					}
-				},
-				"which-module": {
-					"version": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-					"dev": true
-				},
-				"window-size": {
-					"version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-					"dev": true,
-					"optional": true
-				},
-				"wordwrap": {
-					"version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-					"dev": true
-				},
-				"wrap-ansi": {
-					"version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-					"dev": true,
-					"requires": {
-						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"dev": true,
-							"requires": {
-								"code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-								"is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-								"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-							}
-						}
-					}
-				},
-				"wrappy": {
-					"version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true
-				},
-				"write-file-atomic": {
-					"version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-					"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-						"imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-						"slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-					}
-				},
-				"y18n": {
-					"version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-					"dev": true
-				},
-				"yallist": {
-					"version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-					"integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-					"dev": true,
-					"requires": {
-						"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-						"cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-						"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-						"get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-						"os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-						"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-						"require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-						"require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-						"set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-						"string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-						"which-module": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-						"y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-						"yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-							"dev": true
-						},
-						"cliui": {
-							"version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-							"dev": true,
-							"requires": {
-								"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-								"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-								"wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-							},
-							"dependencies": {
-								"string-width": {
-									"version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-									"dev": true,
-									"requires": {
-										"code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-										"is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-										"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-									}
-								}
-							}
-						},
-						"load-json-file": {
-							"version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-							"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-							"dev": true,
-							"requires": {
-								"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-								"parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-								"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-								"strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-							}
-						},
-						"path-type": {
-							"version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-							"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-							"dev": true,
-							"requires": {
-								"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-							}
-						},
-						"read-pkg": {
-							"version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-							"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-							"dev": true,
-							"requires": {
-								"load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-								"normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-								"path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
-							}
-						},
-						"read-pkg-up": {
-							"version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-							"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-							"dev": true,
-							"requires": {
-								"find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-								"read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
-							}
-						},
-						"strip-bom": {
-							"version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-							"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-							"dev": true
-						},
-						"yargs-parser": {
-							"version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-							"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-							"dev": true,
-							"requires": {
-								"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
-							}
-						}
+						"arrify": "1.0.1",
+						"micromatch": "2.3.11",
+						"object-assign": "4.1.1",
+						"read-pkg-up": "1.0.1",
+						"require-main-filename": "1.0.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 					"dev": true,
 					"requires": {
-						"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-							"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-							"dev": true
-						}
+						"camelcase": "3.0.0"
 					}
 				}
 			}
@@ -10672,6 +9443,23 @@
 					"integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
 					"dev": true
 				}
+			}
+		},
+		"parse-css-font": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
+			"integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
+			"optional": true,
+			"requires": {
+				"css-font-size-keywords": "1.0.0",
+				"css-font-stretch-keywords": "1.0.1",
+				"css-font-style-keywords": "1.0.1",
+				"css-font-weight-keywords": "1.0.0",
+				"css-global-keywords": "1.0.1",
+				"css-list-helpers": "1.0.1",
+				"css-system-font-keywords": "1.0.0",
+				"tcomb": "2.7.0",
+				"unquote": "1.1.0"
 			}
 		},
 		"parse-github-repo-url": {
@@ -12448,6 +11236,11 @@
 				"xtend": "4.0.1"
 			}
 		},
+		"tcomb": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
+			"integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA="
+		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -12867,11 +11660,27 @@
 				"crypto-random-string": "1.0.0"
 			}
 		},
+		"units-css": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
+			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
+			"optional": true,
+			"requires": {
+				"isnumeric": "0.2.0",
+				"viewport-dimensions": "0.2.0"
+			}
+		},
 		"universalify": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
 			"integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
 			"dev": true
+		},
+		"unquote": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.0.tgz",
+			"integrity": "sha1-mOH8YItrhUx1r7G5WvwJm6adlC8=",
+			"optional": true
 		},
 		"unused-filename": {
 			"version": "0.1.0",
@@ -13001,6 +11810,7 @@
 			"resolved": "https://registry.npmjs.org/vega/-/vega-2.6.5.tgz",
 			"integrity": "sha1-I3jUZyk0Igvilx3AhxqYflQstb4=",
 			"requires": {
+				"canvas": "1.6.5",
 				"d3": "3.5.17",
 				"d3-cloud": "1.2.4",
 				"d3-geo-projection": "0.2.16",
@@ -13107,6 +11917,7 @@
 			"resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-1.1.0.tgz",
 			"integrity": "sha1-qLkef+v25lf6NvqymE9jiEgQxmM=",
 			"requires": {
+				"canvas": "1.6.5",
 				"d3": "3.5.17",
 				"datalib": "1.7.3"
 			}
@@ -13118,6 +11929,12 @@
 			"requires": {
 				"extsprintf": "1.0.2"
 			}
+		},
+		"viewport-dimensions": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
+			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
+			"optional": true
 		},
 		"vm-browserify": {
 			"version": "0.0.4",


### PR DESCRIPTION
`master` is currently failing after having the cache busted. It fails when Travis (automatically) runs `npm ls`. I'm going to see if disabling the cache helps. ¯\\\_(ツ)\_/¯