### PR TITLE
Tree shake and uglify production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,9 @@
     "sinon": "^3.2.0",
     "sinon-chai": "^2.10.0",
     "style-loader": "^0.19.0",
+    "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
     "url-loader": "^0.6.1",
-    "webpack": "^3.5.5"
+    "webpack": "^3.5.5",
+    "webpack-merge": "^4.1.0"
   }
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -22,7 +22,7 @@
     "spawn": "cross-env NODE_ENV=development electron .",
     "spawn:debug": "cross-env DEBUG=true NODE_ENV=development electron .",
     "prebuild": "rimraf lib",
-    "build": "webpack --progress --colors",
+    "build": "webpack --config webpack.dev.js --progress --colors",
     "build:watch": "npm run build -- --watch",
     "test": "npm run test:unit",
     "pretest:functional": "npm run build",
@@ -43,11 +43,11 @@
     "precoverage": "mkdirp coverage && nyc npm run test:unit",
     "coverage": "nyc report --reporter=text-lcov > coverage/lcov.info",
     "pack":
-      "npm run clean && cross-env NODE_ENV=production webpack && electron-builder --dir",
+      "npm run clean && webpack --config webpack.prod.js && electron-builder --dir",
     "dist":
-      "npm run clean && cross-env NODE_ENV=production webpack && electron-builder",
+      "npm run clean && webpack --config webpack.prod.js && electron-builder",
     "publish":
-      "npm run clean && cross-env NODE_ENV=production webpack && electron-builder -p always",
+      "npm run clean && webpack --config webpack.prod.js && electron-builder -p always",
     "dist:all": "npm run dist -- -mlw",
     "publish:all": "npm run publish -- -mlw"
   },

--- a/packages/desktop/webpack.common.js
+++ b/packages/desktop/webpack.common.js
@@ -1,4 +1,3 @@
-const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const webpack = require("webpack");
 const path = require("path");
@@ -10,7 +9,59 @@ const nodeModules = {
   canvas: "commonjs canvas"
 };
 
