### PR TITLE
Pin electron-builder to 19.33.0

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -118,7 +118,7 @@
     "cross-env": "^5.0.0",
     "date-fns": "^1.28.5",
     "electron": "~1.7.6",
-    "electron-builder": "^19.31.1",
+    "electron-builder": "19.33.0",
     "electron-context-menu": "^0.9.1",
     "electron-log": "^2.2.6",
     "electron-mocha": "^4.0.0",


### PR DESCRIPTION
Adresses #1942 

Looks like there was a bug introduced int 19.34.0 and still present in 19.34.1. We should open a issue on the electron-builder repo.