### PR TITLE
[DONT MERGE] let webpack handle the plotly bits

### DIFF
--- a/packages/transform-plotly/package-lock.json
+++ b/packages/transform-plotly/package-lock.json
@@ -1,16 +1,4440 @@
 {
-	"requires": true,
+	"name": "@nteract/transform-plotly",
+	"version": "2.0.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"@nteract/plotly": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@nteract/plotly/-/plotly-1.0.0.tgz",
 			"integrity": "sha1-HORUqxuqZ9wm5y/1qRfCBl7tkUY="
 		},
+		"@plotly/d3-sankey": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.5.0.tgz",
+			"integrity": "sha1-si+up0LlglEzXuXZ+6JIdyYHgA8=",
+			"requires": {
+				"d3-array": "1.2.0",
+				"d3-collection": "1.0.4",
+				"d3-interpolate": "1.1.5"
+			}
+		},
+		"3d-view": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
+			"integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
+			"requires": {
+				"matrix-camera-controller": "2.1.3",
+				"orbit-camera-controller": "4.0.0",
+				"turntable-camera-controller": "3.0.1"
+			}
+		},
+		"3d-view-controls": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/3d-view-controls/-/3d-view-controls-2.2.0.tgz",
+			"integrity": "sha1-RK7JxEjCe+NLPdUR/5ICq2FQ3KU=",
+			"requires": {
+				"3d-view": "2.0.0",
+				"mouse-change": "1.4.0",
+				"mouse-event-offset": "3.0.2",
+				"mouse-wheel": "1.2.0",
+				"right-now": "1.0.0"
+			}
+		},
+		"a-big-triangle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
+			"integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-vao": "1.3.0",
+				"weak-map": "1.0.5"
+			}
+		},
+		"acorn": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+			"integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+		},
+		"add-line-numbers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
+			"integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
+			"requires": {
+				"pad-left": "1.0.2"
+			}
+		},
+		"affine-hull": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
+			"integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
+			"requires": {
+				"robust-orientation": "1.1.3"
+			}
+		},
+		"ajv": {
+			"version": "4.11.8",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+			"requires": {
+				"co": "4.6.0",
+				"json-stable-stringify": "1.0.1"
+			}
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"requires": {
+				"kind-of": "3.2.2",
+				"longest": "1.0.1",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"almost-equal": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+			"integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
+		},
+		"alpha-complex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
+			"integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
+			"requires": {
+				"circumradius": "1.0.0",
+				"delaunay-triangulate": "1.1.6"
+			}
+		},
+		"alpha-shape": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
+			"integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
+			"requires": {
+				"alpha-complex": "1.0.0",
+				"simplicial-complex-boundary": "1.0.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+		},
+		"ansi-styles": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+			"integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+		},
+		"array-bounds": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
+			"integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
+		},
+		"array-normalize": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.3.tgz",
+			"integrity": "sha1-c/uDf0gW7BkVHTxejYU6RZDOAb0=",
+			"requires": {
+				"array-bounds": "1.0.1"
+			}
+		},
+		"arraytools": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/arraytools/-/arraytools-1.1.2.tgz",
+			"integrity": "sha1-QQ+OgTe2dHXlPBkYVy542JPxH78="
+		},
+		"asn1": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+		},
+		"assert-plus": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
+			"integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
+		},
+		"aws-sign2": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+		},
+		"aws4": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"barycentric": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
+			"integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
+			"requires": {
+				"robust-linear-solve": "1.0.0"
+			}
+		},
+		"base64-js": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+			"integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+			"optional": true,
+			"requires": {
+				"tweetnacl": "0.14.5"
+			}
+		},
+		"big-rat": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
+			"integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+			"requires": {
+				"bit-twiddle": "1.0.2",
+				"bn.js": "4.11.7",
+				"double-bits": "1.1.1"
+			}
+		},
+		"binary-search-bounds": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
+			"integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+		},
+		"bit-twiddle": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+			"integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+		},
+		"bl": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+			"integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"bn.js": {
+			"version": "4.11.7",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+			"integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA=="
+		},
+		"boom": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"bops": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+			"integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
+			"requires": {
+				"base64-js": "0.0.2",
+				"to-utf8": "0.0.1"
+			}
+		},
+		"boundary-cells": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.1.tgz",
+			"integrity": "sha1-6QWo0UGc9Hyza+Pb9SXbXiTeAEI=",
+			"requires": {
+				"tape": "4.7.0"
+			}
+		},
+		"box-intersect": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+			"integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
+			"requires": {
+				"bit-twiddle": "1.0.2",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"brfs": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.3.tgz",
+			"integrity": "sha1-22ddb16SPm3wh/ylhZyQkKrtMhY=",
+			"requires": {
+				"quote-stream": "1.0.2",
+				"resolve": "1.3.3",
+				"static-module": "1.4.0",
+				"through2": "2.0.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"quote-stream": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+					"integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+					"requires": {
+						"buffer-equal": "0.0.1",
+						"minimist": "1.2.0",
+						"through2": "2.0.3"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"buffer-equal": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+		},
+		"call-matcher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.0.1.tgz",
+			"integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
+			"requires": {
+				"core-js": "2.4.1",
+				"deep-equal": "1.0.1",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0"
+			},
+			"dependencies": {
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+				}
+			}
+		},
+		"camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"cdt2d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
+			"integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+			"requires": {
+				"binary-search-bounds": "2.0.3",
+				"robust-in-sphere": "1.1.3",
+				"robust-orientation": "1.1.3"
+			},
+			"dependencies": {
+				"binary-search-bounds": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+					"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+				}
+			}
+		},
+		"cell-orientation": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cell-orientation/-/cell-orientation-1.0.1.tgz",
+			"integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA="
+		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"requires": {
+				"align-text": "0.1.4",
+				"lazy-cache": "1.0.4"
+			}
+		},
+		"chalk": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+			"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+			"requires": {
+				"ansi-styles": "1.0.0",
+				"has-color": "0.1.7",
+				"strip-ansi": "0.1.1"
+			}
+		},
+		"circumcenter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
+			"integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
+			"requires": {
+				"dup": "1.0.0",
+				"robust-linear-solve": "1.0.0"
+			}
+		},
+		"circumradius": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
+			"integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
+			"requires": {
+				"circumcenter": "1.0.0"
+			}
+		},
+		"clamp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+			"integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+		},
+		"clean-pslg": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
+			"integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+			"requires": {
+				"big-rat": "1.0.4",
+				"box-intersect": "1.0.1",
+				"nextafter": "1.0.0",
+				"rat-vec": "1.1.1",
+				"robust-segment-intersect": "1.0.1",
+				"union-find": "1.0.2",
+				"uniq": "1.0.1"
+			}
+		},
+		"cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"requires": {
+				"center-align": "0.1.3",
+				"right-align": "0.1.3",
+				"wordwrap": "0.0.2"
+			},
+			"dependencies": {
+				"wordwrap": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+					"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+				}
+			}
+		},
+		"clone": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+			"integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"color-id": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
+			"integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+			"requires": {
+				"clamp": "1.0.1"
+			}
+		},
+		"color-name": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+			"integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
+		},
+		"color-parse": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.2.tgz",
+			"integrity": "sha1-oUHt8cl7tKpMoAxFUArJEbLxO/8=",
+			"requires": {
+				"color-name": "1.1.2",
+				"is-plain-obj": "1.1.0"
+			}
+		},
+		"color-rgba": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-1.1.0.tgz",
+			"integrity": "sha1-LKnPl/AApOlnaYF2oOMzXH51IVw=",
+			"requires": {
+				"clamp": "1.0.1",
+				"color-parse": "1.3.2",
+				"color-space": "1.14.7"
+			}
+		},
+		"color-space": {
+			"version": "1.14.7",
+			"resolved": "https://registry.npmjs.org/color-space/-/color-space-1.14.7.tgz",
+			"integrity": "sha1-t/WjF3lCe7JfmSemlBDYDC6qpxs=",
+			"requires": {
+				"husl": "5.0.3",
+				"mumath": "3.3.4"
+			}
+		},
+		"colormap": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/colormap/-/colormap-2.2.0.tgz",
+			"integrity": "sha1-kU/gQyBVih/AWC0B4PR7yRPYyKU=",
+			"requires": {
+				"arraytools": "1.1.2",
+				"clone": "1.0.2"
+			}
+		},
+		"colors": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+			"integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+		},
+		"combined-stream": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+			"requires": {
+				"delayed-stream": "1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+			"integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+		},
+		"compare-angle": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
+			"integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
+			"requires": {
+				"robust-orientation": "1.1.3",
+				"robust-product": "1.0.0",
+				"robust-sum": "1.0.0",
+				"signum": "0.0.0",
+				"two-sum": "1.0.0"
+			}
+		},
+		"compare-cell": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/compare-cell/-/compare-cell-1.0.0.tgz",
+			"integrity": "sha1-qetwj24OQa73qlZrEw8ZaNyeGqo="
+		},
+		"compare-oriented-cell": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
+			"integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
+			"requires": {
+				"cell-orientation": "1.0.1",
+				"compare-cell": "1.0.0"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"convert-source-map": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+		},
+		"convex-hull": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
+			"integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
+			"requires": {
+				"affine-hull": "1.0.0",
+				"incremental-convex-hull": "1.0.1",
+				"monotone-convex-hull-2d": "1.0.1"
+			}
+		},
+		"core-js": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+			"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"country-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
+			"integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY="
+		},
+		"cryptiles": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+			"requires": {
+				"boom": "2.10.1"
+			}
+		},
+		"csscolorparser": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+			"integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+		},
+		"cubic-hermite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
+			"integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
+		},
+		"cwise": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
+			"integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
+			"requires": {
+				"cwise-compiler": "1.1.3",
+				"cwise-parser": "1.0.3",
+				"static-module": "1.4.0",
+				"uglify-js": "2.8.29"
+			}
+		},
+		"cwise-compiler": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+			"integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+			"requires": {
+				"uniq": "1.0.1"
+			}
+		},
+		"cwise-parser": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
+			"integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
+			"requires": {
+				"esprima": "1.1.1",
+				"uniq": "1.0.1"
+			}
+		},
+		"d3": {
+			"version": "3.5.17",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+			"integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+		},
+		"d3-array": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.0.tgz",
+			"integrity": "sha1-FH0mlyDhdMQFen9CvosPPyulMQg="
+		},
+		"d3-collection": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
+			"integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+		},
+		"d3-color": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
+			"integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+		},
+		"d3-dispatch": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.3.tgz",
+			"integrity": "sha1-RuFJHqqbWMNY/OW+TovtYm54cfg="
+		},
+		"d3-force": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.0.6.tgz",
+			"integrity": "sha1-6n4bdzDiZkzTFPWU1nGMV8wTK3k=",
+			"requires": {
+				"d3-collection": "1.0.4",
+				"d3-dispatch": "1.0.3",
+				"d3-quadtree": "1.0.3",
+				"d3-timer": "1.0.6"
+			}
+		},
+		"d3-interpolate": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.5.tgz",
+			"integrity": "sha1-aeCZ/zkhRxblY8muw+qdHqS4p58=",
+			"requires": {
+				"d3-color": "1.0.3"
+			}
+		},
+		"d3-quadtree": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.3.tgz",
+			"integrity": "sha1-rHmH4+I/6AWpkPKOG1DTj8uCJDg="
+		},
+		"d3-timer": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.6.tgz",
+			"integrity": "sha1-QES/FdcCXAbOfRFJ9zzQe1Tb14Q="
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"deep-equal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"requires": {
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
+			}
+		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+		},
+		"delaunay-triangulate": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
+			"integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
+			"requires": {
+				"incremental-convex-hull": "1.0.1",
+				"uniq": "1.0.1"
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"double-bits": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
+			"integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+		},
+		"dup": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+			"integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
+		},
+		"duplexer2": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+			"requires": {
+				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				}
+			}
+		},
+		"duplexify": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+			"integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+			"requires": {
+				"end-of-stream": "1.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"stream-shift": "1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"earcut": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.1.tgz",
+			"integrity": "sha1-FXY05fPrtCIk5HUBboalts5Va0U="
+		},
+		"ecc-jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+			"optional": true,
+			"requires": {
+				"jsbn": "0.1.1"
+			}
+		},
+		"edges-to-adjacency-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
+			"integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
+			"requires": {
+				"uniq": "1.0.1"
+			}
+		},
+		"end-of-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+			"integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+			"requires": {
+				"once": "1.3.3"
+			},
+			"dependencies": {
+				"once": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+					"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				}
+			}
+		},
+		"es-abstract": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+			"integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
+			"requires": {
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.0",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"requires": {
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
+			}
+		},
+		"es6-promise": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+		},
+		"escodegen": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+			"integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
+			"requires": {
+				"esprima": "1.1.1",
+				"estraverse": "1.5.1",
+				"esutils": "1.0.0",
+				"source-map": "0.1.43"
+			}
+		},
+		"esprima": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+			"integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
+		},
+		"espurify": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+			"requires": {
+				"core-js": "2.4.1"
+			}
+		},
+		"estraverse": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+			"integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
+		},
+		"esutils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+			"integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
+		},
+		"events": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+		},
+		"extend": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+		},
+		"extract-frustum-planes": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/extract-frustum-planes/-/extract-frustum-planes-1.0.0.tgz",
+			"integrity": "sha1-l9VwP/BWTIw8aDjKxF+ee8UsnvU="
+		},
+		"extsprintf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+			"integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+		},
+		"falafel": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+			"integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+			"requires": {
+				"acorn": "5.1.1",
+				"foreach": "2.0.5",
+				"isarray": "0.0.1",
+				"object-keys": "1.0.11"
+			}
+		},
+		"fast-isnumeric": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.1.tgz",
+			"integrity": "sha1-V7gcB6PAnLnsO++cFhgYmS2JNkM="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"feature-filter": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/feature-filter/-/feature-filter-2.2.0.tgz",
+			"integrity": "sha1-PMNWAV6WjDYq+99/8bt0Td9/wuA="
+		},
+		"filtered-vector": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.4.tgz",
+			"integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
+			"requires": {
+				"binary-search-bounds": "1.0.0",
+				"cubic-hermite": "1.0.0"
+			}
+		},
+		"findup": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+			"integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+			"requires": {
+				"colors": "0.6.2",
+				"commander": "2.1.0"
+			}
+		},
+		"font-atlas-sdf": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/font-atlas-sdf/-/font-atlas-sdf-1.3.3.tgz",
+			"integrity": "sha512-GxUpcdkdoHgC3UrpMuA7JmG1Ty/MY0BhfmV8r7ZSv3bkqBY5vmRIjcj7Pg8iqj20B03vlU6fUhdpyIgEo/Z35w==",
+			"requires": {
+				"optical-properties": "1.0.0",
+				"tiny-sdf": "1.0.2"
+			}
+		},
+		"for-each": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+			"integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+			"requires": {
+				"is-function": "1.0.1"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"requires": {
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.5",
+				"mime-types": "2.1.15"
+			}
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"function-bind": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+			"integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+		},
+		"functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+		},
+		"gamma": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
+			"integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
+		},
+		"geojson-area": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/geojson-area/-/geojson-area-0.1.0.tgz",
+			"integrity": "sha1-1I2AcILPrfSnjfE0m+UPOL8YlK4=",
+			"requires": {
+				"wgs84": "0.0.0"
+			}
+		},
+		"geojson-rewind": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.1.0.tgz",
+			"integrity": "sha1-VwIqBUsZZmDXVTVP5dJmhNkM0Bk=",
+			"requires": {
+				"concat-stream": "1.2.1",
+				"geojson-area": "0.1.0",
+				"minimist": "0.0.5"
+			},
+			"dependencies": {
+				"concat-stream": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.2.1.tgz",
+					"integrity": "sha1-81EAtsRjeL+6i2uA+fDQzN8T3GA=",
+					"requires": {
+						"bops": "0.0.6"
+					}
+				},
+				"minimist": {
+					"version": "0.0.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+					"integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
+				}
+			}
+		},
+		"geojson-vt": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-2.4.0.tgz",
+			"integrity": "sha1-PBz0RJPzXrTSxwyV2mVQ3mYHLAU="
+		},
+		"get-canvas-context": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
+			"integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "1.0.0"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"gl-axes3d": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.2.5.tgz",
+			"integrity": "sha1-srQq+9gAJYWj5lQvzPh036phh2I=",
+			"requires": {
+				"bit-twiddle": "1.0.2",
+				"dup": "1.0.0",
+				"extract-frustum-planes": "1.0.0",
+				"gl-buffer": "2.1.2",
+				"gl-mat4": "1.1.4",
+				"gl-shader": "4.2.0",
+				"gl-state": "1.0.0",
+				"gl-vao": "1.3.0",
+				"gl-vec4": "1.0.1",
+				"glslify": "2.3.1",
+				"robust-orientation": "1.1.3",
+				"split-polygon": "1.0.0",
+				"vectorize-text": "3.0.2"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
+			"integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
+			"requires": {
+				"ndarray": "1.0.18",
+				"ndarray-ops": "1.2.2",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"gl-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
+			"integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM="
+		},
+		"gl-contour2d": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.3.tgz",
+			"integrity": "sha1-hidVZs6sG263bACtcpcieDXM02Q=",
+			"requires": {
+				"binary-search-bounds": "2.0.3",
+				"cdt2d": "1.0.0",
+				"clean-pslg": "1.1.2",
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"glslify": "4.0.0",
+				"iota-array": "1.0.0",
+				"ndarray": "1.0.18",
+				"surface-nets": "1.0.2"
+			},
+			"dependencies": {
+				"binary-search-bounds": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+					"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+				}
+			}
+		},
+		"gl-error2d": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/gl-error2d/-/gl-error2d-1.2.1.tgz",
+			"integrity": "sha1-zGl39kdvIF2zxOrFuMSImeSN/dE=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"glslify": "2.3.1",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-error3d": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.6.tgz",
+			"integrity": "sha1-vgNGZ7YaKOgw7dNxpwmsHCJ6P9w=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"gl-vao": "1.3.0",
+				"glslify": "6.1.0"
+			},
+			"dependencies": {
+				"escodegen": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+					"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+					"requires": {
+						"esprima": "2.7.3",
+						"estraverse": "1.9.3",
+						"esutils": "2.0.2",
+						"optionator": "0.8.2",
+						"source-map": "0.2.0"
+					}
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"glslify": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-6.1.0.tgz",
+					"integrity": "sha1-zf/P0qZXFyISjT0TNWwTbebOl0I=",
+					"requires": {
+						"bl": "1.2.1",
+						"concat-stream": "1.6.0",
+						"duplexify": "3.5.0",
+						"falafel": "2.1.0",
+						"from2": "2.3.0",
+						"glsl-resolve": "0.0.1",
+						"glsl-token-whitespace-trim": "1.0.0",
+						"glslify-bundle": "5.0.0",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"stack-trace": "0.0.9",
+						"static-eval": "1.1.1",
+						"tape": "4.7.0",
+						"through2": "2.0.3",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.0.0.tgz",
+					"integrity": "sha1-AlKtoe+d8wtmAAbguyH9EwtIbkI=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-token-whitespace-trim": "1.0.0",
+						"glsl-tokenizer": "2.1.2",
+						"murmurhash-js": "1.0.0",
+						"shallow-copy": "0.0.1"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"source-map": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"optional": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				},
+				"static-eval": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-1.1.1.tgz",
+					"integrity": "sha1-yoEwIQNUzxPZpyK8fpI3eEV7sZI=",
+					"requires": {
+						"escodegen": "1.8.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				}
+			}
+		},
+		"gl-fbo": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
+			"integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
+			"requires": {
+				"gl-texture2d": "2.1.0"
+			}
+		},
+		"gl-format-compiler-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.2.tgz",
+			"integrity": "sha1-NDl9KuYT4tg6WPNdVx3hvn0wgPo=",
+			"requires": {
+				"add-line-numbers": "1.0.1",
+				"gl-constants": "1.0.0",
+				"glsl-shader-name": "1.0.0",
+				"sprintf-js": "1.1.1"
+			}
+		},
+		"gl-heatmap2d": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.3.tgz",
+			"integrity": "sha1-acthUS4xGF6ovSbwJfXBrx8rChg=",
+			"requires": {
+				"binary-search-bounds": "2.0.3",
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"glslify": "4.0.0",
+				"iota-array": "1.0.0",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"binary-search-bounds": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+					"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+				}
+			}
+		},
+		"gl-line2d": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/gl-line2d/-/gl-line2d-1.4.1.tgz",
+			"integrity": "sha1-v4F5Rzj5p2N9zd6WaGZqRMEqERA=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"gl-texture2d": "2.1.0",
+				"glslify": "2.3.1",
+				"ndarray": "1.0.18",
+				"snap-points-2d": "1.0.1",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-line3d": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.0.tgz",
+			"integrity": "sha1-6K6Va4l/Ew+x1YeY+t90v5ohq5s=",
+			"requires": {
+				"binary-search-bounds": "1.0.0",
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"gl-texture2d": "2.1.0",
+				"gl-vao": "1.3.0",
+				"glsl-read-float": "1.1.0",
+				"glslify": "2.3.1",
+				"ndarray": "1.0.18"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-mat2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-mat2/-/gl-mat2-1.0.0.tgz",
+			"integrity": "sha1-IsBvBrvBQai/rH2Fc/VSjx3inUY="
+		},
+		"gl-mat3": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
+			"integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+		},
+		"gl-mat4": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.1.4.tgz",
+			"integrity": "sha1-HolbVYkuVqiWhnq9g30483oXgIY="
+		},
+		"gl-matrix": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.3.2.tgz",
+			"integrity": "sha1-qsgIx0r31dsF/gTLYMoaD8sXTXQ="
+		},
+		"gl-matrix-invert": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
+			"integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
+			"requires": {
+				"gl-mat2": "1.0.0",
+				"gl-mat3": "1.0.0",
+				"gl-mat4": "1.1.4"
+			}
+		},
+		"gl-mesh3d": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-1.3.0.tgz",
+			"integrity": "sha1-wYlohZKRxTiSOQQLUL+bPSZAYaY=",
+			"requires": {
+				"barycentric": "1.0.1",
+				"colormap": "2.2.0",
+				"gl-buffer": "2.1.2",
+				"gl-mat4": "1.1.4",
+				"gl-shader": "4.2.0",
+				"gl-texture2d": "2.1.0",
+				"gl-vao": "1.3.0",
+				"glsl-specular-cook-torrance": "2.0.1",
+				"glslify": "2.3.1",
+				"ndarray": "1.0.18",
+				"normals": "1.1.0",
+				"polytope-closest-point": "1.0.0",
+				"simplicial-complex-contour": "1.0.2",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-plot2d": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.2.0.tgz",
+			"integrity": "sha1-me6tJG0vZHPMmkvAhhf7ZCerYi0=",
+			"requires": {
+				"binary-search-bounds": "2.0.3",
+				"gl-buffer": "2.1.2",
+				"gl-select-static": "2.0.2",
+				"gl-shader": "4.2.1",
+				"glsl-inverse": "1.0.0",
+				"glslify": "2.3.1",
+				"text-cache": "4.1.0"
+			},
+			"dependencies": {
+				"binary-search-bounds": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+					"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+				},
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"gl-shader": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
+					"integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
+					"requires": {
+						"gl-format-compiler-error": "1.0.2",
+						"weakmap-shim": "1.1.1"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-plot3d": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-1.5.4.tgz",
+			"integrity": "sha1-vpwYaMgppH0KKrA8cNUor4aPnoY=",
+			"requires": {
+				"3d-view-controls": "2.2.0",
+				"a-big-triangle": "1.0.3",
+				"gl-axes3d": "1.2.5",
+				"gl-fbo": "2.0.5",
+				"gl-mat4": "1.1.4",
+				"gl-select-static": "2.0.2",
+				"gl-shader": "4.2.0",
+				"gl-spikes3d": "1.0.5",
+				"glslify": "2.3.1",
+				"is-mobile": "0.2.2",
+				"mouse-change": "1.4.0",
+				"ndarray": "1.0.18"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-pointcloud2d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.0.tgz",
+			"integrity": "sha1-QbrpluBJ4PHf2Pn44V/5A/xPv90=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.1",
+				"glslify": "2.3.1",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"gl-shader": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
+					"integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
+					"requires": {
+						"gl-format-compiler-error": "1.0.2",
+						"weakmap-shim": "1.1.1"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-quat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
+			"integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
+			"requires": {
+				"gl-mat3": "1.0.0",
+				"gl-vec3": "1.0.3",
+				"gl-vec4": "1.0.1"
+			}
+		},
+		"gl-scatter2d": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/gl-scatter2d/-/gl-scatter2d-1.3.2.tgz",
+			"integrity": "sha1-J/Ev+ntDA/QhXyIJpXPXKPGAQ3E=",
+			"requires": {
+				"array-bounds": "1.0.1",
+				"array-normalize": "1.1.3",
+				"binary-search-bounds": "2.0.3",
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"glslify": "2.3.1",
+				"snap-points-2d": "3.1.0",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"binary-search-bounds": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+					"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+				},
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				},
+				"snap-points-2d": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/snap-points-2d/-/snap-points-2d-3.1.0.tgz",
+					"integrity": "sha1-bc/Co8XenasCwnJLhXe5B+Rjzxo=",
+					"requires": {
+						"typedarray-pool": "1.1.0"
+					}
+				}
+			}
+		},
+		"gl-scatter2d-sdf": {
+			"version": "1.3.11",
+			"resolved": "https://registry.npmjs.org/gl-scatter2d-sdf/-/gl-scatter2d-sdf-1.3.11.tgz",
+			"integrity": "sha1-qnYJBdPLPEL0qYp4+DDLO1K9oPQ=",
+			"requires": {
+				"binary-search-bounds": "2.0.3",
+				"clamp": "1.0.1",
+				"color-id": "1.1.0",
+				"font-atlas-sdf": "1.3.3",
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.1",
+				"gl-texture2d": "2.1.0",
+				"glslify": "2.3.1",
+				"snap-points-2d": "3.1.0",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"binary-search-bounds": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.3.tgz",
+					"integrity": "sha1-X/hhbW3SylOIvIWy1iZuK52lAtw="
+				},
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"gl-shader": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
+					"integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
+					"requires": {
+						"gl-format-compiler-error": "1.0.2",
+						"weakmap-shim": "1.1.1"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				},
+				"snap-points-2d": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/snap-points-2d/-/snap-points-2d-3.1.0.tgz",
+					"integrity": "sha1-bc/Co8XenasCwnJLhXe5B+Rjzxo=",
+					"requires": {
+						"typedarray-pool": "1.1.0"
+					}
+				}
+			}
+		},
+		"gl-scatter3d": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.0.10.tgz",
+			"integrity": "sha1-ScV/MxCMO1azWBVBkoqP7rLTfp4=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-mat4": "1.1.4",
+				"gl-shader": "4.2.0",
+				"gl-vao": "1.3.0",
+				"glslify": "2.3.1",
+				"typedarray-pool": "1.1.0",
+				"vectorize-text": "3.0.2"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-select-box": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.1.tgz",
+			"integrity": "sha1-DMjJBczif+jZGLsO4Th/WDj5Wek=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"glslify": "2.3.1"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-select-static": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.2.tgz",
+			"integrity": "sha1-8+GQHfAxgdUy55WFMjBnnUr1fuk=",
+			"requires": {
+				"bit-twiddle": "1.0.2",
+				"cwise": "1.0.10",
+				"gl-fbo": "2.0.5",
+				"ndarray": "1.0.18",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"gl-shader": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.0.tgz",
+			"integrity": "sha1-KPd4E+/6DdXNqdqx8wHRsc2j6H4=",
+			"requires": {
+				"gl-format-compiler-error": "1.0.2",
+				"weakmap-shim": "1.1.1"
+			}
+		},
+		"gl-spikes2d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.1.tgz",
+			"integrity": "sha1-ys2y09vNICuFNFLoUAqLB3lJzAM="
+		},
+		"gl-spikes3d": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.5.tgz",
+			"integrity": "sha1-aX6fLqdZe+Qauke9oRm5X0jKFX0=",
+			"requires": {
+				"gl-buffer": "2.1.2",
+				"gl-shader": "4.2.0",
+				"gl-vao": "1.3.0",
+				"glslify": "2.3.1"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-state": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
+			"integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
+			"requires": {
+				"uniq": "1.0.1"
+			}
+		},
+		"gl-surface3d": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.3.1.tgz",
+			"integrity": "sha1-z5wXdiTrUM87bNfMI6CIWEQ9qPk=",
+			"requires": {
+				"binary-search-bounds": "1.0.0",
+				"bit-twiddle": "1.0.2",
+				"colormap": "2.2.0",
+				"dup": "1.0.0",
+				"gl-buffer": "2.1.2",
+				"gl-mat4": "1.1.4",
+				"gl-shader": "4.2.0",
+				"gl-texture2d": "2.1.0",
+				"gl-vao": "1.3.0",
+				"glsl-specular-beckmann": "1.1.2",
+				"glslify": "2.3.1",
+				"ndarray": "1.0.18",
+				"ndarray-gradient": "1.0.0",
+				"ndarray-ops": "1.2.2",
+				"ndarray-pack": "1.2.1",
+				"ndarray-scratch": "1.2.0",
+				"surface-nets": "1.0.2",
+				"typedarray-pool": "1.1.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "1.0.34"
+					}
+				},
+				"glslify": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/glslify/-/glslify-2.3.1.tgz",
+					"integrity": "sha1-R6jOW/CGCVVqp+x2xqfTQwd23UY=",
+					"requires": {
+						"bl": "0.9.5",
+						"glsl-resolve": "0.0.1",
+						"glslify-bundle": "2.0.4",
+						"glslify-deps": "1.3.0",
+						"minimist": "1.2.0",
+						"resolve": "1.3.3",
+						"static-module": "1.4.0",
+						"through2": "0.6.5",
+						"xtend": "4.0.1"
+					}
+				},
+				"glslify-bundle": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-2.0.4.tgz",
+					"integrity": "sha1-eV3xGYGAeIYaoZiaDHXVnCDs/dY=",
+					"requires": {
+						"glsl-inject-defines": "1.0.3",
+						"glsl-token-defines": "1.0.0",
+						"glsl-token-depth": "1.1.2",
+						"glsl-token-descope": "1.0.2",
+						"glsl-token-scope": "1.1.2",
+						"glsl-token-string": "1.0.1",
+						"glsl-tokenizer": "2.1.2"
+					}
+				}
+			}
+		},
+		"gl-texture2d": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
+			"integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
+			"requires": {
+				"ndarray": "1.0.18",
+				"ndarray-ops": "1.2.2",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"gl-vao": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/gl-vao/-/gl-vao-1.3.0.tgz",
+			"integrity": "sha1-6ekqqVWIyrnVwvBLaTRAw99pGSM="
+		},
+		"gl-vec3": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/gl-vec3/-/gl-vec3-1.0.3.tgz",
+			"integrity": "sha1-EQ/Yl9Byn2OYMHOBVn0JRJQb8is="
+		},
+		"gl-vec4": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gl-vec4/-/gl-vec4-1.0.1.tgz",
+			"integrity": "sha1-l9loeCgbFLUyy84QF4Xf0cs0CWQ="
+		},
+		"glob": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
+			}
+		},
+		"glsl-inject-defines": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
+			"integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
+			"requires": {
+				"glsl-token-inject-block": "1.1.0",
+				"glsl-token-string": "1.0.1",
+				"glsl-tokenizer": "2.1.2"
+			}
+		},
+		"glsl-inverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glsl-inverse/-/glsl-inverse-1.0.0.tgz",
+			"integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
+		},
+		"glsl-read-float": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/glsl-read-float/-/glsl-read-float-1.1.0.tgz",
+			"integrity": "sha1-37CIsBYtz8xW/E7d0vhuGMrDLyY="
+		},
+		"glsl-resolve": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
+			"integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
+			"requires": {
+				"resolve": "0.6.3",
+				"xtend": "2.2.0"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+					"integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+				},
+				"xtend": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+					"integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
+				}
+			}
+		},
+		"glsl-shader-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
+			"integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
+			"requires": {
+				"atob-lite": "1.0.0",
+				"glsl-tokenizer": "2.1.2"
+			}
+		},
+		"glsl-specular-beckmann": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
+			"integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
+		},
+		"glsl-specular-cook-torrance": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
+			"integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
+			"requires": {
+				"glsl-specular-beckmann": "1.1.2"
+			}
+		},
+		"glsl-token-assignments": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
+			"integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8="
+		},
+		"glsl-token-defines": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
+			"integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
+			"requires": {
+				"glsl-tokenizer": "2.1.2"
+			}
+		},
+		"glsl-token-depth": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
+			"integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ="
+		},
+		"glsl-token-descope": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
+			"integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
+			"requires": {
+				"glsl-token-assignments": "2.0.2",
+				"glsl-token-depth": "1.1.2",
+				"glsl-token-properties": "1.0.1",
+				"glsl-token-scope": "1.1.2"
+			}
+		},
+		"glsl-token-inject-block": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
+			"integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ="
+		},
+		"glsl-token-properties": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
+			"integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4="
+		},
+		"glsl-token-scope": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
+			"integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E="
+		},
+		"glsl-token-string": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
+			"integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw="
+		},
+		"glsl-token-whitespace-trim": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
+			"integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA="
+		},
+		"glsl-tokenizer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.2.tgz",
+			"integrity": "sha1-cgMHUi4DxXrzXABVGVDEpw7y37k=",
+			"requires": {
+				"through2": "0.6.5"
+			}
+		},
+		"glslify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/glslify/-/glslify-4.0.0.tgz",
+			"integrity": "sha1-Tbz60TaVPzAVA/pKjgabIzahQjQ=",
+			"requires": {
+				"bl": "1.2.1",
+				"glsl-resolve": "0.0.1",
+				"glslify-bundle": "4.0.1",
+				"glslify-deps": "1.3.0",
+				"minimist": "1.2.0",
+				"resolve": "1.3.3",
+				"static-module": "1.4.0",
+				"through2": "0.6.5",
+				"xtend": "4.0.1"
+			}
+		},
+		"glslify-bundle": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-4.0.1.tgz",
+			"integrity": "sha1-ryzyBs15hRWRALM7XxRjqBt0TaE=",
+			"requires": {
+				"glsl-inject-defines": "1.0.3",
+				"glsl-token-defines": "1.0.0",
+				"glsl-token-depth": "1.1.2",
+				"glsl-token-descope": "1.0.2",
+				"glsl-token-scope": "1.1.2",
+				"glsl-token-string": "1.0.1",
+				"glsl-token-whitespace-trim": "1.0.0",
+				"glsl-tokenizer": "2.1.2",
+				"murmurhash-js": "1.0.0",
+				"shallow-copy": "0.0.1"
+			}
+		},
+		"glslify-deps": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.0.tgz",
+			"integrity": "sha1-CyI0yOqePT/X9rPLfwOuWea1Glk=",
+			"requires": {
+				"events": "1.1.1",
+				"findup": "0.1.5",
+				"glsl-resolve": "0.0.1",
+				"glsl-tokenizer": "2.1.2",
+				"graceful-fs": "4.1.11",
+				"inherits": "2.0.3",
+				"map-limit": "0.0.1",
+				"resolve": "1.3.3"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+		},
+		"grid-index": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.0.0.tgz",
+			"integrity": "sha1-rSxdVM5bNUN/r/HXCprrPR0mERA="
+		},
+		"har-schema": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+			"integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+		},
+		"har-validator": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+			"requires": {
+				"ajv": "4.11.8",
+				"har-schema": "1.0.5"
+			}
+		},
+		"has": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+			"requires": {
+				"function-bind": "1.1.0"
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+		},
+		"hawk": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+			"requires": {
+				"boom": "2.10.1",
+				"cryptiles": "2.0.5",
+				"hoek": "2.16.3",
+				"sntp": "1.0.9"
+			}
+		},
+		"hoek": {
+			"version": "2.16.3",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+		},
+		"http-signature": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+			"requires": {
+				"assert-plus": "0.2.0",
+				"jsprim": "1.4.0",
+				"sshpk": "1.13.1"
+			}
+		},
+		"husl": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/husl/-/husl-5.0.3.tgz",
+			"integrity": "sha1-7icqr/G+vkDfNYjtAHtw3n5nl4g="
+		},
+		"ieee754": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+			"integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+		},
+		"incremental-convex-hull": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
+			"integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
+			"requires": {
+				"robust-orientation": "1.1.3",
+				"simplicial-complex": "1.0.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"interval-tree-1d": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
+			"integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
+			"requires": {
+				"binary-search-bounds": "1.0.0"
+			}
+		},
+		"invert-permutation": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/invert-permutation/-/invert-permutation-1.0.0.tgz",
+			"integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM="
+		},
+		"iota-array": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+			"integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+		},
+		"is-buffer": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+			"integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+		},
+		"is-function": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+		},
+		"is-mobile": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-0.2.2.tgz",
+			"integrity": "sha1-Di4AbZntLCFVt2HfgPKjYZrirZ8="
+		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+		},
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"requires": {
+				"has": "1.0.1"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"requires": {
+				"jsonify": "0.0.0"
+			}
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+		},
+		"jsonlint-lines-primitives": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/jsonlint-lines-primitives/-/jsonlint-lines-primitives-1.6.0.tgz",
+			"integrity": "sha1-u4n2DIubYS/ZE92qI2ZJuEDYZhE=",
+			"requires": {
+				"JSV": "4.0.2",
+				"nomnom": "1.8.1"
+			}
+		},
+		"jsprim": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+			"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.0.2",
+				"json-schema": "0.2.3",
+				"verror": "1.3.6"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"JSV": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+			"integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
+		},
+		"kdbush": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz",
+			"integrity": "sha1-PL0D6d6tnA9vZszblkUOXOzGQOA="
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"requires": {
+				"is-buffer": "1.1.5"
+			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
+			}
+		},
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
 			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+		},
