### PR TITLE
merge in headers from opts with auth

### DIFF
--- a/packages/rx-jupyter/src/base.js
+++ b/packages/rx-jupyter/src/base.js
@@ -19,11 +19,14 @@ export function createAJAXSettings(
   const settings = Object.assign(
     {
       url,
-      responseType: "json",
-      headers
+      responseType: "json"
     },
     serverConfig,
-    opts
+    opts,
+    {
+      // Make sure we merge in the auth headers with user given headers
+      headers: Object.assign({}, headers, opts.headers)
+    }
   );
 
   delete settings.endpoint;


### PR DESCRIPTION
The auth headers weren't getting set on any calls that were setting other custom headers. This included the `kernel.start` method.

With this change, you can now have a little flow of binder container launch, kernel launch, and connect like so:

```js
const { binder } = require("rx-binder");

const { kernels } = require("rx-jupyter");
const { filter, switchMap, tap } = require("rxjs/operators");

const EventSource = require("eventsource");
const { XMLHttpRequest } = require("xmlhttprequest");

global.XMLHttpRequest = XMLHttpRequest;

const kernel$ = binder({ repo: "jupyterlab/jupyterlab" }, EventSource).pipe(
  tap(msg => console.log(msg)),
  filter(m => m.phase === "ready"),
  switchMap(msg => {
    console.log("logging into ", msg.url);

    const serverConfig = {
      endpoint: msg.url.replace(/\/\s*$/, ""),
      uri: "/",
      token: msg.token
    };

    return kernels.start(serverConfig, "python3", "/");
  })
);

kernel$.subscribe({
  next: x => console.log(x),
  error: err => console.error(err)
});
```