### PR TITLE
unpack Display export from `@nteract/display-area`

### DIFF
--- a/packages/display-area/README.md
+++ b/packages/display-area/README.md
@@ -10,7 +10,7 @@ npm install @nteract/display-area
 ## Usage
 
 ```jsx
-import Display from '@nteract/display-area'
+import { Display } from '@nteract/display-area'
 <Display outputs={outputs} />
 ```
 


### PR DESCRIPTION
The README had the wrong usage, which is because we didn't have a default export (we were using commonjs' `module.exports` within our `index.js` file even though we're transpiling).

/cc @kayur 