### PR TITLE
allow vdomnodes to be null and prevent mutation

### DIFF
--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -8,6 +8,9 @@ type Props = {
   data: Object
 };
 
+// Provide object-to-react as an available helper on the library
+export { objectToReactElement };
+
 export default class VDOM extends React.Component<Props> {
   static MIMETYPE = "application/vdom.v1+json";
 

--- a/packages/transform-vdom/src/object-to-react.js
+++ b/packages/transform-vdom/src/object-to-react.js
@@ -4,6 +4,11 @@
  * The original copy of this comes from
  * https://github.com/remarkablemark/REON/blob/1f126e71c17f96daad518abffdb2c53b66b8b792/lib/object-to-react.js
  *
+ * This version is heavily modified to:
+ * 
+ *   * Match the application/vdom.v1+json spec
+ *   * Not mutate the data
+ *
  * MIT License
  *
  * Copyright (c) 2016 Menglin "Mark" Xu <mark@remarkablemark.org>
@@ -104,11 +109,20 @@ export function arrayToReactChildren(arr: Array<VDOMNode>): ReactArray {
     const item = arr[i];
     if (Array.isArray(item)) {
       result.push(arrayToReactChildren(item));
-    } else if (typeof item === "string") {
+    } else if (typeof item === "string" || item === null) {
       result.push(item);
     } else if (typeof item === "object") {
-      const keyedItem = item;
-      item.key = i;
+      // Create a new object so that if we have to set the key, we are not
+      // mutating the original object
+      const keyedItem = {
+        tagName: item.tagName,
+        attributes: item.attributes,
+        children: item.children,
+        key: i
+      };
+      if (item.attributes && item.attributes.key) {
+        keyedItem.key = item.attributes.key;
+      }
       result.push(objectToReactElement(keyedItem));
     } else {
       console.warn("invalid vdom data passed", item);


### PR DESCRIPTION
Right in line with https://github.com/nteract/vdom/pull/25, I wanted to be able to return `None` within the python `vdom` library, similar to when writing React components and writing `null`, realized this was an omission.