### PR TITLE
Webpack: Respect jsnext:main field from node modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ const options = {
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "main"],
+    mainFields: ["nteractDesktop", "jsnext:main", "main"],
     extensions: [".js", ".jsx"]
   }
 };


### PR DESCRIPTION
Some of our dependencies ship ES2015/ES2016 versions of their package
via the `jsnext:main` field. We should make use of it.

I wonder if we should expose this in our `@nteract` modules as well.