### PR TITLE
export message creators from messaging

### DIFF
--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -202,4 +202,4 @@ export const executionStates = () => (
 ): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(ofMessageType("status"), pluck("content", "execution_state"));
 
-export { message, executeRequest };
+export * from "./messages";

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -201,3 +201,5 @@ export const executionStates = () => (
   source: rxjs$Observable<JupyterMessage<*, *>>
 ): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(ofMessageType("status"), pluck("content", "execution_state"));
+
+export { message, executeRequest };


### PR DESCRIPTION
When this got refactored, a TODO was left for `createMessage` yet `message` (the next API) was not exported. This API still feels inflexible, mostly because of needing to know the session id and other runtime info. It makes me wish that we generally have a channels setup that keeps track of the session id, username, and other boilerplate info, making sure to add it on to messages.

At any rate, for now, let's get these helpers out and available to use.