### PR TITLE
UI for specifying a specific binder repo & redirecting to it

### DIFF
--- a/packages/editor/src/styles.js
+++ b/packages/editor/src/styles.js
@@ -125,7 +125,7 @@ export default css`
   :global(.cm-s-composition.CodeMirror) {
     font-family: "Source Code Pro", monospace;
     letter-spacing: 0.3px;
-    word-spacing: 1px;
+    word-spacing: 0px;
     background: var(--cm-background, #fafafa);
     color: var(--cm-color, black);
   }
@@ -238,7 +238,7 @@ export default css`
     resize: none;
     padding: 10px 0 5px 10px;
     letter-spacing: 0.3px;
-    word-spacing: 1px;
+    word-spacing: 0px;
   }
 
   .initialTextAreaForCodeMirror:focus {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -1,11 +1,8 @@
 import * as React from "react";
 
-// TODO: Make a generic little console for some of the styled container pieces,
-//       then make this component inject the binder specific bits
-export class BinderConsole extends React.Component {
+class BinderUI extends React.Component {
   render() {
     const {
-      logs,
       onFormSubmit,
       onGitrefChange,
       onRepoChange,
@@ -13,55 +10,39 @@ export class BinderConsole extends React.Component {
       gitref
     } = this.props;
     return (
-      <div className="binder-console">
-        <div className="binder-ui-wrapper">
-          <a className="anchor" href="https://mybinder.org" target="_blank">
-            <img
-              src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
-              alt="binder logo"
-              height="20px"
+      <div className="binder-ui-wrapper">
+        <a className="anchor" href="https://mybinder.org" target="_blank">
+          <img
+            src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
+            alt="binder logo"
+            height="20px"
+          />
+        </a>
+        <form onSubmit={onFormSubmit} className="form">
+          <fieldset>
+            <label htmlFor="repoInput">GitHub Repo: </label>
+            <input
+              id="repoInput"
+              onChange={onRepoChange}
+              type="text"
+              name="repo"
+              value={repo}
             />
-          </a>
-          <form onSubmit={onFormSubmit} className="form">
-            <fieldset>
-              <label htmlFor="repoInput">GitHub Repo: </label>
-              <input
-                id="repoInput"
-                onChange={onRepoChange}
-                type="text"
-                name="repo"
-                value={repo}
-              />
-            </fieldset>
-            <fieldset>
-              <label htmlFor="gitrefInput">Branch/commit: </label>
-              <input
-                id="gitrefInput"
-                onChange={onGitrefChange}
-                type="text"
-                name="gitref"
-                value={gitref}
-              />
-            </fieldset>
-            <fieldset>
-              <button type="submit"> Submit</button>
-            </fieldset>
-          </form>
-        </div>
-        {logs.length > 0
-          ? logs.map((log, index) => {
-              return (
-                <span className="log" key={index}>
-                  <span className="sidebar" />
-                  <span className="phase">{log.phase}</span>
-                  <span className="content">
-                    <span className="message">{log.message}</span>
-                  </span>
-                </span>
-              );
-            })
-          : null}
-
+          </fieldset>
+          <fieldset>
+            <label htmlFor="gitrefInput">Branch/commit: </label>
+            <input
+              id="gitrefInput"
+              onChange={onGitrefChange}
+              type="text"
+              name="gitref"
+              value={gitref}
+            />
+          </fieldset>
+          <fieldset>
+            <button type="submit"> Submit</button>
+          </fieldset>
+        </form>
         <style jsx>{`
           img {
             vertical-align: middle;
@@ -94,6 +75,39 @@ export class BinderConsole extends React.Component {
             float: left;
           }
 
+          .binder-ui-wrapper {
+            width: 100%;
+            display: inline-block;
+            padding: 0 0 0 10px;
+          }
+        `}</style>
+      </div>
+    );
+  }
+}
+// TODO: Make a generic little console for some of the styled container pieces,
+//       then make this component inject the binder specific bits
+export class BinderConsole extends React.Component {
+  render() {
+    const { logs, ...otherprops } = this.props;
+    return (
+      <div className="binder-console">
+        <BinderUI {...otherprops} />
+        {logs.length > 0
+          ? logs.map((log, index) => {
+              return (
+                <span className="log" key={index}>
+                  <span className="sidebar" />
+                  <span className="phase">{log.phase}</span>
+                  <span className="content">
+                    <span className="message">{log.message}</span>
+                  </span>
+                </span>
+              );
+            })
+          : null}
+
+        <style jsx>{`
           .log {
             padding: 0 15px 0 32px;
             margin: 0;
@@ -137,12 +151,6 @@ export class BinderConsole extends React.Component {
             background-color: #1a1a1a;
             counter-reset: line-numbering;
             margin-top: 0;
-          }
-
-          .binder-ui-wrapper {
-            width: 100%;
-            display: inline-block;
-            padding: 0 0 0 10px;
           }
 
           .log:last-child {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -26,11 +26,15 @@ export class BinderConsole extends React.Component {
           <form onSubmit={this.handleSubmit} className="form">
             <p className="para">
               GitHub Repo:
-              <input type="text" defaultValue="hello" name="ghrepo" />
+              <input
+                type="text"
+                defaultValue="binder-examples/python2_with_3"
+                name="ghrepo"
+              />
             </p>
             <p className="para">
               Branch/commit:
-              <input type="text" defaultValue="hello" name="branch" />
+              <input type="text" defaultValue="master" name="branch" />
             </p>
             <button type="submit"> Submit</button>
           </form>

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -3,6 +3,14 @@ import * as React from "react";
 // TODO: Make a generic little console for some of the styled container pieces,
 //       then make this component inject the binder specific bits
 export class BinderConsole extends React.Component {
+  handleSubmit = event => {
+    event.preventDefault();
+    let ghrepo = event.target.ghrepo.value;
+    let branch = event.target.branch.value;
+    const url = "https://mybinder.org/v2/gh/" + ghrepo + "/" + branch;
+    console.log(url);
+  };
+
   render() {
     const { logs } = this.props;
     return (
@@ -15,8 +23,16 @@ export class BinderConsole extends React.Component {
               height="20px"
             />
           </a>
-          <form className="form">
-            <input defaultValue="hello" />
+          <form onSubmit={this.handleSubmit} className="form">
+            <p className="para">
+              GitHub Repo:
+              <input type="text" defaultValue="hello" name="ghrepo" />
+            </p>
+            <p className="para">
+              Branch/commit:
+              <input type="text" defaultValue="hello" name="branch" />
+            </p>
+            <button type="submit"> Submit</button>
           </form>
         </div>
         {logs.length > 0
@@ -94,6 +110,10 @@ export class BinderConsole extends React.Component {
 
           .binder-ui-wrapper {
             display: inline-block;
+          }
+
+          .para {
+            float: left;
           }
 
           .log:last-child {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -8,7 +8,7 @@ export class BinderConsole extends React.Component {
     let ghrepo = event.target.ghrepo.value;
     let branch = event.target.branch.value;
     const url = "https://mybinder.org/v2/gh/" + ghrepo + "/" + branch;
-    console.log(url);
+    window.location = url;
   };
 
   render() {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -110,15 +110,18 @@ export class BinderConsole extends React.Component {
           }
 
           form {
+            width: 100%;
             float: left;
           }
 
           input {
-            float: left;
+            display: block;
+            width: 30%;
           }
 
           fieldset {
             border: none;
+            width: 100%;
           }
 
           .anchor {
@@ -126,11 +129,13 @@ export class BinderConsole extends React.Component {
           }
 
           .binder-ui-wrapper {
+            width: 100%;
             display: inline-block;
           }
 
           label {
             float: left;
+            min-width: 9em;
           }
 
           .log:last-child {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -3,16 +3,8 @@ import * as React from "react";
 // TODO: Make a generic little console for some of the styled container pieces,
 //       then make this component inject the binder specific bits
 export class BinderConsole extends React.Component {
-  handleSubmit = event => {
-    event.preventDefault();
-    let ghrepo = event.target.ghrepo.value;
-    let branch = event.target.branch.value;
-    const url = "https://mybinder.org/v2/gh/" + ghrepo + "/" + branch;
-    window.location = url;
-  };
-
   render() {
-    const { logs } = this.props;
+    const { logs, onFormSubmit } = this.props;
     return (
       <div className="binder-console">
         <div className="binder-ui-wrapper">
@@ -23,18 +15,18 @@ export class BinderConsole extends React.Component {
               height="20px"
             />
           </a>
-          <form onSubmit={this.handleSubmit} className="form">
+          <form onSubmit={onFormSubmit} className="form">
             <p className="para">
               GitHub Repo:
               <input
                 type="text"
                 defaultValue="binder-examples/python2_with_3"
-                name="ghrepo"
+                name="repo"
               />
             </p>
             <p className="para">
               Branch/commit:
-              <input type="text" defaultValue="master" name="branch" />
+              <input type="text" defaultValue="master" name="ref" />
             </p>
             <button type="submit"> Submit</button>
           </form>

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -6,9 +6,9 @@ export class BinderConsole extends React.Component {
   render() {
     const {
       logs,
-      handleFormSubmit,
-      handleGitrefChange,
-      handleRepoChange,
+      onFormSubmit,
+      onGitrefChange,
+      onRepoChange,
       repo,
       gitref
     } = this.props;
@@ -22,11 +22,11 @@ export class BinderConsole extends React.Component {
               height="20px"
             />
           </a>
-          <form onSubmit={handleFormSubmit} className="form">
+          <form onSubmit={onFormSubmit} className="form">
             <p className="para">
               GitHub Repo:
               <input
-                onChange={handleRepoChange}
+                onChange={onRepoChange}
                 type="text"
                 name="repo"
                 value={repo}
@@ -35,7 +35,7 @@ export class BinderConsole extends React.Component {
             <p className="para">
               Branch/commit:
               <input
-                onChange={handleGitrefChange}
+                onChange={onGitrefChange}
                 type="text"
                 name="gitref"
                 value={gitref}

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -20,24 +20,28 @@ class BinderUI extends React.Component {
         </a>
         <form onSubmit={onFormSubmit} className="form">
           <fieldset>
-            <label htmlFor="repoInput">GitHub Repo: </label>
-            <input
-              id="repoInput"
-              onChange={onRepoChange}
-              type="text"
-              name="repo"
-              value={repo}
-            />
+            <label htmlFor="repoInput">
+              GitHub Repo:
+              <input
+                id="repoInput"
+                onChange={onRepoChange}
+                type="text"
+                name="repo"
+                value={repo}
+              />
+            </label>
           </fieldset>
           <fieldset>
-            <label htmlFor="gitrefInput">Branch/commit: </label>
-            <input
-              id="gitrefInput"
-              onChange={onGitrefChange}
-              type="text"
-              name="gitref"
-              value={gitref}
-            />
+            <label htmlFor="gitrefInput">
+              Branch/commit:
+              <input
+                id="gitrefInput"
+                onChange={onGitrefChange}
+                type="text"
+                name="gitref"
+                value={gitref}
+              />
+            </label>
           </fieldset>
           <fieldset>
             <button type="submit"> Submit</button>

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -11,77 +11,91 @@ class BinderUI extends React.Component {
     } = this.props;
     return (
       <div className="binder-ui-wrapper">
-        <a className="anchor" href="https://mybinder.org" target="_blank">
-          <img
-            src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
-            alt="binder logo"
-            height="20px"
-          />
-        </a>
-        <form onSubmit={onFormSubmit} className="form">
-          <fieldset>
-            <label htmlFor="repoInput">
-              GitHub Repo:
-              <input
-                id="repoInput"
-                onChange={onRepoChange}
-                type="text"
-                name="repo"
-                value={repo}
-                size="80"
-              />
-            </label>
-          </fieldset>
-          <fieldset>
-            <label htmlFor="gitrefInput">
-              Branch/commit:
-              <input
-                id="gitrefInput"
-                onChange={onGitrefChange}
-                type="text"
-                name="gitref"
-                value={gitref}
-                size="80"
-              />
-            </label>
-          </fieldset>
-          <fieldset>
-            <button type="submit"> Submit</button>
-          </fieldset>
-        </form>
+        <div>
+          <a className="anchor" href="https://mybinder.org" target="_blank">
+            <img
+              src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
+              alt="binder logo"
+              height="20px"
+            />
+          </a>
+        </div>
+        <div>
+          <form onSubmit={onFormSubmit} className="form">
+            <fieldset>
+              <label htmlFor="repoInput">
+                <span>GitHub Repo:</span>
+                <input
+                  id="repoInput"
+                  onChange={onRepoChange}
+                  type="text"
+                  name="repo"
+                  value={repo}
+                  size="80"
+                />
+              </label>
+            </fieldset>
+            <fieldset>
+              <label htmlFor="gitrefInput">
+                <span>Branch/commit:</span>
+                <input
+                  id="gitrefInput"
+                  onChange={onGitrefChange}
+                  type="text"
+                  name="gitref"
+                  value={gitref}
+                  size="80"
+                />
+              </label>
+            </fieldset>
+            <fieldset>
+              <button type="submit">Build and Connect</button>
+            </fieldset>
+          </form>
+        </div>
         <style jsx>{`
           img {
+            margin-left: 8px;
             vertical-align: middle;
             padding: 0 0 10px 10px;
           }
 
-          form {
-            width: 100%;
-            float: left;
-          }
-
           input {
-            display: block;
             font-family: inherit;
             font-size: inherit;
+          }
+          form {
+            margin-left: 10px;
+            padding-bottom: 20px;
+          }
+
+          button {
+            font-family: inherit;
+            font-size: inherit;
+            padding: 5px 10px 5px 10px;
+            background-color: black;
+            color: white;
+            border: 1px solid white;
+          }
+
+          button:active {
+            background-color: #1a1a1a;
+            border: 1px solid #e7e7e7;
+          }
+
+          button:hover {
+            background-color: #2a2a2a;
+            border: 1px solid #d7d7d7;
           }
 
           fieldset {
             border: none;
-            width: 100%;
           }
 
-          label {
-          }
-
-          .anchor {
-            float: left;
-          }
-
-          .binder-ui-wrapper {
-            width: 100%;
+          label span {
+            min-width: 10em;
+            width: 10em;
             display: inline-block;
-            padding: 0 0 0 10px;
           }
         `}</style>
       </div>

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -7,13 +7,18 @@ export class BinderConsole extends React.Component {
     const { logs } = this.props;
     return (
       <div className="binder-console">
-        <a href="https://mybinder.org" target="_blank">
-          <img
-            src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
-            alt="binder logo"
-            height="20px"
-          />
-        </a>
+        <div className="binder-ui-wrapper">
+          <a className="anchor" href="https://mybinder.org" target="_blank">
+            <img
+              src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
+              alt="binder logo"
+              height="20px"
+            />
+          </a>
+          <form className="form">
+            <input defaultValue="hello" />
+          </form>
+        </div>
         {logs.length > 0
           ? logs.map((log, index) => {
               return (
@@ -77,6 +82,18 @@ export class BinderConsole extends React.Component {
             background-color: #1a1a1a;
             counter-reset: line-numbering;
             margin-top: 0;
+          }
+
+          .form {
+            float: left;
+          }
+
+          .anchor {
+            float: left;
+          }
+
+          .binder-ui-wrapper {
+            display: inline-block;
           }
 
           .log:last-child {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -142,6 +142,7 @@ export class BinderConsole extends React.Component {
           .binder-ui-wrapper {
             width: 100%;
             display: inline-block;
+            padding: 0 0 0 10px;
           }
 
           .log:last-child {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -28,6 +28,7 @@ class BinderUI extends React.Component {
                 type="text"
                 name="repo"
                 value={repo}
+                size="80"
               />
             </label>
           </fieldset>
@@ -40,6 +41,7 @@ class BinderUI extends React.Component {
                 type="text"
                 name="gitref"
                 value={gitref}
+                size="80"
               />
             </label>
           </fieldset>
@@ -60,7 +62,6 @@ class BinderUI extends React.Component {
 
           input {
             display: block;
-            width: 30%;
             font-family: inherit;
             font-size: inherit;
           }
@@ -71,8 +72,6 @@ class BinderUI extends React.Component {
           }
 
           label {
-            float: left;
-            min-width: 9em;
           }
 
           .anchor {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -23,25 +23,25 @@ export class BinderConsole extends React.Component {
             />
           </a>
           <form onSubmit={onFormSubmit} className="form">
-            <p className="para">
-              GitHub Repo:
+            <fieldset>
+              <label htmlFor="repoInput">GitHub Repo: </label>
               <input
+                id="repoInput"
                 onChange={onRepoChange}
                 type="text"
                 name="repo"
                 value={repo}
               />
-            </p>
-            <p className="para">
-              Branch/commit:
+              <label htmlFor="gitrefInput">Branch/commit: </label>
               <input
+                id="gitrefInput"
                 onChange={onGitrefChange}
                 type="text"
                 name="gitref"
                 value={gitref}
               />
-            </p>
-            <button type="submit"> Submit</button>
+              <button type="submit"> Submit</button>
+            </fieldset>
           </form>
         </div>
         {logs.length > 0
@@ -109,8 +109,16 @@ export class BinderConsole extends React.Component {
             margin-top: 0;
           }
 
-          .form {
+          form {
             float: left;
+          }
+
+          input {
+            float: left;
+          }
+
+          fieldset {
+            border: none;
           }
 
           .anchor {
@@ -121,7 +129,7 @@ export class BinderConsole extends React.Component {
             display: inline-block;
           }
 
-          .para {
+          label {
             float: left;
           }
 

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -55,18 +55,13 @@ class BinderUI extends React.Component {
         </div>
         <style jsx>{`
           img {
-            margin-left: 8px;
             vertical-align: middle;
-            padding: 0 0 10px 10px;
+            margin: 0 0 7px 10px;
           }
 
           input {
             font-family: inherit;
             font-size: inherit;
-          }
-          form {
-            margin-left: 10px;
-            padding-bottom: 20px;
           }
 
           button {
@@ -97,6 +92,10 @@ class BinderUI extends React.Component {
             width: 10em;
             display: inline-block;
           }
+
+          .binder-ui-wrapper {
+            padding: 0px 0px 5px 10px;
+          }
         `}</style>
       </div>
     );
@@ -110,26 +109,32 @@ export class BinderConsole extends React.Component {
     return (
       <div className="binder-console">
         <BinderUI {...otherprops} />
-        {logs.length > 0
-          ? logs.map((log, index) => {
-              return (
-                <span className="log" key={index}>
-                  <span className="sidebar" />
-                  <span className="phase">{log.phase}</span>
-                  <span className="content">
-                    <span className="message">{log.message}</span>
+        <div className="logs">
+          {logs.length > 0
+            ? logs.map((log, index) => {
+                return (
+                  <span className="log" key={index}>
+                    <span className="sidebar" />
+                    <span className="phase">{log.phase}</span>
+                    <span className="content">
+                      <span className="message">{log.message}</span>
+                    </span>
                   </span>
-                </span>
-              );
-            })
-          : null}
+                );
+              })
+            : null}
+        </div>
 
         <style jsx>{`
           .log {
-            padding: 0 15px 0 32px;
+            padding: 0 15px 0 0px;
             margin: 0;
             min-height: 16px;
             display: block;
+          }
+
+          .logs {
+            margin: 5px 0px 5px 0px;
           }
 
           .phase {
@@ -150,7 +155,6 @@ export class BinderConsole extends React.Component {
             display: inline-block;
             text-align: right;
             min-width: 40px;
-            margin-left: -32px;
             text-decoration: none;
             color: #666;
           }
@@ -158,7 +162,7 @@ export class BinderConsole extends React.Component {
           .binder-console {
             clear: left;
             min-height: 42px;
-            padding: 15px 0px 25px 0;
+            padding: 15px 0px 15px 0;
             color: #f1f1f1;
             font-family: Monaco, monospace;
             font-size: 12px;

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -32,6 +32,8 @@ export class BinderConsole extends React.Component {
                 name="repo"
                 value={repo}
               />
+            </fieldset>
+            <fieldset>
               <label htmlFor="gitrefInput">Branch/commit: </label>
               <input
                 id="gitrefInput"
@@ -40,6 +42,8 @@ export class BinderConsole extends React.Component {
                 name="gitref"
                 value={gitref}
               />
+            </fieldset>
+            <fieldset>
               <button type="submit"> Submit</button>
             </fieldset>
           </form>
@@ -61,7 +65,33 @@ export class BinderConsole extends React.Component {
         <style jsx>{`
           img {
             vertical-align: middle;
-            padding: 0 0 20px 20px;
+            padding: 0 0 10px 10px;
+          }
+
+          form {
+            width: 100%;
+            float: left;
+          }
+
+          input {
+            display: block;
+            width: 30%;
+            font-family: inherit;
+            font-size: inherit;
+          }
+
+          fieldset {
+            border: none;
+            width: 100%;
+          }
+
+          label {
+            float: left;
+            min-width: 9em;
+          }
+
+          .anchor {
+            float: left;
           }
 
           .log {
@@ -109,33 +139,9 @@ export class BinderConsole extends React.Component {
             margin-top: 0;
           }
 
-          form {
-            width: 100%;
-            float: left;
-          }
-
-          input {
-            display: block;
-            width: 30%;
-          }
-
-          fieldset {
-            border: none;
-            width: 100%;
-          }
-
-          .anchor {
-            float: left;
-          }
-
           .binder-ui-wrapper {
             width: 100%;
             display: inline-block;
-          }
-
-          label {
-            float: left;
-            min-width: 9em;
           }
 
           .log:last-child {

--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -4,7 +4,14 @@ import * as React from "react";
 //       then make this component inject the binder specific bits
 export class BinderConsole extends React.Component {
   render() {
-    const { logs, onFormSubmit } = this.props;
+    const {
+      logs,
+      handleFormSubmit,
+      handleGitrefChange,
+      handleRepoChange,
+      repo,
+      gitref
+    } = this.props;
     return (
       <div className="binder-console">
         <div className="binder-ui-wrapper">
@@ -15,18 +22,24 @@ export class BinderConsole extends React.Component {
               height="20px"
             />
           </a>
-          <form onSubmit={onFormSubmit} className="form">
+          <form onSubmit={handleFormSubmit} className="form">
             <p className="para">
               GitHub Repo:
               <input
+                onChange={handleRepoChange}
                 type="text"
-                defaultValue="binder-examples/python2_with_3"
                 name="repo"
+                value={repo}
               />
             </p>
             <p className="para">
               Branch/commit:
-              <input type="text" defaultValue="master" name="ref" />
+              <input
+                onChange={handleGitrefChange}
+                type="text"
+                name="gitref"
+                value={gitref}
+              />
             </p>
             <button type="submit"> Submit</button>
           </form>

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -466,7 +466,7 @@ display(
             resize: none;
             padding: 10px 0 5px 10px;
             letter-spacing: 0.3px;
-            word-spacing: 1px;
+            word-spacing: 0px;
           }
 
           .initialTextAreaForCodeMirror:focus {

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -70,6 +70,9 @@ export default class App extends React.Component {
     this.getServer = this.getServer.bind(this);
     this.runSomeCode = this.runSomeCode.bind(this);
     this.onEditorChange = this.onEditorChange.bind(this);
+    this.handleFormSubmit = this.handleFormSubmit.bind(this);
+    this.handleGitrefChange = this.handleGitrefChange.bind(this);
+    this.handleRepoChange = this.handleRepoChange.bind(this);
 
     this.state = {
       binderMessages: [],
@@ -78,6 +81,8 @@ export default class App extends React.Component {
       kernelStatus: "provisioning",
       kernel: null,
       error: null,
+      repo: "binder-examples/jupyter-stacks",
+      gitref: "master",
       source: `from IPython.display import display
 from vdom import h1, p, img, div, b, span
 
@@ -108,6 +113,23 @@ display(
 
   onEditorChange(source) {
     this.setState({ source });
+  }
+
+  handleRepoChange(event) {
+    this.setState({
+      repo: event.target.value
+    });
+  }
+
+  handleGitrefChange(event) {
+    this.setState({
+      gitref: event.target.value
+    });
+  }
+
+  async handleFormSubmit(event) {
+    event.preventDefault();
+    await this.getServer();
   }
 
   async runSomeCode() {
@@ -191,10 +213,8 @@ display(
   }
 
   async getServer() {
-    const serverConfig = await binder(
-      { repo: "binder-examples/jupyter-stacks" },
-      window.EventSource
-    )
+    const { repo, gitref } = this.state;
+    const serverConfig = await binder({ repo, gitref }, window.EventSource)
       .pipe(
         tap(msg => {
           this.setState({
@@ -275,7 +295,14 @@ display(
         </header>
 
         {this.state.showPanel ? (
-          <BinderConsole logs={this.state.binderMessages} />
+          <BinderConsole
+            handleGitrefChange={this.handleGitrefChange}
+            handleRepoChange={this.handleRepoChange}
+            handleFormSubmit={this.handleFormSubmit}
+            logs={this.state.binderMessages}
+            repo={this.state.repo}
+            gitref={this.state.gitref}
+          />
         ) : null}
 
         <div className="play-editor">

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -83,22 +83,18 @@ export default class App extends React.Component {
       error: null,
       repo: "binder-examples/jupyter-stacks",
       gitref: "master",
-      source: `from IPython.display import display
-from vdom import h1, p, img, div, b, span
-
-display(
-    div(
-        h1('Welcome to play.nteract.io'),
-        p('Run Python code via Binder & Jupyter'),
-        img(src="https://bit.ly/storybot-vdom"),
-        p('Change the code, click ',
-            span("▶ Run", style=dict(
-                color="white",
-                backgroundColor="black",
-                padding="10px"
-            )),
-          ' Up above'
-        )
+      source: `from vdom import h1, p, img, div, b, span
+div(
+    h1('Welcome to play.nteract.io'),
+    p('Run Python code via Binder & Jupyter'),
+    img(src="https://bit.ly/storybot-vdom"),
+    p('Change the code, click ',
+        span("▶ Run", style=dict(
+            color="white",
+            backgroundColor="black",
+            padding="10px"
+        )),
+      ' Up above'
     )
 )`,
       outputs: [],

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -129,9 +129,17 @@ display(
 
   async handleFormSubmit(event) {
     event.preventDefault();
-    const serverShutdown = await shutdown(this.state.serverConfig);
+    const oldServerConfig = this.state.serverConfig;
+    const oldMessages = this.state.binderMessages;
+    const serverShutdown = await shutdown(oldServerConfig);
     this.setState({ binderMessages: [] });
-    await this.initialize();
+    await this.initialize().catch(err => {
+      this.setState({
+        error: err,
+        serverConfig: oldServerConfig,
+        binderMessages: oldMessages
+      });
+    });
   }
 
   async runSomeCode() {

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -129,6 +129,7 @@ display(
 
   async handleFormSubmit(event) {
     event.preventDefault();
+    this.setState({ binderMessages: [] });
     await this.initialize();
   }
 

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -25,7 +25,7 @@ const {
 import { BinderConsole } from "../components/consoles";
 
 const { binder } = require("rx-binder");
-const { kernels } = require("rx-jupyter");
+const { kernels, shutdown } = require("rx-jupyter");
 
 const {
   filter,
@@ -129,6 +129,7 @@ display(
 
   async handleFormSubmit(event) {
     event.preventDefault();
+    const serverShutdown = await shutdown(this.state.serverConfig);
     this.setState({ binderMessages: [] });
     await this.initialize();
   }

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -296,9 +296,9 @@ display(
 
         {this.state.showPanel ? (
           <BinderConsole
-            handleGitrefChange={this.handleGitrefChange}
-            handleRepoChange={this.handleRepoChange}
-            handleFormSubmit={this.handleFormSubmit}
+            onGitrefChange={this.handleGitrefChange}
+            onRepoChange={this.handleRepoChange}
+            onFormSubmit={this.handleFormSubmit}
             logs={this.state.binderMessages}
             repo={this.state.repo}
             gitref={this.state.gitref}

--- a/packages/play.nteract.io/pages/index.js
+++ b/packages/play.nteract.io/pages/index.js
@@ -129,7 +129,7 @@ display(
 
   async handleFormSubmit(event) {
     event.preventDefault();
-    await this.getServer();
+    await this.initialize();
   }
 
   async runSomeCode() {

--- a/packages/rx-jupyter/src/index.js
+++ b/packages/rx-jupyter/src/index.js
@@ -15,4 +15,25 @@ function apiVersion(serverConfig: Object) {
   return ajax(req);
 }
 
-export { apiVersion, kernels, kernelspecs, sessions, contents, terminals };
+/**
+ * Creates an AjaxObservable for shutting down a notebook server.
+ *
+ * @param {Object} serverConfig  - The server configuration
+ *
+ * @return  {Object}  An Observable with the request/response
+ */
+function shutdown(serverConfig: Object): Observable<*> {
+  return ajax(
+    createAJAXSettings(serverConfig, "/api/shutdown", { method: "POST" })
+  );
+}
+
+export {
+  apiVersion,
+  shutdown,
+  kernels,
+  kernelspecs,
+  sessions,
+  contents,
+  terminals
+};

--- a/packages/rx-jupyter/test/index-spec.js
+++ b/packages/rx-jupyter/test/index-spec.js
@@ -20,4 +20,15 @@ describe("rx-jupyter", () => {
       expect(request.method).to.equal("GET");
     });
   });
+  describe("shutdown", () => {
+    it(" Creates an AjaxObservable for shutting down a notebook server", () => {
+      const shutdown$ = jupyter.shutdown({
+        endpoint: "https://somewhere.com",
+        crossDomain: true
+      });
+      const request = shutdown$.request;
+      expect(request.url).to.equal("https://somewhere.com/api/shutdown");
+      expect(request.method).to.equal("POST");
+    });
+  });
 });


### PR DESCRIPTION
This creates simple UI elements for linking to a specific binder repository (as opposed to just the main binder page with the binder image).

![image](https://user-images.githubusercontent.com/2482408/33867595-a28bae8a-deb2-11e7-9027-e7b67227e8c2.png)


On submitting the form it will take you to the appropriate URL (in that example: https://mybinder.org/v2/gh/binder-examples/python2_with_3/master )as though you had filled out binder's github repo and branch/tag/commit fields where it will build the appropriate image and launch when it is ready.

The style needs a lot of work (right now the text box doesn't even expand to accommodate the GH repo name, but this functionality is stateless and straightforward. 

I also plan to factor out this form into it's own component to make it easier to rearrange going forward.