### PR TITLE
Allow multiplexing from enchannel-zmq-backend

### DIFF
--- a/packages/enchannel-zmq-backend/README.md
+++ b/packages/enchannel-zmq-backend/README.md
@@ -99,6 +99,43 @@ const channels = createChannels(identity, runtimeConfig)
 const { shell, iopub, stdin, control } = channels;
 ```
 
+`enchannel-zmq-backend` also gives access to all of the `channels` via a
+single multipled channel exposed via `createMainChannel`.
+
+```javascript
+import { createMainChannel } from 'enchannel-zmq-backend';
+```
+
+Similar to the `createChannels` function, the `createMainChannel` function
+accepts both an identity and a runtime object.
+
+```javascript
+const channel = createMainChannel(identity, runtimeConfig);
+```
+
+Messages that are sent via the mutliplexed channel need to define a `type`
+property that outlines which channel they should be sent under.
+
+```javascript
+const body = {
+    header: {
+        msg_id: `execute_9ed11a0f-707e-4f71-829c-a19b8ff8eed8`,
+        username: "rgbkrk",
+        session: "00000000-0000-0000-0000-000000000000",
+        msg_type: "execute_request",
+        version: "5.0"
+    },
+    content: {
+        code: 'print("woo")',
+        silent: false,
+        store_history: true,
+        user_expressions: {},
+        allow_stdin: false
+    }
+};
+const message = { type: "shell", body };
+```
+
 `enchannel-zmq-backend` also offers four convenience functions to
 easily create the messaging channels for `control`, `stdin`, `iopub`,
 and `shell` :

--- a/packages/enchannel-zmq-backend/__tests__/channeling_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/channeling_spec.js
@@ -8,7 +8,7 @@ import {
 } from "../src";
 
 describe("createChannels", () => {
-  it("creates the channels per enchannel spec", () => {
+  test("creates the channels per enchannel spec", () => {
     const config = {
       signature_scheme: "hmac-sha256",
       key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
@@ -35,7 +35,7 @@ describe("createChannels", () => {
 });
 
 describe("createChannelSubject", () => {
-  it("creates a subject for the channel", () => {
+  test("creates a subject for the channel", () => {
     const config = {
       signature_scheme: "hmac-sha256",
       key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
@@ -52,7 +52,7 @@ describe("createChannelSubject", () => {
 });
 
 describe("createIOPubSubject", () => {
-  it("creates a subject with the default iopub subscription", () => {
+  test("creates a subject with the default iopub subscription", () => {
     const config = {
       signature_scheme: "hmac-sha256",
       key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",

--- a/packages/enchannel-zmq-backend/__tests__/constants_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/constants_spec.js
@@ -2,7 +2,7 @@ import * as constants from "../src/constants";
 
 // Solely testing the exported interface
 describe("constants", () => {
-  it("exports the standard Jupyter channels", () => {
+  test("exports the standard Jupyter channels", () => {
     expect(constants.IOPUB).toBe("iopub");
     expect(constants.STDIN).toBe("stdin");
     expect(constants.SHELL).toBe("shell");

--- a/packages/enchannel-zmq-backend/__tests__/index_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/index_spec.js
@@ -21,22 +21,7 @@ describe("the built version of enchannel-zmq-backend", () => {
 });
 
 describe("createMainChannel", () => {
-  it("creates a multiplexed channel", () => {
-    const config = {
-      signature_scheme: "hmac-sha256",
-      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
-      ip: "127.0.0.1",
-      transport: "tcp",
-      shell_port: 19009,
-      stdin_port: 19010,
-      control_port: 19011,
-      iopub_port: 19012
-    };
-    const c = createMainChannel(uuidv4(), config);
-    expect(c).toBeDefined();
-  });
-
-  it("pipes messages from socket appropriately", async () => {
+  it("pipes messages from socket appropriately", () => {
     const sent = new Subject();
     const received = new Subject();
 
@@ -47,16 +32,18 @@ describe("createMainChannel", () => {
 
     const channel = createMainChannelFromChannels(shell, control, stdin, iopub);
 
-    let messages = await shell.pipe(first()).toPromise();
-    channel.send({ type: "SHELL", body: { a: "b" } });
+    let messages = shell.first();
+    channel.next({ type: "SHELL", body: { a: "b" } });
     expect(messages).toEqual({ a: "b" });
 
-    messages = await control.pipe(first()).toPromise();
-    channel.send({ type: "CONTROL", body: { c: "d" } });
+    messages = control.first();
+    channel.next({ type: "CONTROL", body: { c: "d" } });
     expect(messages).toEqual({ c: "d" });
 
-    messages = await stdin.pipe(first()).toPromise();
-    channel.send({ type: "STDIN", body: { e: "f" } });
+    messages = stdin.first();
+    channel.next({ type: "STDIN", body: { e: "f" } });
     expect(messages).toEqual({ e: "f" });
+
+    done();
   });
 });

--- a/packages/enchannel-zmq-backend/__tests__/index_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/index_spec.js
@@ -5,6 +5,10 @@ import {
   createShellSubject
 } from "..";
 
+import uuidv4 from "uuid/v4";
+
+import { createMainChannel } from "../src";
+
 // Solely testing the exported interface on the built ES5 JavaScript
 describe("the built version of enchannel-zmq-backend", () => {
   it("exports create helpers for control, stdin, iopub, and shell", () => {
@@ -12,5 +16,22 @@ describe("the built version of enchannel-zmq-backend", () => {
     expect(createStdinSubject).toBeDefined();
     expect(createIOPubSubject).toBeDefined();
     expect(createShellSubject).toBeDefined();
+  });
+});
+
+describe("createMainChannel", () => {
+  it("creates a multiplexed channel", () => {
+    const config = {
+      signature_scheme: "hmac-sha256",
+      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
+      ip: "127.0.0.1",
+      transport: "tcp",
+      shell_port: 19009,
+      stdin_port: 19010,
+      control_port: 19011,
+      iopub_port: 19012
+    };
+    const c = createMainChannel(uuidv4(), config);
+    expect(c).toBeDefined();
   });
 });

--- a/packages/enchannel-zmq-backend/__tests__/index_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/index_spec.js
@@ -12,7 +12,7 @@ import { createMainChannelFromChannels, createMainChannel } from "../src";
 
 // Solely testing the exported interface on the built ES5 JavaScript
 describe("the built version of enchannel-zmq-backend", () => {
-  it("exports create helpers for control, stdin, iopub, and shell", () => {
+  test("exports create helpers for control, stdin, iopub, and shell", () => {
     expect(createControlSubject).toBeDefined();
     expect(createStdinSubject).toBeDefined();
     expect(createIOPubSubject).toBeDefined();
@@ -21,7 +21,7 @@ describe("the built version of enchannel-zmq-backend", () => {
 });
 
 describe("createMainChannel", () => {
-  it("pipes messages from socket appropriately", () => {
+  test("pipes messages from socket appropriately", () => {
     const sent = new Subject();
     const received = new Subject();
 
@@ -32,18 +32,19 @@ describe("createMainChannel", () => {
 
     const channel = createMainChannelFromChannels(shell, control, stdin, iopub);
 
-    let messages = shell.first();
+    shell.subscribe(value => {
+      expect(value).toEqual({ a: "b" });
+    });
     channel.next({ type: "SHELL", body: { a: "b" } });
-    expect(messages).toEqual({ a: "b" });
 
-    messages = control.first();
+    control.subscribe(value => {
+      expect(value).toEqual({ c: "d" });
+    });
     channel.next({ type: "CONTROL", body: { c: "d" } });
-    expect(messages).toEqual({ c: "d" });
 
-    messages = stdin.first();
+    stdin.subscribe(value => {
+      expect(value).toEqual({ e: "f" });
+    });
     channel.next({ type: "STDIN", body: { e: "f" } });
-    expect(messages).toEqual({ e: "f" });
-
-    done();
   });
 });

--- a/packages/enchannel-zmq-backend/__tests__/subjection_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/subjection_spec.js
@@ -16,7 +16,7 @@ import {
 } from "../src/subjection";
 
 describe("createSubscriber", () => {
-  it("creates a subscriber from a socket", () => {
+  test("creates a subscriber from a socket", () => {
     const hokeySocket = {
       send: jest.fn(),
       removeAllListeners: jest.fn(),
@@ -28,7 +28,7 @@ describe("createSubscriber", () => {
     ob.next(message);
     expect(hokeySocket.send).toBeCalledWith(new jmp.Message(message));
   });
-  it("removes all listeners and closes the socket on complete()", () => {
+  test("removes all listeners and closes the socket on complete()", () => {
     const hokeySocket = {
       send: jest.fn(),
       removeAllListeners: jest.fn(),
@@ -40,7 +40,7 @@ describe("createSubscriber", () => {
     expect(hokeySocket.removeAllListeners).toBeCalled();
     expect(hokeySocket.close).toBeCalled();
   });
-  it("should only close once", () => {
+  test("should only close once", () => {
     const hokeySocket = {
       send: jest.fn(),
       removeAllListeners: jest.fn(),
@@ -61,7 +61,7 @@ describe("createSubscriber", () => {
 });
 
 describe("createObservable", () => {
-  it("publishes clean enchannel messages", done => {
+  test("publishes clean enchannel messages", done => {
     const emitter = new EventEmitter();
     const obs = createObservable(emitter);
 
@@ -75,7 +75,7 @@ describe("createObservable", () => {
 });
 
 describe("createSubject", () => {
-  it("creates a subject that can send and receive", done => {
+  test("creates a subject that can send and receive", done => {
     // This is largely captured above, we make sure that the subject gets
     // created properly
     const hokeySocket = new EventEmitter();
@@ -104,7 +104,7 @@ describe("createSubject", () => {
 });
 
 describe("createSocket", () => {
-  it("creates a JMP socket on the channel with identity", () => {
+  test("creates a JMP socket on the channel with identity", () => {
     const config = {
       signature_scheme: "hmac-sha256",
       key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -11,7 +11,7 @@
     "build": "npm run build:es5",
     "build:es5": "babel src --out-dir lib/ --source-maps",
     "build:docs": "jsdoc -R README.md -d docs src/*.js",
-    "test": "mocha --compilers js:babel-core/register --recursive",
+    "test": "jest",
     "test:watch": "npm run test -- --watch",
     "clean": "rimraf lib/*"
   },

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -5,6 +5,17 @@ import { Observable } from "rxjs";
 import { createSubject, createSocket } from "./subjection";
 
 /**
+ * convertToMultiplex converts an enchannel multiplexed message to a
+ * Jupyter multiplexed message
+ *
+ * @param {Object}  message The enchannel message to convert
+ * @return  {Object}  Converted message
+ */
+export function convertToMultiplex(message) {
+  return Object.assign({}, message.body, { channel: message.type });
+}
+
+/**
  * createMainChannel creates a multiplexed set of channels
  * @param  {string} identity                UUID
  * @param  {Object} config                  Jupyter connection information

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -1,6 +1,60 @@
 import { SHELL, STDIN, IOPUB, CONTROL } from "./constants";
-
+import { Subject } from "rxjs/Subject";
+import { Subscriber } from "rxjs/Subscriber";
+import { Observable } from "rxjs";
 import { createSubject, createSocket } from "./subjection";
+
+/**
+ * createMainChannel creates a multiplexed set of channels
+ * @param  {string} identity                UUID
+ * @param  {Object} config                  Jupyter connection information
+ * @param  {string} config.ip               IP address of the kernel
+ * @param  {string} config.transport        Transport, e.g. TCP
+ * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
+ * @param  {number} config.iopub_port       Port for iopub channel
+ * @param  {string} subscription            subscribed topic; defaults to all
+ * @return {Subject} Subject containing multiplexed channels
+ */
+export function createMainChannel(identity, config, subscription = "") {
+  const { shell, control, stdin, iopub } = createChannels(
+    identity,
+    config,
+    subscription
+  );
+  const main = Subject.create(
+    Subscriber.create({
+      next: message => {
+        switch (message.type) {
+          case SHELL:
+            shell.next(message.body);
+          case CONTROL:
+            control.next(message.body);
+          case STDIN:
+            stdin.next(message.body);
+          case IOPUB:
+            iopub.next(message.body);
+          default:
+            return;
+        }
+      }
+    }),
+    Observable.merge(
+      shell.source.map(body => {
+        return { type: SHELL, body };
+      }),
+      stdin.source.map(body => {
+        return { type: STDIN, body };
+      }),
+      control.source.map(body => {
+        return { type: CONTROL, body };
+      }),
+      iopub.source.map(body => {
+        return { type: IOPUB, body };
+      })
+    )
+  );
+  return main;
+}
 
 /**
  * createChannels creates an enchannel spec channels object

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -32,6 +32,11 @@ export function createMainChannel(identity, config, subscription = "") {
     config,
     subscription
   );
+  const main = createMainChannelFromChannels(shell, control, stdin, iopub);
+  return main;
+}
+
+export function createMainChannelFromChannels(shell, control, stdin, iopub) {
   const main = Subject.create(
     Subscriber.create({
       next: message => {

--- a/packages/enchannel/README.md
+++ b/packages/enchannel/README.md
@@ -13,9 +13,9 @@ the implementation or how the communications are constructed or destructed.
 ### Background
 The core functionality of the notebook is to send messages from a frontend to
 a backend, and from a backend to a frontend ([or many
-frontends](https://github.com/nteract/jupyter-sidecar)). In the case of the
+        frontends](https://github.com/nteract/jupyter-sidecar)). In the case of the
 Jupyter/IPython notebook, it communicates over websockets (which in turn reach
-out to ØMQ on the backend).
+        out to ØMQ on the backend).
 
 ### What if...?
 What if you want to serve the same HTML and Javascript for the notebook
@@ -55,11 +55,11 @@ be between four and five channels:
 
 ```js
 const {
-  shell,
-  stdin,
-  control,
-  iopub,
-  heartbeat, // (optional)
+    shell,
+    stdin,
+    control,
+    iopub,
+    heartbeat, // (optional)
 } = channelsObject;  
 ```
 
@@ -69,31 +69,31 @@ Relying on RxJS's implementation of subjects means the streams can be handled
 like so:
 
 ```javascript
