### PR TITLE
[NO MERGE] let's do it for Science!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - GROUP=lint
   - GROUP=flow
   - GROUP=conformance
+  - GROUP=dist
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:packages":
       "lerna exec --scope enchannel-zmq-backend -- npm rebuild && jest",
     "test:desktop": "lerna run test:unit --scope nteract --stream",
+    "test:dist": "npm run dist:all",
     "precoverage":
       "mkdirp coverage && nyc lerna run test:unit --scope nteract --stream",
     "coverage": "nyc report --reporter=text-lcov > coverage/lcov.info",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -89,7 +89,7 @@
         "Type": "Application",
         "Categories": "Science;Development;"
       },
-      "category": "science",
+      "category": "Science",
       "packageCategory": "editors"
     },
     "files": ["lib/*.js", "lib/*.css", "lib/*.woff", "lib/*.woff2", "static"],


### PR DESCRIPTION
Ref #1942 

Apparently this `science` field was ending up in the `.desktop` file as the improper lowercase version. ¯\\\_(ツ)\_/¯

I don't think it totally fixes the aforementioned issue.