### PR TITLE
VDOM

### DIFF
--- a/example-notebooks/vdom.ipynb
+++ b/example-notebooks/vdom.ipynb
@@ -63,7 +63,7 @@
             "application/vdom.v1+json": {
               "type": "h1",
               "props": {
-                "children": null
+                "children": "Welcome to VDOM"
               }
             }
           },
@@ -111,11 +111,11 @@
             "application/vdom.v1+json": {
               "type": "h1",
               "props": {
-                "children": null
+                "children": "Now you're cooking with VDOM"
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x1050052b0>"
+              "<__main__.VDOM at 0x110a4c278>"
             ]
           },
           "metadata": {}
@@ -194,7 +194,7 @@
             "application/vdom.v1+json": {
               "type": "h1",
               "props": {
-                "children": null,
+                "children": "This is great",
                 "style": {
                   "fontSize": "5em",
                   "color": "DeepPink"
@@ -202,7 +202,7 @@
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x1050057b8>"
+              "<__main__.VDOM at 0x110a4ca58>"
             ]
           },
           "metadata": {}
@@ -338,17 +338,17 @@
             "application/vdom.v1+json": {
               "type": "h1",
               "props": {
-                "children": null
+                "children": "❤️ VDOM ❤️"
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x105005128>"
+              "<__main__.VDOM at 0x1109adb70>"
             ]
           },
           "metadata": {}
         }
       ],
-      "execution_count": 7,
+      "execution_count": 8,
       "metadata": {
         "collapsed": false,
         "outputHidden": false,
@@ -394,20 +394,20 @@
             "application/vdom.v1+json": {
               "type": "h1",
               "props": {
-                "children": null,
+                "children": "WINNER 🐰",
                 "style": {
                   "fontSize": "4em"
                 }
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x105092fd0>"
+              "<__main__.VDOM at 0x110a5d710>"
             ]
           },
           "metadata": {}
         }
       ],
-      "execution_count": 11,
+      "execution_count": 9,
       "metadata": {
         "collapsed": false,
         "outputExpanded": false
@@ -472,11 +472,46 @@
             "application/vdom.v1+json": {
               "type": "div",
               "props": {
-                "children": null
+                "children": [
+                  {
+                    "type": "h1",
+                    "props": {
+                      "children": "Now Incredibly Declarative"
+                    }
+                  },
+                  {
+                    "type": "p",
+                    "props": {
+                      "children": [
+                        "Can you believe we wrote ",
+                        {
+                          "type": "b",
+                          "props": {
+                            "children": "all this from scratch"
+                          }
+                        },
+                        "?"
+                      ]
+                    }
+                  },
+                  {
+                    "type": "img",
+                    "props": {
+                      "children": null,
+                      "src": "https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif"
+                    }
+                  },
+                  {
+                    "type": "p",
+                    "props": {
+                      "children": "SO COOL!"
+                    }
+                  }
+                ]
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x10b8be8d0>"
+              "<__main__.VDOM at 0x110a6bba8>"
             ]
           },
           "metadata": {}
@@ -537,18 +572,37 @@
             "application/vdom.v1+json": {
               "type": "details",
               "props": {
-                "children": null,
+                "children": [
+                  {
+                    "type": "summary",
+                    "props": {
+                      "children": "Job Progress - toggle me"
+                    }
+                  },
+                  {
+                    "type": "progress",
+                    "props": {
+                      "children": null,
+                      "value": 100,
+                      "max": 100,
+                      "style": {
+                        "width": "100%",
+                        "appearance": "none"
+                      }
+                    }
+                  }
+                ],
                 "open": true
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x10b98eb70>"
+              "<__main__.VDOM at 0x1109a3e80>"
             ]
           },
           "metadata": {}
         }
       ],
-      "execution_count": 24,
+      "execution_count": 13,
       "metadata": {
         "collapsed": false,
         "outputHidden": false,
@@ -563,11 +617,6 @@
         "The beauty of all this is that you can update these displays without forcing weird scrolling behavior on the users or changing the state of interactive controls on them.\n",
         "\n🎉 Here's to building cool things! 🎉"
       ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [],
       "metadata": {}
     }
   ],

--- a/example-notebooks/vdom.ipynb
+++ b/example-notebooks/vdom.ipynb
@@ -115,7 +115,7 @@
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x10b89e160>"
+              "<__main__.VDOM at 0x1050052b0>"
             ]
           },
           "metadata": {}
@@ -202,7 +202,7 @@
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x10b89e978>"
+              "<__main__.VDOM at 0x1050057b8>"
             ]
           },
           "metadata": {}
@@ -307,6 +307,8 @@
     {
       "cell_type": "code",
       "source": [
+        "import time\n",
+        "\n",
         "def marquee(children=None, **kwargs):\n",
         "    return {\n",
         "        'type': 'marquee',\n",
@@ -340,13 +342,13 @@
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x10b5832e8>"
+              "<__main__.VDOM at 0x105005128>"
             ]
           },
           "metadata": {}
         }
       ],