-iopub.filter(msg => msg.header.msg_type === 'execute_result')
-     .map(msg => msg.content.data)
-     .subscribe(x => { console.log(`DATA: ${util.inspect(x)}`)})
-```
+    iopub.filter(msg => msg.header.msg_type === 'execute_result')
+    .map(msg => msg.content.data)
+.subscribe(x => { console.log(`DATA: ${util.inspect(x)}`)})
+    ```
 
-As a benefit of subjects, we can go ahead and submit messages to the
-underlying transport:
+    As a benefit of subjects, we can go ahead and submit messages to the
+    underlying transport:
 
-```javascript
-var message = {
-  header: {
-    msg_id: `execute_${uuid.v4()}`,
-    username: '',
-    session: '00000000-0000-0000-0000-000000000000',
-    msg_type: 'execute_request',
-    version: '5.0',
-  },
-  content: {
-    code: 'print("woo")',
-    silent: false,
-    store_history: true,
-    user_expressions: {},
-    allow_stdin: false,
-  },
-};
+    ```javascript
+    var message = {
+header: {
+msg_id: `execute_${uuid.v4()}`,
+        username: '',
+        session: '00000000-0000-0000-0000-000000000000',
+        msg_type: 'execute_request',
+        version: '5.0',
+        },
+content: {
+code: 'print("woo")',
+      silent: false,
+      store_history: true,
+      user_expressions: {},
+      allow_stdin: false,
+         },
+    };
 
 shell.next(message); // send the message
 ```
@@ -107,9 +107,36 @@ is not included in the spec above primarily because it's an implementation
 by-product and may end up being deprecated based on the chosen development
 approach.
 
+## Mutliplexed enchannel
+`enchannel-zmq-backend` exposes a multiplexed subject that allows the developer
+communicate with all four channels via a single interface.
+
+```javascript
+const channel = e.createMainChannel(identity, kernel.config);
+const body = {
+    header: {
+        msg_id: `execute_9ed11a0f-707e-4f71-829c-a19b8ff8eed8`,
+        username: "rgbkrk",
+        session: "00000000-0000-0000-0000-000000000000",
+        msg_type: "execute_request",
+        version: "5.0"
+    },
+    content: {
+        code: 'print("woo")',
+        silent: false,
+        store_history: true,
+        user_expressions: {},
+        allow_stdin: false
+    }
+};
+const message = { type: "shell", body };
+channel.subscribe(console.log);
+channel.next(message);
+```
+
 ## Develop with us
 
- To contribute to the spec or convenience functions, clone this repo and
+To contribute to the spec or convenience functions, clone this repo and
 install it by running the following from the repo root:
 
 ```


