### PR TITLE
ux(print): Update style to ignore focus cell on print for all themes

### DIFF
--- a/static/styles/main.css
+++ b/static/styles/main.css
@@ -22,6 +22,14 @@
   .cell-creator{
     display: none!important;
   }
+  .cell.focused {
+    border: none;
+    background: var(--cell-bg)!important;
+  }
+  .cell:focus .prompt,
+  .cell.focused .prompt {
+      background: var(--pager-bg)!important;
+  }
 
 }
 

--- a/static/styles/theme-nteract.css
+++ b/static/styles/theme-nteract.css
@@ -367,6 +367,17 @@ ul li::before
 }
 
 /* -------------------- */
+/*   Printing Styles    */
+/* -------------------- */
+@media print {
+  .cell:focus .cm-s-composition.CodeMirror,
+  .cell.focused .cm-s-composition.CodeMirror,
+  .cell.focused .rendered{
+    background: var(--cm-background);
+  }
+}
+
+/* -------------------- */
 /* Miscellaneous Styles */
 /* -------------------- */
 


### PR DESCRIPTION
Hi!  I think I fixed #1734 for all of the themes that show up right out of the box (light, dark, classic, nteract, and one-dark).  This is essentially my first contribution to an Open Source project, so let me know if I could do/could have done anything better 😄 

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] My PR title and commit messages are in [conventional-changelog-standard](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md#how-should-i-write-my-commit-messages-and-pr-titles) format.