-      "execution_count": 8,
+      "execution_count": 7,
       "metadata": {
         "collapsed": false,
         "outputHidden": false,
@@ -374,7 +376,7 @@
         "\n\n",
         "game = display(VDOM(h1('GAMETIME')), display_id=\"game\")\n",
         "\n",
-        "for ii in range(91):\n",
+        "for ii in range(40):\n",
         "    winner = random.choice(choices)\n",
         "    game.display(\n",
         "        VDOM(\n",
@@ -399,13 +401,13 @@
               }
             },
             "text/plain": [
-              "<__main__.VDOM at 0x10b8b3588>"
+              "<__main__.VDOM at 0x105092fd0>"
             ]
           },
           "metadata": {}
         }
       ],
-      "execution_count": 9,
+      "execution_count": 11,
       "metadata": {
         "collapsed": false,
         "outputExpanded": false

--- a/example-notebooks/vdom.ipynb
+++ b/example-notebooks/vdom.ipynb
@@ -11,10 +11,13 @@
         "\n",
         "```js\n",
         "{\n",
-        "  'type': 'h1',\n",
-        "  'props': {\n",
-        "    'children': [] // \n",
-        "  }\n",
+        "  'tagName': 'h1',\n",
+        "  'attributes': {\n",
+        "    'style': {\n",
+        "        'color': 'DeepPink'\n",
+        "    },\n",
+        "  },\n",
+        "  'children': []\n",
         "}\n",
         "```\n",
         "\n",
@@ -22,9 +25,9 @@
         "\n",
         "```python\n",
         "layout = (\n",
-        "    Div(children=[\n",
-        "        H1(children='Hello there!'),\n",
-        "        P(children='''\n",
+        "    Div([\n",
+        "        H1('Hello there!'),\n",
+        "        P('''\n",
         "            Living the dream\n",
         "        '''),\n",
         "    ])\n",
@@ -47,10 +50,10 @@
         "display(\n",
         "    {\n",
         "        'application/vdom.v1+json': {\n",
-        "            'type': 'h1',\n",
-        "            'props': {\n",
-        "                'children': 'Welcome to VDOM',\n",
-        "            }\n",
+        "            'tagName': 'h1',\n",
+        "            'attributes': {\n",
+        "            },\n",
+        "            'children': 'Welcome to VDOM',\n",
         "        }\n",
         "    },\n",
         "    raw=True\n",
@@ -61,10 +64,9 @@
           "output_type": "display_data",
           "data": {
             "application/vdom.v1+json": {
-              "type": "h1",
-              "props": {
-                "children": "Welcome to VDOM"
-              }
+              "tagName": "h1",
+              "attributes": {},
+              "children": "Welcome to VDOM"
             }
           },
           "metadata": {}
@@ -97,10 +99,13 @@
         "        }\n",
         "\n",
         "VDOM({\n",
-        "    'type': 'h1',\n",
-        "    'props': {\n",
-        "        'children': 'Now you\\'re cooking with VDOM',\n",
-        "    }\n",
+        "    'tagName': 'h1',\n",
+        "    'attributes': {\n",
+        "        'style': {\n",
+        "            'textAlign': 'center'\n",
+        "        }\n",
+        "    },\n",
+        "    'children': \"Now you're cooking with VDOM\",\n",
         "})"
       ],
       "outputs": [
@@ -109,13 +114,16 @@
           "execution_count": 2,
           "data": {
             "application/vdom.v1+json": {
-              "type": "h1",
-              "props": {
-                "children": "Now you're cooking with VDOM"
-              }
+              "tagName": "h1",
+              "attributes": {
+                "style": {
+                  "textAlign": "center"
+                }
+              },
+              "children": "Now you're cooking with VDOM"
             },
             "text/plain": [
-              "<__main__.VDOM at 0x110a4c278>"
+              "<__main__.VDOM at 0x10f2e03c8>"
             ]
           },
           "metadata": {}
@@ -140,13 +148,14 @@
       "source": [
         "def h1(children=None, **kwargs):\n",
         "    return {\n",
-        "        'type': 'h1',\n",
-        "        'props': {\n",
-        "            'children': children,\n",
+        "        'tagName': 'h1',\n",
+        "        'attributes': {\n",
+        "\n",
         "            # Fold everything else in as props\n",
         "            # Note that we'd _really_ want to do some validation here\n",
         "            **kwargs\n",
         "        },\n",
+        "        'children': children,\n",
         "\n    }"
       ],
       "outputs": [],
@@ -168,7 +177,9 @@
           "execution_count": 4,
           "data": {
             "text/plain": [
-              "{'props': {'children': 'hey', 'style': {'fontSize': '5em'}}, 'type': 'h1'}"
+              "{'attributes': {'style': {'fontSize': '5em'}},\n",
+              " 'children': 'hey',\n",
+              " 'tagName': 'h1'}"
             ]
           },
           "metadata": {}
@@ -184,7 +195,8 @@
     {
       "cell_type": "code",
       "source": [
-        "VDOM(h1('This is great', style={ 'fontSize': '5em', 'color': 'DeepPink' }))"
+        "VDOM(h1('This is great',\n",
+        "        style={ 'fontSize': '5em', 'color': 'DeepPink' }))"
       ],
       "outputs": [
         {
@@ -192,17 +204,17 @@
           "execution_count": 5,
           "data": {
             "application/vdom.v1+json": {
-              "type": "h1",
-              "props": {
-                "children": "This is great",
+              "tagName": "h1",
+              "attributes": {
                 "style": {
                   "fontSize": "5em",
                   "color": "DeepPink"
                 }
-              }
+              },
+              "children": "This is great"
             },
             "text/plain": [
-              "<__main__.VDOM at 0x110a4ca58>"
+              "<__main__.VDOM at 0x10f2e0c18>"
             ]
           },
           "metadata": {}
@@ -311,20 +323,20 @@
         "\n",
         "def marquee(children=None, **kwargs):\n",
         "    return {\n",
-        "        'type': 'marquee',\n",
-        "        'props': {\n",
-        "            'children': children,\n",
+        "        'tagName': 'marquee',\n",
+        "        'attributes': {\n",
         "            # Fold everything else in as props\n",
         "            # Note that we'd _really_ want to do some validation here\n",
         "            **kwargs\n",
         "        },\n",
+        "        'children': children,\n",
         "\n",
         "    }\n",
         "\n",
         "h = display(VDOM(marquee('HERE WE GO VDOM')), display_id='vdom_marquee')\n",
         "time.sleep(1.5)\n",
         "\n",
-        "for ii in range(16):\n",
+        "for ii in range(12):\n",
         "    h.display(VDOM(marquee('😁')), update=True)\n",
         "    time.sleep(0.5)\n",
         "    h.display(VDOM(marquee('😁✌🏻')), update=True)\n",
@@ -336,13 +348,12 @@
           "output_type": "display_data",
           "data": {
             "application/vdom.v1+json": {
-              "type": "h1",
-              "props": {
-                "children": "❤️ VDOM ❤️"
-              }
+              "tagName": "h1",
+              "attributes": {},
+              "children": "❤️ VDOM ❤️"
             },
             "text/plain": [
-              "<__main__.VDOM at 0x1109adb70>"
+              "<__main__.VDOM at 0x10f2f23c8>"
             ]
           },
           "metadata": {}
@@ -366,18 +377,19 @@
     {
       "cell_type": "code",
       "source": [
-        "import random\n",
+        "import secrets\n",
         "import time\n",
         "\n",
         "winner = \"\"\n",
         "\n",
         "# Each player should pick an emoji that you put into this array\n",
-        "choices = [\"🥑\", \"🐰\", \"🍄\", \"🐱\", \"🚁\", \"☃\", \"🌀\", \"🏇\", \"🐼\", \"🦆\", \"🚀\", \"🎡\"]\n",
+        "choices = [\"🥑\", \"🐰\", \"🤷\", \"🚁\", \"🐰\", \"🐱\"]\n",
+        "  #  \"🍄\", \"🐱\", \"🚁\", \"☃\", \"🌀\", \"🏇\", \"🐼\", \"🦆\", \"🚀\", \"🎡\"]\n",
         "\n\n",
         "game = display(VDOM(h1('GAMETIME')), display_id=\"game\")\n",
         "\n",
         "for ii in range(40):\n",
-        "    winner = random.choice(choices)\n",
+        "    winner = secrets.choice(choices)\n",
         "    game.display(\n",
         "        VDOM(\n",
         "            marquee(winner, style={ \"fontSize\" : '4em' })\n",
@@ -392,16 +404,16 @@
           "output_type": "display_data",
           "data": {
             "application/vdom.v1+json": {
-              "type": "h1",
-              "props": {
-                "children": "WINNER 🐰",
+              "tagName": "h1",
+              "attributes": {
                 "style": {
                   "fontSize": "4em"
                 }
-              }
+              },
+              "children": "WINNER 🐱"
             },
             "text/plain": [
-              "<__main__.VDOM at 0x110a5d710>"
+              "<__main__.VDOM at 0x10f2f2470>"
             ]
           },
           "metadata": {}
@@ -427,14 +439,14 @@
         "def element(elementType):\n",
         "    def elemental(children=None, **kwargs):\n",
         "        return {\n",
-        "            'type': elementType,\n",
-        "            'props': {\n",
-        "                'children': children,\n",
+        "            'tagName': elementType,\n",
+        "            'attributes': {\n",
         "                # Fold everything else in as props\n",
         "                # Note that we'd _really_ want to do some validation here\n",
         "                # Likely using http://bit.ly/domprops\n",
         "                **kwargs\n",
         "            },\n",
+        "            'children': children,\n",
         "\n",
         "        }\n",
         "    return elemental"
@@ -470,48 +482,43 @@
           "execution_count": 11,
           "data": {
             "application/vdom.v1+json": {
-              "type": "div",
-              "props": {
-                "children": [
-                  {
-                    "type": "h1",
-                    "props": {
-                      "children": "Now Incredibly Declarative"
-                    }
+              "tagName": "div",
+              "attributes": {},
+              "children": [
+                {
+                  "tagName": "h1",
+                  "attributes": {},
+                  "children": "Now Incredibly Declarative"
+                },
+                {
+                  "tagName": "p",
+                  "attributes": {},
+                  "children": [
+                    "Can you believe we wrote ",
+                    {
+                      "tagName": "b",
+                      "attributes": {},
+                      "children": "all this from scratch"
+                    },
+                    "?"
+                  ]
+                },
+                {
+                  "tagName": "img",
+                  "attributes": {
+                    "src": "https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif"
                   },
-                  {
-                    "type": "p",
-                    "props": {
-                      "children": [
-                        "Can you believe we wrote ",
-                        {
-                          "type": "b",
-                          "props": {
-                            "children": "all this from scratch"
-                          }
-                        },
-                        "?"
-                      ]
-                    }
-                  },
-                  {
-                    "type": "img",
-                    "props": {
-                      "children": null,
-                      "src": "https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif"
-                    }
-                  },
-                  {
-                    "type": "p",
-                    "props": {
-                      "children": "SO COOL!"
-                    }
-                  }
-                ]
-              }
+                  "children": null
+                },
+                {
+                  "tagName": "p",
+                  "attributes": {},
+                  "children": "SO COOL!"
+                }
+              ]
             },
             "text/plain": [
-              "<__main__.VDOM at 0x110a6bba8>"
+              "<__main__.VDOM at 0x10f303a20>"
             ]
           },
           "metadata": {}
@@ -560,8 +567,10 @@
         "    job_progress.display(VDOM(\n",
         "            details([\n",
         "                summary(\"Job Progress - toggle me\"),\n",
-        "                progress(value=value, max=100, style=progress_style)\n",
-        "            ], open=True)\n",
+        "                progress(value=value, max=100, style=progress_style),\n",
+        "                \n",
+        "            ], open=True),\n",
+        "        \n",
         "        ),\n",
         "        update=True)"
       ],
@@ -570,33 +579,32 @@
           "output_type": "display_data",
           "data": {
             "application/vdom.v1+json": {
-              "type": "details",
-              "props": {
-                "children": [
-                  {
-                    "type": "summary",
-                    "props": {
-                      "children": "Job Progress - toggle me"
+              "tagName": "details",
+              "attributes": {
+                "open": true
+              },
+              "children": [
+                {
+                  "tagName": "summary",
+                  "attributes": {},
+                  "children": "Job Progress - toggle me"
+                },
+                {
+                  "tagName": "progress",
+                  "attributes": {
+                    "value": 100,
+                    "max": 100,
+                    "style": {
+                      "width": "100%",
+                      "appearance": "none"
                     }
                   },
-                  {
-                    "type": "progress",
-                    "props": {
-                      "children": null,
-                      "value": 100,
-                      "max": 100,
-                      "style": {
-                        "width": "100%",
-                        "appearance": "none"
-                      }
-                    }
-                  }
-                ],
-                "open": true
-              }
+                  "children": null
+                }
+              ]
             },
             "text/plain": [
-              "<__main__.VDOM at 0x1109a3e80>"
+              "<__main__.VDOM at 0x10f2bfb70>"
             ]
           },
           "metadata": {}

--- a/example-notebooks/vdom.ipynb
+++ b/example-notebooks/vdom.ipynb
@@ -1,0 +1,599 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Declarative layouts\n",
+        "\n",
+        "This notebook demonstrates how to use an _experimental_ display type called `application/vdom.v1+json` or `vdom` for short.\n",
+        "\n",
+        "Instead of sending HTML, you send a declarative JSON format that lists the nodes for HTML like so:\n",
+        "\n",
+        "```js\n",
+        "{\n",
+        "  'type': 'h1',\n",
+        "  'props': {\n",
+        "    'children': [] // \n",
+        "  }\n",
+        "}\n",
+        "```\n",
+        "\n",
+        "This is a bit low level, so you'll have to bear with us. The goal for an end user would be to be able to write something like this in Python:\n",
+        "\n",
+        "```python\n",
+        "layout = (\n",
+        "    Div(children=[\n",
+        "        H1(children='Hello there!'),\n",
+        "        P(children='''\n",
+        "            Living the dream\n",
+        "        '''),\n",
+        "    ])\n",
+        ")\n",
+        "```\n",
+        "\n",
+        "(which is exactly the API that [dash](https://plot.ly/dash) provides)\n",
+        "\n",
+        "We'll start out a little raw and show off some of the chief benefits as we go.\n"
+      ],
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "display(\n",
+        "    {\n",
+        "        'application/vdom.v1+json': {\n",
+        "            'type': 'h1',\n",
+        "            'props': {\n",
+        "                'children': 'Welcome to VDOM',\n",
+        "            }\n",
+        "        }\n",
+        "    },\n",
+        "    raw=True\n",
+        ")"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "h1",
+              "props": {
+                "children": null
+              }
+            }
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 1,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We'll wrap that boilerplate up in a `VDOM` class, similar to the `IPython.display.HTML` class:"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "class VDOM():\n",
+        "    def __init__(self, obj):\n",
+        "        self.obj = obj\n",
+        "        \n",
+        "    def _repr_mimebundle_(self, include, exclude, **kwargs):\n",
+        "        return {\n",
+        "                'application/vdom.v1+json': self.obj\n",
+        "        }\n",
+        "\n",
+        "VDOM({\n",
+        "    'type': 'h1',\n",
+        "    'props': {\n",
+        "        'children': 'Now you\\'re cooking with VDOM',\n",
+        "    }\n",
+        "})"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 2,
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "h1",
+              "props": {
+                "children": null
+              }
+            },
+            "text/plain": [
+              "<__main__.VDOM at 0x10b89e160>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 2,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "If we really want, we could also create individual HTML element helpers"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def h1(children=None, **kwargs):\n",
+        "    return {\n",
+        "        'type': 'h1',\n",
+        "        'props': {\n",
+        "            'children': children,\n",
+        "            # Fold everything else in as props\n",
+        "            # Note that we'd _really_ want to do some validation here\n",
+        "            **kwargs\n",
+        "        },\n",
+        "\n    }"
+      ],
+      "outputs": [],
+      "execution_count": 3,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "h1('hey', style={ 'fontSize': '5em'})"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 4,
+          "data": {
+            "text/plain": [
+              "{'props': {'children': 'hey', 'style': {'fontSize': '5em'}}, 'type': 'h1'}"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 4,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "VDOM(h1('This is great', style={ 'fontSize': '5em', 'color': 'DeepPink' }))"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 5,
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "h1",
+              "props": {
+                "children": null,
+                "style": {
+                  "fontSize": "5em",
+                  "color": "DeepPink"
+                }
+              }
+            },
+            "text/plain": [
+              "<__main__.VDOM at 0x10b89e978>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 5,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Why not just use HTML?\n",
+        "\nWhen we send updates using `display(obj, display_id='x', update=True)`, the HTML gets wiped out losing any state in the frontend. This especially matters with elements like `<details>`:"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%html\n",
+        "<details>\n",
+        "    <summary>Click me to expand</summary>\n",
+        "    <p>I am some hidden text</p>\n",
+        "</details>"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "<details>\n",
+              "    <summary>Click me to expand</summary>\n",
+              "    <p>I am some hidden text</p>\n",
+              "</details>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 6,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "An easier element to demonstrate in a tutorial notebook is the infamous (and deprecated) `<marquee>` tag. Fun fact: It's GPU accelerated on Chrome."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from IPython.display import HTML\n",
+        "import time\n",
+        "\n",
+        "handle = display(HTML(\"\"\"<marquee>Here I am scrolling</marquee>\"\"\"), display_id='html_marquee')\n",
+        "time.sleep(2)\n",
+        "handle.display(HTML(\"\"\"<marquee>RESET MUAHAHAHAHAHAH</marquee>\"\"\"), update=True)\n",
+        "time.sleep(2)\n",
+        "handle.display(HTML(\"\"\"<marquee>😔</marquee>\"\"\"), update=True)"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ],
+            "text/html": [
+              "<marquee>😔</marquee>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 7,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Whereas, if you do it with the VDOM, you get nice clean updates that keep state.\n",
+        "\n"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def marquee(children=None, **kwargs):\n",
+        "    return {\n",
+        "        'type': 'marquee',\n",
+        "        'props': {\n",
+        "            'children': children,\n",
+        "            # Fold everything else in as props\n",
+        "            # Note that we'd _really_ want to do some validation here\n",
+        "            **kwargs\n",
+        "        },\n",
+        "\n",
+        "    }\n",
+        "\n",
+        "h = display(VDOM(marquee('HERE WE GO VDOM')), display_id='vdom_marquee')\n",
+        "time.sleep(1.5)\n",
+        "\n",
+        "for ii in range(16):\n",
+        "    h.display(VDOM(marquee('😁')), update=True)\n",
+        "    time.sleep(0.5)\n",
+        "    h.display(VDOM(marquee('😁✌🏻')), update=True)\n",
+        "    time.sleep(0.5)\n",
+        "\nh.display(VDOM(h1('❤️ VDOM ❤️')), update=True)"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "h1",
+              "props": {
+                "children": null
+              }
+            },
+            "text/plain": [
+              "<__main__.VDOM at 0x10b5832e8>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 8,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Game time\n",
+        "\nWe can use this to make a silly little game where you and your friends pick an emoji and watch as it shuffles through them."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import random\n",
+        "import time\n",
+        "\n",
+        "winner = \"\"\n",
+        "\n",
+        "# Each player should pick an emoji that you put into this array\n",
+        "choices = [\"🥑\", \"🐰\", \"🍄\", \"🐱\", \"🚁\", \"☃\", \"🌀\", \"🏇\", \"🐼\", \"🦆\", \"🚀\", \"🎡\"]\n",
+        "\n\n",
+        "game = display(VDOM(h1('GAMETIME')), display_id=\"game\")\n",
+        "\n",
+        "for ii in range(91):\n",
+        "    winner = random.choice(choices)\n",
+        "    game.display(\n",
+        "        VDOM(\n",
+        "            marquee(winner, style={ \"fontSize\" : '4em' })\n",
+        "        ),\n",
+        "        update=True\n",
+        "    )\n",
+        "    time.sleep(0.1)\n",
+        "\ngame.display(VDOM(h1('WINNER ' + winner, style={ \"fontSize\" : '4em' })), update=True)"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "h1",
+              "props": {
+                "children": null,
+                "style": {
+                  "fontSize": "4em"
+                }
+              }
+            },
+            "text/plain": [
+              "<__main__.VDOM at 0x10b8b3588>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 9,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Collapsible job progress views\n",
+        "\nThat was good and fun, let's try something that would be useful for spark and other background jobs. We've also been making a lot of boilerplate to declare `marquee` and `h1`. Let's create a little wrapper to make new elements simply."
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def element(elementType):\n",
+        "    def elemental(children=None, **kwargs):\n",
+        "        return {\n",
+        "            'type': elementType,\n",
+        "            'props': {\n",
+        "                'children': children,\n",
+        "                # Fold everything else in as props\n",
+        "                # Note that we'd _really_ want to do some validation here\n",
+        "                # Likely using http://bit.ly/domprops\n",
+        "                **kwargs\n",
+        "            },\n",
+        "\n",
+        "        }\n",
+        "    return elemental"
+      ],
+      "outputs": [],
+      "execution_count": 10,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "bold = element('b')\n",
+        "div = element('div')\n",
+        "p = element('p')\n",
+        "img = element('img')\n",
+        "\n\n",
+        "VDOM(\n",
+        "    div([\n",
+        "        h1('Now Incredibly Declarative'),\n",
+        "        p(['Can you believe we wrote ', bold('all this from scratch'), '?']),\n",
+        "        img(src=\"https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif\"),\n",
+        "        p('SO COOL!'),\n",
+        "    ])\n",
+        ")"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 11,
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "div",
+              "props": {
+                "children": null
+              }
+            },
+            "text/plain": [
+              "<__main__.VDOM at 0x10b8be8d0>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 11,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "details = element('details')\n",
+        "summary = element('summary')\n",
+        "progress = element('progress')"
+      ],
+      "outputs": [],
+      "execution_count": 12,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "progress_style= dict(width=\"100%\", appearance=\"none\")\n",
+        "\n",
+        "job_progress = display(\n",
+        "    VDOM(\n",
+        "        details([\n",
+        "            summary(\"Job Progress\"),\n",
+        "            progress(value=0, max=100, style=progress_style)\n",
+        "        ], open=True)\n",
+        "    ),\n",
+        "    display_id=\"job_progression\"\n",
+        ")\n",
+        "\n",
+        "for value in range(10, 105, 5):\n",
+        "    time.sleep(0.2)\n",
+        "\n",
+        "    job_progress.display(VDOM(\n",
+        "            details([\n",
+        "                summary(\"Job Progress - toggle me\"),\n",
+        "                progress(value=value, max=100, style=progress_style)\n",
+        "            ], open=True)\n",
+        "        ),\n",
+        "        update=True)"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vdom.v1+json": {
+              "type": "details",
+              "props": {
+                "children": null,
+                "open": true
+              }
+            },
+            "text/plain": [
+              "<__main__.VDOM at 0x10b98eb70>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 24,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "You can continue to refine these basic building blocks, building even richer UIs, all in declarative Python structures.\n",
+        "\n",
+        "The beauty of all this is that you can update these displays without forcing weird scrolling behavior on the users or changing the state of interactive controls on them.\n",
+        "\n🎉 Here's to building cool things! 🎉"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [],
+      "metadata": {}
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3"
+    },
+    "kernel_info": {
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.6.2",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "nteract": {
+      "version": "0.2.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
 <Notebook
   displayOrder={
     Array [
+      "application/vdom.v1+json",
       "application/json",
       "application/javascript",
       "text/html",
@@ -90,6 +91,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
     Object {
       "application/javascript": [Function],
       "application/json": [Function],
+      "application/vdom.v1+json": [Function],
       "image/gif": [Function],
       "image/jpeg": [Function],
       "image/png": [Function],

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -109,6 +109,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
 <Notebook
   displayOrder={
     Array [
+      "application/vdom.v1+json",
       "application/json",
       "application/javascript",
       "text/html",
@@ -195,6 +196,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
     Object {
       "application/javascript": [Function],
       "application/json": [Function],
+      "application/vdom.v1+json": [Function],
       "image/gif": [Function],
       "image/jpeg": [Function],
       "image/png": [Function],

--- a/packages/transform-vdom/.npmrc
+++ b/packages/transform-vdom/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/packages/transform-vdom/__tests__/index.test.js
+++ b/packages/transform-vdom/__tests__/index.test.js
@@ -1,0 +1,29 @@
+import React from "react";
+import TransformVDOM from "../src";
+import renderer from "react-test-renderer";
+
+test("VDOM Transform is cool", () => {
+  const component = renderer.create(
+    <TransformVDOM
+      data={{
+        tagName: "h1",
+        attributes: {
+          style: {
+            color: "DeepPink"
+          }
+        },
+        children: [
+          {
+            tagName: "img",
+            attributes: {
+              width: "100px",
+              height: "100px",
+              src: "about:blank"
+            },
+            children: []
+          }
+        ]
+      }}
+    />
+  );
+});

--- a/packages/transform-vdom/__tests__/index.test.js
+++ b/packages/transform-vdom/__tests__/index.test.js
@@ -6,13 +6,23 @@ test("VDOM Transform is cool", () => {
   const component = renderer.create(
     <TransformVDOM
       data={{
-        tagName: "h1",
+        tagName: "div",
         attributes: {
           style: {
             color: "DeepPink"
           }
         },
         children: [
+          {
+            tagName: "h1",
+            attributes: {},
+            children: "Wahoo"
+          },
+          {
+            tagName: "h1",
+            attributes: {},
+            children: null
+          },
           {
             tagName: "img",
             attributes: {

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@nteract/transform-vdom",
+  "version": "1.0.0",
+  "description": "VDOM Transform for jupyter outputs",
+  "main": "lib/",
+  "nteractDesktop": "src/index.js",
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "build:clean": "rimraf lib",
+    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch"
+  },
+  "author": "",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "react": "^15.6.1"
+  },
+  "peerDependencies": {
+    "react": "^15.6.1"
+  },
+  "license": "BSD-3-Clause"
+}

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -3,6 +3,8 @@ import React from "react";
 
 import { objectToReactElement } from "./object-to-react";
 
+const cloneDeep = require("lodash").cloneDeep;
+
 type Props = {
   data: Object
 };
@@ -17,7 +19,9 @@ export default class VDOM extends React.Component {
 
   render(): ?React.Element<any> {
     try {
-      return objectToReactElement(this.props.data);
+      // objectToReactElement is mutatitve so we'll clone our object
+      var obj = cloneDeep(this.props.data);
+      return objectToReactElement(obj);
     } catch (err) {
       return (
         <div>

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -2,8 +2,7 @@
 import React from "react";
 
 import { objectToReactElement } from "./object-to-react";
-
-const cloneDeep = require("lodash").cloneDeep;
+import { cloneDeep } from "lodash";
 
 type Props = {
   data: Object
@@ -17,7 +16,7 @@ export default class VDOM extends React.Component {
     return nextProps.data !== this.props.data;
   }
 
-  render(): ?React.Element<any> {
+  render(): React.Element<*> {
     try {
       // objectToReactElement is mutatitve so we'll clone our object
       var obj = cloneDeep(this.props.data);

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -17,7 +17,7 @@ export default class VDOM extends React.Component {
 
   render(): ?React.Element<any> {
     try {
-      return objectToReactElement(this.props.data.toJS());
+      return objectToReactElement(this.props.data);
     } catch (err) {
       return (
         <div>

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -1,0 +1,34 @@
+/* @flow */
+import React from "react";
+
+import { objectToReactElement } from "./object-to-react";
+
+type Props = {
+  data: Object
+};
+
+export default class VDOM extends React.Component {
+  props: Props;
+  static MIMETYPE = "application/vdom.v1+json";
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return nextProps.data !== this.props.data;
+  }
+
+  render(): ?React.Element<any> {
+    try {
+      return objectToReactElement(this.props.data.toJS());
+    } catch (err) {
+      return (
+        <div>
+          <pre>
+            There was an error rendering VDOM data from the kernel or notebook
+          </pre>
+          <code>
+            {JSON.stringify(err, null, 2)}
+          </code>
+        </div>
+      );
+    }
+  }
+}

--- a/packages/transform-vdom/src/object-to-react.js
+++ b/packages/transform-vdom/src/object-to-react.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 /**
  * The original copy of this comes from
  * https://github.com/remarkablemark/REON/blob/1f126e71c17f96daad518abffdb2c53b66b8b792/lib/object-to-react.js
@@ -26,7 +28,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-var React = require("react");
+const React = require("react");
 
 /**
  * Convert an object to React element(s).
@@ -37,7 +39,8 @@ var React = require("react");
  * @param  {Object}       obj - The element object.
  * @return {ReactElement}
  */
-function objectToReactElement(obj) {
+export function objectToReactElement(obj: Object): React$Element<*> {
+  // Pack args for React.createElement
   var args = [];
   var children;
 
@@ -97,7 +100,7 @@ function objectToReactElement(obj) {
  * @param  {Array} arr - The array.
  * @return {Array}     - The array of mixed values.
  */
-function arrayToReactChildren(arr) {
+export function arrayToReactChildren(arr: Array<any>): Array<any> {
   // similar to `props.children`
   var result = [];
   // child of `props.children`
@@ -127,8 +130,3 @@ function arrayToReactChildren(arr) {
 
   return result;
 }
-
-/**
- * Export object to React element converter.
- */
-module.exports = objectToReactElement;

--- a/packages/transform-vdom/src/object-to-react.js
+++ b/packages/transform-vdom/src/object-to-react.js
@@ -1,0 +1,134 @@
+/**
+ * The original copy of this comes from
+ * https://github.com/remarkablemark/REON/blob/1f126e71c17f96daad518abffdb2c53b66b8b792/lib/object-to-react.js
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 Menglin "Mark" Xu <mark@remarkablemark.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+var React = require("react");
+
+/**
+ * Convert an object to React element(s).
+ *
+ * The object schema should be similar to React element's.
+ * Note: The object passed in this function will be mutated.
+ *
+ * @param  {Object}       obj - The element object.
+ * @return {ReactElement}
+ */
+function objectToReactElement(obj) {
+  var args = [];
+  var children;
+
+  // `React.createElement` 1st argument: type
+  args[0] = obj.type;
+
+  // `props` should always be defined
+  // it can be an empty object or contain the React props and/or children
+  if (obj.props) {
+    // save reference to `children` and remove `children` from `props`
+    // as it shouldn't be passed as a prop in `React.createElement`
+    if (obj.props.children) {
+      children = obj.props.children;
+      obj.props.children = null; // more performant than `delete`
+    }
+
+    // set `key` in `prop`
+    if (obj.key !== undefined && obj.key !== null) {
+      obj.props.key = obj.key;
+    }
+
+    // `React.createElement` 2nd argument: props
+    args[1] = obj.props;
+  }
+
+  // `props.children`
+  if (children) {
+    // third argument: children (mixed values)
+    switch (children.constructor) {
+      // text
+      case String:
+        args[2] = children;
+        break;
+      // React element
+      case Object:
+        args[2] = objectToReactElement(children);
+        break;
+      // array (mixed values)
+      case Array:
+        // to be safe (although this should never happen)
+        if (args[1] === undefined) {
+          args[1] = null;
+        }
+        args = args.concat(arrayToReactChildren(children));
+        break;
+      default:
+      // pass
+    }
+  }
+
+  return React.createElement.apply({}, args);
+}
+
+/**
+ * Convert an array of items to React children.
+ *
+ * @param  {Array} arr - The array.
+ * @return {Array}     - The array of mixed values.
+ */
+function arrayToReactChildren(arr) {
+  // similar to `props.children`
+  var result = [];
+  // child of `props.children`
+  var item;
+
+  // iterate through the `children`
+  for (var i = 0, len = arr.length; i < len; i++) {
+    // child can have mixed values: text, React element, or array
+    item = arr[i];
+    switch (item.constructor) {
+      // text node
+      case String:
+        result.push(item);
+        break;
+      // React element
+      case Object:
+        result.push(objectToReactElement(item));
+        break;
+      // array (mixed values)
+      case Array:
+        result.push(arrayToReactChildren(item));
+        break;
+      default:
+      // pass
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Export object to React element converter.
+ */
+module.exports = objectToReactElement;

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -16,11 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/nteract/nteract.git"
   },
-  "keywords": [
-    "nteract",
-    "transforms",
-    "notebook"
-  ],
+  "keywords": ["nteract", "transforms", "notebook"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -31,6 +27,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@nteract/transform-vdom": "^1.0.0",
     "ansi-to-react": "^1.5.1",
     "commonmark": "^0.28.0",
     "commonmark-react-renderer": "^4.3.3",

--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -8,6 +8,7 @@ import MarkdownDisplay from "./markdown";
 import LaTeXDisplay from "./latex";
 import SVGDisplay from "./svg";
 import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image";
+import VDOMDisplay from "@nteract/transform-vdom";
 
 type Transform = {
   MIMETYPE: string
@@ -22,6 +23,7 @@ export type TransformRegister = {
 };
 
 const tfs = [
+  VDOMDisplay,
   JsonDisplay,
   JavaScriptDisplay,
   HTMLDisplay,


### PR DESCRIPTION
Bringing back the vdom mimetype from #1212.

This is (mostly) good to go. Quick demo:

![gametime](https://user-images.githubusercontent.com/836375/29754673-04c127d2-8b58-11e7-88e1-c07e711c40e8.gif)

Problems to fix:

* [x] ~On save, for some reason the `children` array is empty. This is completely confusing behavior considering that it's getting into the component when displayed like normal. Initial digging shows this in the state tree, at least while being deserialized.~ objectToReact is mutative
* [x] ~Invalid attributes will completely break the whole notebook, not at the `createElement` stage but at `ReactDOM.render`, which can't be caught in the component (we can use a safelist though).~ Turns out they're just warnings, I broke something else

