### PR TITLE
docs(commutable): Add a link to the commuter docs in the README

### DIFF
--- a/packages/commutable/README.md
+++ b/packages/commutable/README.md
@@ -22,3 +22,8 @@ Credits to [Tom MacWright](http://www.macwright.org/2015/05/18/practical-undo.ht
 ```
 npm install --save @nteract/commutable
 ```
+
+## Docs
+
+Check out our [docs](https://nteract.github.io/docs/commutable/) for getting started.
+


### PR DESCRIPTION
I didn't know these docs existed! I was going through the code to figure out how commutable worked, I just want to make sure no one else misses this..