+		"lodash._baseisequal": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+			"requires": {
+				"lodash.isarray": "3.0.4",
+				"lodash.istypedarray": "3.0.6",
+				"lodash.keys": "3.1.2"
+			}
+		},
+		"lodash._bindcallback": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+		},
+		"lodash.isequal": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-3.0.4.tgz",
+			"integrity": "sha1-HDXrO27wzR/1F0Pj6jz3/f/ay2Q=",
+			"requires": {
+				"lodash._baseisequal": "3.0.7",
+				"lodash._bindcallback": "3.0.1"
+			}
+		},
+		"lodash.istypedarray": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+			"integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"requires": {
+				"lodash._getnative": "3.9.1",
+				"lodash.isarguments": "3.1.0",
+				"lodash.isarray": "3.0.4"
+			}
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+		},
+		"map-limit": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+			"integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+			"requires": {
+				"once": "1.3.3"
+			},
+			"dependencies": {
+				"once": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+					"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				}
+			}
+		},
+		"mapbox-gl": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.22.1.tgz",
+			"integrity": "sha1-kqllVH1MLyTCLLxIfu2khpTLYno=",
+			"requires": {
+				"csscolorparser": "1.0.3",
+				"earcut": "2.1.1",
+				"feature-filter": "2.2.0",
+				"geojson-rewind": "0.1.0",
+				"geojson-vt": "2.4.0",
+				"gl-matrix": "2.3.2",
+				"grid-index": "1.0.0",
+				"mapbox-gl-function": "1.3.0",
+				"mapbox-gl-shaders": "github:mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
+				"mapbox-gl-style-spec": "github:mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae",
+				"mapbox-gl-supported": "1.2.0",
+				"pbf": "1.3.7",
+				"pngjs": "2.3.1",
+				"point-geometry": "0.0.0",
+				"quickselect": "1.0.0",
+				"request": "2.81.0",
+				"resolve-url": "0.2.1",
+				"shelf-pack": "1.1.0",
+				"supercluster": "2.3.0",
+				"unassertify": "2.0.4",
+				"unitbezier": "0.0.0",
+				"vector-tile": "1.3.0",
+				"vt-pbf": "2.1.2",
+				"webworkify": "1.4.0",
+				"whoots-js": "2.1.0"
+			}
+		},
+		"mapbox-gl-function": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/mapbox-gl-function/-/mapbox-gl-function-1.3.0.tgz",
+			"integrity": "sha1-zuPZV1DBidReg6tBoKV/wqilCbw="
+		},
+		"mapbox-gl-shaders": {
+			"version": "github:mapbox/mapbox-gl-shaders#de2ab007455aa2587c552694c68583f94c9f2747",
+			"requires": {
+				"brfs": "1.4.3"
+			}
+		},
+		"mapbox-gl-style-spec": {
+			"version": "github:mapbox/mapbox-gl-style-spec#83b1a3e5837d785af582efd5ed1a212f2df6a4ae",
+			"requires": {
+				"csscolorparser": "1.0.3",
+				"jsonlint-lines-primitives": "1.6.0",
+				"lodash.isequal": "3.0.4",
+				"minimist": "0.0.8",
+				"rw": "0.1.4",
+				"sort-object": "0.3.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				}
+			}
+		},
+		"mapbox-gl-supported": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz",
+			"integrity": "sha1-y9NN+JQgbK3amjPI2aRgnya7GYk="
+		},
+		"marching-simplex-table": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
+			"integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
+			"requires": {
+				"convex-hull": "1.0.3"
+			}
+		},
+		"mat4-decompose": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
+			"integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
+			"requires": {
+				"gl-mat4": "1.1.4",
+				"gl-vec3": "1.0.3"
+			}
+		},
+		"mat4-interpolate": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
+			"integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
+			"requires": {
+				"gl-mat4": "1.1.4",
+				"gl-vec3": "1.0.3",
+				"mat4-decompose": "1.0.4",
+				"mat4-recompose": "1.0.4",
+				"quat-slerp": "1.0.1"
+			}
+		},
+		"mat4-recompose": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
+			"integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
+			"requires": {
+				"gl-mat4": "1.1.4"
+			}
+		},
+		"matrix-camera-controller": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
+			"integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
+			"requires": {
+				"binary-search-bounds": "1.0.0",
+				"gl-mat4": "1.1.4",
+				"gl-vec3": "1.0.3",
+				"mat4-interpolate": "1.0.4"
+			}
+		},
+		"mime-db": {
+			"version": "1.27.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+			"integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+		},
+		"mime-types": {
+			"version": "2.1.15",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+			"integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+			"requires": {
+				"mime-db": "1.27.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"requires": {
+				"brace-expansion": "1.1.8"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+		},
+		"monotone-convex-hull-2d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+			"integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+			"requires": {
+				"robust-orientation": "1.1.3"
+			}
+		},
+		"mouse-change": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
+			"integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
+			"requires": {
+				"mouse-event": "1.0.5"
+			}
+		},
+		"mouse-event": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
+			"integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI="
+		},
+		"mouse-event-offset": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+			"integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ="
+		},
+		"mouse-wheel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+			"integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
+			"requires": {
+				"right-now": "1.0.0",
+				"signum": "1.0.0",
+				"to-px": "1.0.1"
+			},
+			"dependencies": {
+				"signum": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+					"integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc="
+				}
+			}
+		},
+		"multi-stage-sourcemap": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
+			"integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
+			"requires": {
+				"source-map": "0.1.43"
+			}
+		},
+		"mumath": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+			"integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
+			"requires": {
+				"almost-equal": "1.1.0"
+			}
+		},
+		"murmurhash-js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+			"integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+		},
+		"ndarray": {
+			"version": "1.0.18",
+			"resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
+			"integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+			"requires": {
+				"iota-array": "1.0.0",
+				"is-buffer": "1.1.5"
+			}
+		},
+		"ndarray-extract-contour": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
+			"integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
+			"requires": {
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"ndarray-fill": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
+			"integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
+			"requires": {
+				"cwise": "1.0.10"
+			}
+		},
+		"ndarray-gradient": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
+			"integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
+			"requires": {
+				"cwise-compiler": "1.1.3",
+				"dup": "1.0.0"
+			}
+		},
+		"ndarray-homography": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
+			"integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
+			"requires": {
+				"gl-matrix-invert": "1.0.0",
+				"ndarray-warp": "1.0.1"
+			}
+		},
+		"ndarray-linear-interpolate": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ndarray-linear-interpolate/-/ndarray-linear-interpolate-1.0.0.tgz",
+			"integrity": "sha1-eLySuFuavBW25n7mWCj54hN65ys="
+		},
+		"ndarray-ops": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+			"integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+			"requires": {
+				"cwise-compiler": "1.1.3"
+			}
+		},
+		"ndarray-pack": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
+			"integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+			"requires": {
+				"cwise-compiler": "1.1.3",
+				"ndarray": "1.0.18"
+			}
+		},
+		"ndarray-scratch": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
+			"integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
+			"requires": {
+				"ndarray": "1.0.18",
+				"ndarray-ops": "1.2.2",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"ndarray-sort": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
+			"integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
+			"requires": {
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"ndarray-warp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
+			"integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
+			"requires": {
+				"cwise": "1.0.10",
+				"ndarray-linear-interpolate": "1.0.0"
+			}
+		},
+		"nextafter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
+			"integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+			"requires": {
+				"double-bits": "1.1.1"
+			}
+		},
+		"nomnom": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+			"requires": {
+				"chalk": "0.4.0",
+				"underscore": "1.6.0"
+			}
+		},
+		"normals": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
+			"integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
+		},
+		"numeric": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
+			"integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
+		},
+		"oauth-sign": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"object-inspect": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.2.2.tgz",
+			"integrity": "sha1-yCEV5PzIiK6hTWTCLk8X9qcNXlo="
+		},
+		"object-keys": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+			"integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1.0.2"
+			}
+		},
+		"optical-properties": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/optical-properties/-/optical-properties-1.0.0.tgz",
+			"integrity": "sha512-XnBQYbIIzDVr7U3L7d3xyAEqp1W+HTkqmw/G4L/Ae/+dq57bT1jqW2uDwV0wCUzO8gsTDIZhGQsGrMb17VSkEA=="
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"requires": {
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
+			}
+		},
+		"orbit-camera-controller": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
+			"integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
+			"requires": {
+				"filtered-vector": "1.2.4",
+				"gl-mat4": "1.1.4"
+			}
+		},
+		"pad-left": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
+			"integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
+			"requires": {
+				"repeat-string": "1.6.1"
+			}
+		},
+		"parse-unit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+			"integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+		},
+		"pbf": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-1.3.7.tgz",
+			"integrity": "sha1-Hj0Ee6PL6Ahq6FSiVQOrRTfUM10=",
+			"requires": {
+				"ieee754": "1.1.8",
+				"resolve-protobuf-schema": "2.0.0"
+			}
+		},
+		"performance-now": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+			"integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+		},
+		"permutation-parity": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
+			"integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
+			"requires": {
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"permutation-rank": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
+			"integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
+			"requires": {
+				"invert-permutation": "1.0.0",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"planar-dual": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
+			"integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
+			"requires": {
+				"compare-angle": "1.0.1",
+				"dup": "1.0.0"
+			}
+		},
+		"planar-graph-to-polyline": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
+			"integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
+			"requires": {
+				"edges-to-adjacency-list": "1.0.0",
+				"planar-dual": "1.0.2",
+				"point-in-big-polygon": "2.0.0",
+				"robust-orientation": "1.1.3",
+				"robust-sum": "1.0.0",
+				"two-product": "1.0.2",
+				"uniq": "1.0.1"
+			}
+		},
+		"plotly.js": {
+			"version": "1.28.3",
+			"resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.28.3.tgz",
+			"integrity": "sha1-eSQdEZiC4H7pe/Yq/nzDErUQhmM=",
+			"requires": {
+				"@plotly/d3-sankey": "0.5.0",
+				"3d-view": "2.0.0",
+				"alpha-shape": "1.0.0",
+				"color-rgba": "1.1.0",
+				"convex-hull": "1.0.3",
+				"country-regex": "1.1.0",
+				"d3": "3.5.17",
+				"d3-force": "1.0.6",
+				"delaunay-triangulate": "1.1.6",
+				"es6-promise": "3.3.1",
+				"fast-isnumeric": "1.1.1",
+				"font-atlas-sdf": "1.3.3",
+				"gl-contour2d": "1.1.3",
+				"gl-error2d": "1.2.1",
+				"gl-error3d": "1.0.6",
+				"gl-heatmap2d": "1.0.3",
+				"gl-line2d": "1.4.1",
+				"gl-line3d": "1.1.0",
+				"gl-mat4": "1.1.4",
+				"gl-mesh3d": "1.3.0",
+				"gl-plot2d": "1.2.0",
+				"gl-plot3d": "1.5.4",
+				"gl-pointcloud2d": "1.0.0",
+				"gl-scatter2d": "1.3.2",
+				"gl-scatter2d-sdf": "1.3.11",
+				"gl-scatter3d": "1.0.10",
+				"gl-select-box": "1.0.1",
+				"gl-shader": "4.2.0",
+				"gl-spikes2d": "1.0.1",
+				"gl-surface3d": "1.3.1",
+				"mapbox-gl": "0.22.1",
+				"matrix-camera-controller": "2.1.3",
+				"mouse-change": "1.4.0",
+				"mouse-event-offset": "3.0.2",
+				"mouse-wheel": "1.2.0",
+				"ndarray": "1.0.18",
+				"ndarray-fill": "1.0.2",
+				"ndarray-homography": "1.0.0",
+				"ndarray-ops": "1.2.2",
+				"regl": "1.3.0",
+				"right-now": "1.0.0",
+				"robust-orientation": "1.1.3",
+				"sane-topojson": "2.0.0",
+				"strongly-connected-components": "1.0.1",
+				"superscript-text": "1.0.0",
+				"tinycolor2": "1.4.1",
+				"topojson-client": "2.1.0",
+				"webgl-context": "2.2.0",
+				"world-calendars": "1.0.3"
+			}
+		},
+		"pngjs": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-2.3.1.tgz",
+			"integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
+		},
+		"point-geometry": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz",
+			"integrity": "sha1-b8vK16gDtkGCR91uScKFPFhNr/c="
+		},
+		"point-in-big-polygon": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
+			"integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
+			"requires": {
+				"binary-search-bounds": "1.0.0",
+				"interval-tree-1d": "1.0.3",
+				"robust-orientation": "1.1.3",
+				"slab-decomposition": "1.0.2"
+			}
+		},
+		"polytope-closest-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
+			"integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
+			"requires": {
+				"numeric": "1.2.6"
+			}
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"process-nextick-args": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+		},
+		"protocol-buffers-schema": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz",
+			"integrity": "sha1-0pxs1z+2VZePtpiWkRgNuEQRn2E="
+		},
+		"punycode": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+		},
+		"qs": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+			"integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+		},
+		"quat-slerp": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
+			"integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
+			"requires": {
+				"gl-quat": "1.0.0"
+			}
+		},
+		"quickselect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.0.tgz",
+			"integrity": "sha1-AmMIGPmq5OyrJvAQP5jQYcF8WPM="
+		},
+		"quote-stream": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
+			"integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
+			"requires": {
+				"minimist": "0.0.8",
+				"through2": "0.4.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+				},
+				"object-keys": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+				},
+				"through2": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+					"integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "2.1.2"
+					}
+				},
+				"xtend": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+					"requires": {
+						"object-keys": "0.4.0"
+					}
+				}
+			}
+		},
+		"rat-vec": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
+			"integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+			"requires": {
+				"big-rat": "1.0.4"
+			}
+		},
+		"readable-stream": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "0.0.1",
+				"string_decoder": "0.10.31"
+			}
+		},
+		"reduce-simplicial-complex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
+			"integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
+			"requires": {
+				"cell-orientation": "1.0.1",
+				"compare-cell": "1.0.0",
+				"compare-oriented-cell": "1.0.1"
+			}
+		},
+		"regl": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/regl/-/regl-1.3.0.tgz",
+			"integrity": "sha1-zN6C7/iooGilWVgc6svvGv6njr0="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"request": {
+			"version": "2.81.0",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+			"requires": {
+				"aws-sign2": "0.6.0",
+				"aws4": "1.6.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.5",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.1.4",
+				"har-validator": "4.2.1",
+				"hawk": "3.1.3",
+				"http-signature": "1.1.1",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.15",
+				"oauth-sign": "0.8.2",
+				"performance-now": "0.2.0",
+				"qs": "6.4.0",
+				"safe-buffer": "5.1.1",
+				"stringstream": "0.0.5",
+				"tough-cookie": "2.3.2",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.1.0"
+			}
+		},
+		"resolve": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+			"integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+			"requires": {
+				"path-parse": "1.0.5"
+			}
+		},
+		"resolve-protobuf-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.0.0.tgz",
+			"integrity": "sha1-5nsGKmfwLRG9aIbnDv2niEB+D7Q=",
+			"requires": {
+				"protocol-buffers-schema": "2.2.0"
+			}
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"resumer": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+			"integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+			"requires": {
+				"through": "2.3.8"
+			}
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"requires": {
+				"align-text": "0.1.4"
+			}
+		},
+		"right-now": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+			"integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
+		},
+		"robust-compress": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
+			"integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs="
+		},
+		"robust-determinant": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
+			"integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
+			"requires": {
+				"robust-compress": "1.0.0",
+				"robust-scale": "1.0.2",
+				"robust-sum": "1.0.0",
+				"two-product": "1.0.2"
+			}
+		},
+		"robust-dot-product": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
+			"integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
+			"requires": {
+				"robust-sum": "1.0.0",
+				"two-product": "1.0.2"
+			}
+		},
+		"robust-in-sphere": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
+			"integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
+			"requires": {
+				"robust-scale": "1.0.2",
+				"robust-subtract": "1.0.0",
+				"robust-sum": "1.0.0",
+				"two-product": "1.0.2"
+			}
+		},
+		"robust-linear-solve": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
+			"integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
+			"requires": {
+				"robust-determinant": "1.1.0"
+			}
+		},
+		"robust-orientation": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+			"integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+			"requires": {
+				"robust-scale": "1.0.2",
+				"robust-subtract": "1.0.0",
+				"robust-sum": "1.0.0",
+				"two-product": "1.0.2"
+			}
+		},
+		"robust-product": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
+			"integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
+			"requires": {
+				"robust-scale": "1.0.2",
+				"robust-sum": "1.0.0"
+			}
+		},
+		"robust-scale": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+			"integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+			"requires": {
+				"two-product": "1.0.2",
+				"two-sum": "1.0.0"
+			}
+		},
+		"robust-segment-intersect": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
+			"integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+			"requires": {
+				"robust-orientation": "1.1.3"
+			}
+		},
+		"robust-subtract": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+			"integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+		},
+		"robust-sum": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+			"integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+		},
+		"rw": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
+			"integrity": "sha1-SQPL2AJIrg7eaFv1j9I2p6mymj4="
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+		},
+		"sane-topojson": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-2.0.0.tgz",
+			"integrity": "sha1-QOJXNqKMTM6qojP0W7hjc6J4W4Q="
+		},
+		"shallow-copy": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+			"integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+		},
+		"shelf-pack": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/shelf-pack/-/shelf-pack-1.1.0.tgz",
+			"integrity": "sha1-tGea/dAK1o39m70rWj6BkpOnTYI="
+		},
+		"signum": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
+			"integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+		},
+		"simplicial-complex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
+			"integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
+			"requires": {
+				"bit-twiddle": "1.0.2",
+				"union-find": "1.0.2"
+			}
+		},
+		"simplicial-complex-boundary": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
+			"integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
+			"requires": {
+				"boundary-cells": "2.0.1",
+				"reduce-simplicial-complex": "1.0.0"
+			}
+		},
+		"simplicial-complex-contour": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
+			"integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
+			"requires": {
+				"marching-simplex-table": "1.0.0",
+				"ndarray": "1.0.18",
+				"ndarray-sort": "1.0.1",
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"simplify-planar-graph": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
+			"integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
+			"requires": {
+				"robust-orientation": "1.1.3",
+				"simplicial-complex": "0.3.3"
+			},
+			"dependencies": {
+				"bit-twiddle": {
+					"version": "0.0.2",
+					"resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-0.0.2.tgz",
+					"integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4="
+				},
+				"simplicial-complex": {
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
+					"integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
+					"requires": {
+						"bit-twiddle": "0.0.2",
+						"union-find": "0.0.4"
+					}
+				},
+				"union-find": {
+					"version": "0.0.4",
+					"resolved": "https://registry.npmjs.org/union-find/-/union-find-0.0.4.tgz",
+					"integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY="
+				}
+			}
+		},
+		"slab-decomposition": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
+			"integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
+			"requires": {
+				"binary-search-bounds": "1.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"robust-orientation": "1.1.3"
+			}
+		},
+		"snap-points-2d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/snap-points-2d/-/snap-points-2d-1.0.1.tgz",
+			"integrity": "sha1-imeaR+GV+jFAWwPcbgwD4YIo3PQ=",
+			"requires": {
+				"typedarray-pool": "1.1.0"
+			}
+		},
+		"sntp": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+			"requires": {
+				"hoek": "2.16.3"
+			}
+		},
+		"sort-asc": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+			"integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
+		},
+		"sort-desc": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+			"integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
+		},
+		"sort-object": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+			"integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
+			"requires": {
+				"sort-asc": "0.1.0",
+				"sort-desc": "0.1.1"
+			}
+		},
+		"source-map": {
+			"version": "0.1.43",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+			"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+			"requires": {
+				"amdefine": "1.0.1"
+			}
+		},
+		"split-polygon": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
+			"integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
+			"requires": {
+				"robust-dot-product": "1.0.0",
+				"robust-sum": "1.0.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+			"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+		},
+		"sshpk": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+			"requires": {
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
+			},
+			"dependencies": {
+				"assert-plus": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+				}
+			}
+		},
+		"stack-trace": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+			"integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+		},
+		"static-eval": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
+			"integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
+			"requires": {
+				"escodegen": "0.0.28"
+			},
+			"dependencies": {
+				"escodegen": {
+					"version": "0.0.28",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
+					"integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
+					"requires": {
+						"esprima": "1.0.4",
+						"estraverse": "1.3.2",
+						"source-map": "0.1.43"
+					}
+				},
+				"esprima": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+					"integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+				},
+				"estraverse": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
+					"integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
+				}
+			}
+		},
+		"static-module": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/static-module/-/static-module-1.4.0.tgz",
+			"integrity": "sha1-vvDZtviVhfbyNZuBYb7qsGBV29I=",
+			"requires": {
+				"concat-stream": "1.6.0",
+				"duplexer2": "0.0.2",
+				"escodegen": "1.3.3",
+				"falafel": "2.1.0",
+				"has": "1.0.1",
+				"object-inspect": "0.4.0",
+				"quote-stream": "0.0.0",
+				"readable-stream": "1.0.34",
+				"shallow-copy": "0.0.1",
+				"static-eval": "0.2.4",
+				"through2": "0.4.2"
+			},
+			"dependencies": {
+				"object-inspect": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
+					"integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
+				},
+				"object-keys": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+				},
+				"through2": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+					"integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+					"requires": {
+						"readable-stream": "1.0.34",
+						"xtend": "2.1.2"
+					}
+				},
+				"xtend": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+					"requires": {
+						"object-keys": "0.4.0"
+					}
+				}
+			}
+		},
+		"stream-shift": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"string.prototype.trim": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+			"requires": {
+				"define-properties": "1.1.2",
+				"es-abstract": "1.7.0",
+				"function-bind": "1.1.0"
+			}
+		},
+		"stringstream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+		},
+		"strip-ansi": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+			"integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+		},
+		"strongly-connected-components": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+			"integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
+		},
+		"supercluster": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supercluster/-/supercluster-2.3.0.tgz",
+			"integrity": "sha1-h6tWCBu+qaHXJN9TUe6ejDry9Is=",
+			"requires": {
+				"kdbush": "1.0.1"
+			}
+		},
+		"superscript-text": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+			"integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
+		},
+		"surface-nets": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
+			"integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
+			"requires": {
+				"ndarray-extract-contour": "1.0.1",
+				"triangulate-hypercube": "1.0.1",
+				"zero-crossings": "1.0.1"
+			}
+		},
+		"tape": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/tape/-/tape-4.7.0.tgz",
+			"integrity": "sha512-ePzu2KfZYVtq0v+KKGxBJ9HJWYZ4MaQWeGabD+KpVdMKRen3NJPf6EiwA5BxfMkhQPGtCwnOFWelcB39bhOUng==",
+			"requires": {
+				"deep-equal": "1.0.1",
+				"defined": "1.0.0",
+				"for-each": "0.3.2",
+				"function-bind": "1.1.0",
+				"glob": "7.1.2",
+				"has": "1.0.1",
+				"inherits": "2.0.3",
+				"minimist": "1.2.0",
+				"object-inspect": "1.2.2",
+				"resolve": "1.3.3",
+				"resumer": "0.0.0",
+				"string.prototype.trim": "1.1.2",
+				"through": "2.3.8"
+			}
+		},
+		"text-cache": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.1.0.tgz",
+			"integrity": "sha1-fFgJDoWsCRD5dt9M/Izoqg6lh2Y=",
+			"requires": {
+				"vectorize-text": "3.0.2"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"through2": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+			"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+			"requires": {
+				"readable-stream": "1.0.34",
+				"xtend": "4.0.1"
+			}
+		},
+		"tiny-sdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tiny-sdf/-/tiny-sdf-1.0.2.tgz",
+			"integrity": "sha1-KOdphcRMTlhMS2fY7N2bM6HKwow="
+		},
+		"tinycolor2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+			"integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+		},
+		"to-px": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+			"integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
+			"requires": {
+				"parse-unit": "1.0.1"
+			}
+		},
+		"to-utf8": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+			"integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
+		},
+		"topojson-client": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
+			"integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
+			"requires": {
+				"commander": "2.1.0"
+			}
+		},
+		"tough-cookie": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+			"requires": {
+				"punycode": "1.4.1"
+			}
+		},
+		"triangulate-hypercube": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
+			"integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
+			"requires": {
+				"gamma": "0.1.0",
+				"permutation-parity": "1.0.0",
+				"permutation-rank": "1.0.0"
+			}
+		},
+		"triangulate-polyline": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
+			"integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
+			"requires": {
+				"cdt2d": "1.0.0"
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"turntable-camera-controller": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
+			"integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
+			"requires": {
+				"filtered-vector": "1.2.4",
+				"gl-mat4": "1.1.4",
+				"gl-vec3": "1.0.3"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
+		},
+		"two-product": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+			"integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+		},
+		"two-sum": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+			"integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "1.1.2"
+			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"typedarray-pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.1.0.tgz",
+			"integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
+			"requires": {
+				"bit-twiddle": "1.0.2",
+				"dup": "1.0.0"
+			}
+		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"requires": {
+				"source-map": "0.5.6",
+				"uglify-to-browserify": "1.0.2",
+				"yargs": "3.10.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+					"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"optional": true
+		},
+		"unassert": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/unassert/-/unassert-1.5.1.tgz",
+			"integrity": "sha1-y8iOw4dBfFpeTALTzQe+mL11/3Y=",
+			"requires": {
+				"acorn": "4.0.13",
+				"call-matcher": "1.0.1",
+				"deep-equal": "1.0.1",
+				"espurify": "1.7.0",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"object-assign": "4.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				},
+				"estraverse": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+					"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				}
+			}
+		},
+		"unassertify": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/unassertify/-/unassertify-2.0.4.tgz",
+			"integrity": "sha1-s8orpfKbSDbjWm3Xflsg9tu/jlI=",
+			"requires": {
+				"acorn": "4.0.13",
+				"convert-source-map": "1.5.0",
+				"escodegen": "1.8.1",
+				"multi-stage-sourcemap": "0.2.1",
+				"through": "2.3.8",
+				"unassert": "1.5.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "4.0.13",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+					"integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+				},
+				"escodegen": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+					"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+					"requires": {
+						"esprima": "2.7.3",
+						"estraverse": "1.9.3",
+						"esutils": "2.0.2",
+						"optionator": "0.8.2",
+						"source-map": "0.2.0"
+					}
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+				},
+				"source-map": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"optional": true,
+					"requires": {
+						"amdefine": "1.0.1"
+					}
+				}
+			}
+		},
+		"underscore": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+		},
+		"union-find": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
+			"integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+		},
+		"uniq": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+		},
+		"unitbezier": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/unitbezier/-/unitbezier-0.0.0.tgz",
+			"integrity": "sha1-M79/XXKExTUL/Fx/dw+6dUnFSl4="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+			"integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+		},
+		"vector-tile": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/vector-tile/-/vector-tile-1.3.0.tgz",
+			"integrity": "sha1-BtUWqDsGPwTILvU5zxuxrr62lrQ=",
+			"requires": {
+				"point-geometry": "0.0.0"
+			}
+		},
+		"vectorize-text": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
+			"integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+			"requires": {
+				"cdt2d": "1.0.0",
+				"clean-pslg": "1.1.2",
+				"ndarray": "1.0.18",
+				"planar-graph-to-polyline": "1.0.5",
+				"simplify-planar-graph": "2.0.1",
+				"surface-nets": "1.0.2",
+				"triangulate-polyline": "1.0.3"
+			}
+		},
+		"verror": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+			"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+			"requires": {
+				"extsprintf": "1.0.2"
+			}
+		},
+		"vt-pbf": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-2.1.2.tgz",
+			"integrity": "sha1-dUCf3tX2w5EAc6ZMPldc3ro4fwE=",
+			"requires": {
+				"pbf": "1.3.7",
+				"point-geometry": "0.0.0",
+				"vector-tile": "1.3.0"
+			}
+		},
+		"weak-map": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
+			"integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+		},
+		"weakmap-shim": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
+			"integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k="
+		},
+		"webgl-context": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
+			"integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
+			"requires": {
+				"get-canvas-context": "1.0.2"
+			}
+		},
+		"webworkify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.4.0.tgz",
+			"integrity": "sha1-cSRdHjTKz1TkJr2VX4zG7hLQJMI="
+		},
+		"wgs84": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+			"integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
+		},
+		"whoots-js": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/whoots-js/-/whoots-js-2.1.0.tgz",
+			"integrity": "sha1-vLIBw04OrzNfzOWuLPh0V5qZxIc="
+		},
+		"window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+		},
+		"world-calendars": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
+			"integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
+			"requires": {
+				"object-assign": "4.1.1"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"yargs": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+			"requires": {
+				"camelcase": "1.2.1",
+				"cliui": "2.1.0",
+				"decamelize": "1.2.0",
+				"window-size": "0.1.0"
+			}
+		},
+		"zero-crossings": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
+			"integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
+			"requires": {
+				"cwise-compiler": "1.1.3"
+			}
 		}
 	}
 }

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -17,8 +17,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@nteract/plotly": "^1.0.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "plotly.js": "^1.28.3"
   },
   "peerDependencies": {
     "react": "^15.6.1"

--- a/packages/transform-plotly/src/index.js
+++ b/packages/transform-plotly/src/index.js
@@ -31,7 +31,7 @@ export class PlotlyTransform extends React.Component {
   componentDidMount(): void {
     // Handle case of either string to be `JSON.parse`d or pure object
     const figure = this.getFigure();
-    this.Plotly = require("@nteract/plotly");
+    this.Plotly = require("plotly.js");
     this.Plotly.newPlot(this.el, figure.data, figure.layout);
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "main"],
+    mainFields: ["nteractDesktop", "webpack", "main"],
     extensions: [".js", ".jsx"]
   },
   externals: nodeModules,


### PR DESCRIPTION
This lets nteract desktop's webpack use plotly's non-bundled version. _However_ this likely breaks (or makes unbearable) Hydrogen's use of plotly. Opening for discussion mostly.