### PR TITLE
Back to hoisting

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.1.2",
+  "lerna": "2.4.0",
   "packages": ["packages/*", "packages/nbextension/nteract_on_jupyter"],
   "version": "independent",
   "npmClient": "npm",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "babel-loader": "^7.0.0",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.5.1",
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract.git"
   },
-  "keywords": ["jupyter", "electron", "notebook", "nteract", "data"],
+  "keywords": [
+    "jupyter",
+    "electron",
+    "notebook",
+    "nteract",
+    "data"
+  ],
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -26,8 +32,7 @@
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "lerna run build --parallel",
     "build:packages:watch": "lerna run build:lib:watch --parallel",
-    "build:icon":
-      "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
+    "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
     "build:docs": "esdoc -c esdoc.json",
     "test": "npm run test:unit && npm run test:lint",
     "test:conformance": "node scripts/conformance.js",
@@ -40,8 +45,7 @@
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",
     "precommit": "lint-staged",
-    "prettier":
-      "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
+    "prettier": "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
     "dist": "lerna run dist --scope nteract --stream",
     "pack": "lerna run pack --scope nteract --stream",
     "publish": "lerna run publish --scope nteract --stream",
@@ -49,16 +53,27 @@
     "publish:all": "lerna run publish:all --scope nteract --stream"
   },
   "jest": {
-    "setupFiles": ["raf/polyfill", "./scripts/mockument"],
+    "setupFiles": [
+      "raf/polyfill",
+      "./scripts/mockument"
+    ],
     "moduleNameMapper": {
-      "uuid": "<rootDir>/packages/commutable/node_modules/uuid/",
       "\\.css$": "<rootDir>/scripts/noop-module.js"
     },
-    "coveragePathIgnorePatterns": ["<rootDir>/scripts", "/node_modules/"]
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/scripts",
+      "/node_modules/"
+    ]
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add"],
-    "*.json,!package.json": ["prettier --write", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ],
+    "*.json,!package.json": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "dependencies": {
     "immutable": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,7 @@
     "type": "git",
     "url": "https://github.com/nteract/nteract.git"
   },
-  "keywords": [
-    "jupyter",
-    "electron",
-    "notebook",
-    "nteract",
-    "data"
-  ],
+  "keywords": ["jupyter", "electron", "notebook", "nteract", "data"],
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -26,13 +20,14 @@
     "showcase": "lerna run dev --scope @nteract/showcase --stream",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lerna": "lerna bootstrap",
+    "lerna": "lerna bootstrap --hoist",
     "build": "npm run build:packages && npm run build:desktop",
     "build:desktop": "lerna run build --scope nteract --stream",
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "lerna run build --parallel",
     "build:packages:watch": "lerna run build:lib:watch --parallel",
-    "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
+    "build:icon":
+      "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
     "build:docs": "esdoc -c esdoc.json",
     "test": "npm run test:unit && npm run test:lint",
     "test:conformance": "node scripts/conformance.js",
@@ -45,7 +40,8 @@
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",
     "precommit": "lint-staged",
-    "prettier": "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
+    "prettier":
+      "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
     "dist": "lerna run dist --scope nteract --stream",
     "pack": "lerna run pack --scope nteract --stream",
     "publish": "lerna run publish --scope nteract --stream",
@@ -53,28 +49,16 @@
     "publish:all": "lerna run publish:all --scope nteract --stream"
   },
   "jest": {
-    "setupFiles": [
-      "raf/polyfill",
-      "./scripts/mockument"
-    ],
+    "setupFiles": ["raf/polyfill", "./scripts/mockument"],
     "moduleNameMapper": {
       "uuid": "<rootDir>/packages/commutable/node_modules/uuid/",
       "\\.css$": "<rootDir>/scripts/noop-module.js"
     },
-    "coveragePathIgnorePatterns": [
-      "<rootDir>/scripts",
-      "/node_modules/"
-    ]
+    "coveragePathIgnorePatterns": ["<rootDir>/scripts", "/node_modules/"]
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.json,!package.json": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.js": ["prettier --write", "git add"],
+    "*.json,!package.json": ["prettier --write", "git add"]
   },
   "dependencies": {
     "immutable": "^3.8.1",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,13 +4,7 @@
   "description": "Interactive literate coding notebook!",
   "main": "./lib/webpacked-main.js",
   "repository": "nteract/nteract",
-  "keywords": [
-    "jupyter",
-    "electron",
-    "notebook",
-    "nteract",
-    "data"
-  ],
+  "keywords": ["jupyter", "electron", "notebook", "nteract", "data"],
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -31,15 +25,23 @@
     "pretest:functional": "npm run build",
     "sublaunch": "electron-mocha --compilers js:babel-core/register",
     "test:functional:launch": "npm run sublaunch -- test/main/launch.js",
-    "test:functional:launchNewNotebook": "npm run sublaunch -- test/main/launchNewNotebook.js",
-    "test:functional": "npm run test:functional:launch && npm run test:functional:launchNewNotebook",
-    "test:unit": "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
-    "test:debug": "mocha --debug-brk --inspect -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
-    "test:unit:individual": "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles",
+    "test:functional:launchNewNotebook":
+      "npm run sublaunch -- test/main/launchNewNotebook.js",
+    "test:functional":
+      "npm run test:functional:launch && npm run test:functional:launchNewNotebook",
+    "test:unit":
+      "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
+    "test:debug":
+      "mocha --debug-brk --inspect -r test/setup.js --compilers js:babel-core/register --require ignore-styles \"test/renderer/**/*.js\"",
+    "test:unit:individual":
+      "mocha -r test/setup.js --compilers js:babel-core/register --require ignore-styles",
     "test:watch": "watch 'npm run test' test/",
-    "pack": "npm run clean && webpack --config webpack.prod.js && electron-builder --dir",
-    "dist": "npm run clean && webpack --config webpack.prod.js && electron-builder",
-    "publish": "npm run clean && webpack --config webpack.prod.js && electron-builder -p always",
+    "pack":
+      "npm run clean && webpack --config webpack.prod.js && electron-builder --dir",
+    "dist":
+      "npm run clean && webpack --config webpack.prod.js && electron-builder",
+    "publish":
+      "npm run clean && webpack --config webpack.prod.js && electron-builder -p always",
     "dist:all": "npm run dist -- -mlw",
     "publish:all": "npm run publish -- -mlw"
   },
