### PR TITLE
fix root level dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "*.json": ["prettier --write", "git add"]
   },
   "dependencies": {
-    "enzyme-adapter-react-16": "^1.0.0",
     "immutable": "^3.8.1",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react-dom": "^16.0.0",
+    "rxjs": "^5.4.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -104,6 +104,7 @@
     "prettier": "^1.7.0",
     "raf": "^3.3.2",
     "react-test-renderer": "^16.0.0",
+    "enzyme-adapter-react-16": "^1.0.0",
     "sinon": "^3.2.0",
     "sinon-chai": "^2.10.0",
     "webpack": "^3.5.5"


### PR DESCRIPTION
This addresses one of the comments in #1910, namely where `enzyme-adapter-react-16` belongs. While I was at it, I noticed what the hoisting issue was that I was running into for RxJS between the desktop app and the web app -- it wasn't at the base so it wasn't being hoisted (at all).