-const options = {
+const mainConfig = {
+  entry: {
+    main: "./src/main/index.js"
+  },
+  target: "electron-main",
+  output: {
+    path: path.join(__dirname, "lib"),
+    filename: "webpacked-main.js"
+  },
+  node: {
+    __dirname: false,
+    __filename: false
+  },
+  module: {
+    rules: [
+      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" },
+      { test: /\.json$/, loader: "json-loader" }
+    ]
+  },
+  resolve: {
+    mainFields: ["nteractDesktop", "jsnext:main", "main"],
+    extensions: [".js", ".jsx"]
+  },
+  plugins: [new webpack.IgnorePlugin(/\.(css|less)$/)]
+};
+
+const rendererConfig = {
+  entry: {
+    app: "./src/notebook/index.js",
+    vendor: [
+      "react",
+      "react-dnd",
+      "react-dnd-html5-backend",
+      "react-dom",
+      "react-redux",
+      "react-simple-dropdown",
+      "redux",
+      "redux-logger",
+      "redux-observable",
+      "immutable",
+      "rxjs",
+      "codemirror",
+      "commonmark",
+      "commonmark-react-renderer",
+      "date-fns"
+    ]
+  },
+  target: "electron-renderer",
+  output: {
+    path: path.join(__dirname, "lib"),
+    filename: "webpacked-notebook.js"
+  },
+  externals: nodeModules,
   module: {
     rules: [
       { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" },
@@ -38,72 +89,19 @@ const options = {
   resolve: {
     mainFields: ["nteractDesktop", "jsnext:main", "main"],
     extensions: [".js", ".jsx"]
-  }
-};
-
-const mainConfig = Object.assign({}, options, {
-  entry: {
-    main: "./src/main/index.js"
-  },
-  target: "electron-main",
-  output: {
-    path: path.join(__dirname, "lib"),
-    filename: "webpacked-main.js"
-  },
-  node: {
-    __dirname: false,
-    __filename: false
   },
   plugins: [
-    new webpack.optimize.ModuleConcatenationPlugin(),
-    new webpack.IgnorePlugin(/\.(css|less)$/)
-  ]
-});
-
-const rendererConfig = Object.assign({}, options, {
-  entry: {
-    app: "./src/notebook/index.js",
-    vendor: [
-      "react",
-      "react-dnd",
-      "react-dnd-html5-backend",
-      "react-dom",
-      "react-redux",
-      "react-simple-dropdown",
-      "redux",
-      "redux-logger",
-      "redux-observable",
-      "immutable",
-      "rxjs",
-      "codemirror",
-      "commonmark",
-      "commonmark-react-renderer",
-      "date-fns"
-    ]
-  },
-  target: "electron-renderer",
-  output: {
-    path: path.join(__dirname, "lib"),
-    filename: "webpacked-notebook.js"
-  },
-  externals: nodeModules,
-  plugins: [
-    new LodashModuleReplacementPlugin(),
-    new webpack.optimize.ModuleConcatenationPlugin(),
-
     new webpack.IgnorePlugin(/\.less$/),
-
     // build vendor bundle (including common code chunks used in other bundles)
     new webpack.optimize.CommonsChunkPlugin({
       name: "vendor",
       filename: "vendor.js"
     }),
-    new webpack.SourceMapDevToolPlugin({
-      filename: "[name].js.map",
-      exclude: ["vendor.js"]
-    }),
     new ExtractTextPlugin("styles.css")
   ]
-});
+};
 
-module.exports = [mainConfig, rendererConfig];
+module.exports = {
+  commonMainConfig: mainConfig,
+  commonRendererConfig: rendererConfig
+};

--- a/packages/desktop/webpack.dev.js
+++ b/packages/desktop/webpack.dev.js
@@ -1,0 +1,15 @@
+const webpack = require("webpack");
+const merge = require("webpack-merge");
+
+const { commonMainConfig, commonRendererConfig } = require("./webpack.common");
+
+const rendererConfig = merge(commonRendererConfig, {
+  plugins: [
+    new webpack.SourceMapDevToolPlugin({
+      filename: "[name].js.map",
+      exclude: ["vendor.js"]
+    })
+  ]
+});
+
+module.exports = [commonMainConfig, rendererConfig];

--- a/packages/desktop/webpack.prod.js
+++ b/packages/desktop/webpack.prod.js
@@ -1,0 +1,28 @@
+const webpack = require("webpack");
+const merge = require("webpack-merge");
+
+const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
+const UglifyJSPlugin = require("uglifyjs-webpack-plugin");
+
+const { commonMainConfig, commonRendererConfig } = require("./webpack.common");
+
+const plugins = [
+  new webpack.optimize.ModuleConcatenationPlugin(),
+  new webpack.DefinePlugin({
+    "process.env.NODE_ENV": JSON.stringify("production")
+  }),
+  new UglifyJSPlugin({
+    parallel: true,
+    uglifyOptions: {
+      ecma: 7
+    }
+  })
+];
+
+const mainConfig = merge(commonMainConfig, { plugins: plugins });
+
+const rendererConfig = merge(commonRendererConfig, {
+  plugins: [new LodashModuleReplacementPlugin(), ...plugins]
+});
+
+module.exports = [mainConfig, rendererConfig];


### PR DESCRIPTION
Overall this strips 13.3MB from our `nteract.app` compared to `0.3.1`. Closes #1849

file | size master | size PR
--- | --- | ---
`vendor.js` | 3.1 MB | 0.8 MB
`webpacked-main.js` | 2.9 MB | 1.1 MB
`wegpacked-notebook.js` | 11.8 MB | 5.5 MB

For further runtime improvements we can finetune our babel setup and take a look at:
- https://babeljs.io/docs/plugins/transform-react-inline-elements/
- https://babeljs.io/docs/plugins/transform-react-constant-elements/
- https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types