### PR TITLE
Disable codecov being required to pass

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,13 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
 comment:
   layout: header, changes, diff
 coverage:
   status:
     patch:
       default:
-        target: '30'
+        target: '10'
     project:
       default:
         target: auto


### PR DESCRIPTION
Since we're in the process of transitioning to `jest`, I'd like to disable codecov being a hard requirement for a passing build. We can switch this back on once our global jest config is ready.