### PR TITLE
Help menu: Add link to release notes

### DIFF
--- a/packages/desktop/src/main/menu.js
+++ b/packages/desktop/src/main/menu.js
@@ -478,6 +478,14 @@ const helpDraft = {
       }
     },
     {
+      label: `Release Notes (${app.getVersion()})`,
+      click: () => {
+        shell.openExternal(
+          `https://github.com/nteract/nteract/releases/tag/v${app.getVersion()}`
+        );
+      }
+    },
+    {
       label: "Install Additional Kernels",
       click: () => {
         shell.openExternal(


### PR DESCRIPTION
This adds a link to the release notes together with version information to fix #1939 in the easies way possible:
<img width="379" alt="bildschirmfoto 2017-10-10 um 18 45 24" src="https://user-images.githubusercontent.com/13285808/31416109-ab570632-adec-11e7-9f27-2b3d907408ec.png">
