### PR TITLE
flow type enchannel-zmq-backend

### DIFF
--- a/flow-typed/npm/rxjs_v5.0.x.js
+++ b/flow-typed/npm/rxjs_v5.0.x.js
@@ -1011,9 +1011,16 @@ declare class rxjs$Observer<T> {
   complete(): mixed;
 }
 
-// FIXME(samgoldman) should be `mixins rxjs$Observable<T>, rxjs$Observer<T>`
-// once Babel parsing support exists: https://phabricator.babeljs.io/T6821
-declare class rxjs$Subject<T> extends rxjs$Observable<T> {
+// NOTE: This is the nteract definition, for our subjects -- not that of flow-typed
+// Bring in the latest after https://github.com/flowtype/flow-typed/pull/1616 is
+// reviewed and merged.
+// prettier-ignore
+declare class rxjs$Subject<T> extends rxjs$Observable<T> mixins rxjs$Observer<T> {
+  static create<T>(
+    destination: rxjs$Observer<T>,
+    source: rxjs$Observable<T>
+  ): rxjs$AnonymousSubject<T>;
+
   asObservable(): rxjs$Observable<T>;
 
   observers: Array<rxjs$Observer<T>>;
@@ -1028,6 +1035,11 @@ declare class rxjs$Subject<T> extends rxjs$Observable<T> {
   // For use in subclasses only:
   _next(value: T): void;
   _subscribe(observer: rxjs$PartialObserver<T>): rxjs$Subscription;
+}
+
+declare class rxjs$AnonymousSubject<T> extends rxjs$Subject<T> {
+  destination: rxjs$Observer<T>;
+  source: rxjs$Observable<T>;
 }
 
 declare class rxjs$BehaviorSubject<T> extends rxjs$Subject<T> {

--- a/packages/enchannel-zmq-backend/__tests__/channeling_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/channeling_spec.js
@@ -1,11 +1,7 @@
 /* eslint camelcase: 0 */ // <-- Per Jupyter message spec
 import uuidv4 from "uuid/v4";
 
-import {
-  createChannels,
-  createChannelSubject,
-  createIOPubSubject
-} from "../src";
+import { createChannels, createIOPubSubject } from "../src";
 
 describe("createChannels", () => {
   test("creates the channels per enchannel spec", () => {
@@ -31,23 +27,6 @@ describe("createChannels", () => {
     s.stdin.complete();
     s.control.complete();
     s.iopub.complete();
-  });
-});
-
-describe("createChannelSubject", () => {
-  test("creates a subject for the channel", () => {
-    const config = {
-      signature_scheme: "hmac-sha256",
-      key: "5ca1ab1e-c0da-aced-cafe-c0ffeefacade",
-      ip: "127.0.0.1",
-      transport: "tcp",
-      iopub_port: 19009
-    };
-    const s = createChannelSubject("iopub", uuidv4(), config);
-    expect(typeof s.next).toBe("function");
-    expect(typeof s.complete).toBe("function");
-    expect(typeof s.subscribe).toBe("function");
-    s.complete();
   });
 });
 

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -5,17 +5,18 @@
   "main": "lib/index.js",
   "nteractDesktop": "src/index.js",
   "scripts": {
-    "repl": "babel-node scripts/repl.js",
-    "prepublish": "npm run build",
-    "prebuild": "mkdirp lib && npm run clean",
-    "build": "npm run build:es5",
-    "build:es5": "babel src --out-dir lib/ --source-maps",
-    "build:docs": "jsdoc -R README.md -d docs src/*.js",
+    "prepare": "npm run build",
+    "prebuild": "npm run build:clean",
+    "build": "npm run build:lib && npm run build:flow",
+    "build:clean": "rimraf lib",
+    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch",
     "test": "jest",
-    "test:watch": "npm run test -- --watch",
-    "clean": "rimraf lib/*"
+    "test:watch": "npm run test -- --watch"
   },
-  "repository": "https://github.com/nteract/nteract/tree/master/packages/enchannel-zmq-backend",
+  "repository":
+    "https://github.com/nteract/nteract/tree/master/packages/enchannel-zmq-backend",
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/packages/enchannel-zmq-backend/src/constants.js
+++ b/packages/enchannel-zmq-backend/src/constants.js
@@ -1,3 +1,4 @@
+// @flow
 export const IOPUB = "iopub";
 export const STDIN = "stdin";
 export const SHELL = "shell";

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -1,8 +1,16 @@
+// @flow
 import { SHELL, STDIN, IOPUB, CONTROL } from "./constants";
 import { Subject } from "rxjs/Subject";
 import { Subscriber } from "rxjs/Subscriber";
-import { Observable } from "rxjs";
+import { Observable } from "rxjs/Observable";
+
+import { merge } from "rxjs/observable/merge";
+
+import { map } from "rxjs/operators";
+
 import { createSubject, createSocket } from "./subjection";
+
+import type { JUPYTER_CONNECTION_INFO } from "./subjection";
 
 /**
  * convertToMultiplex converts an enchannel multiplexed message to a
@@ -11,7 +19,7 @@ import { createSubject, createSocket } from "./subjection";
  * @param {Object}  message The enchannel message to convert
  * @return  {Object}  Converted message
  */
-export function convertToMultiplex(message) {
+export function convertToMultiplex(message: any) {
   return Object.assign({}, message.body, { channel: message.type });
 }
 
@@ -26,7 +34,11 @@ export function convertToMultiplex(message) {
  * @param  {string} subscription            subscribed topic; defaults to all
  * @return {Subject} Subject containing multiplexed channels
  */
-export function createMainChannel(identity, config, subscription = "") {
+export function createMainChannel(
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO,
+  subscription: string = ""
+) {
   const { shell, control, stdin, iopub } = createChannels(
     identity,
     config,
@@ -36,7 +48,12 @@ export function createMainChannel(identity, config, subscription = "") {
   return main;
 }
 
-export function createMainChannelFromChannels(shell, control, stdin, iopub) {
+export function createMainChannelFromChannels(
+  shell: *,
+  control: *,
+  stdin: *,
+  iopub: *
+) {
   const main = Subject.create(
     Subscriber.create({
       next: message => {
@@ -58,19 +75,27 @@ export function createMainChannelFromChannels(shell, control, stdin, iopub) {
         }
       }
     }),
-    Observable.merge(
-      shell.source.map(body => {
-        return { type: SHELL, body };
-      }),
-      stdin.source.map(body => {
-        return { type: STDIN, body };
-      }),
-      control.source.map(body => {
-        return { type: CONTROL, body };
-      }),
-      iopub.source.map(body => {
-        return { type: IOPUB, body };
-      })
+    merge(
+      shell.source.pipe(
+        map(body => {
+          return { type: SHELL, body };
+        })
+      ),
+      stdin.source.pipe(
+        map(body => {
+          return { type: STDIN, body };
+        })
+      ),
+      control.source.pipe(
+        map(body => {
+          return { type: CONTROL, body };
+        })
+      ),
+      iopub.source.pipe(
+        map(body => {
+          return { type: IOPUB, body };
+        })
+      )
     )
   );
   return main;
@@ -87,7 +112,11 @@ export function createMainChannelFromChannels(shell, control, stdin, iopub) {
  * @param  {string} subscription            subscribed topic; defaults to all
  * @return {object} channels object, per enchannel spec
  */
-export function createChannels(identity, config, subscription = "") {
+export function createChannels(
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO,
+  subscription: string = ""
+) {
   return {
     shell: createShellSubject(identity, config),
     control: createControlSubject(identity, config),
@@ -96,87 +125,34 @@ export function createChannels(identity, config, subscription = "") {
   };
 }
 
-/**
- * createChannelSubject creates a subject for sending and receiving messages on
- * the given channel
- * @param  {string} channel                 iopub || shell || control || stdin
- * @param  {string} identity                UUID
- * @param  {Object} config                  Jupyter connection information
- * @param  {string} config.ip               IP address of the kernel
- * @param  {string} config.transport        Transport, e.g. TCP
- * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
- * @param  {number} config.shell_port       Port for shell channel
- * @return {Rx.Subject} subject for sending and receiving messages on the shell
- *                      channel
- */
-export function createChannelSubject(channel, identity, config) {
-  return createSubject(createSocket(channel, identity, config));
+export function createShellSubject(
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO
+) {
+  return createSubject(createSocket("shell", identity, config));
 }
 
-/**
- * createShellSubject creates a subject for sending and receiving messages on a
- * kernel's shell channel
- * @param  {string} identity                UUID
- * @param  {Object} config                  Jupyter connection information
- * @param  {string} config.ip               IP address of the kernel
- * @param  {string} config.transport        Transport, e.g. TCP
- * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
- * @param  {number} config.shell_port       Port for shell channel
- * @return {Rx.Subject} subject for sending and receiving messages on the shell
- *                      channel
- */
-export function createShellSubject(identity, config) {
-  return createChannelSubject(SHELL, identity, config);
+export function createControlSubject(
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO
+) {
+  return createSubject(createSocket("control", identity, config));
 }
 
-/**
- * createControlSubject creates a subject for sending and receiving on a
- * kernel's control channel
- * @param  {string} identity                UUID
- * @param  {Object} config                  Jupyter connection information
- * @param  {string} config.ip               IP address of the kernel
- * @param  {string} config.transport        Transport, e.g. TCP
- * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
- * @param  {number} config.control_port     Port for control channel
- * @return {Rx.Subject} subject for sending and receiving messages on the control
- *                      channel
- */
-export function createControlSubject(identity, config) {
-  return createChannelSubject(CONTROL, identity, config);
+export function createStdinSubject(
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO
+) {
+  return createSubject(createSocket("stdin", identity, config));
 }
 
-/**
- * createStdinSubject creates a subject for sending and receiving messages on a
- * kernel's stdin channel
- * @param  {string} identity                UUID
- * @param  {Object} config                  Jupyter connection information
- * @param  {string} config.ip               IP address of the kernel
- * @param  {string} config.transport        Transport, e.g. TCP
- * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
- * @param  {number} config.stdin_port       Port for stdin channel
- * @return {Rx.Subject} subject for sending and receiving messages on the stdin
- *                      channel
- */
-export function createStdinSubject(identity, config) {
-  return createChannelSubject(STDIN, identity, config);
-}
-
-/**
- * createIOPubSubject creates a shell subject for receiving messages on a
- * kernel's iopub channel
- * @param  {string} identity                UUID
- * @param  {Object} config                  Jupyter connection information
- * @param  {string} config.ip               IP address of the kernel
- * @param  {string} config.transport        Transport, e.g. TCP
- * @param  {string} config.signature_scheme Hashing scheme, e.g. hmac-sha256
- * @param  {number} config.iopub_port       Port for iopub channel
- * @param  {string} subscription            subscribed topic; defaults to all
- * @return {Rx.Subject} subject for receiving messages on the shell_port
- *                      channel
- */
-export function createIOPubSubject(identity, config, subscription = "") {
+export function createIOPubSubject(
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO,
+  subscription: string = ""
+) {
   const ioPubSocket = createSocket(IOPUB, identity, config);
-  // ZMQ PUB/SUB subscription (not an Rx subscription)
+  // NOTE: ZMQ PUB/SUB subscription (not an Rx subscription)
   ioPubSocket.subscribe(subscription);
-  return createSubject(ioPubSocket);
+  return createSubject(createSocket("iopub", identity, config));
 }

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -151,8 +151,8 @@ export function createIOPubSubject(
   config: JUPYTER_CONNECTION_INFO,
   subscription: string = ""
 ) {
-  const ioPubSocket = createSocket(IOPUB, identity, config);
+  const ioPubSocket = createSocket("iopub", identity, config);
   // NOTE: ZMQ PUB/SUB subscription (not an Rx subscription)
   ioPubSocket.subscribe(subscription);
-  return createSubject(createSocket("iopub", identity, config));
+  return createSubject(ioPubSocket);
 }

--- a/packages/enchannel-zmq-backend/src/subjection.js
+++ b/packages/enchannel-zmq-backend/src/subjection.js
@@ -1,3 +1,4 @@
+// @flow
 import { Subscriber } from "rxjs/Subscriber";
 import { Subject } from "rxjs/Subject";
 
@@ -8,6 +9,20 @@ import * as jmp from "jmp";
 
 import { ZMQType } from "./constants";
 
+export type CHANNEL_NAME = "iopub" | "stdin" | "shell" | "control";
+
+export type JUPYTER_CONNECTION_INFO = {
+  iopub_port: number,
+  shell_port: number,
+  stdin_port: number,
+  control_port: number,
+  signature_scheme: "hmac-sha256" | string, // Allows practically any string, they're really constrained though
+  hb_port: number,
+  ip: string,
+  key: string,
+  transport: "tcp" | string // Only known transport at the moment, we'll allow string in general though
+};
+
 /**
  * Takes a Jupyter spec connection info object and channel and returns the
  * string for a channel. Abstracts away tcp and ipc(?) connection string
@@ -16,7 +31,10 @@ import { ZMQType } from "./constants";
  * @param {string} channel Jupyter channel ("iopub", "shell", "control", "stdin")
  * @return {string} The connection string
  */
-export function formConnectionString(config, channel) {
+export function formConnectionString(
+  config: JUPYTER_CONNECTION_INFO,
+  channel: CHANNEL_NAME
+) {
   const portDelimiter = config.transport === "tcp" ? ":" : "-";
   const port = config[channel + "_port"];
   if (!port) {
@@ -32,7 +50,7 @@ export function formConnectionString(config, channel) {
  * @return {Rx.Subscriber} a subscriber that allows sending messages on next()
  *                         and closes the underlying socket on complete()
  */
-export function createSubscriber(socket) {
+export function createSubscriber(socket: jmp.Socket) {
   return Subscriber.create({
     next: messageObject => {
       socket.send(new jmp.Message(messageObject));
@@ -50,7 +68,7 @@ export function createSubscriber(socket) {
  * @param {jmp.Socket} socket the jmp/zmq socket connection to a kernel channel
  * @return {Rx.Observable} an Observable that publishes kernel channel messages
  */
-export function createObservable(socket) {
+export function createObservable(socket: jmp.Socket) {
   return fromEvent(socket, "message").pipe(
     map(msg => {
       // Conform to same message format as notebook websockets
@@ -68,12 +86,8 @@ export function createObservable(socket) {
  * @param {jmp.Socket} socket the jmp/zmq socket connection to a kernel channel
  * @return {Rx.Subject} subject for sending and receiving messages to kernels
  */
-export function createSubject(socket) {
-  const subj = Subject.create(
-    createSubscriber(socket),
-    createObservable(socket)
-  );
-  return subj;
+export function createSubject(socket: jmp.Socket) {
+  return Subject.create(createSubscriber(socket), createObservable(socket));
 }
 
 /**
@@ -83,7 +97,11 @@ export function createSubject(socket) {
  * @param {Object} config  Jupyter connection information
  * @return {jmp.Socket} The new Jupyter ZMQ socket
  */
-export function createSocket(channel, identity, config) {
+export function createSocket(
+  channel: CHANNEL_NAME,
+  identity: string,
+  config: JUPYTER_CONNECTION_INFO
+) {
   const zmqType = ZMQType.frontend[channel];
   const scheme = config.signature_scheme.slice("hmac-".length);
   const socket = new jmp.Socket(zmqType, scheme, config.key);


### PR DESCRIPTION
Set up flow types for `enchannel-zmq-backend`. This is a precursor to some sweeping changes to our zmq backed channels since we'll be trying to get `channels` to conform to the same interface across both remote kernels that use Jupyter's websockets and local ZMQ kernels.

I'm going to leave some commentary inline about why I deleted some things (since I can't leave inline comments in code for something taken away).