### PR TITLE
Optional for vega

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,9 +176,6 @@
     "spawn-rx": "^2.0.11",
     "spawnteract": "^4.0.0",
     "uuid": "^3.1.0",
-    "vega": "^2.6.5",
-    "vega-embed": "^2.2.0",
-    "vega-lite": "^1.3.1",
     "yargs": "^8.0.1"
   },
   "devDependencies": {

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -21,7 +21,7 @@
     "@nteract/editor": "^2.1.3",
     "@nteract/transforms": "^2.1.3",
     "codemirror": "^5.27.0",
-    "commonmark": "^0.27.0",
+    "commonmark": "^0.28.0",
     "commonmark-react-renderer": "^4.3.3",
     "mathjax-electron": "^2.0.1"
   },

--- a/packages/transform-vega/.npmrc
+++ b/packages/transform-vega/.npmrc
@@ -1,1 +1,2 @@
 package-lock = false
+optional = false

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -16,11 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/nteract/nteract.git"
   },
-  "keywords": [
-    "nteract",
-    "transforms",
-    "notebook"
-  ],
+  "keywords": ["nteract", "transforms", "notebook"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -32,7 +28,7 @@
   },
   "dependencies": {
     "ansi-to-react": "^1.4.2",
-    "commonmark": "^0.27.0",
+    "commonmark": "^0.28.0",
     "commonmark-react-renderer": "^4.3.3",
     "mathjax-electron": "^2.0.1",
     "react-json-tree": "^0.10.9"


### PR DESCRIPTION
This makes optional dependencies in vega get ignored (no more building of `canvas`, since we don't need it).

Way faster builds now!