### PR DESCRIPTION
I'm just dumping the code to start here to see what I came up with.

Usage looks something like this.

```js
const e = require("./lib");
const uuidv4 = require("uuid/v4");
const spawnteract = require("spawnteract");

async function setUp() {
  const identity = uuidv4();
  const kernel = await spawnteract.launch("python3");

  const channel = e.createMainChannel(identity, kernel.config);
  const body = {
    header: {
      msg_id: `execute_9ed11a0f-707e-4f71-829c-a19b8ff8eed8`,
      username: "rgbkrk",
      session: "00000000-0000-0000-0000-000000000000",
      msg_type: "execute_request",
      version: "5.0"
    },
    content: {
      code: 'print("woo")',
      silent: false,
      store_history: true,
      user_expressions: {},
      allow_stdin: false
    }
  };
  const message = { type: "shell", body };
  channel.subscribe(console.log);
  channel.next(message);
}

setUp();
```

And responses look something like this.

```
{ type: 'control',
  body:
   Message {
     header:
      { version: '5.2',
        date: '2017-11-20T17:18:58.059174Z',
        session: '8f628e9a-ae2a4191891616bff9041006',
        username: 'captainsafia',
        msg_type: 'execute_reply',
        msg_id: 'feee4deb-7101e80b6fc9eef525381569' },
     parent_header:
      { msg_id: 'execute_9ed11a0f-707e-4f71-829c-a19b8ff8eed8',
        username: 'rgbkrk',
        session: '00000000-0000-0000-0000-000000000000',
        msg_type: 'execute_request',
        version: '5.0',
        date: '2017-11-20T17:18:58.051638Z' },
     metadata:
      { started: '2017-11-20T17:18:58.052233Z',
        dependencies_met: true,
        engine: 'c382fd0f-3e32-4aca-b25d-327b3331db51',
        status: 'ok' },
     content:
      { status: 'ok',
        execution_count: 1,
        user_expressions: {},
        payload: [] },
     buffers: [] } }
```
