### PR TITLE
treat pager data as json mimebundle

### DIFF
--- a/packages/desktop/src/notebook/components/cell/code-cell.js
+++ b/packages/desktop/src/notebook/components/cell/code-cell.js
@@ -78,7 +78,7 @@ class CodeCell extends React.PureComponent<Props> {
                 className="pager"
                 displayOrder={this.props.displayOrder}
                 transforms={this.props.transforms}
-                bundle={pager.get("data")}
+                bundle={pager}
                 theme={this.props.theme}
                 key={key}
               />

--- a/packages/desktop/src/notebook/components/cell/code-cell.js
+++ b/packages/desktop/src/notebook/components/cell/code-cell.js
@@ -3,12 +3,10 @@ import React from "react";
 import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import Inputs from "./inputs";
-import { Display } from "@nteract/display-area";
+import { Display, RichestMime } from "@nteract/display-area";
 
 import Editor from "../../providers/editor";
 import LatexRenderer from "../latex";
-
-import Pager from "./pager";
 
 type Props = {
   cell: ImmutableMap<string, any>,
@@ -73,7 +71,7 @@ class CodeCell extends React.PureComponent<Props> {
         {this.props.pagers && !this.props.pagers.isEmpty() ? (
           <div className="pagers">
             {this.props.pagers.map((pager, key) => (
-              <Pager
+              <RichestMime
                 expanded
                 className="pager"
                 displayOrder={this.props.displayOrder}

--- a/packages/desktop/src/notebook/components/cell/pager.js
+++ b/packages/desktop/src/notebook/components/cell/pager.js
@@ -1,5 +1,0 @@
-// @flow
-import { RichestMime } from "@nteract/display-area";
-
-// The pager is really just the RichestMime component
-export default RichestMime;

--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -97,7 +97,7 @@ export function createExecuteRequest(code: string) {
 export function createPagerActions(id: string, payloadStream: Observable<*>) {
   return payloadStream.pipe(
     filter(p => p.source === "page"),
-    scan((acc, pd) => acc.push(Immutable.fromJS(pd)), new Immutable.List()),
+    scan((acc, pd) => acc.push(pd.data), new Immutable.List()),
     map(pagerDatas => updateCellPagers(id, pagerDatas))
   );
 }

--- a/packages/desktop/test/renderer/epics/execute-spec.js
+++ b/packages/desktop/test/renderer/epics/execute-spec.js
@@ -125,9 +125,7 @@ describe("createPagerActions", () => {
     const pagerAction$ = createPagerActions("1", msgObs);
 
     pagerAction$.subscribe(action => {
-      const expected = [
-        { source: "page", data: { "text/html": "this is a test" } }
-      ];
+      const expected = [{ "text/html": "this is a test" }];
       expect(action.id).to.equal("1");
       expect(action.pagers.toJS()).to.deep.equal(expected);
       done();


### PR DESCRIPTION
Fixes #1804

When the transforms / display-area got refactored to use mutable JS objects (as opposed to Immutable.JS), this was missed.