### PR TITLE
Setup auto update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nteract",
-  "version": "0.2.0",
+  "name": "nteract-monorepo",
+  "version": "0.0.0",
   "description": "Interactive literate coding notebook!",
   "repository": {
     "type": "git",
@@ -15,39 +15,41 @@
   "homepage": "https://github.com/nteract/nteract",
   "scripts": {
     "postinstall": "npm run lerna",
-    "start": "lerna run start --scope @nteract/desktop --stream",
-    "spawn": "lerna run spawn --scope @nteract/desktop",
+    "start": "lerna run start --scope nteract --stream",
+    "spawn": "lerna run spawn --scope nteract",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lerna": "lerna bootstrap --hoist rxjs",
     "build": "npm run build:packages && npm run build:desktop",
-    "build:desktop": "lerna run build --scope @nteract/desktop --stream",
-    "build:desktop:watch":
-      "lerna run build:watch --scope @nteract/desktop --stream",
+    "build:desktop": "lerna run build --scope nteract --stream",
+    "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "lerna run build --parallel",
     "build:packages:watch": "lerna run build:lib:watch --parallel",
     "build:icon":
       "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
     "build:docs": "esdoc -c esdoc.json",
     "test":
-      "lerna run test:unit --scope @nteract/desktop && npm run test:packages && npm run test:lint",
+      "lerna run test:unit --scope nteract && npm run test:packages && npm run test:lint",
     "test:conformance": "node scripts/conformance.js",
     "test:coverage": "npm run coverage",
     "test:lint": "npm run lint",
     "test:flow": "npm run flow",
     "test:packages":
       "lerna exec --scope enchannel-zmq-backend -- npm rebuild && jest",
-    "test:desktop": "lerna run test:unit --scope @nteract/desktop --stream",
+    "test:desktop": "lerna run test:unit --scope nteract --stream",
     "precoverage":
-      "mkdirp coverage && nyc lerna run test:unit --scope @nteract/desktop --stream",
+      "mkdirp coverage && nyc lerna run test:unit --scope nteract --stream",
     "coverage": "nyc report --reporter=text-lcov > coverage/lcov.info",
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",
     "precommit": "lint-staged",
     "prettier":
       "prettier --write '**/*.{js,json}' '!**/{lib,.git,flow-typed}/**'",
-    "dist": "lerna run dist --scope @nteract/desktop --stream",
-    "pack": "lerna run pack --scope @nteract/desktop --stream"
+    "dist": "lerna run dist --scope nteract --stream",
+    "pack": "lerna run pack --scope nteract --stream",
+    "publish": "lerna run publish --scope nteract --stream",
+    "dist:all": "lerna run dist:all --scope nteract --stream",
+    "publish:all": "lerna run publish:all --scope nteract --stream"
   },
   "jest": {
     "setupFiles": ["raf/polyfill", "./scripts/mockument"],

--- a/packages/desktop/RELEASING.md
+++ b/packages/desktop/RELEASING.md
@@ -1,29 +1,40 @@
-Let's package a release!
+# :package: Let's package a release!
 
-# All platform precursor
+## All platform precursor
 
-Cut a release using the `npm` workflow:
-
+To be able to publish a release you'll need to generate a GitHub access token by going to <https://github.com/settings/tokens/new>.  The access token should have the `repo` scope/permission.  Once you have the token, assign it to an environment variable (on macOS/linux):
+```bash
+export GH_TOKEN="<YOUR_TOKEN_HERE>"
 ```
+
+## macOS
+
+In order to build a signed copy with working auto-update, you will need to join the Apple developer program and get a certificate. The [Electron docs have a document on submitting your app to the app store](https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md), you only have to get through to the certificate step.
+
+## Release Process
+
+1. Make sure the release is working by running `npm run dist` and testing the built app inside the `./packages/desktop/dist/` folder. You can build for all platforms using `npm run dist:all`.
+
+2. If everything works as expected, bump the version number using `npm`:
+```bash
 npm version {major, minor, patch}
 npm publish
 git push
 git push --tags
 ```
+or manually by editing the version in `./packages/desktop/package.json` and pushing the changes to GitHub.
 
-Now, from GitHub go to [nteract's releases](https://github.com/nteract/nteract/releases) and make a release from the version you just published above. The name should follow our [naming guidelines](https://github.com/nteract/naming), namely that we use the last name of the next scientist in the list with an adjective in front.
+3. Run `npm run publish` on macOS, Windows and Linux or run `npm run publish:all` to build everything on a single machine. This will draft a new release on GitHub and will upload all necessary assets.
 
+4. From GitHub go to [nteract's releases](https://github.com/nteract/nteract/releases), verify everything works and edit the release notes. The name should follow our [naming guidelines](https://github.com/nteract/naming), namely that we use the last name of the next scientist in the list with an adjective in front.
 Example:
-
-```
+```bash
 Last release: Avowed Avogadro
 Next Scientist: Babbage
 Next release: Babbling Babbage
 ```
-
 My favorite way to pick the alliterative adjectives is using the local dictionary and our friend `grep`:
-
-```
+```bash
 $ cat /usr/share/dict/words | grep "^babb"
 babbitt
 babbitter
@@ -39,13 +50,6 @@ babblishly
 babbly
 babby
 ```
+*To ensure that auto-update works, it is best to not modify the name of the release directly, instead just add the chosen one to the release notes.*
 
-## macOS
-
-In order to build a signed copy, you will need to join the Apple developer program and get a certificate. The [Electron docs have a document on submitting your app to the app store](https://github.com/electron/electron/blob/master/docs/tutorial/mac-app-store-submission-guide.md), you only have to get through to the certificate step.
-
-Once your certificate is all set up and your nteract dev environment is ready:
-
-* Run `npm run dist:osx`
-
-https://github.com/nteract/naming
+5. Once you're ready click "Publish release". On Mac and Windows the update will be automatically downloaded and installed.

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nteract/desktop",
+  "name": "nteract",
   "version": "0.2.0",
   "description": "Interactive literate coding notebook!",
   "main": "./lib/webpacked-main.js",
@@ -42,14 +42,19 @@
     "test:watch": "watch 'npm run test' test/",
     "precoverage": "mkdirp coverage && nyc npm run test:unit",
     "coverage": "nyc report --reporter=text-lcov > coverage/lcov.info",
-    "pack": "npm run clean && npm run build && electron-builder --dir",
-    "dist": "npm run clean && npm run build && electron-builder",
-    "dist:all": "npm run dist -- -mlw"
+    "pack":
+      "npm run clean && cross-env NODE_ENV=production webpack && electron-builder --dir",
+    "dist":
+      "npm run clean && cross-env NODE_ENV=production webpack && electron-builder",
+    "publish":
+      "npm run clean && cross-env NODE_ENV=production webpack && electron-builder -p always",
+    "dist:all": "npm run dist -- -mlw",
+    "publish:all": "npm run publish -- -mlw"
   },
   "build": {
-    "electronVersion": "1.7.6",
     "appId": "io.nteract.nteract",
     "productName": "nteract",
+    "publish": [{ "provider": "github" }],
     "fileAssociations": {
       "ext": "ipynb",
       "name": "ipynb"
@@ -112,10 +117,11 @@
     "cross-env": "^5.0.0",
     "date-fns": "^1.28.5",
     "electron": "~1.7.6",
-    "electron-builder": "^19.22.2",
+    "electron-builder": "^19.31.1",
     "electron-context-menu": "^0.9.1",
     "electron-log": "^2.2.6",
     "electron-mocha": "^4.0.0",
+    "electron-updater": "^2.10.0",
     "enchannel": "^3.1.1",
     "enchannel-zmq-backend": "^4.0.2",
     "escape-carriage": "^1.2.0",

--- a/packages/desktop/src/main/auto-updater.js
+++ b/packages/desktop/src/main/auto-updater.js
@@ -1,0 +1,8 @@
+import { autoUpdater } from "electron-updater";
+
+export function initAutoUpdater() {
+  const log = require("electron-log");
+  log.transports.file.level = "info";
+  autoUpdater.logger = log;
+  autoUpdater.checkForUpdatesAndNotify();
+}

--- a/packages/desktop/src/main/index.js
+++ b/packages/desktop/src/main/index.js
@@ -22,6 +22,7 @@ import {
 } from "fs-observable";
 
 import { launch, launchNewNotebook } from "./launch";
+import { initAutoUpdater } from "./auto-updater.js";
 
 import { loadFullMenu } from "./menu";
 
@@ -62,6 +63,8 @@ ipc.on("new-kernel", (event, k) => {
 ipc.on("open-notebook", (event, filename) => {
   launch(resolve(filename));
 });
+
+app.on("ready", initAutoUpdater);
 
 const electronReady$ = Observable.fromEvent(app, "ready");
 


### PR DESCRIPTION
On Windows and Mac new releases will now be automatically downloaded and installed on quit.
[RELEASING.md](https://github.com/lgeiger/nteract/blob/082fec44919bc8d3ed6a4261be978b1d1cd3ea53/packages/desktop/RELEASING.md) documents the new automated release process to make this work.

On macOS the auto-update will look like this: https://youtu.be/dsmb-Piocs0

On Windows it works too (the virtual machine is a bit slow though): https://youtu.be/xUPapWgq4kU
Note: The Windows release was actually built on macOS.

To try it out yourself [download and install `0.2.4`](https://github.com/lgeiger/nteract/releases/tag/v0.2.4) and wait for `0.2.5` to be installed automatically on launch.