### PR TITLE
core was relying on this `date-fns` module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "@nteract/display-area": "^3.1.0",
     "@nteract/editor": "^4.2.1",
     "@nteract/transforms": "^3.0.3",
+    "date-fns": "^1.28.5",
     "commonmark": "^0.28.0",
     "commonmark-react-renderer": "^4.3.3",
     "escape-carriage": "^1.2.0",
@@ -34,10 +35,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "keywords": [
-    "nteract",
-    "ohgodamonomoduleinamonorepo"
-  ],
+  "keywords": ["nteract", "ohgodamonomoduleinamonorepo"],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Hopefully this isn't the only module that didn't get properly configured after the `@nteract/core` extraction of nteract desktop.

This was preventing builds of the play app from solely the released packages. You'd think it would skip this since it's not using the status bar component.  ¯\\\_(ツ)\_/¯