### PR TITLE
[WIP] VDOM + models

### DIFF
--- a/packages/desktop/example-notebooks/model-debug.ipynb
+++ b/packages/desktop/example-notebooks/model-debug.ipynb
@@ -1,116 +1,145 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "outputExpanded": false
-   },
-   "source": [
-    "import IPython"
-   ],
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "outputExpanded": false
-   },
-   "source": [
-    "import ipykernel"
-   ],
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "outputExpanded": false
-   },
-   "source": [
-    "IPython.display.display({\n",
-    "    'application/x-nteract-model-debug+json': 'asdfasf'\n",
-    "},\n",
-    "raw=True)"
-   ],
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "application/x-nteract-model-debug+json": [
-       "asdfasf"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+      "cell_type": "code",
+      "source": [
+        "import IPython"
+      ],
+      "outputs": [],
+      "execution_count": 3,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import ipykernel"
+      ],
+      "outputs": [],
+      "execution_count": 1,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "IPython.display.display({\n",
+        "    'application/x-nteract-model-debug+json': 'asdfasf'\n",
+        "},\n",
+        "raw=True)"
+      ],
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "NameError",
+          "evalue": "name 'IPython' is not defined",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-2-6b85ba3c875b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m IPython.display.display({\n\u001b[0m\u001b[1;32m      2\u001b[0m     \u001b[0;34m'application/x-nteract-model-debug+json'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;34m'asdfasf'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m },\n\u001b[1;32m      4\u001b[0m raw=True)\n",
+            "\u001b[0;31mNameError\u001b[0m: name 'IPython' is not defined"
+          ]
+        }
+      ],
+      "execution_count": 2,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "c = ipykernel.comm.Comm(target_name='setIn', target_module='reducers')"
+      ],
+      "outputs": [],
+      "execution_count": 4,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "c.comm_id"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 5,
+          "data": {
+            "text/plain": [
+              "'7c013fec3c194ddc9b6b2908634f8735'"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 5,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import time\n",
+        "import random\n",
+        "\n",
+        "for ii in range(25) :\n",
+        "  time.sleep(0.1)\n",
+        "  c.send({'path': ['a'], 'value': random.random()})"
+      ],
+      "outputs": [],
+      "execution_count": 7,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false,
+        "outputExpanded": false
+      }
     }
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3"
+    },
+    "kernel_info": {
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.6.2",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "nteract": {
+      "version": "0.2.0"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "outputExpanded": false
-   },
-   "source": [
-    "c = ipykernel.comm.Comm(target_name='setIn', target_module='reducers')"
-   ],
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "outputExpanded": false
-   },
-   "source": [
-    "import time\n",
-    "import random\n",
-    "\n",
-    "for ii in range(25) :\n",
-    "  time.sleep(0.1)\n",
-    "  c.send({'path': ['b', 'c'], 'value': random.random()})"
-   ],
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "outputExpanded": false
-   },
-   "source": [],
-   "outputs": []
-  }
- ],
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "kernelspec": {
-   "name": "python3",
-   "language": "python",
-   "display_name": "Python 3"
-  },
-  "kernel_info": {
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.6.0",
-   "mimetype": "text/x-python",
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "pygments_lexer": "ipython3",
-   "nbconvert_exporter": "python",
-   "file_extension": ".py"
-  }
- }
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/packages/desktop/example-notebooks/vdom-js-yay.ipynb
+++ b/packages/desktop/example-notebooks/vdom-js-yay.ipynb
@@ -1,0 +1,162 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "var attributes = {\n",
+        "    'data-path-set-value': 'what',\n",
+        "    'data-path-meh': 12,\n",
+        "    'value': 3\n",
+        "}\n",
+        "\n",
+        "model = {\n",
+        "    'what': 40\n",
+        "}\n",
+        "\n\n",
+        "allDataPathSetters = Object.keys(attributes)\n",
+        "    .filter(x => x.startsWith('data-path'))\n",
+        "allDataPathSetters"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 11,
+          "data": {
+            "text/plain": [
+              "[ 'data-path-set-value', 'data-path-meh' ]"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 11,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "var _ = require('lodash')"
+      ],
+      "outputs": [],
+      "execution_count": 10,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "allDataPathSetters.reduce(\n",
+        "    (all, dataPath) => {\n",
+        "        return Object.assign(\n",
+        "        {}, { _.get(model, dataPath)} , attributes),\n",
+        "    }\n",
+        "    {})"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 14,
+          "data": {
+            "text/plain": [
+              "{ 'data-path-set-value': 'what', 'data-path-meh': 12, value: 3 }"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 14,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "'data-path-meh'.split('data-path-')[1]"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 17,
+          "data": {
+            "text/plain": [
+              "'meh'"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 17,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "Object.assign({}, { children: \"zoo\" }, {children: undefined })"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 27,
+          "data": {
+            "text/plain": [
+              "{ children: undefined }"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 27,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "node_nteract",
+      "language": "javascript",
+      "display_name": "Node.js (nteract)"
+    },
+    "kernel_info": {
+      "name": "node_nteract"
+    },
+    "language_info": {
+      "name": "javascript",
+      "version": "7.9.0",
+      "mimetype": "application/javascript",
+      "file_extension": ".js"
+    },
+    "nteract": {
+      "version": "0.2.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/packages/desktop/example-notebooks/vdom-model-hacking.ipynb
+++ b/packages/desktop/example-notebooks/vdom-model-hacking.ipynb
@@ -3,10 +3,10 @@
     {
       "cell_type": "code",
       "source": [
-        "from vdom import VDOM, createElement, div, h1, p, img"
+        "from vdom import h, div, h1, p, img, toJSON"
       ],
       "outputs": [],
-      "execution_count": 1,
+      "execution_count": 20,
       "metadata": {
         "collapsed": false,
         "outputHidden": false,
@@ -16,7 +16,259 @@
     {
       "cell_type": "code",
       "source": [
-        "input_ = createElement('input')"
+        "styles = {\n",
+        "    'header': {\n",
+        "            \"color\": \"white\",\n",
+        "            \"backgroundColor\": \"green\",\n",
+        "            \"paddingLeft\": \"20px\"\n",
+        "        }\n",
+        "}\n",
+        "\n",
+        "# styled-components\n",
+        "\n\n\n",
+        "def write_audit_component(description=\"Stuff\"):\n",
+        "    return div([\n",
+        "        h1('Write Audit Publish Report', style=styles['header']),\n",
+        "        p(description),\n",
+        "        h('input')\n",
+        "    ])\n",
+        "\n\n",
+        "div([\n",
+        "    write_audit_component(\"One thing\"),\n",
+        "    write_audit_component(\"TWO\"),\n",
+        "    write_audit_component(\"THREE\"),\n",
+        "])\n"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 25,
+          "data": {
+            "application/vdom.v1+json": {
+              "tagName": "div",
+              "attributes": {},
+              "children": [
+                {
+                  "tagName": "div",
+                  "attributes": {},
+                  "children": [
+                    {
+                      "tagName": "h1",
+                      "attributes": {
+                        "style": {
+                          "color": "white",
+                          "backgroundColor": "green",
+                          "paddingLeft": "20px"
+                        }
+                      },
+                      "children": "Write Audit Publish Report"
+                    },
+                    {
+                      "tagName": "p",
+                      "attributes": {},
+                      "children": "One thing"
+                    },
+                    {
+                      "tagName": "input",
+                      "attributes": {},
+                      "children": null
+                    }
+                  ]
+                },
+                {
+                  "tagName": "div",
+                  "attributes": {},
+                  "children": [
+                    {
+                      "tagName": "h1",
+                      "attributes": {
+                        "style": {
+                          "color": "white",
+                          "backgroundColor": "green",
+                          "paddingLeft": "20px"
+                        }
+                      },
+                      "children": "Write Audit Publish Report"
+                    },
+                    {
+                      "tagName": "p",
+                      "attributes": {},
+                      "children": "TWO"
+                    },
+                    {
+                      "tagName": "input",
+                      "attributes": {},
+                      "children": null
+                    }
+                  ]
+                },
+                {
+                  "tagName": "div",
+                  "attributes": {},
+                  "children": [
+                    {
+                      "tagName": "h1",
+                      "attributes": {
+                        "style": {
+                          "color": "white",
+                          "backgroundColor": "green",
+                          "paddingLeft": "20px"
+                        }
+                      },
+                      "children": "Write Audit Publish Report"
+                    },
+                    {
+                      "tagName": "p",
+                      "attributes": {},
+                      "children": "THREE"
+                    },
+                    {
+                      "tagName": "input",
+                      "attributes": {},
+                      "children": null
+                    }
+                  ]
+                }
+              ]
+            },
+            "text/plain": [
+              "<vdom.core.createComponent.<locals>.Component at 0x11207bc50>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 25,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "toJSON(h1('hey'))"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 23,
+          "data": {
+            "text/plain": [
+              "{'attributes': {}, 'children': 'hey', 'tagName': 'h1'}"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 23,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import time\n",
+        "\n",
+        "handle = display(div([\n",
+        "    h('details', [\n",
+        "        h('summary', 'Click me'),\n",
+        "        write_audit_component(\"Loading... \")\n",
+        "    ])\n",
+        "]), display_id=True)\n",
+        "\n",
+        "time.sleep(1.5)\n",
+        "\n",
+        "handle.update(div([\n",
+        "    h('details', [\n",
+        "        h('summary', 'Click me'),\n",
+        "        write_audit_component(\"DATA \" * 20)\n",
+        "    ])\n",
+        "]))"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vdom.v1+json": {
+              "tagName": "div",
+              "attributes": {},
+              "children": [
+                {
+                  "tagName": "details",
+                  "attributes": {},
+                  "children": [
+                    {
+                      "tagName": "summary",
+                      "attributes": {
+                        "id": "test"
+                      },
+                      "children": "Click me"
+                    },
+                    {
+                      "tagName": "div",
+                      "attributes": {},
+                      "children": [
+                        {
+                          "tagName": "h1",
+                          "attributes": {
+                            "style": {
+                              "color": "white",
+                              "backgroundColor": "green",
+                              "paddingLeft": "20px"
+                            }
+                          },
+                          "children": "Write Audit Publish Report"
+                        },
+                        {
+                          "tagName": "p",
+                          "attributes": {},
+                          "children": "DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA DATA "
+                        },
+                        {
+                          "tagName": "input",
+                          "attributes": {},
+                          "children": null
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "text/plain": [
+              "<vdom.core.createComponent.<locals>.Component at 0x1121090f0>"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 31,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "input_ = partial(h, 'input')"
       ],
       "outputs": [],
       "execution_count": 2,
@@ -40,11 +292,11 @@
           "output_type": "stream",
           "name": "stdout",
           "text": [
-            "552e1c4beed742c7b3d4deb1ffa29ca7\n"
+            "d7cb5950eff046e88b11775a20739e52\n"
           ]
         }
       ],
-      "execution_count": 5,
+      "execution_count": 3,
       "metadata": {
         "collapsed": false,
         "outputHidden": false,
@@ -55,12 +307,11 @@
       "cell_type": "code",
       "source": [
         "display(\n",
-        "    VDOM(\n",
         "        div([\n",
         "            h1('hey'),\n",
-        "            p('woo')\n",
-        "        ])\n",
-        "    ),\n",
+        "            p('woo'),\n",
+        "            input_()\n",
+        "        ]),\n",
         "    metadata={\n",
         "        \"application/vdom.v1+json\": {\n",
         "            \"modelID\": c.comm_id   \n",
@@ -85,21 +336,26 @@
                   "tagName": "p",
                   "attributes": {},
                   "children": "woo"
+                },
+                {
+                  "tagName": "input",
+                  "attributes": {},
+                  "children": null
                 }
               ]
             },
             "text/plain": [
-              "<vdom.core.VDOM at 0x10680f400>"
+              "<vdom.core.createComponent.<locals>.Component at 0x111eb72b0>"
             ]
           },
           "metadata": {
             "application/vdom.v1+json": {
-              "modelID": "552e1c4beed742c7b3d4deb1ffa29ca7"
+              "modelID": "d7cb5950eff046e88b11775a20739e52"
             }
           }
         }
       ],
-      "execution_count": 7,
+      "execution_count": 4,
       "metadata": {
         "collapsed": false,
         "outputHidden": false,
@@ -107,15 +363,34 @@
       }
     },
     {
-      "cell_type": "code",
+      "cell_type": "markdown",
+      "source": [
+        "We have:\n",
+        "\n",
+        "* `comm_id`\n",
+        "* `setIn` reducer\n",
+        "* `data-path-for-value` -- one element can bind multiple attributes\n",
+        "\n\n",
+        "What should I put on models to identify which they want to use\n",
+        "\n",
+        "* `data-comm-id` or `data-model-id` on the top most element?\n",
+        "\n",
+        "Things I'm curious about:\n",
+        "\n",
+        "* Should we be able to consume from multiple models within one output?\n",
+        "\nI feel like extending ourselves to "
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
       "source": [],
-      "outputs": [],
-      "execution_count": null,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
+      "metadata": {}
+    },
+    {
+      "cell_type": "markdown",
+      "source": [],
+      "metadata": {}
     }
   ],
   "metadata": {

--- a/packages/desktop/example-notebooks/vdom-model-hacking.ipynb
+++ b/packages/desktop/example-notebooks/vdom-model-hacking.ipynb
@@ -1,0 +1,148 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "from vdom import VDOM, createElement, div, h1, p, img"
+      ],
+      "outputs": [],
+      "execution_count": 1,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "input_ = createElement('input')"
+      ],
+      "outputs": [],
+      "execution_count": 2,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import ipykernel\n",
+        "\n",
+        "c = ipykernel.comm.Comm(target_name='setIn', target_module='reducers')\n",
+        "print(c.comm_id)\n",
+        "c.send({'path': ['style'], 'value': { 'backgroundColor': 'DeepPink'} })"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "552e1c4beed742c7b3d4deb1ffa29ca7\n"
+          ]
+        }
+      ],
+      "execution_count": 5,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "display(\n",
+        "    VDOM(\n",
+        "        div([\n",
+        "            h1('hey'),\n",
+        "            p('woo')\n",
+        "        ])\n",
+        "    ),\n",
+        "    metadata={\n",
+        "        \"application/vdom.v1+json\": {\n",
+        "            \"modelID\": c.comm_id   \n",
+        "        }\n",
+        "    }\n",
+        ")"
+      ],
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vdom.v1+json": {
+              "tagName": "div",
+              "attributes": {},
+              "children": [
+                {
+                  "tagName": "h1",
+                  "attributes": {},
+                  "children": "hey"
+                },
+                {
+                  "tagName": "p",
+                  "attributes": {},
+                  "children": "woo"
+                }
+              ]
+            },
+            "text/plain": [
+              "<vdom.core.VDOM at 0x10680f400>"
+            ]
+          },
+          "metadata": {
+            "application/vdom.v1+json": {
+              "modelID": "552e1c4beed742c7b3d4deb1ffa29ca7"
+            }
+          }
+        }
+      ],
+      "execution_count": 7,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "collapsed": false,
+        "outputHidden": false,
+        "inputHidden": false
+      }
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3"
+    },
+    "kernel_info": {
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.6.2",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "nteract": {
+      "version": "0.2.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/packages/desktop/src/notebook/components/notebook.js
+++ b/packages/desktop/src/notebook/components/notebook.js
@@ -118,7 +118,7 @@ export class Notebook extends React.PureComponent<Props> {
 
   keyDown(e: KeyboardEvent): void {
     // If enter is not pressed, do nothing
-    if (e.keyCode !== 13) {
+    if (e.key !== "Enter") {
       return;
     }
 

--- a/packages/desktop/src/notebook/reducers/comms.js
+++ b/packages/desktop/src/notebook/reducers/comms.js
@@ -53,6 +53,14 @@ function processCommMessage(
   if (
     commInfo &&
     commInfo.get("target_module") === "reducers" &&
+    commInfo.get("target_name") === "reacttraining"
+  ) {
+    return state;
+  }
+
+  if (
+    commInfo &&
+    commInfo.get("target_module") === "reducers" &&
     commInfo.get("target_name") === "setIn"
   ) {
     const path: Array<string | number> = data.path;

--- a/packages/display-area/src/output.js
+++ b/packages/display-area/src/output.js
@@ -29,8 +29,8 @@ export default function Output(props: Props): ?React$Element<any> | null {
 
     // falls through
     case "display_data": {
-      const bundle = output.data;
-      const metadata = output.metadata;
+      const bundle = output.data || {};
+      const metadata = output.metadata || {};
       return (
         <RichestMime
           expanded={props.expanded}

--- a/packages/display-area/src/richest-mime.js
+++ b/packages/display-area/src/richest-mime.js
@@ -50,8 +50,8 @@ export default class RichestMime extends React.Component<Props> {
     }
 
     const Transform = this.props.transforms[mimetype];
-    const data = this.props.bundle[mimetype];
-    const metadata = this.props.metadata[mimetype];
+    const data = this.props.bundle[mimetype] || {};
+    const metadata = this.props.metadata[mimetype] || {};
     return (
       <Transform
         expanded={this.props.expanded}

--- a/packages/transform-vdom/__tests__/index.test.js
+++ b/packages/transform-vdom/__tests__/index.test.js
@@ -2,6 +2,8 @@ import React from "react";
 import TransformVDOM from "../src";
 import renderer from "react-test-renderer";
 
+import { modelReplaceAttributes } from "../src/data-path";
+
 test("VDOM Transform is cool", () => {
   const component = renderer.create(
     <TransformVDOM
@@ -36,4 +38,35 @@ test("VDOM Transform is cool", () => {
       }}
     />
   );
+});
+
+test("data-path is sweet and I should write a better test description", () => {
+  const attributes = {
+    "data-path-for-value": "what",
+    "data-path-meh": 12,
+    "data-path-for-children": "mine",
+    value: 3
+  };
+
+  const model = {
+    what: 40,
+    mine: "Hear ye, hear ye"
+  };
+
+  const obje = modelReplaceAttributes(model, {
+    attributes: attributes,
+    children: null
+  });
+
+  expect(obje).toEqual({
+    attributes: {
+      "data-path-for-children": "mine",
+      "data-path-for-value": "what",
+      "data-path-meh": 12,
+      value: 40
+    },
+    children: {
+      children: "Hear ye, hear ye"
+    }
+  });
 });

--- a/packages/transform-vdom/src/data-path.js
+++ b/packages/transform-vdom/src/data-path.js
@@ -1,0 +1,55 @@
+const _ = require("lodash");
+const DATA_PATH_PREFIX = "data-path-for-";
+const DATA_PATH_FOR_CHILDREN = "data-path-for-children";
+
+// Given a collection of attributes and a model that (hopefully) contains
+// those paths, return a new collection of attributes replaces them according
+// to the model.
+function modelReplaceAttributes(model, obj) {
+  const changes = _.reduce(
+    obj.attributes,
+    (result, value, key) => {
+      if (key.startsWith(DATA_PATH_PREFIX)) {
+        const changeKey = key.slice(DATA_PATH_PREFIX.length);
+        const path = value;
+        if (changeKey.length > 0) {
+          result[changeKey] = _.get(model, path);
+        }
+      }
+      return result;
+    },
+    {}
+  );
+
+  return changes;
+
+  const attributes = Object.assign({}, changes, obj.attributes);
+  let children = obj.children;
+
+  // Special case children & data- attributes
+  if (obj.attributes[DATA_PATH_FOR_CHILDREN]) {
+    children = _.get(model, obj.attributes[DATA_PATH_FOR_CHILDREN]);
+  }
+
+  return Object.assign({}, { children, attributes }, obj);
+}
+
+/**
+
+var attributes = {
+    'data-path-for-value': 'what',
+    'data-path-meh': 12,
+    'data-path-for-children': 'mine',
+    'value': 3
+}
+
+model = {
+    'what': 40,
+    'mine': "Hear ye, hear ye"
+}
+
+modelReplaceAttributes(model, { attributes: attributes, children: null })
+
+
+
+ */

--- a/packages/transform-vdom/src/data-path.js
+++ b/packages/transform-vdom/src/data-path.js
@@ -5,7 +5,7 @@ const DATA_PATH_FOR_CHILDREN = "data-path-for-children";
 // Given a collection of attributes and a model that (hopefully) contains
 // those paths, return a new collection of attributes that replaces them
 // according to the model.
-function modelReplaceAttributes(model, obj) {
+export function modelReplaceAttributes(model, obj) {
   const changes = _.reduce(
     // Iterate over all the attributes
     obj.attributes,
@@ -42,17 +42,3 @@ function modelReplaceAttributes(model, obj) {
     { children: childrenChanges }
   );
 }
-
-var attributes = {
-  "data-path-for-value": "what",
-  "data-path-meh": 12,
-  "data-path-for-children": "mine",
-  value: 3
-};
-
-model = {
-  what: 40,
-  mine: "Hear ye, hear ye"
-};
-
-modelReplaceAttributes(model, { attributes: attributes, children: null });

--- a/packages/transform-vdom/src/data-path.js
+++ b/packages/transform-vdom/src/data-path.js
@@ -21,17 +21,16 @@ function modelReplaceAttributes(model, obj) {
     {}
   );
 
-  return changes;
+  const childrenChanges = {};
 
-  const attributes = Object.assign({}, changes, obj.attributes);
-  let children = obj.children;
-
-  // Special case children & data- attributes
-  if (obj.attributes[DATA_PATH_FOR_CHILDREN]) {
-    children = _.get(model, obj.attributes[DATA_PATH_FOR_CHILDREN]);
+  // If there are any changes to children, they belong at the top level,
+  // so we ensure they don't end up at the attribute level
+  if (changes["children"]) {
+    childrenChanges["children"] = changes["children"];
+    delete changes["children"];
   }
 
-  return Object.assign({}, { children, attributes }, obj);
+  return Object.assign({}, obj, childrenChanges, { attributes: changes });
 }
 
 /**
@@ -49,7 +48,5 @@ model = {
 }
 
 modelReplaceAttributes(model, { attributes: attributes, children: null })
-
-
 
  */

--- a/packages/transform-vdom/src/data-path.js
+++ b/packages/transform-vdom/src/data-path.js
@@ -3,12 +3,14 @@ const DATA_PATH_PREFIX = "data-path-for-";
 const DATA_PATH_FOR_CHILDREN = "data-path-for-children";
 
 // Given a collection of attributes and a model that (hopefully) contains
-// those paths, return a new collection of attributes replaces them according
-// to the model.
+// those paths, return a new collection of attributes that replaces them
+// according to the model.
 function modelReplaceAttributes(model, obj) {
   const changes = _.reduce(
+    // Iterate over all the attributes
     obj.attributes,
     (result, value, key) => {
+      // If they match our specced data-path-for-ATTRIBUTE, extract the model value
       if (key.startsWith(DATA_PATH_PREFIX)) {
         const changeKey = key.slice(DATA_PATH_PREFIX.length);
         const path = value;
@@ -30,23 +32,27 @@ function modelReplaceAttributes(model, obj) {
     delete changes["children"];
   }
 
-  return Object.assign({}, obj, childrenChanges, { attributes: changes });
+  // We either have to do a _.merge of the objects or we pluck exactly what we
+  // need to make the structure
+  const mergedAttributes = Object.assign({}, obj.attributes, changes);
+  return Object.assign(
+    {},
+    obj,
+    { attributes: mergedAttributes },
+    { children: childrenChanges }
+  );
 }
-
-/**
 
 var attributes = {
-    'data-path-for-value': 'what',
-    'data-path-meh': 12,
-    'data-path-for-children': 'mine',
-    'value': 3
-}
+  "data-path-for-value": "what",
+  "data-path-meh": 12,
+  "data-path-for-children": "mine",
+  value: 3
+};
 
 model = {
-    'what': 40,
-    'mine': "Hear ye, hear ye"
-}
+  what: 40,
+  mine: "Hear ye, hear ye"
+};
 
-modelReplaceAttributes(model, { attributes: attributes, children: null })
-
- */
+modelReplaceAttributes(model, { attributes: attributes, children: null });

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -5,21 +5,37 @@ import { objectToReactElement } from "./object-to-react";
 import { cloneDeep } from "lodash";
 
 type Props = {
-  data: Object
+  data: Object,
+  metadata: Object,
+  models: any
 };
 
 export default class VDOM extends React.Component<Props> {
   static MIMETYPE = "application/vdom.v1+json";
 
   shouldComponentUpdate(nextProps: Props): boolean {
-    return nextProps.data !== this.props.data;
+    return (
+      nextProps.data !== this.props.data ||
+      nextProps.models !== this.props.models
+    );
   }
 
   render(): React$Element<any> {
+    // Later, make this transient
+    let model;
+    if (
+      this.props.metadata &&
+      typeof this.props.metadata.modelID === "string" &&
+      Object.keys(this.props.models).length > 0
+    ) {
+      const modelID = this.props.metadata.modelID;
+      model = this.props.models[modelID];
+    }
+
     try {
       // objectToReactElement is mutatitve so we'll clone our object
       var obj = cloneDeep(this.props.data);
-      return objectToReactElement(obj);
+      return objectToReactElement(obj, model);
     } catch (err) {
       return (
         <div>

--- a/packages/transform-vdom/src/object-to-react.js
+++ b/packages/transform-vdom/src/object-to-react.js
@@ -38,9 +38,9 @@ type VDOMEl = {
   key: number | string | null
 };
 
-type ReactArray = Array<React$Element<*> | ReactArray | string>;
-
 type VDOMNode = VDOMEl | string | Array<VDOMNode>;
+
+type ReactArray = Array<React$Element<*> | ReactArray | string>;
 
 /**
  * Convert an object to React element(s).
@@ -67,6 +67,12 @@ export function objectToReactElement(
 
   // `React.createElement` 1st argument: type
   args[0] = obj.tagName;
+
+  const allDataPathSetters = Object.keys(obj.attributes).filter(attr =>
+    attr.startsWith("data-path-set")
+  );
+
+  // allDataPathSetters.reduce();
 
   const model_path = obj.attributes["model_path"];
   delete obj.attributes["model_path"];

--- a/packages/transform-vdom/src/object-to-react.js
+++ b/packages/transform-vdom/src/object-to-react.js
@@ -29,6 +29,7 @@
  */
 
 const React = require("react");
+const _ = require("lodash");
 
 type VDOMEl = {
   tagName: string, // Could be an enum honestly
@@ -50,7 +51,10 @@ type VDOMNode = VDOMEl | string | Array<VDOMNode>;
  * @param  {Object}       obj - The element object.
  * @return {ReactElement}
  */
-export function objectToReactElement(obj: VDOMEl): React$Element<*> {
+export function objectToReactElement(
+  obj: VDOMEl,
+  model: any = {}
+): React$Element<*> {
   // Pack args for React.createElement
   var args = [];
 
@@ -63,7 +67,20 @@ export function objectToReactElement(obj: VDOMEl): React$Element<*> {
 
   // `React.createElement` 1st argument: type
   args[0] = obj.tagName;
-  args[1] = obj.attributes;
+
+  const model_path = obj.attributes["model_path"];
+  delete obj.attributes["model_path"];
+
+  if (model_path) {
+    args[1] = Object.assign({}, _.get(model, model_path), obj.attributes);
+  } else {
+    args[1] = obj.attributes;
+  }
+
+  // $FlowFixMe: fuck it, let's go
+  args[1]["onChange"] = event => {
+    // console.log(args[0], event.target.name, event.target.value);
+  };
 
   const children = obj.children;
 
@@ -82,6 +99,8 @@ export function objectToReactElement(obj: VDOMEl): React$Element<*> {
       console.warn("invalid vdom data passed", children);
     }
   }
+
+  console.log(args);
 
   // $FlowFixMe: React
   return React.createElement.apply({}, args);


### PR DESCRIPTION
I've been experimenting with something along with @mpacer and @willingc, just posting this PR to get something up. I'll fill this out to be more rigorous and tested since it's going to be a pretty impactful change, in terms of the supported API.

# Goal

Create a simple way to create interactive forms and layouts that will work across all Jupyter frontends that is compatible with real-time (consistent serializable state tree + diffs that can be propagated).

# Related PRs:

* Models #1313

# Core concepts

* When a VDOM output contains `data-path-for-ATTRIBUTE`, it replaces the actual `ATTRIBUTE` with a value from a model (as in #1313)
* When the value is bound, we can set an implicit `onChange` handler (need to spec this out a bit)

This is fairly similar to how [React's (deprecated) `LinkedStateMixin` worked](https://facebook.github.io/react/docs/two-way-binding-helpers.html)

## Missing pieces

### `onChange` implicit bindings

Status: 🤔 

To start things off, we're going to allow changing form fields that use `name` and `value`, working in tandem with the `setIn` based models from #1313.

Rough sketch is that when an `<input>` is changed, we bubble up the event as an action that will both set the local model as well as send it to the kernel (to change the "server side" model).

### `onClick` implicit bindings

Not scoped for this PR (or any :soon: release), I want only actions that can be viewed if there were more than one viewer at the same time.

My current thinking on this is that we possibly bubble the `onClick` event up for a given `name` (which means only supporting `<button>`s for the moment).

### Specifying the model to use

Status: 🤔 

Potential options:

* Within the transient field of the vdom output, set a `model_id`
