### PR TITLE
create an `npm run showcase` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "postinstall": "npm run lerna",
     "start": "lerna run start --scope nteract --stream",
     "spawn": "lerna run spawn --scope nteract",
+    "showcase": "lerna run dev --scope @nteract/showcase --stream",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lerna": "lerna bootstrap",


### PR DESCRIPTION
This makes it nice and easy to kick off the `showcase` app to work with our components directly.

```
$ npm run showcase

> nteract-monorepo@0.0.0 showcase /Users/kylek/code/src/github.com/nteract/nteract
> lerna run dev --scope @nteract/showcase --stream

lerna info version 2.5.1
lerna info versioning independent
lerna info scope @nteract/showcase
@nteract/showcase: > @nteract/showcase@0.0.1-beta dev /Users/kylek/code/src/github.com/nteract/nteract/packages/showcase
@nteract/showcase: > next
@nteract/showcase: > Using external babel configuration
@nteract/showcase: > Location: "/Users/kylek/code/src/github.com/nteract/nteract/packages/showcase/.babelrc"
@nteract/showcase: > Using "webpack" config function defined in next.config.js.
@nteract/showcase:  DONE  Compiled successfully in 1978ms22:25:04
@nteract/showcase: > Ready on http://localhost:3000
@nteract/showcase: > Building page: /core
```