### PR TITLE
Don't show close warning when file is already saved

### DIFF
--- a/packages/desktop/src/main/launch.js
+++ b/packages/desktop/src/main/launch.js
@@ -36,14 +36,14 @@ export function launch(filename) {
   const index = path.join(__dirname, "..", "static", "index.html");
   win.loadURL(`file://${index}`);
 
-  win.on("close", e => {
+  win.webContents.on("will-prevent-unload", e => {
     const response = dialog.showMessageBox({
       type: "question",
       buttons: ["Yes", "No"],
       title: "Confirm",
       message: "Unsaved data will be lost. Are you sure you want to quit?"
     });
-    if (response == 1) {
+    if (response == 0) {
       e.preventDefault();
     }
   });

--- a/packages/desktop/src/notebook/global-events.js
+++ b/packages/desktop/src/notebook/global-events.js
@@ -3,6 +3,8 @@
 import type { Store } from "redux";
 import type { AppState } from "./records";
 
+import { dialog } from "electron";
+import { is } from "immutable";
 import { forceShutdownKernel } from "./kernel/shutdown";
 
 export function unload(store: Store<AppState, Action>) {
@@ -15,6 +17,19 @@ export function unload(store: Store<AppState, Action>) {
   forceShutdownKernel(kernel);
 }
 
+export function beforeUnload(store: Store<AppState, Action>, e: any) {
+  const state = store.getState();
+  const saved = is(
+    state.document.get("notebook"),
+    state.document.get("savedNotebook")
+  );
+  if (!saved) {
+    // Will prevent closing "will-prevent-unload"
+    e.returnValue = true;
+  }
+}
+
 export function initGlobalHandlers(store: Store<AppState, Action>) {
-  global.window.onunload = unload.bind(null, store);
+  window.onbeforeunload = beforeUnload.bind(null, store);
+  window.onunload = unload.bind(null, store);
 }

--- a/packages/desktop/test/renderer/global-events-spec.js
+++ b/packages/desktop/test/renderer/global-events-spec.js
@@ -20,10 +20,33 @@ describe("unload", () => {
   });
 });
 
+describe("beforeUnload", () => {
+  it("should set event.returnValue if notebook is modified to prevent unload", () => {
+    const store = dummyStore();
+
+    const event = {};
+
+    globalEvents.beforeUnload(store, event);
+
+    expect(event.returnValue).to.not.be.undefined;
+  });
+
+  it("should should not set event.returnValue if notebook is saved", () => {
+    const store = dummyStore({ saved: true });
+
+    const event = {};
+
+    globalEvents.beforeUnload(store, event);
+
+    expect(event.returnValue).to.be.undefined;
+  });
+});
+
 describe("initGlobalHandlers", () => {
   it("adds an unload poperty to the window object", () => {
     const store = dummyStore();
     globalEvents.initGlobalHandlers(store);
     expect(global.window.onunload).to.not.be.undefined;
+    expect(global.window.onbeforeunload).to.not.be.undefined;
   });
 });

--- a/packages/desktop/test/utils.js
+++ b/packages/desktop/test/utils.js
@@ -77,6 +77,7 @@ export function dummyStore(config) {
     {
       document: DocumentRecord({
         notebook: dummyNotebook,
+        savedNotebook: config && config.saved === true ? dummyNotebook : null,
         cellPagers: new Immutable.Map(),
         stickyCells: new Immutable.Map(),
         outputStatuses: new Immutable.Map(),


### PR DESCRIPTION
This is based on #1901 so only the last commit is relevant for review. It will prevent the dialog to be shown if file is already saved.

This is the new workflow:
![close dialog](https://user-images.githubusercontent.com/13285808/30488037-84506314-9a35-11e7-9c9b-1c66b0c7be91.gif)


Fixes #1886 
Fixes #1090
Fixes #1445