### PR TITLE
run prettier through current code base

### DIFF
--- a/packages/desktop/test/renderer/native-window-spec.js
+++ b/packages/desktop/test/renderer/native-window-spec.js
@@ -85,7 +85,7 @@ describe("createTitleFeed", () => {
     }, null, () => {
       expect(allAttributes).to.deep.equal([
         {
-          modified: (process.platform === "darwin") ? true : false,
+          modified: process.platform === "darwin" ? true : false,
           fullpath: "titled.ipynb",
           executionState: "not connected"
         }

--- a/packages/desktop/test/renderer/reducers/document-spec.js
+++ b/packages/desktop/test/renderer/reducers/document-spec.js
@@ -170,8 +170,13 @@ describe("setNotebookCheckpoint", () => {
       type: constants.DONE_SAVING,
       notebook: dummyCommutable
     });
-    expect(is(state.document.get("notebook")), initialDocument.get("notebook")).to.equal(true);
-    expect(is(state.document.get("savedNotebook"), dummyCommutable)).to.equal(true);
+    expect(
+      is(state.document.get("notebook")),
+      initialDocument.get("notebook")
+    ).to.equal(true);
+    expect(is(state.document.get("savedNotebook"), dummyCommutable)).to.equal(
+      true
+    );
   });
 });
 


### PR DESCRIPTION
Noticed this while running `npm run prettier` on #1899.