### PR TITLE
set inner HTML for server side render

### DIFF
--- a/packages/transforms/src/html.js
+++ b/packages/transforms/src/html.js
@@ -8,6 +8,11 @@ type Props = {
 // Note: createRange and Range must be polyfilled on older browsers with
 //       https://github.com/timdown/rangy
 export function createFragment(html: string): Node {
+  /**
+   * createFragment takes in an HTML string and outputs a DOM element that is
+   * treated as if it originated on the page "like normal".
+   * @type {Node} - https://developer.mozilla.org/en-US/docs/Web/API/Node
+   */
   // Create a range to ensure that scripts are invoked from within the HTML
   const range = document.createRange();
   const fragment = range.createContextualFragment(html);
@@ -21,10 +26,14 @@ export default class HTMLDisplay extends React.Component {
 
   componentDidMount(): void {
     // clear out all DOM element children
-    // This matters on server side render
+    // This matters on server side render otherwise we'll get both the `innerHTML`ed
+    // version + the fragment version right after each other
+    // In the desktop app (and successive loads with tools like commuter) this
+    // will be a no-op
     while (this.el.firstChild) {
       this.el.removeChild(this.el.firstChild);
     }
+    // DOM element appended with a real DOM Node fragment
     this.el.appendChild(createFragment(this.props.data));
   }
 

--- a/packages/transforms/src/html.js
+++ b/packages/transforms/src/html.js
@@ -20,6 +20,11 @@ export default class HTMLDisplay extends React.Component {
   static MIMETYPE = "text/html";
 
   componentDidMount(): void {
+    // clear out all DOM element children
+    // This matters on server side render
+    while (this.el.firstChild) {
+      this.el.removeChild(this.el.firstChild);
+    }
     this.el.appendChild(createFragment(this.props.data));
   }
 
@@ -37,6 +42,7 @@ export default class HTMLDisplay extends React.Component {
   render(): ?React.Element<any> {
     return (
       <div
+        dangerouslySetInnerHTML={{ __html: this.props.data }}
         ref={el => {
           this.el = el;
         }}


### PR DESCRIPTION
Following on to #1777, now with even less flicker since the HTML portion can be server side rendered.

![less-flicker](https://user-images.githubusercontent.com/836375/27990044-f17d523e-63fe-11e7-8ada-d2ca15d92f62.gif)

Props to @lgeiger for making me want to perfect it even more.