### PR TITLE
Npm build only

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "build:packages": "lerna run build --parallel --ignore @nteract/play --ignore @nteract/showcase --ignore nteract",
     "build:packages:watch": "lerna run build:lib:watch --parallel --ignore @nteract/play --ignore @nteract/showcase --ignore nteract",
     "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",
+    "build:only": "lerna run build --scope",
+    "build:only:watch": "lerna run build:watch --scope",
     "test": "jest",
     "test:unit": "npm run test",
     "test:coverage": "npm run test:unit -- --coverage",

--- a/packages/ansi-to-react/package.json
+++ b/packages/ansi-to-react/package.json
@@ -14,6 +14,7 @@
     "build": "npm run build:es5 && npm run build:flow",
     "build:flow": "flow-copy-source -v -i '**/tests/**' src lib",
     "build:es5": "babel src --out-dir lib/ --source-maps",
+    "build:watch": "npm run build:es5 --watch && npm run build:flow",
     "clean": "rimraf lib/*"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/ansi-to-react",

--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/commutable",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow",
     "test": "jest",
     "test:watch": "npm run test -- --watch"
   },

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/display-area",
   "keywords": [

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/editor",
   "keywords": [

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -12,6 +12,7 @@
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow",
     "test": "jest",
     "test:integration": "node scripts/exercise-enchannel.js",
     "test:watch": "npm run test -- --watch"

--- a/packages/fs-observable/package.json
+++ b/packages/fs-observable/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/fs-observable",
   "keywords": [

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/messaging",
   "dependencies": {

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/notebook-preview",
   "publishConfig": {

--- a/packages/rx-binder/package.json
+++ b/packages/rx-binder/package.json
@@ -10,6 +10,7 @@
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow",
     "test": "jest"
   },
   "repository": {

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -10,6 +10,7 @@
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow",
     "pretest": "npm run build",
     "test": "npm run test:unit && npm run test:lint",
     "test:unit": "mocha --compilers js:babel-core/register --recursive",

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-dataresource",

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-geojson",
   "dependencies": {

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-model-debug",
   "author": "",

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-plotly",
   "author": "",

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-vdom",
   "author": "",

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "author": "",
   "publishConfig": {

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transforms-full",
   "keywords": [

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -10,7 +10,8 @@
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
-    "build:lib:watch": "npm run build:lib -- --watch"
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transforms",
   "keywords": [


### PR DESCRIPTION
These `build:watch` commands are not exactly the same as `build` because they won't run flow until after the rest of the process is completed (which will never occur). I probably should just remove those `&& npm run build:flow` bits…

Right now there doesn't seem to be a good way to have type checking running as part of what is triggered with the build. 

If anyone has any ideas I'm all ears!