### PR TITLE
provide some starter styles to the SSR <textarea>

### DIFF
--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -400,7 +400,7 @@ class CodeMirrorEditor extends React.Component<
           }}
           defaultValue={this.props.value}
           autoComplete="off"
-          className="CodeMirror-code initialTextAreaForCodeMirror"
+          className="initialTextAreaForCodeMirror"
         />
         <style jsx>{showHintStyles}</style>
         <style jsx>{codemirrorStyles}</style>

--- a/packages/editor/src/styles.js
+++ b/packages/editor/src/styles.js
@@ -217,4 +217,32 @@ export default css`
     background: var(--cm-hint-bg-active, #abd1ff);
     color: var(--cm-hint-color-active, black);
   }
+
+  :global(.initialTextAreaForCodeMirror) {
+    font-family: "Source Code Pro";
+    font-size: 14px;
+    line-height: 20px;
+
+    height: auto;
+
+    background: none;
+
+    border: none;
+    overflow: hidden;
+
+    -webkit-scrollbar: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+    width: 100%;
+    resize: none;
+    padding: 10px 0 5px 10px;
+    letter-spacing: 0.3px;
+    word-spacing: 1px;
+  }
+
+  :global(.initialTextAreaForCodeMirror:focus) {
+    outline: none;
+    border: none;
+  }
 `;

--- a/packages/editor/src/styles.js
+++ b/packages/editor/src/styles.js
@@ -218,8 +218,8 @@ export default css`
     color: var(--cm-hint-color-active, black);
   }
 
-  :global(.initialTextAreaForCodeMirror) {
-    font-family: "Source Code Pro";
+  .initialTextAreaForCodeMirror {
+    font-family: "Source Code Pro", "Monaco", monospace;
     font-size: 14px;
     line-height: 20px;
 
@@ -241,7 +241,7 @@ export default css`
     word-spacing: 1px;
   }
 
-  :global(.initialTextAreaForCodeMirror:focus) {
+  .initialTextAreaForCodeMirror:focus {
     outline: none;
     border: none;
   }

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -399,11 +399,43 @@ display(
           body {
             margin: 0;
           }
+
+          /** In development mode, these aren't set right away so we set them
+          direct to start off. Same styled-jsx issue we typically run into with
+          our lerna app... */
           .CodeMirror {
             height: 100%;
           }
           .CodeMirror-gutters {
             box-shadow: unset;
+          }
+
+          .initialTextAreaForCodeMirror {
+            font-family: "Source Code Pro", "Monaco", monospace;
+            font-size: 14px;
+            line-height: 20px;
+
+            height: auto;
+
+            background: none;
+
+            border: none;
+            overflow: hidden;
+
+            -webkit-scrollbar: none;
+            -webkit-box-shadow: none;
+            -moz-box-shadow: none;
+            box-shadow: none;
+            width: 100%;
+            resize: none;
+            padding: 10px 0 5px 10px;
+            letter-spacing: 0.3px;
+            word-spacing: 1px;
+          }
+
+          .initialTextAreaForCodeMirror:focus {
+            outline: none;
+            border: none;
           }
         `}</style>
       </div>


### PR DESCRIPTION
This fixes (some of) that annoying lack of styling to the `<textarea>` at the start of page load of `@nteract/play`. However, I had to repeat the styles to make sure `styled-jsx` was setting the right styles for the dev mode setup (long story, issue somewhere about lerna + `styled-jsx`). When this goes to prod mode, everything is one nice neat little bundle.