### PR TITLE
Don't run build script on install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ node_js:
 - "8"
 env:
   matrix:
-  - GROUP=coverage
-  - GROUP=packages
+  - GROUP=coverage BUILD=build
+  - GROUP=packages BUILD=build:packages
   - GROUP=lint
-  - GROUP=flow
+  - GROUP=flow BUILD=build:packages
   - GROUP=conformance
 
 cache:
@@ -23,10 +23,11 @@ before_install:
 before_script:
 - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
 - greenkeeper-lockfile-update
-- chmod +x node_modules/flow-bin/flow-linux64-v0.54.0/flow
 install:
 - npm install
-script: npm run test:$GROUP
+script:
+- 'if [ -n "${BUILD}" ]; then npm run $BUILD; fi'
+- npm run test:$GROUP
 after_script: greenkeeper-lockfile-upload
 after_success:
   - 'if [[ $GROUP == coverage* ]]; then bash <(curl -s https://codecov.io/bash); fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,12 @@ cache:
 
 before_install:
 - npm install -g npm@5
-- npm install -g greenkeeper-lockfile@1
 before_script:
 - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
-- greenkeeper-lockfile-update
 install:
 - npm install
 script:
 - 'if [ -n "${BUILD}" ]; then npm run $BUILD; fi'
 - npm run test:$GROUP
-after_script: greenkeeper-lockfile-upload
 after_success:
   - 'if [[ $GROUP == coverage* ]]; then bash <(curl -s https://codecov.io/bash); fi'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,4 +20,5 @@ install:
 test_script:
   - node --version
   - npm --version
+  - npm run build
   - npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/nteract/nteract",
   "scripts": {
-    "postinstall": "electron-builder install-app-deps",
+    "postinstall": "npm run lerna && electron-builder install-app-deps",
     "reinstall": "npm run clean && rimraf node_modules && npm install",
     "prestart": "npm run build:webpack",
     "start": "npm run spawn",
@@ -26,7 +26,6 @@
     "lint:fix": "eslint . --fix",
     "prebuild": "rimraf lib",
     "lerna": "lerna bootstrap --hoist",
-    "install": "npm run lerna && npm run build",
     "build": "npm run build:packages && npm run build:webpack",
     "build:webpack": "webpack --progress --colors",
     "build:webpack:watch": "npm run build:webpack -- --watch",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build": "npm run build:packages && npm run build:webpack",
     "build:webpack": "webpack --progress --colors",
     "build:webpack:watch": "npm run build:webpack -- --watch",
-    "build:packages": "lerna run build --ignore @nteract/notebook-preview-demo",
+    "build:packages":
+      "lerna run build:lib --ignore @nteract/notebook-preview-demo",
     "build:packages:watch": "lerna run build:lib:watch --stream",
     "build:icon":
       "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",


### PR DESCRIPTION
Running the entire build script on install is often unnecessary and takes a lot of time.

This should speedup the CI builds since we don't need the full build for all jobs.