### PR TITLE
[WIP][webapp] set up basics for execution

### DIFF
--- a/packages/nbextension/nteract_on_jupyter/actions/index.js
+++ b/packages/nbextension/nteract_on_jupyter/actions/index.js
@@ -2,4 +2,21 @@
 import type { CONTENTS_ACTIONS } from "./contents";
 import type { KERNELSPECS_ACTIONS } from "./kernelspecs";
 
-export type ALL_ACTIONS = CONTENTS_ACTIONS | KERNELSPECS_ACTIONS;
+export type GENERIC_AJAX_FAIL = {
+  type: "GENERIC_AJAX_FAIL",
+  payload: any,
+  status: number
+};
+
+export function genericAjaxFail(ajaxError: any): GENERIC_AJAX_FAIL {
+  return {
+    type: "GENERIC_AJAX_FAIL",
+    payload: ajaxError.response,
+    status: ajaxError.status
+  };
+}
+
+export type ALL_ACTIONS =
+  | CONTENTS_ACTIONS
+  | KERNELSPECS_ACTIONS
+  | GENERIC_AJAX_FAIL;

--- a/packages/nbextension/nteract_on_jupyter/actions/kernels.js
+++ b/packages/nbextension/nteract_on_jupyter/actions/kernels.js
@@ -1,0 +1,5 @@
+export type START_KERNEL = {
+  type: "START_KERNEL",
+  name: string,
+  path: string
+};

--- a/packages/nbextension/nteract_on_jupyter/actions/kernelspecs.js
+++ b/packages/nbextension/nteract_on_jupyter/actions/kernelspecs.js
@@ -9,10 +9,4 @@ export type KERNELSPECS_LISTED = {
   payload: any
 };
 
-export type GENERIC_AJAX_FAIL = {
-  type: "GENERIC_AJAX_FAIL",
-  payload: any,
-  status: number
-};
-
 export type KERNELSPECS_ACTIONS = LIST_KERNELSPECS | KERNELSPECS_LISTED;

--- a/packages/nbextension/nteract_on_jupyter/epics/index.js
+++ b/packages/nbextension/nteract_on_jupyter/epics/index.js
@@ -1,7 +1,8 @@
 // @flow
 import { loadEpic } from "./contents";
 import { listKernelSpecsEpic } from "./kernelspecs";
+import { startKernelEpic, autoconnectEpic } from "./kernels";
 
-const epics = [loadEpic, listKernelSpecsEpic];
+const epics = [loadEpic, listKernelSpecsEpic, startKernelEpic, autoconnectEpic];
 
 export default epics;

--- a/packages/nbextension/nteract_on_jupyter/epics/kernels.js
+++ b/packages/nbextension/nteract_on_jupyter/epics/kernels.js
@@ -1,0 +1,92 @@
+/* @flow */
+
+import { kernels } from "rx-jupyter";
+
+import { of } from "rxjs/add/observable/of";
+import { merge } from "rxjs/add/observable/merge";
+
+import {
+  tap,
+  map,
+  switchMap,
+  mapTo,
+  mergeMap,
+  catchError
+} from "rxjs/operators";
+
+import type { ActionsObservable } from "redux-observable";
+
+import type { START_KERNEL } from "../actions/kernels";
+
+import type { ALL_ACTIONS } from "../actions/";
+
+import { genericAjaxFail } from "../actions";
+
+function startKernel(name: string, path: string): START_KERNEL {
+  return { type: "START_KERNEL", name, path };
+}
+
+export function startKernelEpic(
+  action$: ActionsObservable<ALL_ACTIONS>,
+  store: Store<*, *>
+) {
+  return action$.ofType("START_KERNEL").pipe(
+    switchMap((action: START_KERNEL) => {
+      // TODO: Reflect on how the desktop app is doing this so that we
+      // can share code for kernel lifecycle
+
+      const config = store.getState().config;
+      // TODO: Stop normalizing every time we do our call and make it part of
+      // our state
+      const serverConfig = {
+        endpoint: config.baseUrl,
+        crossDomain: false
+      };
+
+      // $FlowFixMe: WTF
+      return kernels.start(serverConfig, action.name, action.path).pipe(
+        tap(xhr => {
+          console.log(xhr);
+          if (xhr.status !== 200) {
+            throw new Error(xhr.response);
+          }
+        }),
+        map(xhr => {
+          return {
+            type: "LAUNCHED_KERNEL",
+            payload: xhr.response
+          };
+        }),
+        catchError((xhrError: any) => of(genericAjaxFail(xhrError)))
+      );
+    })
+  );
+}
+
+export function autoconnectEpic(
+  action$: ActionsObservable<ALL_ACTIONS>,
+  store: Store<*, *>
+) {
+  return action$.ofType("LAUNCHED_KERNEL").pipe(
+    switchMap((action: any) => {
+      // TODO: Reflect on how the desktop app is doing this so that we
+      // can share code for kernel lifecycle
+
+      const config = store.getState().config;
+      // TODO: Stop normalizing every time we do our call and make it part of
+      // our state
+      const serverConfig = {
+        endpoint: config.baseUrl,
+        crossDomain: false
+      };
+
+      // These aren't pure nteract channels, we'll adapt them though
+      const channels = kernels.connect(serverConfig, action.id);
+      return of({
+        type: "LAUNCHED_KERNEL",
+        channels,
+        id: action.id
+      });
+    })
+  );
+}

--- a/packages/nbextension/nteract_on_jupyter/epics/kernelspecs.js
+++ b/packages/nbextension/nteract_on_jupyter/epics/kernelspecs.js
@@ -16,23 +16,14 @@ import {
 
 import type { ActionsObservable } from "redux-observable";
 
-import type { ALL_ACTIONS } from "../actions/";
+import type { ALL_ACTIONS, GENERIC_AJAX_FAIL } from "../actions/";
 
-import type {
-  LIST_KERNELSPECS,
-  GENERIC_AJAX_FAIL
-} from "../actions/kernelspecs";
+import type { LIST_KERNELSPECS } from "../actions/kernelspecs";
+
+import { genericAjaxFail } from "../actions";
 
 function listKernelSpecs(): LIST_KERNELSPECS {
   return { type: "LIST_KERNELSPECS" };
-}
-
-function genericAjaxFail(ajaxError: any): GENERIC_AJAX_FAIL {
-  return {
-    type: "GENERIC_AJAX_FAIL",
-    payload: ajaxError.response,
-    status: ajaxError.status
-  };
 }
 
 type ServerConfig = {

--- a/packages/nbextension/nteract_on_jupyter/views/types.js
+++ b/packages/nbextension/nteract_on_jupyter/views/types.js
@@ -1,0 +1,4 @@
+export type ServerConfig = {
+  endpoint: string,
+  crossDomain?: boolean
+};


### PR DESCRIPTION
This begins the setup for executing on the nteract nbextension.

Missing pieces:

* [ ] `rx-jupyter` doesn't seem to handle tokens / the XSRF token (requires investigation)
* [ ] `channels` are not in line with `enchannel` (they're multiplexed websockets)

I'm tempted to step away from this PR for a sec and bring `rx-jupyter` into the monorepo