### PR TITLE
Scroll cell into view when active

### DIFF
--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -85,12 +85,14 @@ export class Cell extends React.PureComponent {
 
   scrollIntoViewIfNeeded(prevCellFocused?: string): void {
     // If the previous cell that was focused was not us, we go ahead and scroll
-    //
 
     if (
       this.props.cellFocused &&
       this.props.cellFocused === this.props.id &&
-      prevCellFocused !== this.props.cellFocused
+      prevCellFocused !== this.props.cellFocused &&
+      // Don't scroll into view if already hovered over, this prevents
+      // accidentally selecting text within the codemirror area
+      !this.state.hoverCell
     ) {
       // $FlowFixMe: This is only valid in Chrome, WebKit
       this.cellDiv.scrollIntoViewIfNeeded();

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -94,9 +94,12 @@ export class Cell extends React.PureComponent {
       // accidentally selecting text within the codemirror area
       !this.state.hoverCell
     ) {
-      // $FlowFixMe: This is only valid in Chrome, WebKit
-      this.cellDiv.scrollIntoViewIfNeeded();
-      // TODO: Polyfill as best we can for the webapp version
+      if ("scrollIntoViewIfNeeded" in this.cellDiv) {
+        // $FlowFixMe: This is only valid in Chrome, WebKit
+        this.cellDiv.scrollIntoViewIfNeeded();
+      } else {
+        // TODO: Polyfill as best we can for the webapp version
+      }
     }
   }
 

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -49,6 +49,7 @@ export class Cell extends React.PureComponent {
   focusCellEditor: () => void;
   setCellHoverState: (mouseEvent: MouseEvent) => void;
   cellDiv: HTMLElement;
+  scrollIntoViewIfNeeded: Function;
 
   static contextTypes = {
     store: PropTypes.object
@@ -61,11 +62,16 @@ export class Cell extends React.PureComponent {
     this.focusAboveCell = this.focusAboveCell.bind(this);
     this.focusBelowCell = this.focusBelowCell.bind(this);
     this.setCellHoverState = this.setCellHoverState.bind(this);
+    this.scrollIntoViewIfNeeded = this.scrollIntoViewIfNeeded.bind(this);
   }
 
   state = {
     hoverCell: false
   };
+
+  componentDidUpdate(prevProps: CellProps) {
+    this.scrollIntoViewIfNeeded(prevProps.cellFocused);
+  }
 
   componentDidMount(): void {
     // Listen to the page level mouse move event and manually check for
@@ -73,6 +79,23 @@ export class Cell extends React.PureComponent {
     // any mouse events.  The hover region is an invisible element that
     // describes the "hot region" that toggles the creator buttons.
     document.addEventListener("mousemove", this.setCellHoverState, false);
+
+    this.scrollIntoViewIfNeeded();
+  }
+
+  scrollIntoViewIfNeeded(prevCellFocused?: string): void {
+    // If the previous cell that was focused was not us, we go ahead and scroll
+    //
+
+    if (
+      this.props.cellFocused &&
+      this.props.cellFocused === this.props.id &&
+      prevCellFocused !== this.props.cellFocused
+    ) {
+      // $FlowFixMe: This is only valid in Chrome, WebKit
+      this.cellDiv.scrollIntoViewIfNeeded();
+      // TODO: Polyfill as best we can for the webapp version
+    }
   }
 
   componentWillUnmount(): void {

--- a/src/notebook/components/cell/cell.js
+++ b/src/notebook/components/cell/cell.js
@@ -19,7 +19,7 @@ import {
   focusNextCellEditor
 } from "../../actions";
 
-// TODO: Remove after provider refactor finished
+// NOTE: PropTypes are required for the sake of contextTypes
 const PropTypes = require("prop-types");
 
 export type CellProps = {

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -20,7 +20,7 @@ import {
 } from "../actions";
 import type { CellProps } from "./cell/cell";
 
-// TODO: Remove after provider refactor finished
+// NOTE: PropTypes are required for the sake of contextTypes
 const PropTypes = require("prop-types");
 
 type Props = {
@@ -100,7 +100,7 @@ export class Notebook extends React.PureComponent {
     document.addEventListener("keydown", this.keyDown);
   }
 
-  componentDidUpdate(): void {
+  componentDidUpdate(prevProps: Props): void {
     if (this.stickyCellsPlaceholder) {
       // Make sure the document is vertically shifted so the top non-stickied
       // cell is always visible.

--- a/src/notebook/components/notebook.js
+++ b/src/notebook/components/notebook.js
@@ -168,6 +168,14 @@ export class Notebook extends React.PureComponent {
       transforms: this.props.transforms,
       moveCell: this.moveCell,
       pagers: this.props.cellPagers.get(id),
+      // TODO: This prop should likely be id === this.props.cellFocused
+      //       so that computation is not done by all the cells.
+      //       They just need to know if they're focused.
+      //       Then again... It does feel like scroll behavior belongs in the
+      //       notebook itself, would require fixing up refs passing with connect()
+      //
+      //       Then again, having the previous focusedCellID (cellFocused) is useful
+      //       for within the cell doing scrolling
       cellFocused: this.props.cellFocused,
       editorFocused: this.props.editorFocused,
       running: transient.get("status") === "busy",

--- a/test/renderer/components/cell/cell-spec.js
+++ b/test/renderer/components/cell/cell-spec.js
@@ -27,6 +27,10 @@ describe("Cell", () => {
     });
     expect(cell).to.not.be.null;
     expect(cell.find("div.cell.text").length).to.be.greaterThan(0);
+
+    cell.update();
+
+    cell.setProps({ cellFocused: "1", id: "1" });
   });
   it("should be able to render a code cell", () => {
     const store = dummyStore();


### PR DESCRIPTION
Well this is neat, I figured out how to do scrolling in a Chrome & WebKit specific way `scrollIntoViewIfNeeded`. It works pretty well, tending to focus the next cell into the middle.