### PR TITLE
RxJS: Fix usage of toPromise

### DIFF
--- a/packages/desktop/__tests__/renderer/epics/comm-spec.js
+++ b/packages/desktop/__tests__/renderer/epics/comm-spec.js
@@ -15,7 +15,7 @@ import {
 } from "../../../src/notebook/constants";
 
 import { of } from "rxjs/observable/of";
-import { toArray, toPromise } from "rxjs/operators";
+import { toArray } from "rxjs/operators";
 
 describe("createCommMessage", () => {
   test("creates a comm_msg", () => {
@@ -75,7 +75,7 @@ describe("createCommErrorAction", () => {
   test("creates a COMM_ERROR action with an error", () => {
     const err = new Error();
     return createCommErrorAction(err)
-      .pipe(toPromise())
+      .toPromise()
       .then(action => {
         expect(action.type).toBe(COMM_ERROR);
         expect(action.payload).toBe(err);

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -144,7 +144,7 @@
     "redux-logger": "^3.0.6",
     "redux-observable": "^0.16.0",
     "rimraf": "^2.6.1",
-    "rxjs": "^5.5.0-beta.2",
+    "rxjs": "^5.5.0-beta.5",
     "shell-env": "^0.3.0",
     "sinon": "^3.2.0",
     "sinon-chai": "^2.10.0",

--- a/packages/desktop/src/main/index.js
+++ b/packages/desktop/src/main/index.js
@@ -12,7 +12,6 @@ import {
   skipUntil,
   buffer,
   catchError,
-  toPromise,
   first
 } from "rxjs/operators";
 
@@ -104,7 +103,7 @@ const prepJupyterObservable = prepareEnv.pipe(
 );
 
 const kernelSpecsPromise = prepJupyterObservable
-  .pipe(toPromise())
+  .toPromise()
   .then(() => kernelspecs.findAll())
   .then(specs => initializeKernelSpecs(specs));
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -25,7 +25,7 @@
     "exenv": "^1.2.2",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "rxjs": "^5.5.0-beta.2"
+    "rxjs": "^5.5.0-beta.5"
   },
   "peerDependencies": {
     "immutable": "^3.8.1",

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
     "jmp": "^0.7.5",
-    "rxjs": "^5.5.0-beta.2",
+    "rxjs": "^5.5.0-beta.5",
     "uuid": "^3.1.0"
   }
 }

--- a/packages/enchannel/package.json
+++ b/packages/enchannel/package.json
@@ -20,6 +20,6 @@
   "homepage": "https://github.com/nteract/nteract#readme",
   "dependencies": {
     "@nteract/messaging": "^2.0.0",
-    "rxjs": "^5.5.0-beta.2"
+    "rxjs": "^5.5.0-beta.5"
   }
 }

--- a/packages/fs-observable/package.json
+++ b/packages/fs-observable/package.json
@@ -28,10 +28,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "rxjs": "^5.5.0-beta.2"
+    "rxjs": "^5.5.0-beta.5"
   },
   "peerDependencies": {
-    "rxjs": "^5.5.0-beta.2"
+    "rxjs": "^5.5.0-beta.5"
   },
   "dependencies": {
     "mkdirp": "^0.5.1"

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -1,5 +1,5 @@
 import { from } from "rxjs/observable/from";
-import { pluck, tap, count, toPromise } from "rxjs/operators";
+import { pluck, tap, count } from "rxjs/operators";
 import { ofMessageType, childOf } from "../src/index";
 
 import { createMessage, getUsername } from "../";
@@ -29,7 +29,8 @@ describe("childOf", () => {
       { parent_header: { msg_id: "300" } },
       { parent_header: { msg_id: "100" } }
     ])
-      .pipe(childOf({ header: { msg_id: "100" } }), count(), toPromise())
+      .pipe(childOf({ header: { msg_id: "100" } }), count())
+      .toPromise()
       .then(val => {
         expect(val).toEqual(3);
       }));
@@ -67,9 +68,9 @@ describe("ofMessageType", () => {
           expect(val.header.msg_type === "a" || val.header.msg_type === "d");
         }),
         pluck("header", "msg_type"),
-        count(),
-        toPromise()
+        count()
       )
+      .toPromise()
       .then(val => {
         expect(val).toEqual(4);
       });

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -13,7 +13,7 @@
     "build:lib:watch": "npm run build:lib -- --watch"
   },
   "dependencies": {
-    "rxjs": "^5.5.0-beta.2",
+    "rxjs": "^5.5.0-beta.5",
     "uuid": "^3.1.0"
   },
   "publishConfig": {

--- a/packages/nbextension/nteract_on_jupyter/package.json
+++ b/packages/nbextension/nteract_on_jupyter/package.json
@@ -29,7 +29,7 @@
     "redux": "^3.7.0",
     "redux-observable": "^0.16.0",
     "rx-jupyter": "^1.3.0-0",
-    "rxjs": "^5.5.0-beta.2"
+    "rxjs": "^5.5.0-beta.5"
   },
   "babel": {
     "presets": ["next/babel"],


### PR DESCRIPTION
`toPromise` actually isn't a lettable operator. [This was fixed in beta 5](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#550-beta5-2017-10-06).