### PR TITLE
fix: [nbextension] tell google not to translate the page

### DIFF
--- a/packages/nbextension/nteract_on_jupyter/index.html
+++ b/packages/nbextension/nteract_on_jupyter/index.html
@@ -7,6 +7,8 @@ Distributed under the terms of the Modified BSD License.
 
 <head>
   <meta charset="utf-8">
+  <meta name="google" content="notranslate">
+  <meta http-equiv="Content-Language" content="en">
 
   <title>{% block title %}{{page_title}}{% endblock %}</title>
 


### PR DESCRIPTION
For a deployment I just made, the page was being detected as Afrikaans. Generally the initial text is in English and google should not offer to autotranslate a notebook.