### PR TITLE
Fix typo in README.md for @nteract/display-area

### DIFF
--- a/packages/display-area/README.md
+++ b/packages/display-area/README.md
@@ -10,7 +10,7 @@ npm install @nteract/display-area
 ## Usage
 
 ```jsx
-import Display from '@nteract/display-area`
+import Display from '@nteract/display-area'
 <Display outputs={outputs} />
 ```
 


### PR DESCRIPTION
Fix typo in README.md for @nteract/display-area

The js code snippet has a backtick instead of a single quote. This made copy pasting the example snippet impossible. I changed the backtick to a single quote. 

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)