### PR TITLE
pin rx-jupyter to the prerelease version

### DIFF
--- a/packages/nbextension/nteract_on_jupyter/package.json
+++ b/packages/nbextension/nteract_on_jupyter/package.json
@@ -21,7 +21,7 @@
     "redux-observable": "^0.16.0",
     "react-notification-system": "^0.2.14",
     "react-redux": "^5.0.5",
-    "rx-jupyter": "^1.2.0",
+    "rx-jupyter": "^1.3.0-0",
     "rxjs": "^5.5.0-beta.2",
     "anser": "^1.4.1",
     "codemirror": "^5.28.0",


### PR DESCRIPTION
I made a prerelease of `rx-jupyter` that relies on the rxjs beta release for us to use here.