### PR TITLE
[WIP] Outline what we'll do for saving

### DIFF
--- a/src/main/launch.js
+++ b/src/main/launch.js
@@ -39,6 +39,7 @@ export function launch(filename) {
   let actuallyExit = false;
 
   win.on("close", e => {
+    actuallyExit = true;
     if (!actuallyExit) {
       e.preventDefault();
       dialog.showMessageBox(

--- a/src/notebook/global-events.js
+++ b/src/notebook/global-events.js
@@ -15,6 +15,58 @@ export function unload(store: Store<AppState, Action>) {
   forceShutdownKernel(kernel);
 }
 
+import { save } from "./actions";
+
+import { remote } from "electron";
+const dialog = remote.dialog;
+
+// HACK: module level global
+// this function should emit two actions:
+// * SAVE_AND_QUIT
+// * JUST_QUIT_ALREADY
+let totallyExit = false;
+export function beforeUnload(store: Store<AppState, Action>, e: any) {
+  if (totallyExit) {
+    return;
+  }
+  e.preventDefault();
+  e.returnValue = false;
+
+  const win = remote.getCurrentWindow();
+
+  dialog.showMessageBox(
+    win,
+    {
+      type: "question",
+      buttons: ["Save", "Don't Save"],
+      defaultId: 0,
+      title: "Save Notebook",
+      message: "Save notebook before closing?",
+      detail: "Would you like to save this notebook before closing?"
+    },
+    index => {
+      if (index === 0) {
+        const state = store.getState();
+        const notebook = state.document.get("notebook");
+        // TODO if this is a totally unsaved notebook, we won't have a filename
+        //      and would have to do the save as mechanics as we have in ./menu here
+        const filename = state.metadata.get("filename");
+
+        store.dispatch(save(filename, notebook));
+        // TODO Wait for save
+        // TODO Wait for kernels to close
+        // TODO Actually close
+        totallyExit = true;
+      } else {
+        win.close();
+        totallyExit = true;
+      }
+    }
+  );
+}
+
 export function initGlobalHandlers(store: Store<AppState, Action>) {
+  console.log("registered global handlers");
+  global.window.onbeforeunload = beforeUnload.bind(null, store);
   global.window.onunload = unload.bind(null, store);
 }


### PR DESCRIPTION
This brings over @captainsafia's work in #1147 and hopefully finishes up our document, kernel, and app lifecycle.

I've put in the same hacky thing I did in the main thread to set a module level global variable `totallyExit`. This misses quite a few bits though:

* kernels need to be properly cleaned up
  * connection file
  * the underlying kernel process and its own children
  * all connections
* we must wait for the save and give feedback for each of the edge cases
  * file hasn't been saved yet (have to do saveAs)
  * file can't be saved (permissions), need to try to save somewhere else or generally give the user a way out

I'm thinking about having specific `SAVE_AND_QUIT` and `FULLY_QUIT` actions with associated epics.