### PR TITLE
bring in redux devtools into the nbextension

### DIFF
--- a/packages/nbextension/nteract_on_jupyter/store.js
+++ b/packages/nbextension/nteract_on_jupyter/store.js
@@ -1,6 +1,8 @@
 /* @flow */
-import { createStore, applyMiddleware } from "redux";
+import { createStore, applyMiddleware, compose } from "redux";
 import { createEpicMiddleware, combineEpics } from "redux-observable";
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 import epics from "./epics";
 
@@ -23,6 +25,6 @@ export default function configureStore(initialState: AppState = {}) {
   return createStore(
     rootReducer,
     initialState,
-    applyMiddleware(...middlewares)
+    composeEnhancers(applyMiddleware(...middlewares))
   );
 }


### PR DESCRIPTION
Make things a bit nicer while we're building out the nbextension by bringing in the redux devtools (when installed via chrome plugin).