### PR TITLE
switch to nteract assets 3 for smaller size

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,9 +110,9 @@
     "github": "^9.0.0",
     "ijavascript": "^5.0.17",
     "jmp": "^0.7.5",
-    "normalize.css": "^7.0.0",
-    "nteract-assets": "^2.1.0",
     "mathjax-electron": "^2.0.1",
+    "normalize.css": "^7.0.0",
+    "nteract-assets": "^3.0.0",
     "uuid": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Using https://github.com/nteract/assets/pull/8, this makes our app size go down by more than 13 MB.