### PR TITLE
Use synchronous close dialog to fix cmd+q

### DIFF
--- a/packages/desktop/src/main/launch.js
+++ b/packages/desktop/src/main/launch.js
@@ -36,26 +36,15 @@ export function launch(filename) {
   const index = path.join(__dirname, "..", "static", "index.html");
   win.loadURL(`file://${index}`);
 
-  let actuallyExit = false;
-
   win.on("close", e => {
-    if (!actuallyExit) {
+    const response = dialog.showMessageBox({
+      type: "question",
+      buttons: ["Yes", "No"],
+      title: "Confirm",
+      message: "Unsaved data will be lost. Are you sure you want to quit?"
+    });
+    if (response == 1) {
       e.preventDefault();
-      dialog.showMessageBox(
-        {
-          type: "question",
-          buttons: ["Yes", "No"],
-          title: "Confirm",
-          message: "Unsaved data will be lost. Are you sure you want to quit?"
-        },
-        function(response) {
-          if (response === 0) {
-            e.returnValue = false;
-            actuallyExit = true;
-            win.close();
-          }
-        }
-      );
     }
   });
 


### PR DESCRIPTION
Fully closing nteract with `cmd+q` doesn't work right now because `win.close();`won't fully quit the app. This adds two steps for fully closing nteract.

This PR prevents that by using a synchronous close dialog which will block the process. I don't think blocking here is too bad, but if you like I could search for another solution.