### PR TITLE
match repository link style across lerna packages

### DIFF
--- a/packages/ansi-to-react/package.json
+++ b/packages/ansi-to-react/package.json
@@ -16,11 +16,7 @@
     "build:es5": "babel src --out-dir lib/ --source-maps",
     "clean": "rimraf lib/*"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/nteract.git"
-  },
-  "homepage":
+  "repository":
     "https://github.com/nteract/nteract/tree/master/packages/ansi-to-react",
   "keywords": ["ansi", "react"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",

--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -12,10 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/nteract/nteract/tree/master/packages/commutable"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/commutable",
   "keywords": ["commutable", "nteract", "notebooks"],
   "publishConfig": {
     "access": "public"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -3,17 +3,15 @@
   "version": "0.3.4",
   "description": "Interactive literate coding notebook!",
   "main": "./lib/webpacked-main.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/nteract/nteract.git"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/desktop",
   "keywords": ["jupyter", "electron", "notebook", "nteract", "data"],
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"
   },
-  "homepage": "https://github.com/nteract/nteract",
+  "homepage": "https://nteract.io",
   "scripts": {
     "clean": "rimraf lib dist",
     "postinstall": "electron-builder install-app-deps",

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -12,11 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
-  "repository": {
-    "type": "git",
-    "url":
-      "https://github.com/nteract/nteract/tree/master/packages/display-area"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/display-area",
   "keywords": ["nteract", "display", "jupyter"],
   "publishConfig": {
     "access": "public"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/editor",
   "keywords": ["nteract", "editor", "notebook", "jupyter"],
   "publishConfig": {
     "access": "public"

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -15,16 +15,13 @@
     "test:watch": "npm run test -- --watch",
     "clean": "rimraf lib/*"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/enchannel-zmq-backend.git"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/enchannel-zmq-backend",
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/nteract/enchannel-zmq-backend/issues"
+    "url": "https://github.com/nteract/nteract/issues"
   },
-  "homepage": "https://github.com/nteract/enchannel-zmq-backend#readme",
   "dependencies": {
     "jmp": "^0.7.5",
     "rxjs": "^5.5.0",

--- a/packages/enchannel/package.json
+++ b/packages/enchannel/package.json
@@ -7,17 +7,14 @@
   "scripts": {
     "test": "mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/nteract.git"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/enchannel",
   "keywords": ["enchannel", "jupyter"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"
   },
-  "homepage": "https://github.com/nteract/nteract#readme",
   "dependencies": {
     "@nteract/messaging": "^2.0.1",
     "rxjs": "^5.5.0"

--- a/packages/fs-observable/package.json
+++ b/packages/fs-observable/package.json
@@ -12,10 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/nteract.git"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/fs-observable",
   "keywords": ["rxjs", "fs", "observable"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/messaging",
   "dependencies": {
     "rxjs": "^5.5.0",
     "uuid": "^3.1.0"

--- a/packages/nbextension/package.json
+++ b/packages/nbextension/package.json
@@ -8,6 +8,8 @@
     "prebuild:python": "rimraf dist",
     "publish": "echo 'not really publishing'"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/nbextension",
   "publishConfig": {
     "access": "public",
     "dry-run": true

--- a/packages/notebook-preview-demo/package.json
+++ b/packages/notebook-preview-demo/package.json
@@ -4,6 +4,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/notebook-preview-demo",
   "dependencies": {
     "@nteract/commutable": "^2.1.2",
     "@nteract/notebook-preview": "^3.0.2",

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/notebook-preview",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -19,22 +19,14 @@
     "precoverage": "nyc npm run test:unit",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/rx-jupyter.git"
-  },
-  "keywords": [
-    "jupyter",
-    "rxjs",
-    "notebook",
-    "api"
-  ],
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/rx-jupyter",
+  "keywords": ["jupyter", "rxjs", "notebook", "api"],
   "author": "nteract Contributors",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/nteract/rx-jupyter/issues"
+    "url": "https://github.com/nteract/nteract/issues"
   },
-  "homepage": "https://github.com/nteract/rx-jupyter#readme",
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
@@ -58,12 +50,8 @@
     "ws": "^3.2.0"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "transform-flow-strip-types"
-    ]
+    "presets": ["es2015"],
+    "plugins": ["transform-flow-strip-types"]
   },
   "dependencies": {
     "rxjs": "^5.5.0"

--- a/packages/rx-jupyter/src/sessions.js
+++ b/packages/rx-jupyter/src/sessions.js
@@ -40,7 +40,10 @@ export function get(serverConfig: Object, sessionID: string): Observable<*> {
  *
  * @return {Object} - An Observable with the request/response
  */
-export function destroy(serverConfig: Object, sessionID: string): Observable<*> {
+export function destroy(
+  serverConfig: Object,
+  sessionID: string
+): Observable<*> {
   return ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
       method: "DELETE"

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -13,6 +13,8 @@
     "build:lib:watch": "npm run build:lib -- --watch"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transform-dataresource",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transform-geojson",
   "dependencies": {
     "leaflet": "^1.0.3"
   },

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transform-model-debug",
   "author": "",
   "publishConfig": {
     "access": "public"

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transform-plotly",
   "author": "",
   "publishConfig": {
     "access": "public"

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -12,6 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transform-vdom",
   "author": "",
   "publishConfig": {
     "access": "public"

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -16,6 +16,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transform-vega",
   "dependencies": {
     "d3": "^3.5.17",
     "lodash": "^4.17.4",

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -12,10 +12,8 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/nteract.git"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transforms-full",
   "keywords": ["nteract", "transforms", "notebook"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -12,17 +12,14 @@
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nteract/nteract.git"
-  },
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/transforms",
   "keywords": ["nteract", "transforms", "notebook"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"
   },
-  "homepage": "https://github.com/nteract/nteract#readme",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Tiny little cleanup to make sure that the links on npmjs.com resolve to the right spot in our `packages`.