### PR TITLE
create individual BinderLogs and BinderLogo components

### DIFF
--- a/packages/play.nteract.io/components/consoles.js
+++ b/packages/play.nteract.io/components/consoles.js
@@ -1,5 +1,26 @@
 import * as React from "react";
 
+class BinderLogo extends React.Component {
+  render() {
+    return (
+      <div>
+        <a className="anchor" href="https://mybinder.org" target="_blank">
+          <img
+            src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
+            alt="binder logo"
+            height="20px"
+          />
+        </a>
+        <style jsx>{`
+          img {
+            vertical-align: middle;
+            margin: 0 0 7px 0px;
+          }
+        `}</style>
+      </div>
+    );
+  }
+}
 class BinderUI extends React.Component {
   render() {
     const {
@@ -11,54 +32,38 @@ class BinderUI extends React.Component {
     } = this.props;
     return (
       <div className="binder-ui-wrapper">
-        <div>
-          <a className="anchor" href="https://mybinder.org" target="_blank">
-            <img
-              src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
-              alt="binder logo"
-              height="20px"
-            />
-          </a>
-        </div>
-        <div>
-          <form onSubmit={onFormSubmit} className="form">
-            <fieldset>
-              <label htmlFor="repoInput">
-                <span>GitHub Repo:</span>
-                <input
-                  id="repoInput"
-                  onChange={onRepoChange}
-                  type="text"
-                  name="repo"
-                  value={repo}
-                  size="80"
-                />
-              </label>
-            </fieldset>
-            <fieldset>
-              <label htmlFor="gitrefInput">
-                <span>Branch/commit:</span>
-                <input
-                  id="gitrefInput"
-                  onChange={onGitrefChange}
-                  type="text"
-                  name="gitref"
-                  value={gitref}
-                  size="80"
-                />
-              </label>
-            </fieldset>
-            <fieldset>
-              <button type="submit">Build and Connect</button>
-            </fieldset>
-          </form>
-        </div>
+        <form onSubmit={onFormSubmit} className="form">
+          <fieldset>
+            <label htmlFor="repoInput">
+              <span>GitHub Repo:</span>
+              <input
+                id="repoInput"
+                onChange={onRepoChange}
+                type="text"
+                name="repo"
+                value={repo}
+                size="80"
+              />
+            </label>
+          </fieldset>
+          <fieldset>
+            <label htmlFor="gitrefInput">
+              <span>Branch/commit:</span>
+              <input
+                id="gitrefInput"
+                onChange={onGitrefChange}
+                type="text"
+                name="gitref"
+                value={gitref}
+                size="80"
+              />
+            </label>
+          </fieldset>
+          <fieldset>
+            <button type="submit">Build and Connect</button>
+          </fieldset>
+        </form>
         <style jsx>{`
-          img {
-            vertical-align: middle;
-            margin: 0 0 7px 10px;
-          }
-
           input {
             font-family: inherit;
             font-size: inherit;
@@ -85,6 +90,8 @@ class BinderUI extends React.Component {
 
           fieldset {
             border: none;
+            padding-left: 0px;
+            margin-left: 0px;
           }
 
           label span {
@@ -93,38 +100,33 @@ class BinderUI extends React.Component {
             display: inline-block;
           }
 
-          .binder-ui-wrapper {
-            padding: 0px 0px 5px 10px;
-          }
+          // .binder-ui-wrapper {
+          //   padding: 0px 0px 5px 10px;
+          // }
         `}</style>
       </div>
     );
   }
 }
-// TODO: Make a generic little console for some of the styled container pieces,
-//       then make this component inject the binder specific bits
-export class BinderConsole extends React.Component {
-  render() {
-    const { logs, ...otherprops } = this.props;
-    return (
-      <div className="binder-console">
-        <BinderUI {...otherprops} />
-        <div className="logs">
-          {logs.length > 0
-            ? logs.map((log, index) => {
-                return (
-                  <span className="log" key={index}>
-                    <span className="sidebar" />
-                    <span className="phase">{log.phase}</span>
-                    <span className="content">
-                      <span className="message">{log.message}</span>
-                    </span>
-                  </span>
-                );
-              })
-            : null}
-        </div>
 
+class BinderLogs extends React.Component {
+  render() {
+    const { logs } = this.props;
+    return (
+      <div className="logs">
+        {logs.length > 0
+          ? logs.map((log, index) => {
+              return (
+                <span className="log" key={index}>
+                  <span className="sidebar" />
+                  <span className="phase">{log.phase}</span>
+                  <span className="content">
+                    <span className="message">{log.message}</span>
+                  </span>
+                </span>
+              );
+            })
+          : null}
         <style jsx>{`
           .log {
             padding: 0 15px 0 0px;
@@ -153,16 +155,35 @@ export class BinderConsole extends React.Component {
 
           .sidebar {
             display: inline-block;
-            text-align: right;
-            min-width: 40px;
+            text-align: left;
+            min-width: 20px;
             text-decoration: none;
             color: #666;
           }
 
+          .log:last-child {
+            background-color: #292929;
+          }
+        `}</style>
+      </div>
+    );
+  }
+}
+// TODO: Make a generic little console for some of the styled container pieces,
+//       then make this component inject the binder specific bits
+export class BinderConsole extends React.Component {
+  render() {
+    const { logs, ...otherprops } = this.props;
+    return (
+      <div className="binder-console">
+        <BinderLogo />
+        <BinderUI {...otherprops} />
+        <BinderLogs logs={logs} />
+        <style jsx>{`
           .binder-console {
             clear: left;
             min-height: 42px;
-            padding: 15px 0px 15px 0;
+            padding: 15px 0px 20px 25px;
             color: #f1f1f1;
             font-family: Monaco, monospace;
             font-size: 12px;
@@ -172,10 +193,6 @@ export class BinderConsole extends React.Component {
             background-color: #1a1a1a;
             counter-reset: line-numbering;
             margin-top: 0;
-          }
-
-          .log:last-child {
-            background-color: #292929;
           }
         `}</style>
       </div>


### PR DESCRIPTION
This follows up on a comment from #2141 to refactor the structure. I didn't actually take out the `...other props` bit because the problem isn't that it needs to be refactored further but that at the level that it's being passed down there there are just too many props for it to be easily legible.

We could break it up into a Higher-level component and subcomponents, but that would seem to isolate some of the functionality, though we could do that if it were desired by using `this.props.children`.