### PR TITLE
ux(notebook): change padding after last cell so user can scroll cell to top

### DIFF
--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -104,7 +104,8 @@ export class Notebook extends React.PureComponent {
     if (this.stickyCellsPlaceholder) {
       // Make sure the document is vertically shifted so the top non-stickied
       // cell is always visible.
-      this.stickyCellsPlaceholder.style.height = `${this.stickyCellContainer.clientHeight}px`;
+      this.stickyCellsPlaceholder.style.height = `${this.stickyCellContainer
+        .clientHeight}px`;
     }
   }
 
@@ -179,6 +180,7 @@ export class Notebook extends React.PureComponent {
 
   createCellElement(id: string): ?React.Element<any> {
     const cellMap = this.props.notebook.get("cellMap");
+    const cellOrder = this.props.notebook.get("cellOrder");
     const cell = cellMap.get(id);
     const transient = this.props.transient.getIn(
       ["cellMap", id],

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -180,7 +180,6 @@ export class Notebook extends React.PureComponent {
 
   createCellElement(id: string): ?React.Element<any> {
     const cellMap = this.props.notebook.get("cellMap");
-    const cellOrder = this.props.notebook.get("cellOrder");
     const cell = cellMap.get(id);
     const transient = this.props.transient.getIn(
       ["cellMap", id],

--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -181,10 +181,11 @@ body
     padding-right: 10px;
 }
 
-.notebook .cell-container:last-child {
-    padding-bottom: 200px;
+@media not print {
+    .notebook .cell-container:last-child {
+        padding-bottom: calc(100vh - 110px);
+    }
 }
-
 /*
   Cell
  */

--- a/static/styles/theme-classic.css
+++ b/static/styles/theme-classic.css
@@ -77,13 +77,6 @@
   padding: 0px 0px 0px calc(var(--prompt-width) + 10px);
 }
 
-.draggable-cell {
-  padding: 0px !important;
-  border-top-width: 1px !important;
-  border-bottom-width: 1px !important;
-  margin-bottom: -1px;
-}
-
 .cell-toolbar {
   box-shadow: 0 1px 0.5px 0 rgba(0,0,0,.10);
   border-radius: 3px;


### PR DESCRIPTION
This commit addresses issue #1733
This commit incorporates feedback from pr #1761 

This simply changes CSS to add dynamic padding so that the last cell may be scrolled to the top.

I've removed some CSS from the classic theme. I could not see it helping anything, but it gives a different cell spacing compared to other themes.