### PR TITLE
create a simplified SET_IN_CELL action

### DIFF
--- a/packages/desktop/__tests__/renderer/actions-spec.js
+++ b/packages/desktop/__tests__/renderer/actions-spec.js
@@ -1,3 +1,4 @@
+// @flow
 import * as actions from "../../src/notebook/actions";
 import * as constants from "../../src/notebook/constants";
 
@@ -47,9 +48,10 @@ describe("setNotebookKernelInfo", () => {
 describe("updateCellSource", () => {
   test("creates a UPDATE_CELL_SOURCE action", () => {
     expect(actions.updateCellSource("1234", "# test")).toEqual({
-      type: constants.UPDATE_CELL_SOURCE,
+      type: "SET_IN_CELL",
       id: "1234",
-      source: "# test"
+      path: ["source"],
+      value: "# test"
     });
   });
 });
@@ -66,9 +68,10 @@ describe("clearOutputs", () => {
 describe("updateCellExecutionCount", () => {
   test("creates a UPDATE_CELL_EXECUTION_COUNT action", () => {
     expect(actions.updateCellExecutionCount("1234", 3)).toEqual({
-      type: constants.UPDATE_CELL_EXECUTION_COUNT,
+      type: "SET_IN_CELL",
       id: "1234",
-      count: 3
+      path: ["execution_count"],
+      value: 3
     });
   });
 });

--- a/packages/desktop/__tests__/renderer/providers/editor-spec.js
+++ b/packages/desktop/__tests__/renderer/providers/editor-spec.js
@@ -27,8 +27,8 @@ describe("EditorProvider", () => {
     new Promise(resolve => {
       const dispatch = action => {
         expect(action.id).toBe("test");
-        expect(action.source).toBe("i love nteract");
-        expect(action.type).toBe(UPDATE_CELL_SOURCE);
+        expect(action.value).toBe("i love nteract");
+        expect(action.type).toBe("SET_IN_CELL");
         resolve();
       };
       store.dispatch = dispatch;

--- a/packages/desktop/__tests__/renderer/reducers/document-spec.js
+++ b/packages/desktop/__tests__/renderer/reducers/document-spec.js
@@ -1,3 +1,4 @@
+// @flow
 /* eslint-disable max-len */
 import { List, Map, Set, is } from "immutable";
 
@@ -395,9 +396,10 @@ describe("updateExecutionCount", () => {
     const id = originalState.document.getIn(["notebook", "cellOrder"]).last();
 
     const action = {
-      type: constants.UPDATE_CELL_EXECUTION_COUNT,
+      type: "SET_IN_CELL",
       id,
-      count: 42
+      path: ["execution_count"],
+      value: 42
     };
 
     const state = reducers(originalState, action);
@@ -639,9 +641,10 @@ describe("updateSource", () => {
     const id = originalState.document.getIn(["notebook", "cellOrder"]).first();
 
     const action = {
-      type: constants.UPDATE_CELL_SOURCE,
+      type: "SET_IN_CELL",
       id,
-      source: "This is a test"
+      path: ["source"],
+      value: "This is a test"
     };
 
     const state = reducers(originalState, action);

--- a/packages/desktop/src/notebook/actions.js
+++ b/packages/desktop/src/notebook/actions.js
@@ -43,14 +43,6 @@ export function setExecutionState(executionState: string) {
   };
 }
 
-export function updateCellSource(id: string, source: string) {
-  return {
-    type: constants.UPDATE_CELL_SOURCE,
-    id,
-    source
-  };
-}
-
 export function clearOutputs(id: string) {
   return {
     type: constants.CLEAR_OUTPUTS,
@@ -110,6 +102,27 @@ export function mergeCellAfter(id: string) {
   };
 }
 
+/**
+ * setInCell can generically be used to set any attribute on a cell, including
+ * and especially for changing metadata per cell.
+ * @param {CellID} id    cell ID
+ * @param {Array<string>} path  path within a cell to set
+ * @param {any} value what to set it to
+ *
+ * Example:
+ *
+ * > action = setInCell('123', ['metadata', 'cool'], true)
+ * > documentReducer(state, action)
+ * {
+ *   ...
+ *   '123': {
+ *     'metadata': {
+ *       'cool': true
+ *     }
+ *   }
+ * }
+ *
+ */
 export function setInCell(id: CellID, path: Array<string>, value: any) {
   return {
     type: "SET_IN_CELL",
@@ -117,6 +130,10 @@ export function setInCell(id: CellID, path: Array<string>, value: any) {
     path,
     value
   };
+}
+
+export function updateCellSource(id: string, source: string) {
+  return setInCell(id, ["source"], source);
 }
 
 export function updateCellExecutionCount(id: string, count: number) {

--- a/packages/desktop/src/notebook/actions.js
+++ b/packages/desktop/src/notebook/actions.js
@@ -110,12 +110,17 @@ export function mergeCellAfter(id: string) {
   };
 }
 
-export function updateCellExecutionCount(id: string, count: number) {
+export function setInCell(id: CellID, path: Array<string>, value: any) {
   return {
-    type: constants.UPDATE_CELL_EXECUTION_COUNT,
+    type: "SET_IN_CELL",
     id,
-    count
+    path,
+    value
   };
+}
+
+export function updateCellExecutionCount(id: string, count: number) {
+  return setInCell(id, ["execution_count"], count);
 }
 
 export function changeOutputVisibility(id: string) {

--- a/packages/desktop/src/notebook/actions.js
+++ b/packages/desktop/src/notebook/actions.js
@@ -125,7 +125,7 @@ export function mergeCellAfter(id: string) {
  */
 export function setInCell(id: CellID, path: Array<string>, value: any) {
   return {
-    type: "SET_IN_CELL",
+    type: constants.SET_IN_CELL,
     id,
     path,
     value

--- a/packages/desktop/src/notebook/constants.js
+++ b/packages/desktop/src/notebook/constants.js
@@ -19,6 +19,8 @@ export const INTERRUPT_KERNEL = "INTERRUPT_KERNEL";
 
 export const EXIT = "EXIT";
 
+export const SET_IN_CELL = "SET_IN_CELL";
+
 export const SET_NOTEBOOK = "SET_NOTEBOOK";
 
 export const MOVE_CELL = "MOVE_CELL";

--- a/packages/desktop/src/notebook/reducers/document.js
+++ b/packages/desktop/src/notebook/reducers/document.js
@@ -461,10 +461,6 @@ function updateCellPagers(
   return state.setIn(["cellPagers", id], pagers);
 }
 
-////////////////////////////////////////////////////////////////////////
-/////// reducers destined to be merged into one SET_IN_CELL_DATA ///////
-////////////////////////////////////////////////////////////////////////
-
 type SetInCellAction = {
   type: "SET_IN_CELL",
   id: CellID,
@@ -478,31 +474,7 @@ function setInCell(state: DocumentState, action: SetInCellAction) {
   );
 }
 
-type UpdateExecutionCountAction = {
-  type: "UPDATE_CELL_EXECUTION_COUNT",
-  id: CellID,
-  count: number
-};
-function updateExecutionCount(
-  state: DocumentState,
-  action: UpdateExecutionCountAction
-) {
-  return state.setIn(
-    ["notebook", "cellMap", action.id, "execution_count"],
-    action.count
-  );
-}
-
-type UpdateSourceAction = {
-  type: "UPDATE_CELL_SOURCE",
-  id: CellID,
-  source: string
-};
-function updateSource(state: DocumentState, action: UpdateSourceAction) {
-  const { id, source } = action;
-  return state.setIn(["notebook", "cellMap", id, "source"], source);
-}
-
+// TODO: This should be called TOGGLE_OUTPUT_VISIBILITY
 type ChangeOutputVisibilityAction = {
   type: "CHANGE_OUTPUT_VISIBILITY",
   id: CellID
@@ -518,6 +490,7 @@ function changeOutputVisibility(
   );
 }
 
+// TODO: This should be called TOGGLE_INPUT_VISIBILITY
 type ChangeInputVisibilityAction = {
   type: "CHANGE_INPUT_VISIBILITY",
   id: CellID
@@ -545,8 +518,6 @@ function updateCellStatus(
   const { id, status } = action;
   return state.setIn(["transient", "cellMap", id, "status"], status);
 }
-
-///// END CELL SET
 
 type SetLanguageInfoAction = {
   type: "SET_LANGUAGE_INFO",
@@ -699,14 +670,12 @@ type DocumentAction =
   | ClearOutputsAction
   | AppendOutputAction
   | UpdateDisplayAction
-  | UpdateExecutionCountAction
   | MoveCellAction
   | RemoveCellAction
   | NewCellAfterAction
   | NewCellBeforeAction
   | NewCellAppendAction
   | MergeCellAfterAction
-  | UpdateSourceAction
   | ChangeOutputVisibilityAction
   | ChangeInputVisibilityAction
   | UpdateCellPagersAction
@@ -754,8 +723,6 @@ function handleDocument(
       return toggleStickyCell(state, action);
     case "SET_IN_CELL":
       return setInCell(state, action);
-    case constants.UPDATE_CELL_EXECUTION_COUNT:
-      return updateExecutionCount(state, action);
     case constants.MOVE_CELL:
       return moveCell(state, action);
     case constants.REMOVE_CELL:
@@ -768,8 +735,6 @@ function handleDocument(
       return mergeCellAfter(state, action);
     case constants.NEW_CELL_APPEND:
       return newCellAppend(state, action);
-    case constants.UPDATE_CELL_SOURCE:
-      return updateSource(state, action);
     case constants.CHANGE_OUTPUT_VISIBILITY:
       return changeOutputVisibility(state, action);
     case constants.CHANGE_INPUT_VISIBILITY:

--- a/packages/desktop/src/notebook/reducers/document.js
+++ b/packages/desktop/src/notebook/reducers/document.js
@@ -721,7 +721,7 @@ function handleDocument(
       return focusPreviousCellEditor(state, action);
     case constants.TOGGLE_STICKY_CELL:
       return toggleStickyCell(state, action);
-    case "SET_IN_CELL":
+    case constants.SET_IN_CELL:
       return setInCell(state, action);
     case constants.MOVE_CELL:
       return moveCell(state, action);

--- a/packages/desktop/test/renderer/epics/execute-spec.js
+++ b/packages/desktop/test/renderer/epics/execute-spec.js
@@ -198,7 +198,7 @@ describe("updateCellNumberingAction", () => {
 
     cellAction$.subscribe(action => {
       expect(action.id).to.equal("1");
-      expect(action.count).to.equal(3);
+      expect(action.value).to.equal(3);
       done();
     });
   });
@@ -217,7 +217,7 @@ describe("createSourceUpdateAction", () => {
     const cellAction$ = createSourceUpdateAction("1", msgObs);
 
     cellAction$.subscribe(action => {
-      expect(action.source).to.equal("This is some test text.");
+      expect(action.value).to.equal("This is some test text.");
       done();
     });
   });


### PR DESCRIPTION
Starting to tick off the boxes of current sprawl that I think we can control with a `SET_IN_CELL` action. Since I realized how much boilerplate was happening to implement #1952 (and any others that use metadata), I figured I could turn this into a `setIn` setup.

I'd love to see what people think here. Validation will happen at the level of the action creator.