### PR TITLE
provide support for top level source hidden

### DIFF
--- a/packages/notebook-preview/src/cell.js
+++ b/packages/notebook-preview/src/cell.js
@@ -14,7 +14,8 @@ export type CellProps = {
   language: string,
   theme: string,
   tip: boolean,
-  transforms: ImmutableMap<string, any>
+  transforms: ImmutableMap<string, any>,
+  sourceHidden: boolean
 };
 
 export class Cell extends React.PureComponent {
@@ -46,6 +47,7 @@ export class Cell extends React.PureComponent {
                   language={this.props.language}
                   displayOrder={this.props.displayOrder}
                   transforms={this.props.transforms}
+                  sourceHidden={this.props.sourceHidden}
                 />
               );
             case "raw":

--- a/packages/notebook-preview/src/code-cell.js
+++ b/packages/notebook-preview/src/code-cell.js
@@ -18,7 +18,8 @@ type Props = {
   tip: boolean,
   transforms: Object,
   running: boolean,
-  models: ImmutableMap<string, any>
+  models: ImmutableMap<string, any>,
+  sourceHidden: boolean
 };
 
 class CodeCell extends React.PureComponent {
@@ -27,7 +28,8 @@ class CodeCell extends React.PureComponent {
   static defaultProps = {
     running: false,
     tabSize: 4,
-    models: new ImmutableMap()
+    models: new ImmutableMap(),
+    sourceHidden: false
   };
 
   isOutputHidden(): any {
@@ -36,6 +38,7 @@ class CodeCell extends React.PureComponent {
 
   isInputHidden(): any {
     return (
+      this.props.sourceHidden ||
       this.props.cell.getIn(["metadata", "inputHidden"]) ||
       this.props.cell.getIn(["metadata", "hide_input"])
     );

--- a/packages/notebook-preview/src/notebook.js
+++ b/packages/notebook-preview/src/notebook.js
@@ -49,6 +49,9 @@ export class Notebook extends React.PureComponent {
     const cellMap = this.props.notebook.get("cellMap");
     const cell = cellMap.get(id);
 
+    // Propagated from the hide_(all)_input nbextension
+    const sourceHidden = this.props.notebook.getIn("metadata", "hide_input");
+
     return (
       <div className="cell-container" key={`cell-container-${id}`}>
         {/* Note: We don't have a draggable cell yet want to keep the same DOM structure for styling */}
@@ -62,6 +65,7 @@ export class Notebook extends React.PureComponent {
             transforms={this.props.transforms}
             theme={this.props.theme}
             language={getLanguageMode(this.props.notebook)}
+            sourceHidden={sourceHidden}
           />
         </div>
       </div>


### PR DESCRIPTION
This will handle the [`hide_all_input`](http://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/hide_input_all/readme.html) extension for notebook preview and commuter.