### PR TITLE
Clear execution count when clearing cell output

### DIFF
--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -151,7 +151,9 @@ function clearOutputs(state: DocumentState, action: ClearOutputsAction) {
 
   if (type === "code") {
     return cleanCellTransient(
-      state.setIn(["notebook", "cellMap", id, "outputs"], new Immutable.List()),
+      state
+        .setIn(["notebook", "cellMap", id, "outputs"], new Immutable.List())
+        .setIn(["notebook", "cellMap", id, "execution_count"], null),
       id
     );
   }


### PR DESCRIPTION
Fixes #2107 

Is `null` the right thing to set the execution count to? It works but maybe there is something that I should be using.