### PR TITLE
move error handling into componentDidCatch to trigger error boundaries

### DIFF
--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -18,29 +18,33 @@ export default class VDOM extends React.Component<Props> {
     return nextProps.data !== this.props.data;
   }
 
+  componentDidCatch(error, info) {
+    return (
+      <div>
+        <pre
+          style={{
+            backgroundColor: "ghostwhite",
+            color: "black",
+            fontWeight: "600",
+            display: "block",
+            padding: "10px",
+            marginBottom: "20px"
+          }}
+        >
+          There was an error rendering VDOM data from the kernel or notebook
+        </pre>
+        <code>{error.toString()}</code>
+      </div>
+    );
+  }
+
   render(): React$Element<any> {
     try {
       // objectToReactElement is mutatitve so we'll clone our object
       var obj = cloneDeep(this.props.data);
       return objectToReactElement(obj);
     } catch (err) {
-      return (
-        <div>
-          <pre
-            style={{
-              backgroundColor: "ghostwhite",
-              color: "black",
-              fontWeight: "600",
-              display: "block",
-              padding: "10px",
-              marginBottom: "20px"
-            }}
-          >
-            There was an error rendering VDOM data from the kernel or notebook
-          </pre>
-          <code>{err.toString()}</code>
-        </div>
-      );
+      return componentDidCatch(err, "");
     }
   }
 }

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -18,7 +18,7 @@ export default class VDOM extends React.Component<Props> {
     return nextProps.data !== this.props.data;
   }
 
-  componentDidCatch(error, info) {
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
     return (
       <div>
         <pre

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -44,7 +44,7 @@ export default class VDOM extends React.Component<Props> {
       var obj = cloneDeep(this.props.data);
       return objectToReactElement(obj);
     } catch (err) {
-      return componentDidCatch(err, "");
+      return this.componentDidCatch(err, "");
     }
   }
 }


### PR DESCRIPTION
Closes #2026 

I'm implementing the solution suggested for catching errors. 

Right now the error catching was "already happening" inside the vdom element, so it was easy enough to work around. 

However, as I'm trying to deal with other mimetypes. I'm having trouble figuring out how to trigger the error in a way that componentDidCatch will be tripped. It seems that the method needs to be defined in a higher order component. I'm going to commit the non-working LaTeX approach in a bit so that people can weigh in.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

