### PR TITLE
RxJS: Use es2015 build in webpack

### DIFF
--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -235,7 +235,7 @@ export function executeCellStream(
     ofMessageType(["execute_reply"]),
     pluck("content", "payload"),
     filter(Boolean),
-    mergeMap(payloads => Observable.from(payloads))
+    mergeMap(payloads => from(payloads))
   );
 
   // Payload stream for setting the input, whether in place or "next"

--- a/packages/desktop/webpack.common.js
+++ b/packages/desktop/webpack.common.js
@@ -29,7 +29,7 @@ const mainConfig = {
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "es2015", "jsnext:main", "main"],
+    mainFields: ["nteractDesktop", "es2015", "jsnext:main", "module", "main"],
     extensions: [".js", ".jsx"]
   },
   plugins: [new webpack.IgnorePlugin(/\.(css|less)$/)]
@@ -87,7 +87,7 @@ const rendererConfig = {
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "es2015", "jsnext:main", "main"],
+    mainFields: ["nteractDesktop", "es2015", "jsnext:main", "module", "main"],
     extensions: [".js", ".jsx"]
   },
   plugins: [

--- a/packages/desktop/webpack.common.js
+++ b/packages/desktop/webpack.common.js
@@ -29,7 +29,7 @@ const mainConfig = {
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "jsnext:main", "main"],
+    mainFields: ["nteractDesktop", "es2015", "jsnext:main", "main"],
     extensions: [".js", ".jsx"]
   },
   plugins: [new webpack.IgnorePlugin(/\.(css|less)$/)]
@@ -87,7 +87,7 @@ const rendererConfig = {
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "jsnext:main", "main"],
+    mainFields: ["nteractDesktop", "es2015", "jsnext:main", "main"],
     extensions: [".js", ".jsx"]
   },
   plugins: [

--- a/packages/nbextension/nteract_on_jupyter/epics/kernelspecs.js
+++ b/packages/nbextension/nteract_on_jupyter/epics/kernelspecs.js
@@ -2,7 +2,6 @@
 
 import { kernelspecs } from "rx-jupyter";
 
-import { Observable } from "rxjs/Observable";
 import { of } from "rxjs/add/observable/of";
 import { merge } from "rxjs/add/observable/merge";
 
@@ -67,7 +66,7 @@ export function listKernelSpecsEpic(
             payload: xhr.response
           };
         }),
-        catchError((xhrError: any) => Observable.of(genericAjaxFail(xhrError)))
+        catchError((xhrError: any) => of(genericAjaxFail(xhrError)))
       );
     })
   );


### PR DESCRIPTION
This should improve tree-shaking of RxJS.