### PR TITLE
Enable auto-updates on Linux AppImage

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -87,7 +87,7 @@
         "Type": "Application",
         "Categories": "Science;Development;"
       },
-      "category": "science",
+      "category": "Science",
       "packageCategory": "editors"
     },
     "files": ["lib/*.js", "lib/*.css", "lib/*.woff", "lib/*.woff2", "static"],
@@ -116,11 +116,11 @@
     "cross-env": "^5.0.0",
     "date-fns": "^1.28.5",
     "electron": "~1.7.6",
-    "electron-builder": "19.33.0",
+    "electron-builder": "^19.37.1",
     "electron-context-menu": "^0.9.1",
     "electron-log": "^2.2.6",
     "electron-mocha": "^4.0.0",
-    "electron-updater": "^2.10.0",
+    "electron-updater": "^2.12.1",
     "enchannel": "^4.0.1",
     "enchannel-zmq-backend": "^5.0.1",
     "escape-carriage": "^1.2.0",

--- a/packages/desktop/src/main/auto-updater.js
+++ b/packages/desktop/src/main/auto-updater.js
@@ -1,11 +1,8 @@
 import { autoUpdater } from "electron-updater";
 
 export function initAutoUpdater() {
-  // Autoupdate should only get called on macOS and Windows
-  if (process.platform === "darwin" || process.platform === "win32") {
-    const log = require("electron-log");
-    log.transports.file.level = "info";
-    autoUpdater.logger = log;
-    autoUpdater.checkForUpdatesAndNotify();
-  }
+  const log = require("electron-log");
+  log.transports.file.level = "info";
+  autoUpdater.logger = log;
+  autoUpdater.checkForUpdatesAndNotify();
 }


### PR DESCRIPTION
This enables auto updates on Linux with AppImage, which is super new for Electron apps.

For multi-platform builds on mac I had to run `brew install glib` to make it work. I'll open a issue on the `electron-builder` repo, since `electron-builder` shouldn't require external dependencies.

Note: I haven't tested the AppImage build on Linux yet.