### PR TITLE
[NO MERGE] bufferOutputs via bufferTime, reduce stream data

### DIFF
--- a/packages/desktop/src/notebook/epics/execute.js
+++ b/packages/desktop/src/notebook/epics/execute.js
@@ -6,6 +6,7 @@ import {
   childOf,
   updatedOutputs,
   outputs,
+  bufferedOutputs,
   payloads,
   executionStates,
   executionCounts
@@ -126,8 +127,8 @@ export function executeCellStream(
 
     // All actions for new outputs
     cellMessages.pipe(
-      outputs(),
-      map(output => ({ type: "APPEND_OUTPUT", id, output })),
+      bufferedOutputs(),
+      map(outputs => ({ type: "APPEND_BATCHED_OUTPUTS", id, outputs })),
       startWith(clearOutputs(id))
     ),
 

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -11,7 +11,8 @@ import {
   outputs,
   payloads,
   executionCounts,
-  executionStates
+  executionStates,
+  bufferedOutputs
 } from "../";
 
 import {
@@ -224,6 +225,53 @@ describe("outputs", () => {
             metadata: {},
             transient: {}
           }
+        ]);
+      });
+  });
+});
+
+describe("bufferedOutputs", () => {
+  it("will combine stream data within a bufferTimeSpan", () => {
+    const hacking = of(
+      displayData({ data: { "text/plain": "woo" } }),
+      stream({ name: "stdout", text: "Eleanor" }),
+      stream({ name: "stdout", text: " Rigby\n" }),
+      stream({ name: "stdout", text: " died in a chur" }),
+      stream({ name: "stdout", text: "ch and was buried along with her name" }),
+      displayData({ data: { "text/plain": "hoo" } }),
+      stream({ name: "stdout", text: "nobody came" })
+    );
+
+    return hacking
+      .pipe(bufferedOutputs(), toArray())
+      .toPromise()
+      .then(arr => {
+        expect(arr).toEqual([
+          [
+            {
+              data: { "text/plain": "woo" },
+              output_type: "display_data",
+              metadata: {},
+              transient: {}
+            },
+            {
+              output_type: "stream",
+              name: "stdout",
+              text:
+                "Eleanor Rigby\n died in a church and was buried along with her name"
+            },
+            {
+              data: { "text/plain": "hoo" },
+              output_type: "display_data",
+              metadata: {},
+              transient: {}
+            },
+            {
+              output_type: "stream",
+              name: "stdout",
+              text: "nobody came"
+            }
+          ]
         ]);
       });
   });

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -13,7 +13,7 @@ import {
   executionCounts,
   executionStates,
   bufferedOutputs
-} from "../";
+} from "../src";
 
 import {
   executeInput,
@@ -48,6 +48,7 @@ describe("createMessage", () => {
 describe("createExecuteRequest", () => {
   it("creates an execute_request message", () => {
     const code = 'print("test")';
+    console.log("createExecuteRequest:", createExecuteRequest);
     const executeRequest = createExecuteRequest(code);
 
     expect(executeRequest.content.code).toEqual(code);

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -170,7 +170,7 @@ export const updatedOutputs = () => (
   );
 
 // TODO: Strongly type as jupyter outputs
-function simpleOutputReduction(outputs: Array<*>) {
+function simpleOutputReduction(outputs: Array<*>): Array<*> {
   return outputs.reduce((acc, output) => {
     if (acc.length === 0) {
       acc.push(output);
@@ -193,12 +193,15 @@ function simpleOutputReduction(outputs: Array<*>) {
   }, []);
 }
 
+// TODO: Strongly type as jupyter outputs
+type OutputReducer = (outputArray: Array<*>) => Array<*>;
+
 /**
  * Creates batches of output messages rather than single output messages individually.
  */
 export const bufferedOutputs = (
   bufferTimeSpan: number = 100,
-  reducer = simpleOutputReduction
+  reducer: OutputReducer = simpleOutputReduction
 ) => (
   source: rxjs$Observable<JupyterMessage<*, *>>
 ): rxjs$Observable<JupyterMessage<*, *>> =>

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -39,6 +39,7 @@ export function getUsername(): string {
 }
 
 import { message, executeRequest } from "./messages";
+import { Output } from "./types";
 
 // TODO: The current expectation of this library is that createMessage hides the
 //       fact that there is a session number and a username
@@ -169,8 +170,7 @@ export const updatedOutputs = () => (
     map(msg => Object.assign({}, msg.content, { output_type: "display_data" }))
   );
 
-// TODO: Strongly type as jupyter outputs
-function simpleOutputReduction(outputs: Array<*>): Array<*> {
+function simpleOutputReduction(outputs: Array<Output>): Array<Output> {
   return outputs.reduce((acc, output) => {
     if (acc.length === 0) {
       acc.push(output);
@@ -193,8 +193,7 @@ function simpleOutputReduction(outputs: Array<*>): Array<*> {
   }, []);
 }
 
-// TODO: Strongly type as jupyter outputs
-type OutputReducer = (outputArray: Array<*>) => Array<*>;
+type OutputReducer = (outputArray: Array<Output>) => Array<Output>;
 
 /**
  * Creates batches of output messages rather than single output messages individually.

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -205,7 +205,18 @@ export const bufferedOutputs = (
 ) => (
   source: rxjs$Observable<JupyterMessage<*, *>>
 ): rxjs$Observable<JupyterMessage<*, *>> =>
-  source.pipe(outputs(), bufferTime(bufferTimeSpan), map(reducer));
+  source.pipe(
+    ofMessageType(
+      "execute_result",
+      "display_data",
+      "stream",
+      "error",
+      "update_display_data"
+    ),
+    map(convertOutputMessageToNotebookFormat),
+    bufferTime(bufferTimeSpan),
+    map(reducer)
+  );
 
 /**
    * Get all the payload message content from an observable of jupyter messages

--- a/packages/messaging/src/types.js
+++ b/packages/messaging/src/types.js
@@ -27,3 +27,45 @@ export type ExecuteRequest = JupyterMessage<
   "execute_request",
   ExecuteMessageContent
 >;
+
+export type ImmutableJSON =
+  | string
+  | number
+  | boolean
+  | null
+  | ImmutableJSONMap
+  | ImmutableJSONList; // eslint-disable-line no-use-before-define
+export type ImmutableJSONMap = Immutable.Map<string, ImmutableJSON>;
+export type ImmutableJSONList = Immutable.List<ImmutableJSON>;
+
+export type ExecutionCount = number | null;
+
+export type MimeBundle = Immutable.Map<string, ImmutableJSON>;
+
+export type ExecuteResult = {
+  output_type: "execute_result",
+  execution_count: ExecutionCount,
+  data: MimeBundle,
+  metadata: ImmutableJSONMap
+};
+
+export type DisplayData = {
+  output_type: "display_data",
+  data: MimeBundle,
+  metadata: ImmutableJSONMap
+};
+
+export type StreamOutput = {
+  output_type: "stream",
+  name: "stdout" | "stderr",
+  text: string
+};
+
+export type ErrorOutput = {
+  output_type: "error",
+  ename: string,
+  evalue: string,
+  traceback: Immutable.List<string>
+};
+
+export type Output = ExecuteResult | DisplayData | StreamOutput | ErrorOutput;

--- a/packages/messaging/src/types.js
+++ b/packages/messaging/src/types.js
@@ -28,6 +28,9 @@ export type ExecuteRequest = JupyterMessage<
   ExecuteMessageContent
 >;
 
+export type ImmutableJSONMap = Immutable.Map<string, ImmutableJSON>;
+export type ImmutableJSONList = Immutable.List<ImmutableJSON>;
+
 export type ImmutableJSON =
   | string
   | number
@@ -35,8 +38,6 @@ export type ImmutableJSON =
   | null
   | ImmutableJSONMap
   | ImmutableJSONList; // eslint-disable-line no-use-before-define
-export type ImmutableJSONMap = Immutable.Map<string, ImmutableJSON>;
-export type ImmutableJSONList = Immutable.List<ImmutableJSON>;
 
 export type ExecutionCount = number | null;
 


### PR DESCRIPTION
First steps before closing down on #1737. This introduces a bufferOutputs operator that will emit arrays of outputs within a `bufferTimeSpan`. I went and did a little extra by reducing stream outputs on the fly through the stream. This... could use some error recovery, but it's a start for people to work with on the desktop app side.

/cc @captainsafia @lgeiger 