### PR TITLE
view md render when editor explicitly not focused

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -119,7 +119,9 @@ export class Cell extends React.PureComponent {
     const editorFocused = this.props.editorFocused === this.props.id;
     return (
       <div
-        className={`cell ${type === "markdown" || type === "raw" ? "text" : "code"} ${cellFocused ? "focused" : ""}`}
+        className={`cell ${type === "markdown" || type === "raw"
+          ? "text"
+          : "code"} ${cellFocused ? "focused" : ""}`}
         onClick={this.selectCell}
         role="presentation"
         ref={el => {
@@ -141,22 +143,24 @@ export class Cell extends React.PureComponent {
               theme={this.props.theme}
             />
           : type === "code"
-              ? <CodeCell
-                  focusAbove={this.focusAboveCell}
-                  focusBelow={this.focusBelowCell}
-                  cellFocused={cellFocused}
-                  editorFocused={editorFocused}
-                  cell={cell}
-                  id={this.props.id}
-                  theme={this.props.theme}
-                  language={this.props.language}
-                  displayOrder={this.props.displayOrder}
-                  transforms={this.props.transforms}
-                  pagers={this.props.pagers}
-                  running={this.props.running}
-                  models={this.props.models}
-                />
-              : <pre>{cell.get("source")}</pre>}
+            ? <CodeCell
+                focusAbove={this.focusAboveCell}
+                focusBelow={this.focusBelowCell}
+                cellFocused={cellFocused}
+                editorFocused={editorFocused}
+                cell={cell}
+                id={this.props.id}
+                theme={this.props.theme}
+                language={this.props.language}
+                displayOrder={this.props.displayOrder}
+                transforms={this.props.transforms}
+                pagers={this.props.pagers}
+                running={this.props.running}
+                models={this.props.models}
+              />
+            : <pre>
+                {cell.get("source")}
+              </pre>}
       </div>
     );
   }

--- a/src/notebook/components/cell/markdown-cell.js
+++ b/src/notebook/components/cell/markdown-cell.js
@@ -68,6 +68,7 @@ export default class MarkdownCell extends React.PureComponent {
 
   componentWillReceiveProps(nextProps: Props): void {
     this.setState({
+      view: !nextProps.editorFocused,
       source: nextProps.cell.get("source")
     });
   }


### PR DESCRIPTION
This fixes a regression that went into 0.1.0 that I'm _super_ happy to have fixed now.

![behavior](https://user-images.githubusercontent.com/836375/29435522-3833aab2-835c-11e7-88c6-e6194383bac6.gif)

Note to self: I need pay for an upgrade to screenflow...