### PR TITLE
[jupyter-ext] use our builtin Notebook package

### DIFF
--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -10,9 +10,8 @@ import { Map as ImmutableMap } from "immutable";
 import NotificationSystem from "react-notification-system";
 
 import configureStore from "./store";
-// TODO: This should pull from a regular import that webpack and jest will use to
-//       load the right copy
-import Notebook from "@nteract/core/lib/components/notebook.js";
+
+import { Notebook } from "@nteract/core/components";
 
 import { setNotificationSystem } from "@nteract/core/actions";
 

--- a/applications/jupyter-extension/README.md
+++ b/applications/jupyter-extension/README.md
@@ -13,13 +13,18 @@ jupyter serverextension enable nteract_on_jupyter
 
 Make sure you've done the `npm install` at the base of the nteract/nteract monorepo, then within this package:
 
-``` 
+```
 pip install -e .
 jupyter serverextension enable nteract_on_jupyter
+```
+
+Now, `cd` into `nteract_on_jupyter` and run:
+
+```
+npm run build:watch
 ```
 
 ## ROADMAP(ish)
 
 * In development mode, have a clean webpack build locally
 * In production, be able to toggle an endpoint to get the bundle from
-

--- a/applications/jupyter-extension/nteract_on_jupyter/extension.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/extension.py
@@ -15,6 +15,7 @@ from .config import Config
 
 from .handlers import add_handlers
 
+
 def get_app_dir(app_dir=None):
     """Get the configured nteract app directory.
     """
@@ -34,7 +35,7 @@ def load_jupyter_server_extension(nbapp):
     #if hasattr(nbapp, 'app_dir'):
     #    app_dir = get_app_dir(nbapp.app_dir)
 
-    app_dir = here # bundle is part of the python package
+    app_dir = here  # bundle is part of the python package
 
     web_app = nbapp.web_app
     config = Config()

--- a/applications/jupyter-extension/nteract_on_jupyter/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.js
@@ -35,7 +35,6 @@ function createApp(jupyterConfigData: JupyterConfigData) {
         <Provider store={store}>
           <div>
             {/* <Contents /> */}
-            <pre>it should be here...</pre>
             <Notebook />
             <NotificationSystem
               ref={notificationSystem => {

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -2,4 +2,4 @@ import Notebook from "./notebook";
 
 const _nextgen = require("./ng");
 
-export { _nextgen };
+export { _nextgen, Notebook };


### PR DESCRIPTION
This brings out nbextension back to a working state with the current core (though the store is not fully hooked up). This also cleans up a flow/jest error that will intermittently happen with the desktop app.