### PR TITLE
create a showcase for components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ packages/desktop/bin/nteract-env
 
 # Ignore lerna lock
 packages/*/yarn.lock
+
+.next

--- a/package.json
+++ b/package.json
@@ -6,13 +6,7 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract.git"
   },
-  "keywords": [
-    "jupyter",
-    "electron",
-    "notebook",
-    "nteract",
-    "data"
-  ],
+  "keywords": ["jupyter", "electron", "notebook", "nteract", "data"],
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -31,7 +25,8 @@
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "lerna run build --parallel",
     "build:packages:watch": "lerna run build:lib:watch --parallel",
-    "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
+    "build:icon":
+      "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
     "build:docs": "esdoc -c esdoc.json",
     "test": "npm run test:unit && npm run test:lint",
     "test:conformance": "node scripts/conformance.js",
@@ -44,7 +39,8 @@
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",
     "precommit": "lint-staged",
-    "prettier": "prettier --write '**/*.{js,json}' '!**/{lib,.git,flow-typed}/**'",
+    "prettier":
+      "prettier --write '**/*.{js,json}' '!**/{lib,.git,flow-typed}/**'",
     "dist": "lerna run dist --scope nteract --stream",
     "pack": "lerna run pack --scope nteract --stream",
     "publish": "lerna run publish --scope nteract --stream",
@@ -52,28 +48,16 @@
     "publish:all": "lerna run publish:all --scope nteract --stream"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "./scripts/mockument"
-    ],
+    "setupFiles": ["raf/polyfill", "./scripts/mockument"],
     "moduleNameMapper": {
       "uuid": "<rootDir>/packages/commutable/node_modules/uuid/",
       "\\.css$": "<rootDir>/scripts/noop-module.js"
     },
-    "coveragePathIgnorePatterns": [
-      "<rootDir>/scripts",
-      "/node_modules/"
-    ]
+    "coveragePathIgnorePatterns": ["<rootDir>/scripts", "/node_modules/"]
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.json,!package.json": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.js": ["prettier --write", "git add"],
+    "*.json,!package.json": ["prettier --write", "git add"]
   },
   "dependencies": {
     "immutable": "^3.8.1",

--- a/packages/showcase/.babelrc
+++ b/packages/showcase/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": ["transform-flow-strip-types"]
+}

--- a/packages/showcase/.npmrc
+++ b/packages/showcase/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/packages/showcase/next.config.js
+++ b/packages/showcase/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  webpack: (config, { buildId, dev }) => {
+    config.module.rules.push({
+      test: /\.js$/,
+      exclude: /node_modules/,
+      loader: "babel-loader"
+    });
+
+    config.resolve = Object.assign({}, config.resolve, {
+      mainFields: ["nteractDesktop", "es2015", "jsnext:main", "module", "main"]
+    });
+    return config;
+  }
+};

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nteract/showcase",
+  "version": "0.0.1-beta",
+  "description": "showcase of nteract components",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@nteract/transforms": "^3.0.2",
+    "next": "^4.1.4",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-markdown": "^2.5.0",
+    "react-syntax-highlighter": "^5.8.0",
+    "@nteract/core": "0.0.1-beta",
+
+    "@nteract/commutable": "^2.1.2",
+    "@nteract/display-area": "^3.0.2",
+    "@nteract/editor": "^3.0.2",
+    "@nteract/transforms-full": "^3.0.2",
+
+    "react-redux": "^5.0.5",
+    "rxjs": "^5.5.0",
+    "uuid": "^3.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": ["nteract", "ohgodamonomoduleinamonorepo"],
+  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "license": "BSD-3-Clause"
+}

--- a/packages/showcase/pages/index.js
+++ b/packages/showcase/pages/index.js
@@ -1,0 +1,48 @@
+import React from "react";
+
+import {
+  richestMimetype,
+  standardDisplayOrder,
+  standardTransforms
+} from "@nteract/transforms";
+
+// Jupyter style MIME bundle
+const bundle = {
+  "text/plain": "This is great",
+  "image/png": "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+  "application/vdom.v1+json": {
+    tagName: "h1",
+    children: "raw data ➡ rendered view",
+    attributes: {}
+  }
+};
+
+// Find out which mimetype is the richest
+const mimetype = richestMimetype(
+  bundle,
+  standardDisplayOrder,
+  standardTransforms
+);
+
+// Get the matching React.Component for that mimetype
+let Transform = standardTransforms[mimetype];
+
+export default () => {
+  return (
+    <div className="root">
+      <h1>Showcasing nteract components</h1>
+
+      <hr />
+
+      <h2>
+        <pre>@nteract/transforms</pre>
+      </h2>
+      <Transform data={bundle[mimetype]} />
+
+      <style jsx>{`
+        font-family: "Source Sans Pro", Helvetica Neue, Helvetica, Arial,
+          sans-serif;
+      `}</style>
+    </div>
+  );
+};


### PR DESCRIPTION
Instead of #2042, I've created a next app that uses our webpack and babelrc config to make it easy to showcase components. You'll be able to make new "feature" pages while editing the original source components (without having to run a build step yourself).