### PR TITLE
create an rx-binder package

### DIFF
--- a/packages/rx-binder/README.md
+++ b/packages/rx-binder/README.md
@@ -1,0 +1,24 @@
+# rx-binder
+
+Observables for Binders.
+
+## Usage
+
+```js
+const { binder } = require("rx-binder");
+
+binder({ repo: "nteract/vdom" }).subscribe(msg => console.log(msg));
+```
+
+Output:
+
+```
+{ phase: 'built',
+  imageName: 'gcr.io/binder-prod/prod-v4-1-nteract-vdom:78fa2b549f67afc3525543b0bccfb08a9e06b006',
+  message: 'Found built image, launching...\n' }
+{ phase: 'launching', message: 'Launching server...\n' }
+{ phase: 'ready',
+  message: 'server running at https://hub.mybinder.org/user/nteract-vdom-r115e00y/\n',
+  url: 'https://hub.mybinder.org/user/nteract-vdom-r115e00y/',
+  token: 'tocwpFakeToken' }
+```

--- a/packages/rx-binder/__tests__/index.test.js
+++ b/packages/rx-binder/__tests__/index.test.js
@@ -1,0 +1,77 @@
+// @flow
+const { binder, formBinderURL } = require("..");
+
+import { toArray } from "rxjs/operators";
+
+test("formBinderURL has default values with empty options", () => {
+  expect(formBinderURL()).toEqual(
+    "https://mybinder.org/build/gh/jupyter/notebook/master"
+  );
+
+  expect(formBinderURL({})).toEqual(
+    "https://mybinder.org/build/gh/jupyter/notebook/master"
+  );
+});
+
+test("formBinderURL correctly creates a full binder URL", () => {
+  expect(
+    formBinderURL({
+      repo: "nteract/vdom",
+      ref: "0.5"
+    })
+  ).toEqual("https://mybinder.org/build/gh/nteract/vdom/0.5");
+
+  expect(
+    formBinderURL({
+      repo: "nteract/vdom",
+      ref: "0.5",
+      binderURL: "https://binder.nteract.io"
+    })
+  ).toEqual("https://binder.nteract.io/build/gh/nteract/vdom/0.5");
+});
+
+test("binder", () => {
+  const sources = {};
+
+  class PretendEventSource {
+    constructor(url) {
+      sources[url] = this;
+      this.close = jest.fn();
+    }
+  }
+
+  const messagesPromise = binder({ repo: "nteract/vdom" }, PretendEventSource)
+    .pipe(toArray())
+    .toPromise();
+
+  const messages = [
+    {
+      phase: "built",
+      imageName:
+        "gcr.io/binder-prod/prod-v4-1-nteract-vdom:78fa2b549f67afc3525543b0bccfb08a9e06b006",
+      message: "Found built image, launching...\n"
+    },
+    { phase: "launching", message: "Launching server...\n" },
+    {
+      phase: "ready",
+      message:
+        "server running at https://hub.mybinder.org/user/nteract-vdom-r115e00y/\n",
+      url: "https://hub.mybinder.org/user/nteract-vdom-r115e00y/",
+      token: "tocwpFakeToken"
+    }
+  ];
+
+  const liveSource =
+    sources["https://mybinder.org/build/gh/nteract/vdom/master"];
+
+  for (var message of messages) {
+    liveSource.onmessage({
+      data: JSON.stringify(message)
+    });
+  }
+
+  return messagesPromise.then(pumpedMessages => {
+    expect(pumpedMessages).toEqual(messages);
+    expect(liveSource.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rx-binder/index.js
+++ b/packages/rx-binder/index.js
@@ -1,0 +1,85 @@
+// @flow
+const EventSource = require("eventsource");
+const { Observable } = require("rxjs/Observable");
+
+const mybinderURL = "https://mybinder.org";
+
+function cleanRepo(repo) {
+  return (
+    // trim github.com from repo
+    repo
+      .replace(/^(https?:\/\/)?github.com\//, "")
+      // trim trailing or leading '/' on repo
+      .replace(/(^\/)|(\/?$)/g, "")
+  );
+}
+
+/*::
+type BinderOptions = {
+  repo: string,
+  ref: string,
+  binderURL: string,
+}
+*/
+
+function formBinderURL(
+  {
+    repo = "jupyter/notebook",
+    ref = "master",
+    binderURL = mybinderURL
+  } /*: BinderOptions */ = {}
+) /*: string */ {
+  repo = cleanRepo(repo);
+  // trim trailing / on binderURL
+  binderURL = binderURL.replace(/(\/?$)/g, "");
+
+  const url = `${binderURL}/build/gh/${repo}/${ref}`;
+  return url;
+}
+
+function binder(
+  options /*: BinderOptions */,
+  /** Allow overriding EventSource for testing and ponyfilling **/
+  EventSource = EventSource
+) /*: Observable<*> */ {
+  const url = formBinderURL(options);
+  return Observable.create(observer => {
+    const es = new EventSource(url);
+
+    es.onmessage = evt => {
+      const msg = JSON.parse(evt.data);
+
+      // Pass messages onward, closing on "failed" or "ready"
+      observer.next(msg);
+
+      switch (msg.phase) {
+        case "failed":
+          // The message of failed is a message and shouldn't go on the error
+          // part of the stream, we should just complete it
+          observer.complete();
+          break;
+        case "ready":
+          // When the server is ready, we can close the event source
+          observer.complete();
+          break;
+        default:
+          // do nothing, we already sent the message on
+          break;
+      }
+    };
+
+    es.onerror = err => {
+      observer.error(err);
+    };
+
+    // disposal of the observable closes the EventSource
+    return () => {
+      es.close();
+    };
+  });
+}
+
+module.exports = {
+  formBinderURL,
+  binder
+};

--- a/packages/rx-binder/package.json
+++ b/packages/rx-binder/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rx-binder",
+  "version": "1.0.0",
+  "description": "RxJS bindings to Binder",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nteract/nteract.git"
+  },
+  "keywords": ["binder", "mybinder", "jupyter", "notebook", "nteract"],
+  "dependencies": {
+    "eventsource": "^1.0.5",
+    "rxjs": "^5.5.0"
+  },
+  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/nteract/nteract/issues"
+  },
+  "homepage": "https://github.com/nteract/nteract#readme"
+}


### PR DESCRIPTION
Right now: allows connecting up to mybinder to launch a binder.

```js
const { binder } = require("rx-binder");

binder({ repo: "nteract/vdom" }).subscribe(msg => console.log(msg));
```

Output:

```
{ phase: 'built',
  imageName: 'gcr.io/binder-prod/prod-v4-1-nteract-vdom:78fa2b549f67afc3525543b0bccfb08a9e06b006',
  message: 'Found built image, launching...\n' }
{ phase: 'launching', message: 'Launching server...\n' }
{ phase: 'ready',
  message: 'server running at https://hub.mybinder.org/user/nteract-vdom-r115e00y/\n',
  url: 'https://hub.mybinder.org/user/nteract-vdom-r115e00y/',
  token: 'tocwpFakeToken' }
```

All the usual observable operators are available to you in Rx land, I'm just showing the basics here.

/cc @captainsafia -- could be fun to link this up with `rx-jupyter` + your current remote kernels work.

Notes:

* this is mostly gleaned from @minrk's thebelab
* `eventsource` is included to make this work in node. Hopefully it's a decent polyfill when on the web.