### PR TITLE
bootstrap a core package

### DIFF
--- a/packages/core/.npmrc
+++ b/packages/core/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nteract/core",
+  "version": "0.0.1-beta",
+  "description": "core modules and components for nteract apps",
+  "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "build:clean": "rimraf lib",
+    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch"
+  },
+  "dependencies": {
+    "rxjs": "^5.5.0",
+    "uuid": "^3.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": ["nteract", "ohgodamonomoduleinamonorepo"],
+  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "license": "BSD-3-Clause"
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,0 +1,3 @@
+//@flow
+
+// Nothing here yet


### PR DESCRIPTION
Goal: Get more of the desktop app exported for use in the web apps. I'm going to start this off with a new package to make merging later easy. After this PR I'm going to bring in all the actions, reducers, epics, and components.

-----------

Further detail:

Since exporting at a granular level from the desktop application is proving to feel more constraining (to me) than using our actions and reducers as a whole, I'm going to try out making a `core` package here that uses them directly as is here. We can keep this package free of electron specific bits and export the actions / reducers / epics as modules to incorporate within both desktop and the web app(s).