### PR TITLE
[play] load up the jupyter-stacks image by default

### DIFF
--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -192,7 +192,7 @@ display(
 
   async getServer() {
     const serverConfig = await binder(
-      { repo: "nteract/vdom" },
+      { repo: "binder-examples/jupyter-stacks" },
       window.EventSource
     )
       .pipe(


### PR DESCRIPTION
This sets the default image for `@nteract/play` to use [binder-examples/jupyter-stacks](https://github.com/binder-examples/jupyter-stacks) which uses [`all-spark-notebook`](https://github.com/jupyter/docker-stacks/tree/master/all-spark-notebook) underneath.

At some point we'll want to expose a way for the users to set the repo and ref they want. For now (and in general), we'll set a reasonable default here that has a good collection of packages.

/cc @yuvipanda 