### PR TITLE
Fix "modified indicator" on mac

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -34,9 +34,9 @@
       "npm run test:functional:launch && npm run test:functional:launchNewNotebook",
     "test:coverage": "npm run coverage",
     "test:unit":
-      "mocha -r test/setup.js --compilers js:babel-core/register \"test/renderer/**/*.js\" \"test/utils/**/*.js\"",
+      "mocha -r test/setup.js --compilers js:babel-core/register \"test/renderer/**/*.js\"",
     "test:debug":
-      "mocha --debug-brk --inspect -r test/setup.js --compilers js:babel-core/register \"test/renderer/**/*.js\" \"test/utils/**/*.js\"",
+      "mocha --debug-brk --inspect -r test/setup.js --compilers js:babel-core/register \"test/renderer/**/*.js\"",
     "test:unit:individual":
       "mocha -r test/setup.js --compilers js:babel-core/register ",
     "test:watch": "watch 'npm run test' test/",

--- a/packages/desktop/src/notebook/actions.js
+++ b/packages/desktop/src/notebook/actions.js
@@ -327,8 +327,9 @@ export function saveAs(filename: string, notebook: any) {
   };
 }
 
-export function doneSaving() {
+export function doneSaving(notebook: any) {
   return {
-    type: constants.DONE_SAVING
+    type: constants.DONE_SAVING,
+    notebook
   };
 }

--- a/packages/desktop/src/notebook/epics/saving.js
+++ b/packages/desktop/src/notebook/epics/saving.js
@@ -65,7 +65,7 @@ export function saveEpic(
               autoDismiss: 2,
               level: "success"
             });
-            return doneSaving();
+            return doneSaving(action.notebook);
           })
       // .startWith({ type: START_SAVING })
       // since SAVE effectively acts as the same as START_SAVING

--- a/packages/desktop/src/notebook/epics/saving.js
+++ b/packages/desktop/src/notebook/epics/saving.js
@@ -58,13 +58,15 @@ export function saveEpic(
             })
           )
           .map(() => {
-            const state = store.getState();
-            const notificationSystem = state.app.get("notificationSystem");
-            notificationSystem.addNotification({
-              title: "Save successful!",
-              autoDismiss: 2,
-              level: "success"
-            });
+            if (process.platform !== "darwin") {
+              const state = store.getState();
+              const notificationSystem = state.app.get("notificationSystem");
+              notificationSystem.addNotification({
+                title: "Save successful!",
+                autoDismiss: 2,
+                level: "success"
+              });
+            }
             return doneSaving(action.notebook);
           })
       // .startWith({ type: START_SAVING })

--- a/packages/desktop/src/notebook/native-window.js
+++ b/packages/desktop/src/notebook/native-window.js
@@ -1,4 +1,5 @@
 import { remote } from "electron";
+import { is } from "immutable";
 
 import path from "path";
 
