### PR TITLE
Some quick chores

### DIFF
--- a/packages/desktop/src/notebook/components/notebook.js
+++ b/packages/desktop/src/notebook/components/notebook.js
@@ -8,7 +8,6 @@ import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 import { displayOrder, transforms } from "@nteract/transforms-full";
 
-import Cell from "./cell/cell";
 import DraggableCell from "../providers/draggable-cell";
 import CellCreator from "../providers/cell-creator";
 import StatusBar from "./status-bar";

--- a/packages/desktop/src/notebook/components/notebook.js
+++ b/packages/desktop/src/notebook/components/notebook.js
@@ -211,6 +211,7 @@ export class Notebook extends React.PureComponent<Props> {
   }
 
   createStickyCellElement(id: string): ?React$Element<any> {
+    const CellComponent = this.props.CellComponent;
     const cellMap = this.props.notebook.get("cellMap");
     const transient = this.props.transient.getIn(
       ["cellMap", id],
@@ -219,7 +220,7 @@ export class Notebook extends React.PureComponent<Props> {
     const cell = cellMap.get(id);
     return (
       <div key={`cell-container-${id}`}>
-        <Cell {...this.createCellProps(id, cell, transient)} />
+        <CellComponent {...this.createCellProps(id, cell, transient)} />
       </div>
     );
   }

--- a/packages/transforms/__tests__/text-spec.js
+++ b/packages/transforms/__tests__/text-spec.js
@@ -7,10 +7,7 @@ import Text from "../src/text";
 describe("Text", () => {
   it("renders plain text", () => {
     const wrapper = mount(<Text data={"hey"} />);
+    // TODO: This test should be replaced with jest snapshots
     expect(wrapper.html()).toEqual("<code><span>hey</span></code>");
-
-    const component = wrapper.instance();
-
-    expect(component.shouldComponentUpdate()).toEqual(true);
   });
 });

--- a/packages/transforms/src/text.js
+++ b/packages/transforms/src/text.js
@@ -7,12 +7,8 @@ type Props = {
   data: string
 };
 
-export default class TextDisplay extends React.Component<Props> {
+export default class TextDisplay extends React.PureComponent<Props> {
   static MIMETYPE = "text/plain";
-
-  shouldComponentUpdate(): boolean {
-    return true;
-  }
 
   render(): ?React$Element<any> {
     return <Ansi>{this.props.data}</Ansi>;


### PR DESCRIPTION
Since I was on a plane without internet for a bit, I went digging in our code to see what things I could fix up. They're small enough to me that I thought they'd be ok to just group a few. I can break this out into separate PRs if people like. They're at least separate commits!

* Sticky cell wasn't using the "passed in" `Cell` component
* The plaintext mimetype transform should be a `PureComponent` and not have a shouldComponentUpdate (`PureComponent` will do the handling)