### PR TITLE
fix(notebook-preview-demo): Fix placeholder CSS to load smooth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,17 +1799,6 @@
 			"integrity": "sha1-El+wBgS2P7sYjblqZnziki3NbN0=",
 			"dev": true
 		},
-		"canvas": {
-			"version": "1.6.5",
-			"resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.5.tgz",
-			"integrity": "sha1-VX+ZiPXSyV/cJHxhpe5D3lL2cXw=",
-			"optional": true,
-			"requires": {
-				"nan": "2.6.2",
-				"parse-css-font": "2.0.2",
-				"units-css": "0.4.0"
-			}
-		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -2545,45 +2534,6 @@
 			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 			"dev": true
 		},
-		"css-font-size-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
-			"integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
-			"optional": true
-		},
-		"css-font-stretch-keywords": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
-			"integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
-			"optional": true
-		},
-		"css-font-style-keywords": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
-			"integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
-			"optional": true
-		},
-		"css-font-weight-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
-			"integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
-			"optional": true
-		},
-		"css-global-keywords": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
-			"integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
-			"optional": true
-		},
-		"css-list-helpers": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
-			"integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
-			"optional": true,
-			"requires": {
-				"tcomb": "2.7.0"
-			}
-		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -2595,12 +2545,6 @@
 				"domutils": "1.5.1",
 				"nth-check": "1.0.1"
 			}
-		},
-		"css-system-font-keywords": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
-			"integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
-			"optional": true
 		},
 		"css-what": {
 			"version": "2.1.0",
@@ -6658,12 +6602,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
-		"isnumeric": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
-			"optional": true
-		},
 		"isobject": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
@@ -9445,23 +9383,6 @@
 				}
 			}
 		},
-		"parse-css-font": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
-			"integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
-			"optional": true,
-			"requires": {
-				"css-font-size-keywords": "1.0.0",
-				"css-font-stretch-keywords": "1.0.1",
-				"css-font-style-keywords": "1.0.1",
-				"css-font-weight-keywords": "1.0.0",
-				"css-global-keywords": "1.0.1",
-				"css-list-helpers": "1.0.1",
-				"css-system-font-keywords": "1.0.0",
-				"tcomb": "2.7.0",
-				"unquote": "1.1.0"
-			}
-		},
 		"parse-github-repo-url": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz",
@@ -11236,11 +11157,6 @@
 				"xtend": "4.0.1"
 			}
 		},
-		"tcomb": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
-			"integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA="
-		},
 		"temp-dir": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -11660,27 +11576,11 @@
 				"crypto-random-string": "1.0.0"
 			}
 		},
-		"units-css": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
-			"optional": true,
-			"requires": {
-				"isnumeric": "0.2.0",
-				"viewport-dimensions": "0.2.0"
-			}
-		},
 		"universalify": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
 			"integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
 			"dev": true
-		},
-		"unquote": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.0.tgz",
-			"integrity": "sha1-mOH8YItrhUx1r7G5WvwJm6adlC8=",
-			"optional": true
 		},
 		"unused-filename": {
 			"version": "0.1.0",
@@ -11810,7 +11710,6 @@
 			"resolved": "https://registry.npmjs.org/vega/-/vega-2.6.5.tgz",
 			"integrity": "sha1-I3jUZyk0Igvilx3AhxqYflQstb4=",
 			"requires": {
-				"canvas": "1.6.5",
 				"d3": "3.5.17",
 				"d3-cloud": "1.2.4",
 				"d3-geo-projection": "0.2.16",
@@ -11917,7 +11816,6 @@
 			"resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-1.1.0.tgz",
 			"integrity": "sha1-qLkef+v25lf6NvqymE9jiEgQxmM=",
 			"requires": {
-				"canvas": "1.6.5",
 				"d3": "3.5.17",
 				"datalib": "1.7.3"
 			}
@@ -11929,12 +11827,6 @@
 			"requires": {
 				"extsprintf": "1.0.2"
 			}
-		},
-		"viewport-dimensions": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
-			"optional": true
 		},
 		"vm-browserify": {
 			"version": "0.0.4",

--- a/packages/notebook-preview-demo/static/main.css
+++ b/packages/notebook-preview-demo/static/main.css
@@ -47,7 +47,6 @@ div#loading {
 .cell pre
 {
     font-size: 14px;
-    line-height: 1.21429em;
 
     word-wrap: break-word;
 }

--- a/packages/notebook-preview-demo/static/nbp.css
+++ b/packages/notebook-preview-demo/static/nbp.css
@@ -17,6 +17,7 @@
   box-shadow: none;
   width: 100%;
   resize: none;
-  padding-top: .4em;
-  padding-bottom: .4em;
+  padding: 10px 0 5px 10px;
+  letter-spacing: 0.3px;
+  word-spacing: 1px;
 }


### PR DESCRIPTION
## PR
![pr](https://user-images.githubusercontent.com/13285808/27989935-ef49daa8-6446-11e7-8575-0b60e9057d3c.gif)
## master
![master](https://user-images.githubusercontent.com/13285808/27989934-ef49ec5a-6446-11e7-9c31-dcd4bc9081bc.gif)

Now the only thing that flickers is the code mirror wrapping which cannot be fixed with simple CSS.