### PR TITLE
relocate status bar styling to component

### DIFF
--- a/packages/core/src/components/status-bar.js
+++ b/packages/core/src/components/status-bar.js
@@ -38,6 +38,28 @@ export default class StatusBar extends React.Component<Props> {
             {name} | {this.props.executionState}
           </p>
         </span>
+        <style jsx>{`
+          .status-bar {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            font-size: 12px;
+            line-height: 0.5em;
+            background: var(--status-bar);
+            z-index: 99;
+          }
+
+          .pull-right {
+            float: right;
+            padding-right: 10px;
+          }
+
+          .pull-left {
+            display: block;
+            padding-left: 10px;
+          }
+        `}</style>
       </div>
     );
   }

--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -421,29 +421,6 @@ li.CodeMirror-hint-active {
   display: inline-block;
   opacity: 1;
 }
-
-/* Styling for status bar */
-.pull-right {
-  float: right;
-  padding-right: 10px;
-}
-
-.pull-left {
-  display: block;
-  padding-left: 10px;
-}
-
-.status-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  font-size: 12px;
-  line-height: 0.5em;
-  background: var(--status-bar);
-  z-index: 99;
-}
-
 /*Tooltip styling*/
 .bt {
   float: right;


### PR DESCRIPTION
This merely relocates the styling for the status bar from `main.css` into the component itself. I opted not to change anything, even though we would someday want to be able to display this component in the showcase without `position: fixed`, `bottom: 0`, etc.