### PR TITLE
fix: add PlotlyTransform and PlotlyNullTransform.

### DIFF
--- a/packages/transform-plotly/__tests__/plotly.test.js
+++ b/packages/transform-plotly/__tests__/plotly.test.js
@@ -50,7 +50,7 @@ describe("PlotlyTransform", () => {
 
     expect(instance.shouldComponentUpdate({ data: "" })).toBeTruthy();
     expect(plotly.newPlot).lastCalledWith(
-      instance.el,
+      instance.plotDiv,
       [
         { x: [1999, 2000, 2001, 2002], y: [10, 15, 13, 17], type: "scatter" },
         { x: [1999, 2000, 2001, 2002], y: [16, 5, 11, 9], type: "scatter" }
@@ -73,7 +73,7 @@ describe("PlotlyTransform", () => {
 
     expect(instance.shouldComponentUpdate({ data: "" })).toBeTruthy();
     expect(plotly.newPlot).lastCalledWith(
-      instance.el,
+      instance.plotDiv,
       [
         { x: [1999, 2000, 2001, 2002], y: [10, 15, 13, 17], type: "scatter" },
         { x: [1999, 2000, 2001, 2002], y: [16, 5, 11, 9], type: "scatter" }
@@ -96,8 +96,8 @@ describe("PlotlyTransform", () => {
       data: _.set(_.cloneDeep(figure), ["data", 0, "type"], "bar")
     });
 
-    expect(instance.el.data[0].type).toEqual("bar");
+    expect(instance.plotDiv.data[0].type).toEqual("bar");
 
-    expect(plotly.redraw).lastCalledWith(instance.el);
+    expect(plotly.redraw).lastCalledWith(instance.plotDiv);
   });
 });

--- a/packages/transform-plotly/src/index.js
+++ b/packages/transform-plotly/src/index.js
@@ -11,27 +11,32 @@ type Props = {
 declare class PlotlyHTMLElement extends HTMLElement {
   data: Object;
   layout: Object;
+  newPlot: () => void;
+  redraw: () => void;
 }
 
+const NULL_MIMETYPE = "text/vnd.plotly.v1+html";
 const MIMETYPE = "application/vnd.plotly.v1+json";
 
+/*
+ * As part of the init notebook mode, Plotly sneaks a <script> tag in to load
+ * the plotlyjs lib. We have already loaded this though, so we "handle" the
+ * transform by doing nothing and returning null.
+ */
+const PlotlyNullTransform = () => null;
+PlotlyNullTransform.MIMETYPE = NULL_MIMETYPE;
+
 export class PlotlyTransform extends React.Component<Props> {
-  getFigure: () => Object;
-  el: ?PlotlyHTMLElement;
+  plotDiv: ?PlotlyHTMLElement;
   Plotly: Object;
 
   static MIMETYPE = MIMETYPE;
-
-  constructor(): void {
-    super();
-    this.getFigure = this.getFigure.bind(this);
-  }
 
   componentDidMount(): void {
     // Handle case of either string to be `JSON.parse`d or pure object
     const figure = this.getFigure();
     this.Plotly = require("@nteract/plotly");
-    this.Plotly.newPlot(this.el, figure.data, figure.layout);
+    this.Plotly.newPlot(this.plotDiv, figure.data, figure.layout);
   }
 
   shouldComponentUpdate(nextProps: Props): boolean {
@@ -40,13 +45,17 @@ export class PlotlyTransform extends React.Component<Props> {
 
   componentDidUpdate() {
     const figure = this.getFigure();
-    if (!this.el) return;
-    this.el.data = figure.data;
-    this.el.layout = figure.layout;
-    this.Plotly.redraw(this.el);
+    if (!this.plotDiv) return;
+    this.plotDiv.data = figure.data;
+    this.plotDiv.layout = figure.layout;
+    this.Plotly.redraw(this.plotDiv);
   }
 
-  getFigure(): Object {
+  plotDivRef = (plotDiv: PlotlyHTMLElement | null): void => {
+    this.plotDiv = plotDiv;
+  };
+
+  getFigure = (): Object => {
     const figure = this.props.data;
     if (typeof figure === "string") {
       return JSON.parse(figure);
@@ -58,7 +67,7 @@ export class PlotlyTransform extends React.Component<Props> {
       return cloneDeep(figure);
     }
     return figure;
-  }
+  };
 
   render(): ?React$Element<any> {
     const { layout } = this.getFigure();
@@ -66,15 +75,9 @@ export class PlotlyTransform extends React.Component<Props> {
     if (layout && layout.height && !layout.autosize) {
       style.height = layout.height;
     }
-    return (
-      <div
-        style={style}
-        ref={el => {
-          this.el = el;
-        }}
-      />
-    );
+    return <div ref={this.plotDivRef} style={style} />;
   }
 }
 
+export { PlotlyNullTransform };
 export default PlotlyTransform;

--- a/packages/transforms-full/src/index.js
+++ b/packages/transforms-full/src/index.js
@@ -2,7 +2,9 @@
  * Thus begins our path for custom mimetypes and future extensions
  */
 
-import PlotlyTransform from "@nteract/transform-plotly";
+import PlotlyTransform, {
+  PlotlyNullTransform
+} from "@nteract/transform-plotly";
 import GeoJSONTransform from "@nteract/transform-geojson";
 
 import ModelDebug from "@nteract/transform-model-debug";
@@ -21,6 +23,7 @@ import {
 const additionalTransforms = [
   DataResourceTransform,
   ModelDebug,
+  PlotlyNullTransform,
   PlotlyTransform,
   GeoJSONTransform,
   VegaLite,


### PR DESCRIPTION
The PlotlyNullTransform is our sneaky way of ignoring a Plotly HTML
MIMETYPE. When in offline mode, the plotly.py library attempts to do
two things:

1. On init_notebook_mode, it attempts to load in PlotlyJS. Instead we
   want to do nothing in this case.
2. On `iplot`, it attempts to run a <script> that makes a plot. Instead
   we want to handle the raw JSON string.

For the second case, we have an `application/*` MIMETYPE that we can
use, however, for the first case, we basically register the MIMETYPE so
that we can later ignore it.
