### PR TITLE
Fix dropdown menu bug (hovering over toolbar under menu) 

### DIFF
--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -268,14 +268,15 @@ body {
   background-color: var(--cell-bg-focus);
 }
 
-/* Show the cell toolbar if hovering on cell,
+/* Show the cell-toolbar-mask if hovering on cell,
    or cell was the last clicked (has .focused class). */
-.cell:hover .cell-toolbar,
-.cell.focused .cell-toolbar {
+.cell:hover .cell-toolbar-mask,
+.cell.focused .cell-toolbar-mask {
   display: block;
 }
 
 .cell-toolbar-mask {
+  display: none;
   position: absolute;
   top: 0px;
   right: 0px;
@@ -293,7 +294,6 @@ body {
 }
 
 .cell-toolbar {
-  display: none;
   background-color: var(--toolbar-bg);
   opacity: 0.4;
   transition: opacity 0.4s;


### PR DESCRIPTION
This makes changes to the `.cell-toolbar-mask` CSS. The problem before was that the cell toolbar mask was interfering with the dropdown menu.
