### PR TITLE
create a starter storybook setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/nteract/nteract",
   "scripts": {
     "postinstall": "npm run lerna",
+    "storybook": "lerna run storybook --scope @nteract/core",
     "start": "lerna run start --scope nteract --stream",
     "spawn": "lerna run spawn --scope nteract",
     "lint": "eslint .",

--- a/packages/core/.storybook/config.js
+++ b/packages/core/.storybook/config.js
@@ -1,0 +1,8 @@
+import { configure } from "@storybook/react";
+
+function loadStories() {
+  require("../stories/index.js");
+  // You can require as many stories as you need.
+}
+
+configure(loadStories, module);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "storybook": "start-storybook -p 9001 -c .storybook"
   },
   "dependencies": {
     "@nteract/commutable": "^2.1.2",
@@ -33,5 +34,8 @@
   },
   "keywords": ["nteract", "ohgodamonomoduleinamonorepo"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "@storybook/react": "^3.2.14"
+  }
 }

--- a/packages/core/stories/index.js
+++ b/packages/core/stories/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import Inputs from "../src/components/cell/inputs";
+
+storiesOf("InputCounter", module)
+  .add("running", () => <Inputs running />)
+  .add("no execution yet", () => <Inputs />)
+  .add("execution #10", () => <Inputs executionCount={10} />);


### PR DESCRIPTION
This starts off a storybook setup for us, starting with the input component. Since our styles are still coupled to CSS files that exist only in the desktop app, it's time to start migrating them into here.

My primary thinking for this is that we'll use inline styling via `styled-jsx`, accepting CSS variables to control what it looks like.

/cc @klebba 