@@ -57,28 +59,18 @@
     },
     "mac": {
       "category": "public.app-category.developer-tools",
-      "target": [
-        "dmg",
-        "zip"
-      ]
+      "target": ["dmg", "zip"]
     },
     "nsis": {
       "perMachine": true,
       "oneClick": false
     },
     "win": {
-      "target": [
-        "nsis",
-        "zip"
-      ]
+      "target": ["nsis", "zip"]
     },
     "linux": {
       "maintainer": "nteract contributors <jupyter@googlegroups.com>",
-      "target": [
-        "deb",
-        "AppImage",
-        "tar.gz"
-      ],
+      "target": ["deb", "AppImage", "tar.gz"],
       "desktop": {
         "Comment": "Interactive literate coding notebook",
         "Exec": "/opt/nteract/nteract %U",
@@ -94,28 +86,17 @@
       "category": "Science",
       "packageCategory": "editors"
     },
-    "files": [
-      "lib/*.js",
-      "lib/*.css",
-      "lib/*.woff",
-      "lib/*.woff2",
-      "static"
-    ],
-    "extraResources": [
-      "bin",
-      "example-notebooks"
-    ],
+    "files": ["lib/*.js", "lib/*.css", "lib/*.woff", "lib/*.woff2", "static"],
+    "extraResources": ["bin", "example-notebooks"],
     "npmSkipBuildFromSource": true
   },
   "jest": {
-    "setupFiles": [
-      "./scripts/mockument"
-    ]
+    "setupFiles": ["./scripts/mockument"]
   },
   "dependencies": {
     "github": "^9.0.0",
-    "ijavascript": "^5.0.17",
-    "jmp": "^0.7.5",
+    "ijavascript": "^5.0.20",
+    "jmp": "^1.0.0",
     "mathjax-electron": "^2.0.1",
     "redux-electron-store": "^0.4.1",
     "uuid": "^3.1.0"

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -15,14 +15,15 @@
     "test:watch": "npm run test -- --watch",
     "clean": "rimraf lib/*"
   },
-  "repository": "https://github.com/nteract/nteract/tree/master/packages/enchannel-zmq-backend",
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/enchannel-zmq-backend",
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"
   },
   "dependencies": {
-    "jmp": "^0.7.5",
+    "jmp": "^1.0.0",
     "rxjs": "^5.5.0",
     "uuid": "^3.1.0"
   }

--- a/packages/nbextension/nteract_on_jupyter/package.json
+++ b/packages/nbextension/nteract_on_jupyter/package.json
@@ -33,12 +33,8 @@
     "rxjs": "^5.5.0"
   },
   "babel": {
-    "presets": [
-      "next/babel"
-    ],
-    "plugins": [
-      "transform-flow-strip-types"
-    ]
+    "presets": ["next/babel"],
+    "plugins": ["transform-flow-strip-types"]
   },
   "devDependencies": {
     "css-loader": "^0.28.7",

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -17,13 +17,9 @@
     "precoverage": "nyc npm run test:unit",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
-  "repository": "https://github.com/nteract/nteract/tree/master/packages/rx-jupyter",
-  "keywords": [
-    "jupyter",
-    "rxjs",
-    "notebook",
-    "api"
-  ],
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/rx-jupyter",
+  "keywords": ["jupyter", "rxjs", "notebook", "api"],
   "author": "nteract Contributors",
   "license": "BSD-3-Clause",
   "bugs": {
@@ -44,12 +40,8 @@
     "ws": "^3.2.0"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "transform-flow-strip-types"
-    ]
+    "presets": ["es2015"],
+    "plugins": ["transform-flow-strip-types"]
   },
   "dependencies": {
     "rxjs": "^5.5.0"

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -27,10 +27,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "nteract",
-    "ohgodamonomoduleinamonorepo"
-  ],
+  "keywords": ["nteract", "ohgodamonomoduleinamonorepo"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Apologies to @lgeiger for all the swapping back and forth on yarn, npm, and hoisting. I'm trying to see if I can get styled-jsx hoisted at the very least and generally make everything neat and tidy. For now I'm going after general hoisting again though I'm running into issues during desktop's postinstall, which I'm now trying to debug manually:

```
nteract/packages/desktop$ ./node_modules/.bin/electron-builder install-app-deps
electron-builder 19.46.4
Error: Unresolved node modules: follow-redirects, https-proxy-agent, mime, netrc, jp-kernel, zeromq, lodash
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder-lib/src/util/packageDependencies.ts:112:19
From previous event:
    at Collector.resolveUnresolvedHoisted (/Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder-lib/out/util/packageDependencies.js:208:11)
    at /Users/kylek/code/src/github.com/nteract/nteract/node_modules/electron-builder-lib/src/util/packageDependencies.ts:88:18
    at Generator.next (<anonymous>)
    at runCallback (timers.js:800:20)
    at tryOnImmediate (timers.js:762:5)
    at processImmediate [as _immediateCallback] (timers.js:733:5)
```