### PR TITLE
Extract operators from execution epic

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "test:coverage": "npm run test:unit -- --coverage",
     "test:lint": "npm run lint",
     "test:flow": "npm run flow",
-    "test:unit":
-      "lerna exec --scope enchannel-zmq-backend -- npm rebuild && jest",
+    "pretest:unit": "lerna exec --scope enchannel-zmq-backend -- npm rebuild",
+    "test:unit": "jest",
     "test:desktop": "lerna run test:unit --scope nteract --stream",
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",

--- a/packages/desktop/src/notebook/epics/comm.js
+++ b/packages/desktop/src/notebook/epics/comm.js
@@ -124,12 +124,12 @@ export function commMessageAction(message: any) {
  */
 export function commActionObservable(newKernelAction: any) {
   const commOpenAction$ = newKernelAction.channels.iopub.pipe(
-    ofMessageType(["comm_open"]),
+    ofMessageType("comm_open"),
     map(commOpenAction)
   );
 
   const commMessageAction$ = newKernelAction.channels.iopub.pipe(
-    ofMessageType(["comm_msg"]),
+    ofMessageType("comm_msg"),
     map(commMessageAction)
   );
 

--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -132,7 +132,7 @@ export function executeCellStream(
     ),
 
     // clear_output display message
-    cellMessages.pipe(ofMessageType(["clear_output"]), mapTo(clearOutputs(id)))
+    cellMessages.pipe(ofMessageType("clear_output"), mapTo(clearOutputs(id)))
   );
 
   // On subscription, send the message

--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -45,13 +45,6 @@ import {
 
 const Immutable = require("immutable");
 
-export const createErrorActionObservable = (type: string) => (error: Error) =>
-  of({
-    type,
-    payload: error,
-    error: true
-  });
-
 /**
  * Create an object that adheres to the jupyter notebook specification.
  * http://jupyter-client.readthedocs.io/en/latest/messaging.html
@@ -338,7 +331,7 @@ export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
     // Bring back all the inner Observables into one stream
     mergeAll(),
     catchError((err, source) =>
-      merge(createErrorActionObservable(ERROR_EXECUTING)(err), source)
+      merge(of({ type: ERROR_EXECUTING, payload: err, error: true }), source)
     )
   );
 }
@@ -355,7 +348,9 @@ export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
           Object.assign({}, output, { output_type: "display_data" })
         ),
         map(output => ({ type: "UPDATE_DISPLAY", output })),
-        catchError(createErrorActionObservable(ERROR_UPDATE_DISPLAY))
+        catchError(err =>
+          of({ type: ERROR_UPDATE_DISPLAY, payload: err, error: true })
+        )
       )
     )
   );

--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -1,5 +1,16 @@
 // @flow
-import { createMessage, ofMessageType, childOf } from "@nteract/messaging";
+import {
+  createMessage,
+  createExecuteRequest,
+  ofMessageType,
+  childOf,
+  updatedOutputs,
+  outputs,
+  payloads,
+  executionStates,
+  executionCounts,
+  setNextInputs
+} from "@nteract/messaging";
 
 import { Observable } from "rxjs/Observable";
 import { of } from "rxjs/observable/of";
@@ -8,16 +19,14 @@ import { merge } from "rxjs/observable/merge";
 import { _throw } from "rxjs/observable/throw";
 
 import {
-  pluck,
-  first,
   groupBy,
   filter,
   scan,
   map,
   mapTo,
   switchMap,
+  startWith,
   mergeAll,
-  mergeMap,
   takeUntil,
   catchError,
   tap
@@ -44,155 +53,6 @@ import {
 } from "../constants";
 
 const Immutable = require("immutable");
-
-/**
- * Create an object that adheres to the jupyter notebook specification.
- * http://jupyter-client.readthedocs.io/en/latest/messaging.html
- *
- * @param {Object} msg - Message that has content which can be converted to nbformat
- * @return {Object} formattedMsg  - Message with the associated output type
- */
-export function msgSpecToNotebookFormat(msg: any) {
-  return Object.assign({}, msg.content, {
-    output_type: msg.header.msg_type
-  });
-}
-
-/**
- * Insert the content requisite for a code request to a kernel message.
- *
- * @param {String} code - Code to be executed in a message to the kernel.
- * @return {Object} msg - Message object containing the code to be sent.
- */
-export function createExecuteRequest(code: string) {
-  const executeRequest = createMessage("execute_request");
-  executeRequest.content = {
-    code,
-    silent: false,
-    store_history: true,
-    user_expressions: {},
-    allow_stdin: false,
-    stop_on_error: false
-  };
-  return executeRequest;
-}
-
-/**
- * Reads a payloadStream and inspects it for pager data to be dispatched upon
- * specific cell executions.
- *
- * @param {String} id - Universally Unique ID of the cell message.
- * @param {Observable<Action>} payloadStream - Stream containing messages from the
- * kernel.
- * @return {Observable<Action>} pagerDataStream - Observable stream containing
- * Pager data.
- */
-export function createPagerActions(id: string, payloadStream: Observable<*>) {
-  return payloadStream.pipe(
-    filter(p => p.source === "page"),
-    scan((acc, pd) => acc.push(pd.data), new Immutable.List()),
-    map(pagerDatas => updateCellPagers(id, pagerDatas))
-  );
-}
-
-/**
- * Emits `createSourceUpdateAction` to update the source of a cell if the
- * kernel has requested so by setting `replace` to true.
- *
- * @param {String} id -  Universally Unique Identifier of cell receiving
- * messages.
- * @param {Observable<Action>} setInputStream - Stream containing messages from the kernel.
- * @return {Observable<Action>} updateSourceStream - Stream with updateCellSource actions.
- */
-export function createSourceUpdateAction(
-  id: string,
-  setInputStream: Observable<*>
-) {
-  return setInputStream.pipe(
-    filter(x => x.replace),
-    map(c => updateCellSource(id, c.text))
-  );
-}
-
-/**
- * Emits a `createCellAfter` action into a group of messages.
- *
- * @param {String} id -  Universally Unique Identifier of cell to have a cell
- * created after it.
- * @param {Object} setInputStream - Stream that contains a subset of messages
- * from the kernel that instruct the frontend what it should do.
- * @return {Immutable.List<Object>} updatedOutputs - Outputs with updated
- * changes.
- */
-export function createCellAfterAction(
-  id: string,
-  setInputStream: Observable<*>
-) {
-  return setInputStream.pipe(
-    filter(x => !x.replace),
-    map(c => createCellAfter("code", id, c.text))
-  );
-}
-
-/**
- * Emits a create cell status action into a group of messages.
- *
- * @param {String} id -  Universally Unique Identifier of cell receiving
- * an update in cell status.
- * @param {Observable<jmp.Message>} cellMessages - Messages to receive create cell status action.
- * @return {Observable<jmp.Message>} updatedCellMessages - Updated messages.
- */
-export function createCellStatusAction(
-  id: string,
-  cellMessages: Observable<*>
-) {
-  return cellMessages.pipe(
-    ofMessageType(["status"]),
-    pluck("content", "execution_state"),
-    map(status => updateCellStatus(id, status))
-  );
-}
-
-/**
- * Cells are numbered according to the order in which they were executed.
- * http://jupyter-client.readthedocs.io/en/latest/messaging.html#execution-counter-prompt-number
- * This code emits an action to update the cell execution count.
- *
- * @param {String} id -  Universally Unique Identifier of cell receiving an
- * update to the execution count.
- * @param {Observable<jmp.Message>} cellMessages - Messages to receive updates.
- * @return {Observable<jmp.Message>} cellMessages - Updated messages.
- */
-export function updateCellNumberingAction(
-  id: string,
-  cellMessages: Observable<*>
-) {
-  return cellMessages.pipe(
-    ofMessageType(["execute_input"]),
-    pluck("content", "execution_count"),
-    first(),
-    map(ct => updateCellExecutionCount(id, ct))
-  );
-}
-
-/**
- * Creates a stream of APPEND_OUTPUT actions from notebook formatable messages.
- *
- * @param {String} id - Universally Unique Identifier of cell receiving
- * messages.
- * @param {Observable} cellMessages - Set of sent cell messages.
- * @return {Observable<Action>} actions - Stream of APPEND_OUTPUT actions.
- */
-export function handleFormattableMessages(
-  id: string,
-  cellMessages: Observable<*>
-) {
-  return cellMessages.pipe(
-    ofMessageType(["execute_result", "display_data", "stream", "error"]),
-    map(msgSpecToNotebookFormat),
-    map(output => ({ type: "APPEND_OUTPUT", id, output }))
-  );
-}
 
 type Channels = {
   iopub: Subject<*>,
@@ -222,43 +82,58 @@ export function executeCellStream(
 
   const { iopub, shell } = channels;
 
-  // Payload streams in general
-  const payloadStream = shell.pipe(
-    childOf(executeRequest),
-    ofMessageType(["execute_reply"]),
-    pluck("content", "payload"),
-    filter(Boolean),
-    mergeMap(payloads => from(payloads))
-  );
+  // All the payload streams, intended for one user (since it's the shell channel)
+  const payloadStream = shell.pipe(childOf(executeRequest), payloads());
 
-  // Payload stream for setting the input, whether in place or "next"
-  const setInputStream = payloadStream.pipe(
-    filter(payload => payload.source === "set_next_input")
-  );
-
-  // All child messages for the cell
+  // All the streams intended for all frontends (since it's the iopub channel)
   const cellMessages = iopub.pipe(childOf(executeRequest));
 
   const cellAction$ = merge(
-    // Clear cell outputs
-    of(clearOutputs(id)),
-    of(updateCellStatus(id, "busy")),
-    // clear_output display message
-    cellMessages.pipe(ofMessageType(["clear_output"]), mapTo(clearOutputs(id))),
-    // Inline %load
-    createSourceUpdateAction(id, setInputStream),
-    // %load for the cell _after_
-    createCellAfterAction(id, setInputStream),
-    // Clear any old pager
-    of(updateCellPagers(id, new Immutable.List())),
-    // Update the doc/pager section with new bundles
-    createPagerActions(id, payloadStream),
-    // Set the cell status
-    createCellStatusAction(id, cellMessages),
+    // help menu in IPython
+    // TODO: This should let the reducer in redux do the clear and append instead
+    payloadStream.pipe(
+      filter(p => p.source === "page"),
+      // TODO: Switch to "APPEND_PAGER" action
+      scan((acc, pd) => acc.push(pd.data), new Immutable.List()),
+      map(pagerDatas => updateCellPagers(id, pagerDatas)),
+      // TODO: Switch to "CLEAR_PAGER" action
+      // TODO: Consider a RESET_CELL action that would clear out outputs, pagers, etc.
+      startWith(updateCellPagers(id, new Immutable.List()))
+    ),
+
+    // set_next_input
+    payloadStream.pipe(
+      filter(payload => payload.source === "set_next_input"),
+      map(
+        c =>
+          c.replace
+            ? updateCellSource(id, c.text)
+            : createCellAfter("code", id, c.text)
+      )
+    ),
+
+    // All actions for updating cell status
+    cellMessages.pipe(
+      executionStates(),
+      map(status => updateCellStatus(id, status)),
+      startWith(updateCellStatus(id, "busy"))
+    ),
+
     // Update the input numbering: `[ ]`
-    updateCellNumberingAction(id, cellMessages),
-    // Handle all nbformattable messages
-    handleFormattableMessages(id, cellMessages)
+    cellMessages.pipe(
+      executionCounts(),
+      map(ct => updateCellExecutionCount(id, ct))
+    ),
+
+    // All actions for new outputs
+    cellMessages.pipe(
+      outputs(),
+      map(output => ({ type: "APPEND_OUTPUT", id, output })),
+      startWith(clearOutputs(id))
+    ),
+
+    // clear_output display message
+    cellMessages.pipe(ofMessageType(["clear_output"]), mapTo(clearOutputs(id)))
   );
 
   // On subscription, send the message
@@ -338,19 +213,16 @@ export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
 
 export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
   // Global message watcher so we need to set up a feed for each new kernel
-  action$.ofType(NEW_KERNEL).pipe(
-    switchMap(({ channels }) =>
-      channels.iopub.pipe(
-        ofMessageType(["update_display_data"]),
-        map(msgSpecToNotebookFormat),
-        // Convert 'update_display_data' to 'display_data'
-        map(output =>
-          Object.assign({}, output, { output_type: "display_data" })
-        ),
-        map(output => ({ type: "UPDATE_DISPLAY", output })),
-        catchError(err =>
-          of({ type: ERROR_UPDATE_DISPLAY, payload: err, error: true })
+  action$
+    .ofType(NEW_KERNEL)
+    .pipe(
+      switchMap(({ channels }) =>
+        channels.iopub.pipe(
+          updatedOutputs(),
+          map(output => ({ type: "UPDATE_DISPLAY", output })),
+          catchError(err =>
+            of({ type: ERROR_UPDATE_DISPLAY, payload: err, error: true })
+          )
         )
       )
-    )
-  );
+    );

--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -8,8 +8,7 @@ import {
   outputs,
   payloads,
   executionStates,
-  executionCounts,
-  setNextInputs
+  executionCounts
 } from "@nteract/messaging";
 
 import { Observable } from "rxjs/Observable";

--- a/packages/desktop/src/notebook/epics/kernel-launch.js
+++ b/packages/desktop/src/notebook/epics/kernel-launch.js
@@ -66,7 +66,7 @@ export function acquireKernelInfo(channels: Channels) {
 
   const obs = channels.shell.pipe(
     childOf(message),
-    ofMessageType(["kernel_info_reply"]),
+    ofMessageType("kernel_info_reply"),
     first(),
     pluck("content", "language_info"),
     map(setLanguageInfo)

--- a/packages/desktop/test/renderer/epics/execute-spec.js
+++ b/packages/desktop/test/renderer/epics/execute-spec.js
@@ -15,15 +15,7 @@ import {
   executeCellStream,
   executeCellEpic,
   updateDisplayEpic,
-  createExecuteRequest,
-  msgSpecToNotebookFormat,
-  createPagerActions,
-  createSourceUpdateAction,
-  createCellAfterAction,
-  createCellStatusAction,
-  createExecuteCellStream,
-  updateCellNumberingAction,
-  createErrorActionObservable
+  createExecuteCellStream
 } from "../../../src/notebook/epics/execute";
 
 const Immutable = require("immutable");
@@ -72,9 +64,9 @@ describe("executeCellStream", () => {
     action$.pipe(bufferCount(3)).subscribe(messages => {
       expect(messages).to.deep.equal([
         // TODO: Order doesn't actually matter here
-        { type: CLEAR_OUTPUTS, id: "0" },
+        { type: UPDATE_CELL_PAGERS, id: "0", pagers: Immutable.List() },
         { type: UPDATE_CELL_STATUS, id: "0", status: "busy" },
-        { type: UPDATE_CELL_PAGERS, id: "0", pagers: Immutable.List() }
+        { type: CLEAR_OUTPUTS, id: "0" }
       ]);
       done(); // TODO: Make sure message check above is called
     });
@@ -89,139 +81,6 @@ describe("executeCellStream", () => {
   });
 });
 
-describe("createExecuteRequest", () => {
-  it("creates an execute_request message", () => {
-    const code = 'print("test")';
-    const executeRequest = createExecuteRequest(code);
-
-    expect(executeRequest.content.code).to.equal(code);
-    expect(executeRequest.header.msg_type).to.equal("execute_request");
-  });
-});
-
-describe("msgSpecToNotebookFormat", () => {
-  it("converts a message to the notebook format", () => {
-    const msg = {
-      content: { data: "test" },
-      header: { msg_type: "test_header" }
-    };
-    const notebookSpecMsg = msgSpecToNotebookFormat(msg);
-
-    expect(notebookSpecMsg).to.have.property("output_type");
-    expect(notebookSpecMsg).to.have.property("data");
-    expect(notebookSpecMsg.output_type).to.equal("test_header");
-  });
-});
-
-describe("createPagerActions", () => {
-  it("emits actions to set pagers", done => {
-    const msgObs = from([
-      {
-        source: "page",
-        data: { "text/html": "this is a test" }
-      }
-    ]);
-
-    const pagerAction$ = createPagerActions("1", msgObs);
-
-    pagerAction$.subscribe(action => {
-      const expected = [{ "text/html": "this is a test" }];
-      expect(action.id).to.equal("1");
-      expect(action.pagers.toJS()).to.deep.equal(expected);
-      done();
-    });
-  });
-});
-
-describe("createCellAfterAction", () => {
-  it("emits a createCellAfter action", done => {
-    const msgObs = from([
-      {
-        source: "set_next_input",
-        text: "This is some test text.",
-        replace: false
-      }
-    ]);
-
-    const cellAction$ = createCellAfterAction("1", msgObs);
-
-    cellAction$.subscribe(action => {
-      expect(action.id).to.equal("1");
-      done();
-    });
-  });
-});
-
-describe("createCellStatusAction", () => {
-  it("emits an updateCellStatus action", done => {
-    const msgObs = from([
-      {
-        header: {
-          msg_id: "123",
-          msg_type: "status"
-        },
-        parent_header: {},
-        content: {
-          execution_state: "idle"
-        },
-        metadata: {}
-      }
-    ]);
-
-    const cellAction$ = createCellStatusAction("1", msgObs);
-
-    cellAction$.subscribe(action => {
-      expect(action.id).to.equal("1");
-      expect(action.status).to.equal("idle");
-      done();
-    });
-  });
-});
-
-describe("updateCellNumberingAction", () => {
-  it("emits updateCellExecutionCount action", done => {
-    const msgObs = from([
-      {
-        header: {
-          msg_id: "123",
-          msg_type: "execute_input"
-        },
-        parent_header: {},
-        content: {
-          execution_count: 3
-        },
-        metadata: {}
-      }
-    ]);
-
-    const cellAction$ = updateCellNumberingAction("1", msgObs);
-
-    cellAction$.subscribe(action => {
-      expect(action.id).to.equal("1");
-      expect(action.value).to.equal(3);
-      done();
-    });
-  });
-});
-
-describe("createSourceUpdateAction", () => {
-  it("emits updateCellSource action", done => {
-    const msgObs = from([
-      {
-        source: "set_next_input",
-        text: "This is some test text.",
-        replace: true
-      }
-    ]);
-
-    const cellAction$ = createSourceUpdateAction("1", msgObs);
-
-    cellAction$.subscribe(action => {
-      expect(action.value).to.equal("This is some test text.");
-      done();
-    });
-  });
-});
 describe("createExecuteCellStream", () => {
   it("errors if the kernel is not connected in create", done => {
     const frontendToShell = new Subject();
@@ -281,9 +140,9 @@ describe("createExecuteCellStream", () => {
       err => expect.fail(err, null)
     );
     expect(actionBuffer).to.deep.equal([
-      CLEAR_OUTPUTS,
+      UPDATE_CELL_PAGERS,
       UPDATE_CELL_STATUS,
-      UPDATE_CELL_PAGERS
+      CLEAR_OUTPUTS
     ]);
     done();
   });
@@ -426,28 +285,6 @@ describe("updateDisplayEpic", () => {
             }
           }
         ]);
-        done();
-      }
-    );
-  });
-});
-
-describe("createErrorActionObservable", () => {
-  it("returns a function that creates an observable", done => {
-    const func = createErrorActionObservable("TEST_IT");
-    const err = new Error("HEY");
-    const obs = func(err);
-
-    obs.subscribe(
-      x => {
-        expect(x.type).to.equal("TEST_IT");
-        expect(x.payload).to.equal(err);
-        expect(x.error).to.equal(true);
-      },
-      e => {
-        throw e;
-      },
-      () => {
         done();
       }
     );

--- a/packages/editor/src/tooltip.js
+++ b/packages/editor/src/tooltip.js
@@ -8,7 +8,7 @@ import { js_idx_to_char_idx } from "./surrogate";
 export function tooltipObservable(channels, editor, message) {
   const tip$ = channels.shell.pipe(
     childOf(message),
-    ofMessageType(["inspect_reply"]),
+    ofMessageType("inspect_reply"),
     pluck("content"),
     first(),
     map(results => ({

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -157,15 +157,6 @@ describe("ofMessageType", () => {
   });
 });
 
-/**
- *   convertOutputMessageToNotebookFormat,
-   outputs,
-   payloads,
-   executionCounts,
-   executionStates
-
- */
-
 describe("convertOutputMessageToNotebookFormat", () => {
   it("ensures that fields end up notebook format style", () => {
     const message = {
@@ -191,5 +182,29 @@ describe("convertOutputMessageToNotebookFormat", () => {
     convertOutputMessageToNotebookFormat(message);
 
     expect(message).toEqual(copy);
+  });
+});
+
+describe("outputs", () => {
+  it("should be tested", () => {
+    expect(outputs()).toBeTruthy();
+  });
+});
+
+describe("payloads", () => {
+  it("should be tested", () => {
+    expect(payloads()).toBeTruthy();
+  });
+});
+
+describe("executionCounts", () => {
+  it("should be tested", () => {
+    expect(executionCounts()).toBeTruthy();
+  });
+});
+
+describe("executionStates", () => {
+  it("should be tested", () => {
+    expect(executionStates()).toBeTruthy();
   });
 });

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -102,4 +102,46 @@ describe("ofMessageType", () => {
           done();
         }
       ));
+  it("handles both the legacy and current arguments for ofMessageType", () => {
+    from([
+      { header: { msg_type: "a" } },
+      { header: { msg_type: "d" } },
+      { header: { msg_type: "b" } },
+      { header: { msg_type: "a" } },
+      { header: { msg_type: "d" } }
+    ])
+      .pipe(
+        ofMessageType(["a", "d"]),
+        tap(val => {
+          expect(val.header.msg_type === "a" || val.header.msg_type === "d");
+        }),
+        pluck("header", "msg_type"),
+        count()
+      )
+      .toPromise()
+      .then(val => {
+        expect(val).toEqual(4);
+      });
+
+    from([
+      { header: { msg_type: "a" } },
+      { header: { msg_type: "d" } },
+      { header: { msg_type: "b" } },
+      { header: { msg_type: "a" } },
+      { header: { msg_type: "d" } }
+    ])
+      .pipe(
+        // Note the lack of array brackets on the arguments
+        ofMessageType("a", "d"),
+        tap(val => {
+          expect(val.header.msg_type === "a" || val.header.msg_type === "d");
+        }),
+        pluck("header", "msg_type"),
+        count()
+      )
+      .toPromise()
+      .then(val => {
+        expect(val).toEqual(4);
+      });
+  });
 });

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -2,7 +2,7 @@ import { from } from "rxjs/observable/from";
 import { pluck, tap, count } from "rxjs/operators";
 import { ofMessageType, childOf } from "../src/index";
 
-import { createMessage, getUsername } from "../";
+import { createMessage, getUsername, createExecuteRequest } from "../";
 
 describe("createMessage", () => {
   it("makes a msg", () => {
@@ -17,6 +17,16 @@ describe("createMessage", () => {
     expect(msg.header.msg_type).toBe("a");
     expect(msg.parent_header.msg_id).toBe("100");
     expect(msg.content.data.foo).toBe("bar");
+  });
+});
+
+describe("createExecuteRequest", () => {
+  it("creates an execute_request message", () => {
+    const code = 'print("test")';
+    const executeRequest = createExecuteRequest(code);
+
+    expect(executeRequest.content.code).toEqual(code);
+    expect(executeRequest.header.msg_type).toEqual("execute_request");
   });
 });
 

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -1,4 +1,5 @@
 import { from } from "rxjs/observable/from";
+import { of } from "rxjs/observable/of";
 import { pluck, tap, count } from "rxjs/operators";
 import { ofMessageType, childOf } from "../src/index";
 

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -1,6 +1,6 @@
 import { from } from "rxjs/observable/from";
 import { of } from "rxjs/observable/of";
-import { pluck, tap, count } from "rxjs/operators";
+import { pluck, tap, count, toArray } from "rxjs/operators";
 import { ofMessageType, childOf } from "../src/index";
 
 import {
@@ -13,6 +13,15 @@ import {
   executionCounts,
   executionStates
 } from "../";
+
+import {
+  displayData,
+  updateDisplayData,
+  executeResult,
+  error,
+  stream,
+  status
+} from "../src/messages";
 
 import { cloneDeep } from "lodash";
 
@@ -188,7 +197,32 @@ describe("convertOutputMessageToNotebookFormat", () => {
 
 describe("outputs", () => {
   it("should be tested", () => {
-    expect(outputs()).toBeTruthy();
+    const hacking = of(
+      status("busy"),
+      displayData({ data: { "text/plain": "woo" } }),
+      displayData({ data: { "text/plain": "hoo" } }),
+      status("idle")
+    );
+
+    return hacking
+      .pipe(outputs(), toArray())
+      .toPromise()
+      .then(arr => {
+        expect(arr).toEqual([
+          {
+            data: { "text/plain": "woo" },
+            output_type: "display_data",
+            metadata: {},
+            transient: {}
+          },
+          {
+            data: { "text/plain": "hoo" },
+            output_type: "display_data",
+            metadata: {},
+            transient: {}
+          }
+        ]);
+      });
   });
 });
 

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -196,7 +196,7 @@ describe("convertOutputMessageToNotebookFormat", () => {
 });
 
 describe("outputs", () => {
-  it("should be tested", () => {
+  it("extracts outputs as nbformattable contents", () => {
     const hacking = of(
       status("busy"),
       displayData({ data: { "text/plain": "woo" } }),

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -15,6 +15,7 @@ import {
 } from "../";
 
 import {
+  executeInput,
   displayData,
   updateDisplayData,
   executeResult,
@@ -233,8 +234,28 @@ describe("payloads", () => {
 });
 
 describe("executionCounts", () => {
-  it("should be tested", () => {
-    expect(executionCounts()).toBeTruthy();
+  it("extracts all execution counts from a session", () => {
+    return of(
+      status("starting"),
+      status("idle"),
+      status("busy"),
+      executeInput({
+        code: "display('woo')\ndisplay('hoo')",
+        execution_count: 0
+      }),
+      displayData({ data: { "text/plain": "woo" } }),
+      displayData({ data: { "text/plain": "hoo" } }),
+      executeInput({
+        code: "",
+        execution_count: 1
+      }),
+      status("idle")
+    )
+      .pipe(executionCounts(), toArray())
+      .toPromise()
+      .then(arr => {
+        expect(arr).toEqual([0, 1]);
+      });
   });
 });
 

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -2,7 +2,18 @@ import { from } from "rxjs/observable/from";
 import { pluck, tap, count } from "rxjs/operators";
 import { ofMessageType, childOf } from "../src/index";
 
-import { createMessage, getUsername, createExecuteRequest } from "../";
+import {
+  createMessage,
+  getUsername,
+  createExecuteRequest,
+  convertOutputMessageToNotebookFormat,
+  outputs,
+  payloads,
+  executionCounts,
+  executionStates
+} from "../";
+
+import { cloneDeep } from "lodash";
 
 describe("createMessage", () => {
   it("makes a msg", () => {
@@ -143,5 +154,42 @@ describe("ofMessageType", () => {
       .then(val => {
         expect(val).toEqual(4);
       });
+  });
+});
+
+/**
+ *   convertOutputMessageToNotebookFormat,
+   outputs,
+   payloads,
+   executionCounts,
+   executionStates
+
+ */
+
+describe("convertOutputMessageToNotebookFormat", () => {
+  it("ensures that fields end up notebook format style", () => {
+    const message = {
+      content: { yep: true },
+      header: { msg_type: "test", msg_id: "10", username: "rebecca" },
+      metadata: { purple: true }
+    };
+
+    expect(convertOutputMessageToNotebookFormat(message)).toEqual({
+      yep: true,
+      output_type: "test"
+    });
+  });
+
+  it("should not mutate the message", () => {
+    const message = {
+      content: { yep: true },
+      header: { msg_type: "test", msg_id: "10", username: "rebecca" },
+      metadata: { purple: true }
+    };
+
+    const copy = cloneDeep(message);
+    convertOutputMessageToNotebookFormat(message);
+
+    expect(message).toEqual(copy);
   });
 });

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -21,7 +21,9 @@ import {
   executeResult,
   error,
   stream,
-  status
+  status,
+  executeReply,
+  message
 } from "../src/messages";
 
 import { cloneDeep } from "lodash";
@@ -228,7 +230,20 @@ describe("outputs", () => {
 });
 
 describe("payloads", () => {
-  it("should be tested", () => {
+  it("extracts payloads from execute_reply messages", () => {
+    return of(
+      status("idle"),
+      status("busy"),
+      executeReply({ payload: [{ c: "d" }] }),
+      executeReply({ payload: [{ a: "b" }, { g: "6" }] }),
+      executeReply({ status: "ok" }),
+      message({ msg_type: "fake" }, { payload: [{ should: "not be in it" }] })
+    )
+      .pipe(payloads(), toArray())
+      .toPromise()
+      .then(arr => {
+        expect(arr).toEqual([{ c: "d" }, { a: "b" }, { g: "6" }]);
+      });
     expect(payloads()).toBeTruthy();
   });
 });

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -239,7 +239,19 @@ describe("executionCounts", () => {
 });
 
 describe("executionStates", () => {
-  it("should be tested", () => {
-    expect(executionStates()).toBeTruthy();
+  it("extracts all the execution states from status messages", () => {
+    return of(
+      status("starting"),
+      status("idle"),
+      status("busy"),
+      displayData({ data: { "text/plain": "woo" } }),
+      displayData({ data: { "text/plain": "hoo" } }),
+      status("idle")
+    )
+      .pipe(executionStates(), toArray())
+      .toPromise()
+      .then(arr => {
+        expect(arr).toEqual(["starting", "idle", "busy", "idle"]);
+      });
   });
 });

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -60,7 +60,7 @@ export function createMessage(
 
 // TODO: Deprecate
 export function createExecuteRequest(code: string = ""): ExecuteRequest {
-  return executeRequest(sessionInfo, code);
+  return executeRequest(code, {}, sessionInfo);
 }
 
 /**

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -36,35 +36,7 @@ export function getUsername() {
   );
 }
 
-export type JupyterMessageHeader<MT> = {
-  msg_id: string,
-  username: string,
-  date: string, // ISO 8601 timestamp
-  msg_type: MT, // this could be an enum
-  version: string // this could be an enum
-};
-
-export type JupyterMessage<MT, C> = {
-  header: JupyterMessageHeader<MT>,
-  parent_header: JupyterMessageHeader<*>,
-  metadata: Object,
-  content: C,
-  buffers?: Array<any> | null
-};
-
-export type ExecuteMessageContent = {
-  code: string,
-  silent: boolean,
-  store_history: boolean,
-  user_expressions: Object,
-  allow_stdin: boolean,
-  stop_on_error: boolean
-};
-
-export type ExecuteRequest = JupyterMessage<
-  "execute_request",
-  ExecuteMessageContent
->;
+import type { JupyterMessage, ExecuteRequest } from "./types";
 
 export function createMessage(
   msg_type: string,

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -197,20 +197,6 @@ export const executionCounts = () => (
     pluck("content", "execution_count")
   );
 
-/**
- * Get the set_next_input payloads from a payload stream
- *
- * > sni$ = shell$.pipe(
- *     childOf(originalMessage),
- *     payloads(),
- *     setNextInputs()
- *   )
- *
- * NOTE: To keep the interface consistent, this is created as an operator function
- */
-export const setNextInputs = () =>
-  filter(payload => payload.source === "set_next_input");
-
 export const executionStates = () => (
   source: rxjs$Observable<*>
 ): rxjs$Observable<*> =>

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -113,7 +113,7 @@ export function createExecuteRequest(code: string = ""): ExecuteRequest {
  * parentMessage's header
  */
 export const childOf = (parentMessage: JupyterMessage<*, *>) => (
-  source: rxjs$Observable<*>
+  source: rxjs$Observable<JupyterMessage<*, *>>
 ) => {
   const parentMessageID = parentMessage.header.msg_id;
   return new Observable(subscriber =>
@@ -150,7 +150,9 @@ export const ofMessageType = (
     return ofMessageType(...messageTypes[0]);
   }
 
-  return (source: rxjs$Observable<*>): rxjs$Observable<*> =>
+  return (
+    source: rxjs$Observable<JupyterMessage<*, *>>
+  ): rxjs$Observable<JupyterMessage<*, *>> =>
     new Observable(subscriber =>
       source.subscribe(
         msg => {
@@ -178,7 +180,9 @@ export const ofMessageType = (
  * @param {Object} msg - Message that has content which can be converted to nbformat
  * @return {Object} formattedMsg  - Message with the associated output type
  */
-export function convertOutputMessageToNotebookFormat(msg: any) {
+export function convertOutputMessageToNotebookFormat(
+  msg: JupyterMessage<*, *>
+) {
   return Object.assign({}, msg.content, {
     output_type: msg.header.msg_type
   });
@@ -193,7 +197,9 @@ export function convertOutputMessageToNotebookFormat(msg: any) {
  *     outputs()
  *   )
  */
-export const outputs = () => (source: rxjs$Observable<*>): rxjs$Observable<*> =>
+export const outputs = () => (
+  source: rxjs$Observable<JupyterMessage<*, *>>
+): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(
     ofMessageType("execute_result", "display_data", "stream", "error"),
     map(convertOutputMessageToNotebookFormat)
@@ -216,8 +222,8 @@ export const updatedOutputs = () => (
    *   )
    */
 export const payloads = () => (
-  source: rxjs$Observable<*>
-): rxjs$Observable<*> =>
+  source: rxjs$Observable<JupyterMessage<*, *>>
+): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(
     ofMessageType("execute_reply"),
     pluck("content", "payload"),
@@ -229,14 +235,14 @@ export const payloads = () => (
  * Get all the execution counts from an observable of jupyter messages
  */
 export const executionCounts = () => (
-  source: rxjs$Observable<*>
-): rxjs$Observable<*> =>
+  source: rxjs$Observable<JupyterMessage<*, *>>
+): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(
     ofMessageType("execute_input"),
     pluck("content", "execution_count")
   );
 
 export const executionStates = () => (
-  source: rxjs$Observable<*>
-): rxjs$Observable<*> =>
+  source: rxjs$Observable<JupyterMessage<*, *>>
+): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(ofMessageType("status"), pluck("content", "execution_state"));

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -61,7 +61,7 @@ export type ExecuteMessageContent = {
   stop_on_error: boolean
 };
 
-export type ExecuteMessage = JupyterMessage<
+export type ExecuteRequest = JupyterMessage<
   "execute_request",
   ExecuteMessageContent
 >;
@@ -95,7 +95,7 @@ export function createMessage(
  * @param {String} code - Code to be executed in a message to the kernel.
  * @return {Object} msg - Message object containing the code to be sent.
  */
-export function createExecuteRequest(code: string = ""): ExecuteMessage {
+export function createExecuteRequest(code: string = ""): ExecuteRequest {
   const executeRequest = createMessage("execute_request");
   executeRequest.content = {
     code,

--- a/packages/messaging/src/messages.js
+++ b/packages/messaging/src/messages.js
@@ -1,0 +1,82 @@
+// @flow
+
+import type { JupyterMessage, ExecuteRequest } from "./types";
+
+import * as uuid from "uuid";
+
+export function message(
+  header: { msg_type: string, username: string, session: string },
+  content: Object = {}
+): JupyterMessage<*, *> {
+  return {
+    header: {
+      msg_id: uuid.v4(),
+      date: new Date(),
+      version: "5.0",
+      ...header
+    },
+    metadata: {},
+    parent_header: {},
+    content
+  };
+}
+
+const defaultExecuteOptions = {
+  silent: false,
+  store_history: true,
+  user_expressions: {},
+  allow_stdin: false,
+  stop_on_error: false
+};
+
+/**
+ * An execute request creator
+ *
+ * > executeRequest({ username: 'kyle', session: '123' }, 'print("hey")', { 'allow_stdin': true })
+ * { header:
+ *    { msg_id: 'f344cc6b-4308-4405-a8e8-a166b0345579',
+ *      date: 2017-10-23T22:33:39.970Z,
+ *      version: '5.0',
+ *      msg_type: 'execute_request',
+ *      username: 'kyle',
+ *      session: '123' },
+ *   metadata: {},
+ *   parent_header: {},
+ *   content:
+ *    { code: 'print("hey")',
+ *      silent: false,
+ *      store_history: true,
+ *      user_expressions: {},
+ *      allow_stdin: true,
+ *      stop_on_error: false } }
+ *
+*/
+export function executeRequest(
+  sessionInfo: { username: string, session: string },
+  code: string = "",
+  options: {
+    silent: boolean,
+    store_history: boolean,
+    user_expressions: Object,
+    allow_stdin: boolean,
+    stop_on_error: boolean
+  } = {
+    silent: false,
+    store_history: true,
+    user_expressions: {},
+    allow_stdin: false,
+    stop_on_error: false
+  }
+): ExecuteRequest {
+  const executeRequest = message({
+    msg_type: "execute_request",
+    ...sessionInfo
+  });
+
+  executeRequest.content = {
+    code,
+    ...defaultExecuteOptions,
+    ...options
+  };
+  return executeRequest;
+}

--- a/packages/messaging/src/messages.js
+++ b/packages/messaging/src/messages.js
@@ -253,3 +253,16 @@ export function clearOutput(
     content
   );
 }
+
+export function executeInput(
+  content: { code: string, execution_count: number },
+  sessionInfo?: SessionInfo
+) {
+  return message(
+    {
+      msg_type: "execute_input",
+      ...sessionInfo
+    },
+    content
+  );
+}

--- a/packages/messaging/src/types.js
+++ b/packages/messaging/src/types.js
@@ -1,0 +1,29 @@
+export type JupyterMessageHeader<MT> = {
+  msg_id: string,
+  username: string,
+  date: string, // ISO 8601 timestamp
+  msg_type: MT, // this could be an enum
+  version: string // this could be an enum
+};
+
+export type JupyterMessage<MT, C> = {
+  header: JupyterMessageHeader<MT>,
+  parent_header: JupyterMessageHeader<*>,
+  metadata: Object,
+  content: C,
+  buffers?: Array<any> | null
+};
+
+export type ExecuteMessageContent = {
+  code: string,
+  silent: boolean,
+  store_history: boolean,
+  user_expressions: Object,
+  allow_stdin: boolean,
+  stop_on_error: boolean
+};
+
+export type ExecuteRequest = JupyterMessage<
+  "execute_request",
+  ExecuteMessageContent
+>;


### PR DESCRIPTION
This extracts some operators out of our execution epic for use elsewhere while cutting down the messaging logic from the desktop app. My hope is that the execution epic will only be tied to its core function of creating a notebook from the messages.

Generally I want to create some observable operators that you can use like this:

```js
iopub.pipe(
  childOf(someMessage),
  outputs()
)
```

Where the signature on `outputs` is `() => (Observable<JupyterMessage>): Observable<JupyterOutput>`

While doing this refactor I was pretty tempted to set this up quite differently by pumping the pure messages through the redux store instead, coupled with the cell ID. All the `takeUntil` logic would still be there, the execution epic would become a glorified router of messages that came from the parent ID to the proper cell ID.

------------------

Now that I've gone through this, we've got some nice primitives here which may make building kernels really easy as well. If you look at the tests you'll see the declarative nature of our message creators and how to work with our operators:

```js
import {of} from 'rxjs/observable/of';

import {
  createMessage,
  getUsername,
  createExecuteRequest,
  convertOutputMessageToNotebookFormat,
  outputs,
  payloads,
  executionCounts,
  executionStates,
} from '@nteract/messaging';

import {
  executeInput,
  displayData,
  updateDisplayData,
  executeResult,
  error,
  stream,
  status,
  executeReply,
  message,
  // TODO: Move outside this lib namespace
} from '@nteract/messaging/lib/messages';

// @format
of(
  status('starting'),
  status('idle'),
  status('busy'),
  executeInput({
    code: "display('woo')\ndisplay('hoo')",
    execution_count: 0,
  }),
  displayData({data: {'text/plain': 'woo'}}),
  displayData({data: {'text/plain': 'hoo'}}),
  status('idle'),
).pipe(executionCounts());
```

Since these are just JSON payloads and observable operators, people can still make the interfaces they want, mixing and matching styles as they see fit.
