### PR TITLE
[wip] transition to yarn workspaces

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,8 @@
   "lerna": "2.1.2",
   "packages": ["packages/*", "packages/nbextension/nteract_on_jupyter"],
   "version": "independent",
-  "npmClient": "npm",
+  "npmClient": "yarn",
+  "useWorkspaces": true,
   "commands": {
     "publish": {
       "ignore": [

--- a/package.json
+++ b/package.json
@@ -135,5 +135,7 @@
     "url-loader": "^0.6.1",
     "webpack": "^3.5.5",
     "webpack-merge": "^4.1.0"
-  }
+  },
+  "private": true,
+  "workspaces": ["packages/*", "packages/nbextension/nteract_on_jupyter"]
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,13 +4,7 @@
   "description": "Interactive literate coding notebook!",
   "main": "./lib/webpacked-main.js",
   "repository": "nteract/nteract",
-  "keywords": [
-    "jupyter",
-    "electron",
-    "notebook",
-    "nteract",
-    "data"
-  ],
+  "keywords": ["jupyter", "electron", "notebook", "nteract", "data"],
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -19,7 +13,8 @@
   "homepage": "https://nteract.io",
   "scripts": {
     "clean": "rimraf lib dist",
-    "postinstall": "electron-builder install-app-deps",
+    "postinstall":
+      "ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 electron-builder install-app-deps",
     "prestart": "npm run build",
     "start": "npm run spawn",
     "spawn": "cross-env NODE_ENV=development electron .",
@@ -31,15 +26,23 @@
     "pretest:functional": "npm run build",
     "sublaunch": "electron-mocha --compilers js:babel-core/register",
     "test:functional:launch": "npm run sublaunch -- test/main/launch.js",
-    "test:functional:launchNewNotebook": "npm run sublaunch -- test/main/launchNewNotebook.js",
-    "test:functional": "npm run test:functional:launch && npm run test:functional:launchNewNotebook",
-    "test:unit": "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
-    "test:debug": "mocha --debug-brk --inspect -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
-    "test:unit:individual": "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles",
+    "test:functional:launchNewNotebook":
+      "npm run sublaunch -- test/main/launchNewNotebook.js",
+    "test:functional":
+      "npm run test:functional:launch && npm run test:functional:launchNewNotebook",
+    "test:unit":
+      "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
+    "test:debug":
+      "mocha --debug-brk --inspect -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
+    "test:unit:individual":
+      "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles",
     "test:watch": "watch 'npm run test' test/",
-    "pack": "npm run clean && webpack --config webpack.prod.js && electron-builder --dir",
-    "dist": "npm run clean && webpack --config webpack.prod.js && electron-builder",
-    "publish": "npm run clean && webpack --config webpack.prod.js && electron-builder -p always",
+    "pack":
+      "npm run clean && webpack --config webpack.prod.js && ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 electron-builder --dir",
+    "dist":
+      "npm run clean && webpack --config webpack.prod.js && ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 electron-builder",
+    "publish":
+      "npm run clean && webpack --config webpack.prod.js && ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=1 electron-builder -p always",
     "dist:all": "npm run dist -- -mlw",
     "publish:all": "npm run publish -- -mlw"
   },
@@ -57,28 +60,18 @@
     },
     "mac": {
       "category": "public.app-category.developer-tools",
-      "target": [
-        "dmg",
-        "zip"
-      ]
+      "target": ["dmg", "zip"]
     },
     "nsis": {
       "perMachine": true,
       "oneClick": false
     },
     "win": {
-      "target": [
-        "nsis",
-        "zip"
-      ]
+      "target": ["nsis", "zip"]
     },
     "linux": {
       "maintainer": "nteract contributors <jupyter@googlegroups.com>",
-      "target": [
-        "deb",
-        "AppImage",
-        "tar.gz"
-      ],
+      "target": ["deb", "AppImage", "tar.gz"],
       "desktop": {
         "Comment": "Interactive literate coding notebook",
         "Exec": "/opt/nteract/nteract %U",
@@ -94,23 +87,12 @@
       "category": "Science",
       "packageCategory": "editors"
     },
-    "files": [
-      "lib/*.js",
-      "lib/*.css",
-      "lib/*.woff",
-      "lib/*.woff2",
-      "static"
-    ],
-    "extraResources": [
-      "bin",
-      "example-notebooks"
-    ],
+    "files": ["lib/*.js", "lib/*.css", "lib/*.woff", "lib/*.woff2", "static"],
+    "extraResources": ["bin", "example-notebooks"],
     "npmSkipBuildFromSource": true
   },
   "jest": {
-    "setupFiles": [
-      "./scripts/mockument"
-    ]
+    "setupFiles": ["./scripts/mockument"]
   },
   "dependencies": {
     "github": "^9.0.0",


### PR DESCRIPTION
Closes #2039 

@lgeiger, check this out when you have a chance -- I'm running into issues and unsure what to do next.

<details>
<summary>Failed run, expand me</summary>

```
$ yarn
yarn install v1.3.2
info No lockfile found.
[1/4] 🔍  Resolving packages...
warning babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
warning sinon > build > wrench@1.3.9: wrench.js is deprecated! You should check out fs-extra (https://github.com/jprichardson/node-fs-extra) for any operations you were using wrench for. Thanks for all the usage over the years.
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > rx-jupyter > codecov > request > node-uuid@1.4.8: Use uuid module instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > feature-filter@2.2.0: This package has been merged into the 'mapbox-gl-style-spec' package
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > mapbox-gl-function@1.3.0: This package has been merged with the 'mapbox-gl-style-spec' package
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > point-geometry@0.0.0: This module has moved: please install @mapbox/point-geometry instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > shelf-pack@1.1.0: This module is now under the @mapbox namespace: install @mapbox/shelf-pack instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > unitbezier@0.0.0: This module has moved: switch to @mapbox/unitbezier
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > vector-tile@1.3.0: This module has moved: please install @mapbox/vector-tile instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > vector-tile > point-geometry@0.0.0: This module has moved: please install @mapbox/point-geometry instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > vt-pbf > vector-tile@1.3.0: This module has moved: please install @mapbox/vector-tile instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > whoots-js@2.1.0: This module is now under the @mapbox namespace: install @mapbox/whoots-js instead
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract > electron > electron-download > nugget > progress-stream > through2 > xtend > object-keys@0.4.0:
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/notebook-preview-demo > next > glob-promise > semantic-release > npmconf@2.1.2: this package has been reintegrated into npm and is now out of date with respect to npm
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > color-rgba > color-space > husl@5.0.3: Project renamed to HSLuv
warning workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > plotly.js > mapbox-gl > geojson-rewind > geojson-area@0.1.0: This module is now under the @mapbox namespace: install @mapbox/geojson-area instead
[2/4] 🚚  Fetching packages...
info 7zip-bin-win@2.1.1: The platform "darwin" is incompatible with this module.
info "7zip-bin-win@2.1.1" is an optional dependency and failed compatibility check. Excluding it from installation.
info 7zip-bin-linux@1.1.0: The platform "darwin" is incompatible with this module.
info "7zip-bin-linux@1.1.0" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] 🔗  Linking dependencies...
warning " > babel-loader@7.1.2" has unmet peer dependency "babel-core@6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc".
warning " > chai-immutable@1.6.0" has incorrect peer dependency "chai@>= 2.0.0 < 4".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > fs-observable@2.0.1" has unmet peer dependency "rxjs@^5.5.0".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/core > commonmark-react-renderer@4.3.3" has incorrect peer dependency "commonmark@^0.27.0 || ^0.26.0 || ^0.24.0".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/core > react-redux@5.0.6" has unmet peer dependency "redux@^2.0.0 || ^3.0.0".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/core > react-simple-dropdown@3.2.0" has incorrect peer dependency "react@0.14.x || 15.x".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/core > react-simple-dropdown@3.2.0" has incorrect peer dependency "react-dom@0.14.x || 15.x".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract > redux-observable@0.16.0" has unmet peer dependency "rxjs@^5.0.0".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > next@3.2.2" has incorrect peer dependency "react@^15.5.4".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > next@3.2.2" has incorrect peer dependency "react-dom@^15.5.4".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/transforms > react-json-tree@0.10.9" has incorrect peer dependency "react@^15.0.0".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/transforms > react-json-tree@0.10.9" has incorrect peer dependency "react-dom@^15.0.0".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > @nteract/notebook-preview-demo > next > glob-promise@3.2.0" has unmet peer dependency "glob@*".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > next > glob-promise@3.1.0" has unmet peer dependency "glob@*".
warning "workspace-aggregator-bed363b4-48f1-45c4-bc33-7009207579ff > nteract-on-jupyter > next > styled-jsx@1.0.11" has incorrect peer dependency "react@15.x.x".
[4/4] 📃  Building fresh packages...
[-/9] ⠠ waiting...
[-/9] ⠠ waiting...
[-/9] ⠠ waiting...
[-/9] ⠠ waiting...
error /Users/kylek/code/src/github.com/nteract/nteract/node_modules/nteract: Command failed.
Exit code: 255
Command: electron-builder install-app-deps
Arguments:
Directory: /Users/kylek/code/src/github.com/nteract/nteract/node_modules/nteract
Output:
electron-builder 19.45.0
Error: Unresolved node modules: follow-redirects, https-proxy-agent, mime, netrc, jp-kernel, zeromq, lodash
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/packageDependencies.ts:112:19
From previous event:
    at Collector.resolveUnresolvedHoisted (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/util/packageDependencies.js:208:11)
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/packageDependencies.ts:88:18
    at Generator.next (<anonymous>)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
From previous event:
    at Collector.collect (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/util/packageDependencies.js:156:11)
    at computeDependencies (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/packageDependencies.ts:51:26)
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/packageDependencies.ts:46:28
    at Generator.next (<anonymous>)
From previous event:
    at getProductionDependencies (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/util/packageDependencies.js:29:21)
    at Lazy [as creator] (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/packageDependencies.ts:40:25)
    at Lazy.get value [as value] (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/lazy-val/src/main.ts:18:23)
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/yarn.ts:123:65
    at Generator.next (<anonymous>)
From previous event:
    at rebuild (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/util/yarn.js:94:22)
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/util/yarn.ts:21:11
    at Generator.next (<anonymous>)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
From previous event:
    at installOrRebuild (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/util/yarn.js:32:21)
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/src/cli/install-app-deps.ts:58:42
    at Generator.next (<anonymous>)
From previous event:
    at installAppDeps (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/cli/install-app-deps.js:51:21)
    at then (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/cli/cli.js:127:128)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
From previous event:
    at Object.args [as handler] (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/cli/cli.js:127:117)
    at Object.runCommand (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/node_modules/yargs/lib/command.js:228:22)
    at Object.parseArgs [as _parseArgs] (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/node_modules/yargs/yargs.js:1013:30)
    at Object.get [as argv] (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/node_modules/yargs/yargs.js:957:21)
    at Object.<anonymous> (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder/out/cli/cli.js:123:441)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```

</details>