### PR TITLE
stick in missing style for editor on markdown cell

### DIFF
--- a/packages/core/src/components/cell/cell.js
+++ b/packages/core/src/components/cell/cell.js
@@ -204,20 +204,22 @@ export class ConnectedCell extends React.PureComponent<CellProps, *> {
             editorFocused={editorFocused}
             cell={cell}
           >
-            <CodeMirror
-              language="markdown"
-              id={this.props.id}
-              value={this.props.cell.get("source")}
-              theme={this.props.theme}
-              focusAbove={this.focusAboveCell}
-              focusBelow={this.focusBelowCell}
-              cellFocused={cellFocused}
-              editorFocused={editorFocused}
-              options={{
-                // Markdown should always be line wrapped
-                lineWrapping: true
-              }}
-            />
+            <Editor>
+              <CodeMirror
+                language="markdown"
+                id={this.props.id}
+                value={this.props.cell.get("source")}
+                theme={this.props.theme}
+                focusAbove={this.focusAboveCell}
+                focusBelow={this.focusBelowCell}
+                cellFocused={cellFocused}
+                editorFocused={editorFocused}
+                options={{
+                  // Markdown should always be line wrapped
+                  lineWrapping: true
+                }}
+              />
+            </Editor>
           </MarkdownCell>
         );
         break;


### PR DESCRIPTION
If there's a sure sign that this refactor isn't finished and me used to the components, it's that this is what broke the markdown cells in the last release.

Closes #2100 