### PR TITLE
Mimetype wrapper

### DIFF
--- a/packages/transforms/src/html.js
+++ b/packages/transforms/src/html.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React from "react";
+import MimeWrapper from "./mimewrapper";
 
 type Props = {
   data: string
@@ -51,12 +52,14 @@ export default class HTMLDisplay extends React.Component<Props> {
 
   render(): ?React$Element<any> {
     return (
-      <div
-        dangerouslySetInnerHTML={{ __html: this.props.data }}
-        ref={el => {
-          this.el = el;
-        }}
-      />
+      <MimeWrapper>
+        <div
+          dangerouslySetInnerHTML={{ __html: this.props.data }}
+          ref={el => {
+            this.el = el;
+          }}
+        />
+      </MimeWrapper>
     );
   }
 }

--- a/packages/transforms/src/image.js
+++ b/packages/transforms/src/image.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React from "react";
+import MimeWrapper from "./mimewrapper";
 
 type TopProps = {
   data: string,
@@ -21,7 +22,13 @@ export default function ImageDisplay(props: TopProps): ?React$Element<any> {
   }
 
   return (
-    <img alt="" src={`data:${props.mimetype};base64,${props.data}`} {...size} />
+    <MimeWrapper>
+      <img
+        alt=""
+        src={`data:${props.mimetype};base64,${props.data}`}
+        {...size}
+      />
+    </MimeWrapper>
   );
 }
 

--- a/packages/transforms/src/javascript.js
+++ b/packages/transforms/src/javascript.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React from "react";
+import MimeWrapper from "./mimewrapper";
 
 type Props = {
   data: string
@@ -42,11 +43,13 @@ export default class JavaScript extends React.Component<Props> {
 
   render(): ?React$Element<any> {
     return (
-      <div
-        ref={el => {
-          this.el = el;
-        }}
-      />
+      <MimeWrapper>
+        <div
+          ref={el => {
+            this.el = el;
+          }}
+        />
+      </MimeWrapper>
     );
   }
 }

--- a/packages/transforms/src/json.js
+++ b/packages/transforms/src/json.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import JSONTree from "react-json-tree";
+import MimeWrapper from "./mimewrapper";
 
 const defaultTheme = {
   base00: "transparent",
@@ -78,12 +79,14 @@ export default class JsonDisplay extends React.Component<Props> {
   render(): ?React$Element<any> {
     const theme = getTheme(this.props.theme);
     return (
-      <JSONTree
-        data={this.props.data}
-        theme={theme}
-        invertTheme={false}
-        shouldExpandNode={this.shouldExpandNode}
-      />
+      <MimeWrapper>
+        <JSONTree
+          data={this.props.data}
+          theme={theme}
+          invertTheme={false}
+          shouldExpandNode={this.shouldExpandNode}
+        />
+      </MimeWrapper>
     );
   }
 }

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -33,7 +33,6 @@ export default class LaTeXDisplay extends React.Component<Props> {
       <MimeWrapper>
         <div
           ref={el => {
-            throw new Error("anything");
             this.el = el;
           }}
         />

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -1,40 +1,11 @@
 /* @flow */
 import React from "react";
 import mathjaxHelper from "mathjax-electron";
+import MimeWrapper from "./mimewrapper";
 
 type Props = {
   data: string
 };
-
-export class DumbWrapper extends React.Component<Props> {
-  componentDidCatch(error, info) {
-    return (
-      <div>
-        <pre
-          style={{
-            backgroundColor: "ghostwhite",
-            color: "black",
-            fontWeight: "600",
-            display: "block",
-            padding: "10px",
-            marginBottom: "20px"
-          }}
-        >
-          There was an error rendering LaTeX data from the kernel or notebook
-        </pre>
-        <code>{error.toString()}</code>
-      </div>
-    );
-  }
-
-  render(): ?React$Element<any> {
-    try {
-      return <div>{this.props.children}</div>;
-    } catch (err) {
-      return componentDidCatch(err, "");
-    }
-  }
-}
 
 export default class LaTeXDisplay extends React.Component<Props> {
   el: ?HTMLElement;
@@ -59,14 +30,14 @@ export default class LaTeXDisplay extends React.Component<Props> {
   render(): ?React$Element<any> {
     // throw new Error("anything");
     return (
-      <DumbWrapper>
+      <MimeWrapper>
         <div
           ref={el => {
             throw new Error("anything");
             this.el = el;
           }}
         />
-      </DumbWrapper>
+      </MimeWrapper>
     );
   }
 }

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -6,6 +6,36 @@ type Props = {
   data: string
 };
 
+export class DumbWrapper extends React.Component<Props> {
+  componentDidCatch(error, info) {
+    return (
+      <div>
+        <pre
+          style={{
+            backgroundColor: "ghostwhite",
+            color: "black",
+            fontWeight: "600",
+            display: "block",
+            padding: "10px",
+            marginBottom: "20px"
+          }}
+        >
+          There was an error rendering LaTeX data from the kernel or notebook
+        </pre>
+        <code>{error.toString()}</code>
+      </div>
+    );
+  }
+
+  render(): ?React$Element<any> {
+    try {
+      return <div>{this.props.children}</div>;
+    } catch (err) {
+      return componentDidCatch(err, "");
+    }
+  }
+}
+
 export default class LaTeXDisplay extends React.Component<Props> {
   el: ?HTMLElement;
   static MIMETYPE = "text/latex";
@@ -27,12 +57,16 @@ export default class LaTeXDisplay extends React.Component<Props> {
   }
 
   render(): ?React$Element<any> {
+    // throw new Error("anything");
     return (
-      <div
-        ref={el => {
-          this.el = el;
-        }}
-      />
+      <DumbWrapper>
+        <div
+          ref={el => {
+            throw new Error("anything");
+            this.el = el;
+          }}
+        />
+      </DumbWrapper>
     );
   }
 }

--- a/packages/transforms/src/markdown.js
+++ b/packages/transforms/src/markdown.js
@@ -2,6 +2,7 @@
 import React from "react";
 import CommonMark from "commonmark";
 import MarkdownRenderer from "commonmark-react-renderer";
+import MimeWrapper from "./mimewrapper";
 
 type Props = {
   data: string
@@ -22,7 +23,11 @@ export class MarkdownDisplay extends React.Component<Props> {
   }
 
   render(): ?React$Element<any> {
-    return <div>{mdRender(this.props.data)}</div>;
+    return (
+      <MimeWrapper>
+        <div>{mdRender(this.props.data)}</div>
+      </MimeWrapper>
+    );
   }
 }
 

--- a/packages/transforms/src/mimewrapper.js
+++ b/packages/transforms/src/mimewrapper.js
@@ -1,0 +1,36 @@
+/* @flow */
+import React from "react";
+
+type Props = {
+  data: string
+};
+
+export default class MimeWrapper extends React.Component<Props> {
+  componentDidCatch(error, info) {
+    return (
+      <div>
+        <pre
+          style={{
+            backgroundColor: "ghostwhite",
+            color: "black",
+            fontWeight: "600",
+            display: "block",
+            padding: "10px",
+            marginBottom: "20px"
+          }}
+        >
+          There was an error rendering LaTeX data from the kernel or notebook
+        </pre>
+        <code>{error.toString()}</code>
+      </div>
+    );
+  }
+
+  render(): ?React$Element<any> {
+    try {
+      return <div>{this.props.children}</div>;
+    } catch (err) {
+      return componentDidCatch(err, "");
+    }
+  }
+}

--- a/packages/transforms/src/mimewrapper.js
+++ b/packages/transforms/src/mimewrapper.js
@@ -28,7 +28,7 @@ export default class MimeWrapper extends React.Component<Props> {
 
   render(): ?React$Element<any> {
     try {
-      return <div>{this.props.children}</div>;
+      return this.props.children;
     } catch (err) {
       return componentDidCatch(err, "");
     }

--- a/packages/transforms/src/svg.js
+++ b/packages/transforms/src/svg.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React from "react";
+import MimeWrapper from "./mimewrapper";
 
 type Props = {
   data: string
@@ -30,11 +31,13 @@ export default class SVGDisplay extends React.Component<Props> {
 
   render(): ?React$Element<any> {
     return (
-      <div
-        ref={el => {
-          this.el = el;
-        }}
-      />
+      <MimeWrapper>
+        <div
+          ref={el => {
+            this.el = el;
+          }}
+        />
+      </MimeWrapper>
     );
   }
 }

--- a/packages/transforms/src/text.js
+++ b/packages/transforms/src/text.js
@@ -2,6 +2,7 @@
 import React from "react";
 
 import Ansi from "ansi-to-react";
+import MimeWrapper from "./mimewrapper";
 
 type Props = {
   data: string
@@ -11,6 +12,10 @@ export default class TextDisplay extends React.PureComponent<Props> {
   static MIMETYPE = "text/plain";
 
   render(): ?React$Element<any> {
-    return <Ansi>{this.props.data}</Ansi>;
+    return (
+      <MimeWrapper>
+        <Ansi>{this.props.data}</Ansi>
+      </MimeWrapper>
+    );
   }
 }


### PR DESCRIPTION
This is part of closing #2026. 

This attempts to deal with the more general case of adding error catching with didComponentCatch for all Mimetype rendering. 

Unfortunately, the approach I took required changing many files. I'm sure there's a way inside  `index.js` to apply this wrapper in a format agnostic fashion. However, I'm a little stumped as to how to do that since there are no actual components defined inside index.js.