### PR TITLE
Cleanup core/components/notebook

### DIFF
--- a/packages/core/__tests__/components/notebook-spec.js
+++ b/packages/core/__tests__/components/notebook-spec.js
@@ -26,7 +26,8 @@ describe("Notebook", () => {
   test("accepts an Immutable.List of cells", () => {
     const component = shallow(
       <Notebook
-        notebook={dummyCommutable}
+        cellOrder={dummyCommutable.get("cellOrder")}
+        cellMap={dummyCommutable.get("cellMap")}
         transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
         cellPagers={new Immutable.Map()}
         cellStatuses={new Immutable.Map()}
@@ -42,14 +43,13 @@ describe("Notebook", () => {
 
   describe("getLanguageMode", () => {
     test("determines the right language from the notebook metadata", () => {
-      const lang = getLanguageMode(dummyCommutable);
+      const lang = getLanguageMode(dummyCommutable.get("metadata"));
       expect(lang).toBe("ipython");
 
       const lang2 = getLanguageMode(
-        dummyCommutable.setIn(
-          ["metadata", "language_info", "codemirror_mode", "name"],
-          "r"
-        )
+        dummyCommutable
+          .setIn(["metadata", "language_info", "codemirror_mode", "name"], "r")
+          .get("metadata")
       );
       expect(lang2).toBe("r");
     });
@@ -65,7 +65,8 @@ describe("Notebook", () => {
 
       const component = shallow(
         <Notebook
-          notebook={dummyCommutable}
+          cellOrder={dummyCommutable.get("cellOrder")}
+          cellMap={dummyCommutable.get("cellMap")}
           transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}
@@ -99,7 +100,8 @@ describe("Notebook", () => {
 
       const component = shallow(
         <Notebook
-          notebook={dummyCommutable}
+          cellOrder={dummyCommutable.get("cellOrder")}
+          cellMap={dummyCommutable.get("cellMap")}
           transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}
@@ -133,7 +135,8 @@ describe("Notebook", () => {
 
       const component = shallow(
         <Notebook
-          notebook={dummyCommutable}
+          cellOrder={dummyCommutable.get("cellOrder")}
+          cellMap={dummyCommutable.get("cellMap")}
           transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}

--- a/packages/core/src/components/cell/cell.js
+++ b/packages/core/src/components/cell/cell.js
@@ -235,6 +235,16 @@ export class ConnectedCell extends React.PureComponent<CellProps, *> {
           <Toolbar type={cellType} cell={cell} id={this.props.id} />
           {element}
         </div>
+        <style jsx>{`
+          /*
+           * Show the cell-toolbar-mask if hovering on cell,
+           * or cell was the last clicked (has .focused class).
+           */
+          :global(.cell:hover .cell-toolbar-mask),
+          :global(.cell.focused .cell-toolbar-mask) {
+            display: block;
+          }
+        `}</style>
       </Cell>
     );
   }

--- a/packages/core/src/components/draggable-cell.js
+++ b/packages/core/src/components/draggable-cell.js
@@ -6,9 +6,11 @@ import * as React from "react";
 import { DragSource, DropTarget } from "react-dnd";
 
 /**
-  Basically just
+  The cell drag preview image is just a little stylized version of
 
    [ ]
+
+  It matches nteract's default light theme
 
  */
 const cellDragPreviewImage = [
@@ -42,7 +44,7 @@ type Props = {|
   isDragging: boolean,
   isOver: boolean,
   moveCell: (source: string, dest: string, above: boolean) => Object,
-  children: React.Node
+  children: React.Element<any>
 |};
 
 type State = {|
@@ -143,7 +145,7 @@ class DraggableCellView extends React.PureComponent<Props, State> {
             role="presentation"
           />
         )}
-        <div>{this.props.children}</div>
+        {this.props.children}
         <style jsx>{`
           .draggable-cell {
             position: relative;

--- a/packages/core/src/components/notebook.js
+++ b/packages/core/src/components/notebook.js
@@ -308,7 +308,21 @@ export class Notebook extends React.PureComponent<Props> {
             padding-top: 10px;
             padding-left: 10px;
             padding-right: 10px;
-            padding-bottom: calc(100vh - 110px);
+          }
+
+          @media not print {
+            .cells {
+              padding-bottom: calc(100vh - 110px);
+            }
+          }
+        `}</style>
+        <style jsx global>{`
+          /* Show the cell-toolbar-mask if hovering on cell,
+             or cell was the last clicked (has .focused class). */
+
+          .cell:hover .cell-toolbar-mask,
+          .cell.focused .cell-toolbar-mask {
+            display: block;
           }
         `}</style>
         <link

--- a/packages/core/src/components/notebook.js
+++ b/packages/core/src/components/notebook.js
@@ -56,7 +56,7 @@ const PinnedPlaceHolderCell = () => (
         text-align: center;
         color: var(--main-fg-color);
         padding: 10px;
-        opacity: var(--cell-placeholder-opacity);
+        opacity: var(--cell-placeholder-opacity, 0.3);
       }
 
       .octicon {
@@ -308,21 +308,6 @@ export class Notebook extends React.PureComponent<Props> {
             padding-top: 10px;
             padding-left: 10px;
             padding-right: 10px;
-          }
-
-          @media not print {
-            .cells {
-              padding-bottom: calc(100vh - 110px);
-            }
-          }
-        `}</style>
-        <style jsx global>{`
-          /* Show the cell-toolbar-mask if hovering on cell,
-             or cell was the last clicked (has .focused class). */
-
-          .cell:hover .cell-toolbar-mask,
-          .cell.focused .cell-toolbar-mask {
-            display: block;
           }
         `}</style>
         <link

--- a/packages/core/src/components/notebook.js
+++ b/packages/core/src/components/notebook.js
@@ -291,13 +291,12 @@ export class Notebook extends React.PureComponent<Props> {
   render(): ?React$Element<any> {
     return (
       <div>
-        <div className="notebook">
-          {this.renderStickyCells()}
-          <div className="cells">
-            <CellCreator id={this.props.cellOrder.get(0, null)} above />
-            {/* Actual cells! */}
-            {this.props.cellOrder.map(this.createCellElement)}
-          </div>
+        {/* Sticky cells */}
+        {this.renderStickyCells()}
+        {/* Actual cells! */}
+        <div className="cells">
+          <CellCreator id={this.props.cellOrder.get(0, null)} above />
+          {this.props.cellOrder.map(this.createCellElement)}
         </div>
         <StatusBar
           lastSaved={this.props.lastSaved}

--- a/packages/core/src/components/notebook.js
+++ b/packages/core/src/components/notebook.js
@@ -98,7 +98,6 @@ const mapStateToProps = (state: Object) => ({
 
 export class Notebook extends React.PureComponent<Props> {
   createCellElement: (s: string) => ?React$Element<any>;
-  createStickyCellElement: (s: string) => ?React$Element<any>;
   keyDown: (e: KeyboardEvent) => void;
   moveCell: (source: string, dest: string, above: boolean) => void;
   selectCell: (id: string) => void;
@@ -119,7 +118,6 @@ export class Notebook extends React.PureComponent<Props> {
   constructor(): void {
     super();
     this.createCellElement = this.createCellElement.bind(this);
-    this.createStickyCellElement = this.createStickyCellElement.bind(this);
     this.keyDown = this.keyDown.bind(this);
     this.moveCell = this.moveCell.bind(this);
     this.selectCell = this.selectCell.bind(this);
@@ -192,7 +190,6 @@ export class Notebook extends React.PureComponent<Props> {
 
   renderStickyCells(): React.Node {
     const cellOrder = this.props.cellOrder;
-    // TODO: This could be part of map state to props
     const stickyCells = cellOrder.filter(id => this.props.stickyCells.get(id));
 
     return (
@@ -209,12 +206,20 @@ export class Notebook extends React.PureComponent<Props> {
             this.stickyCellContainer = ref;
           }}
         >
-          {stickyCells.map(this.createStickyCellElement)}
+          {stickyCells.map(id => (
+            <div key={`sticky-cell-container-${id}`} className="sticky-cell">
+              {this.renderCell(id)}
+            </div>
+          ))}
         </div>
         <style jsx>{`
+          .sticky-cell {
+            padding-right: 20px;
+          }
+
           .sticky-cell-container {
-            background: var(--main-bg-color);
-            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+            background: var(--main-bg-color, white);
+            border-bottom: dashed var(--primary-border, #cbcbcb) 1px;
 
             top: 0px;
             position: fixed;
@@ -222,8 +227,11 @@ export class Notebook extends React.PureComponent<Props> {
             width: 100%;
             max-height: 50%;
 
+            padding-left: 10px;
+            padding-right: 10px;
             padding-bottom: 10px;
             padding-top: 20px;
+
             overflow: auto;
           }
 
@@ -280,28 +288,30 @@ export class Notebook extends React.PureComponent<Props> {
     );
   }
 
-  createStickyCellElement(id: string): ?React$Element<any> {
-    return (
-      <div className="cell-container" key={`cell-container-${id}`}>
-        {this.renderCell(id)}
-      </div>
-    );
-  }
-
   render(): ?React$Element<any> {
     return (
       <div>
         <div className="notebook">
           {this.renderStickyCells()}
-          <CellCreator id={this.props.cellOrder.get(0, null)} above />
-          {/* Actual cells! */}
-          {this.props.cellOrder.map(this.createCellElement)}
+          <div className="cells">
+            <CellCreator id={this.props.cellOrder.get(0, null)} above />
+            {/* Actual cells! */}
+            {this.props.cellOrder.map(this.createCellElement)}
+          </div>
         </div>
         <StatusBar
           lastSaved={this.props.lastSaved}
           kernelSpecDisplayName={this.props.kernelSpecDisplayName}
           executionState={this.props.executionState}
         />
+        <style jsx>{`
+          .cells {
+            padding-top: 10px;
+            padding-left: 10px;
+            padding-right: 10px;
+            padding-bottom: calc(100vh - 110px);
+          }
+        `}</style>
         <link
           rel="stylesheet"
           // TODO: Tear this out or switch to styled-jsx for the inline setting here

--- a/packages/core/src/components/status-bar.js
+++ b/packages/core/src/components/status-bar.js
@@ -3,7 +3,6 @@ import React from "react";
 import distanceInWordsToNow from "date-fns/distance_in_words_to_now";
 
 type Props = {
-  notebook: any,
   lastSaved: Date,
   kernelSpecDisplayName: string,
   executionState: string
@@ -12,7 +11,6 @@ type Props = {
 export default class StatusBar extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     if (
-      this.props.notebook !== nextProps.notebook ||
       this.props.lastSaved !== nextProps.lastSaved ||
       this.props.executionState !== nextProps.executionState
     ) {

--- a/packages/desktop/.babelrc
+++ b/packages/desktop/.babelrc
@@ -3,6 +3,7 @@
     "test": {
       "presets": ["es2015", "react"],
       "plugins": [
+        "styled-jsx/babel",
         "transform-class-properties",
         "transform-flow-strip-types",
         "transform-object-rest-spread"
@@ -12,6 +13,7 @@
   "presets": [["env", { "targets": { "electron": "1.7" } }], "react"],
   "plugins": [
     "lodash",
+    "styled-jsx/babel",
     "transform-class-properties",
     "transform-flow-strip-types",
     "transform-object-rest-spread"

--- a/packages/desktop/__tests__/renderer/__snapshots__/index-spec.js.snap
+++ b/packages/desktop/__tests__/renderer/__snapshots__/index-spec.js.snap
@@ -12,7 +12,9 @@ exports[`App renders app 1`] = `
     }
   }
 >
-  <div>
+  <div
+    className="jsx-825914725 jsx-825914725"
+  >
     <Connect(DragDropContext(Notebook))
       displayOrder={
         Array [
@@ -63,6 +65,10 @@ exports[`App renders app 1`] = `
       allowHTML={false}
       noAnimation={false}
       style={Object {}}
+    />
+    <JSXStyle
+      css="body{font-family:\\"Source Sans Pro\\";font-size:16px;line-height:22px;background-color:var(--main-bg-color);color:var(--main-fg-color);line-height:1.3 !important;}#app{padding-top:20px;}@-webkit-keyframes fadeOut{from{opacity:1;}to{opacity:0;}}@keyframes fadeOut{from{opacity:1;}to{opacity:0;}}div#loading{-webkit-animation-name:fadeOut;animation-name:fadeOut;-webkit-animation-duration:0.25s;animation-duration:0.25s;-webkit-animation-fill-mode:forwards;animation-fill-mode:forwards;}"
+      styleId="825914725"
     />
   </div>
 </Provider>

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -147,6 +147,7 @@
     "sinon-chai": "^2.10.0",
     "spawn-rx": "^2.0.11",
     "spawnteract": "^4.0.0",
+    "styled-jsx": "^2.1.3",
     "watch": "^1.0.0",
     "yargs": "^8.0.1"
   }

--- a/packages/desktop/src/notebook/index.js
+++ b/packages/desktop/src/notebook/index.js
@@ -67,6 +67,78 @@ export default class App extends React.PureComponent<Object, Object> {
               this.notificationSystem = notificationSystem;
             }}
           />
+          <style jsx global>{`
+            body {
+              font-family: "Source Sans Pro";
+              font-size: 16px;
+              line-height: 22px;
+              background-color: var(--main-bg-color);
+              color: var(--main-fg-color);
+              /* All the old theme setups declared this, putting it back for consistency */
+              line-height: 1.3 !important;
+            }
+
+            /**
+             * TODO: Bring these styles into our nextgen components directly as part of
+             *       their inline styled-jsx
+             */
+            @media print {
+              * {
+                box-shadow: none !important;
+              }
+              .status-bar {
+                display: none !important;
+              }
+              .notifications-wrapper {
+                display: none !important;
+              }
+              .cell-toolbar {
+                display: none !important;
+              }
+              .cell-creator {
+                display: none !important;
+              }
+              .cell.focused {
+                border: none;
+                background: var(--cell-bg) !important;
+              }
+              .cell:focus .prompt,
+              .cell.focused .prompt {
+                background: var(--pager-bg) !important;
+              }
+              .draggable-cell {
+                padding: 0px !important;
+              }
+              .cell-drag-handle {
+                display: none !important;
+              }
+              .cell-toolbar-mask {
+                display: none !important;
+              }
+              .invisible {
+                display: none !important;
+              }
+            }
+
+            #app {
+              padding-top: 20px;
+            }
+
+            @keyframes fadeOut {
+              from {
+                opacity: 1;
+              }
+              to {
+                opacity: 0;
+              }
+            }
+
+            div#loading {
+              animation-name: fadeOut;
+              animation-duration: 0.25s;
+              animation-fill-mode: forwards;
+            }
+          `}</style>
         </div>
       </Provider>
     );

--- a/packages/desktop/src/notebook/index.js
+++ b/packages/desktop/src/notebook/index.js
@@ -78,48 +78,6 @@ export default class App extends React.PureComponent<Object, Object> {
               line-height: 1.3 !important;
             }
 
-            /**
-             * TODO: Bring these styles into our nextgen components directly as part of
-             *       their inline styled-jsx
-             */
-            @media print {
-              * {
-                box-shadow: none !important;
-              }
-              .status-bar {
-                display: none !important;
-              }
-              .notifications-wrapper {
-                display: none !important;
-              }
-              .cell-toolbar {
-                display: none !important;
-              }
-              .cell-creator {
-                display: none !important;
-              }
-              .cell.focused {
-                border: none;
-                background: var(--cell-bg) !important;
-              }
-              .cell:focus .prompt,
-              .cell.focused .prompt {
-                background: var(--pager-bg) !important;
-              }
-              .draggable-cell {
-                padding: 0px !important;
-              }
-              .cell-drag-handle {
-                display: none !important;
-              }
-              .cell-toolbar-mask {
-                display: none !important;
-              }
-              .invisible {
-                display: none !important;
-              }
-            }
-
             #app {
               padding-top: 20px;
             }

--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -196,32 +196,6 @@ body {
   display: block;
 }
 
-.cell-placeholder {
-  text-align: center;
-  color: var(--main-fg-color);
-  padding: 10px;
-  opacity: var(--cell-placeholder-opacity);
-}
-
-.sticky-cell-container {
-  background: var(--main-bg-color);
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
-
-  top: 0px;
-  position: fixed;
-  z-index: 300;
-  width: 100%;
-  max-height: 50%;
-
-  padding-bottom: 10px;
-  padding-top: 20px;
-  overflow: auto;
-}
-
-.sticky-cell-container:empty {
-  display: none;
-}
-
 /** TODO: Recover this in the styling -- this likely relates to pinned cells */
 .cell .input-container.invisible {
   height: 34px;

--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -310,6 +310,8 @@ body {
   font-size: 90%;
   font-family: "Source Code Pro", monospace;
 
+  z-index: 9001;
+
   overflow-y: auto;
 }
 

--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -163,26 +163,13 @@ body {
   line-height: 22px;
   background-color: var(--main-bg-color);
   color: var(--main-fg-color);
-}
-
-body {
   /* All the old theme setups declared this, putting it back for consistency */
   line-height: 1.3 !important;
 }
 
-/*
-  Notebook
- */
-
-.notebook {
-  padding-top: 10px;
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
 @media not print {
   .notebook .cell-container:last-child {
-    padding-bottom: calc(100vh - 110px);
+    /*padding-bottom: calc(100vh - 110px);*/
   }
 }
 /*
@@ -194,11 +181,6 @@ body {
 .cell:hover .cell-toolbar-mask,
 .cell.focused .cell-toolbar-mask {
   display: block;
-}
-
-/** TODO: Recover this in the styling -- this likely relates to pinned cells */
-.cell .input-container.invisible {
-  height: 34px;
 }
 
 /*

--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -8,13 +8,6 @@
 @import "../../node_modules/nteract-assets/fonts/source-sans-pro/source-sans-pro.css";
 @import "../../node_modules/nteract-assets/fonts/source-code-pro/source-code-pro.css";
 
-:root {
-  --prompt-width: 50px;
-  --cell-placeholder-opacity: 0.3;
-  --link-color-unvisited: blue;
-  --link-color-visited: var(--link-color-unvisited);
-}
-
 /* completions styles */
 
 .CodeMirror-hint {

--- a/packages/desktop/src/notebook/main.css
+++ b/packages/desktop/src/notebook/main.css
@@ -15,71 +15,6 @@
   --link-color-visited: var(--link-color-unvisited);
 }
 
-/**
- * TODO: Bring these styles into our nextgen components directly as part of
- *       their inline styled-jsx
- */
-@media print {
-  * {
-    box-shadow: none !important;
-  }
-  .status-bar {
-    display: none !important;
-  }
-  .notifications-wrapper {
-    display: none !important;
-  }
-  .cell-toolbar {
-    display: none !important;
-  }
-  .cell-creator {
-    display: none !important;
-  }
-  .cell.focused {
-    border: none;
-    background: var(--cell-bg) !important;
-  }
-  .cell:focus .prompt,
-  .cell.focused .prompt {
-    background: var(--pager-bg) !important;
-  }
-  .draggable-cell {
-    padding: 0px !important;
-  }
-  .cell-drag-handle {
-    display: none !important;
-  }
-  .cell-toolbar-mask {
-    display: none !important;
-  }
-  .invisible {
-    display: none !important;
-  }
-}
-
-#app {
-  padding-top: 20px;
-}
-
-@keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-div#loading {
-  animation-name: fadeOut;
-  animation-duration: 0.25s;
-  animation-fill-mode: forwards;
-}
-
-/*
-  Globals
- */
-
 /* completions styles */
 
 .CodeMirror-hint {
@@ -156,32 +91,6 @@ div#loading {
 }
 
 /* end completion type color and content */
-
-body {
-  font-family: "Source Sans Pro";
-  font-size: 16px;
-  line-height: 22px;
-  background-color: var(--main-bg-color);
-  color: var(--main-fg-color);
-  /* All the old theme setups declared this, putting it back for consistency */
-  line-height: 1.3 !important;
-}
-
-@media not print {
-  .notebook .cell-container:last-child {
-    /*padding-bottom: calc(100vh - 110px);*/
-  }
-}
-/*
-  Cell
- */
-
-/* Show the cell-toolbar-mask if hovering on cell,
-   or cell was the last clicked (has .focused class). */
-.cell:hover .cell-toolbar-mask,
-.cell.focused .cell-toolbar-mask {
-  display: block;
-}
 
 /*
     Codemirror

--- a/packages/desktop/static/index.html
+++ b/packages/desktop/static/index.html
@@ -4,6 +4,55 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../lib/styles.css"/>
     <script type="text/javascript" src="../node_modules/mathjax-electron/resources/MathJax/MathJax.js?config=electron"></script>
+    <style>
+    /**
+     * styled-jsx can't handle nesting so these have to end up in an inline
+     * <style> as is, at the top of our setup
+     */
+    @media print {
+      * {
+        box-shadow: none !important;
+      }
+      .status-bar {
+        display: none !important;
+      }
+      .notifications-wrapper {
+        display: none !important;
+      }
+      .cell-toolbar {
+        display: none !important;
+      }
+      .cell-creator {
+        display: none !important;
+      }
+      .cell.focused {
+        border: none;
+        background: var(--cell-bg, white) !important;
+      }
+      .cell:focus .prompt,
+      .cell.focused .prompt {
+        background: var(--pager-bg, #fafafa) !important;
+      }
+      .draggable-cell {
+        padding: 0px !important;
+      }
+      .cell-drag-handle {
+        display: none !important;
+      }
+      .cell-toolbar-mask {
+        display: none !important;
+      }
+      .invisible {
+        display: none !important;
+      }
+    }
+
+    @media not print {
+      .cells {
+        padding-bottom: calc(100vh - 110px);
+      }
+    }
+  </style>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
This turned out to be a major refactor in some parts, ending up with nice styles for the pinned cell (vs. our last release) while I was at it.

`v0.3.4`:

![screen shot 2017-11-18 at 8 09 55 pm](https://user-images.githubusercontent.com/836375/32987310-9f43af0c-cc9c-11e7-986c-023ea491a972.png)

This PR:

![screen shot 2017-11-18 at 8 11 58 pm](https://user-images.githubusercontent.com/836375/32987316-c2df394a-cc9c-11e7-8843-a371411ce184.png)