@@ -57,22 +58,16 @@ export function setTitleFromAttributes(attributes) {
 
 export function createTitleFeed(state$) {
   const modified$ = state$
-    .map(state => ({
-      // Assume not modified to start
-      modified: false,
-      notebook: state.document.get("notebook")
-    }))
-    .distinctUntilChanged(last => last.notebook)
-    .scan((last, current) => ({
-      // We're missing logic for saved...
-      // All we know is if it was modified from last time
-      // The logic should be
-      //    modified: saved.notebook !== current.notebook
-      //        we don't have saved.notebook here
-      modified: last.notebook !== current.notebook,
-      notebook: current.notebook
-    }))
-    .pluck("modified");
+    .map(
+      state =>
+        process.platform === "darwin"
+          ? !is(
+              state.document.get("savedNotebook"),
+              state.document.get("notebook")
+            )
+          : false
+    )
+    .distinctUntilChanged();
 
   const fullpath$ = state$.map(
     state => state.metadata.get("filename") || "Untitled"

--- a/packages/desktop/src/notebook/records.js
+++ b/packages/desktop/src/notebook/records.js
@@ -153,6 +153,7 @@ export type Document = {
 
 export const DocumentRecord = Immutable.Record({
   notebook: null,
+  savedNotebook: null,
   // $FlowFixMe: Immutable
   transient: new Immutable.Map({
     keyPathsForDisplays: new Immutable.Map()

--- a/packages/desktop/src/notebook/reducers/document.js
+++ b/packages/desktop/src/notebook/reducers/document.js
@@ -128,6 +128,17 @@ function setNotebook(state: DocumentState, action: SetNotebookAction) {
     .setIn(["transient", "cellMap"], new Immutable.Map());
 }
 
+type SetNotebookCheckpointAction = {
+  type: "DONE_SAVING",
+  notebook: ImmutableNotebook
+};
+function setNotebookCheckpoint(
+  state: DocumentState,
+  action: SetNotebookCheckpointAction
+) {
+  return state.set("savedNotebook", action.notebook);
+}
+
 type FocusCellAction = { type: "FOCUS_CELL", id: CellID };
 function focusCell(state: DocumentState, action: FocusCellAction) {
   return state.set("cellFocused", action.id);
@@ -698,6 +709,8 @@ function handleDocument(
   switch (action.type) {
     case constants.SET_NOTEBOOK:
       return setNotebook(state, action);
+    case constants.DONE_SAVING:
+      return setNotebookCheckpoint(state, action);
     case constants.FOCUS_CELL:
       return focusCell(state, action);
     case constants.CLEAR_OUTPUTS:

--- a/packages/desktop/test/renderer/actions-spec.js
+++ b/packages/desktop/test/renderer/actions-spec.js
@@ -325,3 +325,28 @@ describe("toggleOutputExpansion", () => {
     });
   });
 });
+
+describe("save", () => {
+  it("creates a SAVE action", () => {
+    expect(actions.save("foo.ipynb", dummyCommutable)).to.deep.equal({
+      type: constants.SAVE,
+      filename: "foo.ipynb",
+      notebook: dummyCommutable
+    });
+  });
+
+  it("creates a SAVE_AS action", () => {
+    expect(actions.saveAs("foo.ipynb", dummyCommutable)).to.deep.equal({
+      type: constants.SAVE_AS,
+      filename: "foo.ipynb",
+      notebook: dummyCommutable
+    });
+  });
+
+  it("creates a SAVE_AS action", () => {
+    expect(actions.doneSaving(dummyCommutable)).to.deep.equal({
+      type: constants.DONE_SAVING,
+      notebook: dummyCommutable
+    });
+  });
+});

--- a/packages/desktop/test/renderer/native-window-spec.js
+++ b/packages/desktop/test/renderer/native-window-spec.js
@@ -60,7 +60,7 @@ describe("setTitleFromAttributes", () => {
 });
 
 describe("createTitleFeed", () => {
-  it("creates an observable that updates title attributes", done => {
+  it("creates an observable that updates title attributes for modified notebook", done => {
     const notebook = new Immutable.Map().setIn(
       ["metadata", "kernelspec", "display_name"],
       "python3000"
@@ -68,6 +68,41 @@ describe("createTitleFeed", () => {
     const state = {
       document: DocumentRecord({
         notebook
+      }),
+      app: AppRecord({
+        executionState: "not connected"
+      }),
+      metadata: MetadataRecord({
+        filename: "titled.ipynb"
+      })
+    };
+
+    const state$ = Observable.from([state]);
+
+    const allAttributes = [];
+    nativeWindow.createTitleFeed(state$).subscribe(attributes => {
+      allAttributes.push(attributes);
+    }, null, () => {
+      expect(allAttributes).to.deep.equal([
+        {
+          modified: (process.platform === "darwin") ? true : false,
+          fullpath: "titled.ipynb",
+          executionState: "not connected"
+        }
+      ]);
+      done();
+    });
+  });
+
+  it("creates an observable that updates title attributes", done => {
+    const notebook = new Immutable.Map().setIn(
+      ["metadata", "kernelspec", "display_name"],
+      "python3000"
+    );
+    const state = {
+      document: DocumentRecord({
+        notebook,
+        savedNotebook: notebook
       }),
       app: AppRecord({
         executionState: "not connected"

--- a/packages/desktop/test/renderer/reducers/document-spec.js
+++ b/packages/desktop/test/renderer/reducers/document-spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { List, Map, Set } from "immutable";
+import { List, Map, Set, is } from "immutable";
 
 import { expect } from "chai";
 
@@ -156,6 +156,22 @@ describe("setNotebook", () => {
       notebook
     });
     expect(state.document.getIn(["notebook", "nbformat"])).to.equal(4);
+  });
+});
+
+describe("setNotebookCheckpoint", () => {
+  it("stores saved notebook", () => {
+    const initialState = {
+      app: new Map(),
+      document: initialDocument
+    };
+
+    const state = reducers(initialState, {
+      type: constants.DONE_SAVING,
+      notebook: dummyCommutable
+    });
+    expect(is(state.document.get("notebook")), initialDocument.get("notebook")).to.equal(true);
+    expect(is(state.document.get("savedNotebook"), dummyCommutable)).to.equal(true);
   });
 });
 


### PR DESCRIPTION
This PR fixes the "modified indicator" (don't know how to call the dot in the close button) on macOS and paves the way towards fixing #1886.

![save](https://user-images.githubusercontent.com/13285808/30481019-e4b217ca-9a1c-11e7-99e8-40db0cc62072.gif)

Main changes in this PR are:
- Store the last saved Notebook in the document store. I don't know if this is the right thing to do in terms of performance and memory consumption, but it was the easiest to implement.
- Don't display saving notification on Mac since we now have a working saving indicator.