### PR TITLE
dx: make desktop app resolve using the direct src

### DIFF
--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.4",
   "description": "library for immutable notebook operations",
   "main": "index.js",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
@@ -15,11 +16,7 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract/tree/master/packages/commutable"
   },
-  "keywords": [
-    "commutable",
-    "nteract",
-    "notebooks"
-  ],
+  "keywords": ["commutable", "nteract", "notebooks"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.1",
   "description": "Display area for nteract outputs",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
@@ -15,11 +16,7 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract/tree/master/packages/display-area"
   },
-  "keywords": [
-    "nteract",
-    "display",
-    "jupyter"
-  ],
+  "keywords": ["nteract", "display", "jupyter"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.14",
   "description": "The editor that lives inside cells in nteract",
   "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
@@ -11,12 +12,7 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
-  "keywords": [
-    "nteract",
-    "editor",
-    "notebook",
-    "jupyter"
-  ],
+  "keywords": ["nteract", "editor", "notebook", "jupyter"],
   "publishConfig": {
     "access": "public"
   },

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.10",
   "description": "Messaging mechanics for nteract apps (jupyter spec)",
   "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
@@ -18,12 +19,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "nteract",
-    "messaging",
-    "jmp",
-    "jupyter"
-  ],
+  "keywords": ["nteract", "messaging", "jmp", "jupyter"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"
 }

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.2",
   "description": "View a notebook using a React Component",
   "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.7",
   "description": "Transform for data resource JSON",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.4",
   "description": "GeoJSON Transform",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.11",
   "description": "Transform for debug usage with nteract models",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "Plotly Transform",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.12",
   "description": "Vega Transform",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.0",
   "description": "Transforms from nteract",
   "main": "lib/",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
@@ -15,11 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/nteract/nteract.git"
   },
-  "keywords": [
-    "nteract",
-    "transforms",
-    "notebook"
-  ],
+  "keywords": ["nteract", "transforms", "notebook"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "Common transforms for Jupyter",
   "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run build:clean && npm run build:lib && npm run build:flow",
@@ -15,11 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/nteract/nteract.git"
   },
-  "keywords": [
-    "nteract",
-    "transforms",
-    "notebook"
-  ],
+  "keywords": ["nteract", "transforms", "notebook"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/src/notebook/providers/editor.js
+++ b/src/notebook/providers/editor.js
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 
 import { focusCell, focusCellEditor, updateCellSource } from "../actions";
-import EditorView from "../../../packages/editor/lib";
+import EditorView from "../../../packages/editor/";
 
 type Props = {
   dispatch: Dispatch<*>,

--- a/src/notebook/reducers/document.js
+++ b/src/notebook/reducers/document.js
@@ -29,9 +29,9 @@ import type {
   ImmutableOutput,
   ImmutableOutputs,
   MimeBundle
-} from "../../../packages/commutable/lib/types";
+} from "../../../packages/commutable/src/types";
 
-import type { Output, StreamOutput } from "../../../packages/commutable/lib/v4";
+import type { Output, StreamOutput } from "../../../packages/commutable/src/v4";
 
 type Pager = {
   source: "page",
@@ -439,9 +439,8 @@ function newCellAppend(state: DocumentState, action: NewCellAppendAction) {
   const { cellType } = action;
   const notebook: ImmutableNotebook = state.get("notebook");
   const cellOrder: ImmutableCellOrder = notebook.get("cellOrder");
-  const cell: ImmutableCell = cellType === "markdown"
-    ? emptyMarkdownCell
-    : emptyCodeCell;
+  const cell: ImmutableCell =
+    cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
   const index = cellOrder.count();
   const cellID = uuid.v4();
   return state.set("notebook", insertCellAt(notebook, cell, cellID, index));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = {
     ]
   },
   resolve: {
+    mainFields: ["nteractDesktop", "main"],
     extensions: [".js", ".jsx"]
   },
   externals: nodeModules,


### PR DESCRIPTION
This brings us back to the golden age of hacking on nteract.

You can now run two terminals for ease of hacking:

## Terminal 1

```
npm run build:renderer:watch
```

## Terminal 2

```
npm run build:main && npm run spawn
```

No more having to build the subpackages. Initial `npm i` is still a bit painstaking.