### PR TITLE
Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,22 +149,22 @@
     "yargs": "^8.0.1"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.24.1",
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.0",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^7.0.0",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
-    "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.5.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "chai": "^4.0.0",
     "chai-immutable": "^1.6.0",
     "cross-env": "^5.0.0",
-    "electron": "^1.7.1",
-    "electron-builder": "^19.11.1",
+    "electron": "^1.7.6",
+    "electron-builder": "^19.22.2",
     "electron-mocha": "^4.0.0",
     "enzyme": "^2.7.1",
     "enzyme-to-json": "^1.5.1",
@@ -195,6 +195,6 @@
     "sinon": "^3.2.0",
     "sinon-chai": "^2.10.0",
     "watch": "^1.0.0",
-    "webpack": "^3.5.4"
+    "webpack": "^3.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "precommit": "lint-staged"
   },
   "build": {
-    "electronVersion": "1.7.1",
+    "electronVersion": "1.7.6",
     "appId": "io.nteract.nteract",
     "fileAssociations": {
       "ext": "ipynb",


### PR DESCRIPTION
It did not occur to me that greenkeeper hasn't been upgrading devDependencies. Since the `package.json` kept changing on install, I wanted to make sure that prettier was really running over the json files properly. It now appears we were on an old version of prettier, so that could be why. 
¯\\\_(ツ)\_/¯