### PR TITLE
[MRG] Don't use shellEnv when launched from terminal

### DIFF
--- a/packages/desktop/src/main/prepare-env.js
+++ b/packages/desktop/src/main/prepare-env.js
@@ -10,7 +10,10 @@ import "rxjs/add/operator/publishReplay";
 const env$ = Observable.fromPromise(shellEnv())
   .first()
   .do(env => {
-    Object.assign(process.env, env);
+    // no need to change the env if started from the terminal on Mac
+    if (process.platform !== "darwin" || !process.env.TERM) {
+      Object.assign(process.env, env);
+    }
   })
   .publishReplay(1);
 


### PR DESCRIPTION
Related to #620 

This is pretty hacky but does mean you get a kernel that corresponds to the conda environment in which you typed `npm run start`. There are two things that puzzle me:

1. the `process.env` print out I inserted shows various custom env variables I set in my terminal, as well as `CONDA_blah` variables that belong to the current conda env, but it shows a different PATH. So it seems to inherit some variables but does something special to PATH. Any ideas where that is happening?

1. only seems to work with `ipykernel~=4.6.x`, at least in some of my envs where the version is 4.3.x executing a cell never completes. Just seems to hang and I can't find an error message anywhere.

If we can track down when/where PATH gets modified maybe we can prevent it from removing (or re-add) the path for the current conda environment. Maybe the real way to do this is to add a kernel spec like this if we detect that we are in either a virtualenv or a conda env and do "the right thing" for either to work.

WDYT?