### PR TITLE
Binder kernels — trying to make a UI so that it's configurable

### DIFF
--- a/applications/play/components/kernelUI.js
+++ b/applications/play/components/kernelUI.js
@@ -12,14 +12,11 @@ class KernelSelector extends React.Component {
     const { kernelspecs, currentKernel, onChange } = this.props;
     return (
       <form>
-        <label>
-          Current Kernel:
-          <select value={currentKernel} onChange={onChange}>
-            {Object.keys(kernelspecs).map((kernelName, index) => {
-              return <KernelOption kernelName={kernelName} key={kernelName} />;
-            })}
-          </select>
-        </label>
+        <select value={currentKernel} onBlur={onChange} onChange={onChange}>
+          {Object.keys(kernelspecs).map((kernelName, index) => {
+            return <KernelOption kernelName={kernelName} key={kernelName} />;
+          })}
+        </select>
         <style jsx>
           {`
             form label,

--- a/applications/play/components/kernelUI.js
+++ b/applications/play/components/kernelUI.js
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+// TODO: Make a generic little console for some of the styled container pieces,
+//       then make this component inject the binder specific bits
+export class KernelUI extends React.Component {
+  render() {
+    const { status } = this.props;
+    return (
+      <div className="kernel-data">
+        <div className="kernelInfo">
+          <span className="kernel">Runtime: </span>
+          {this.props.status}
+        </div>
+        <style jsx>{`
+          .kernelInfo {
+            color: #f1f1f1;
+            line-height: var(--header-height);
+            font-family: Monaco, monospace, system-ui;
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            vertical-align: middle;
+            display: table-cell;
+            padding-right: 20px;
+          }
+          .kernel {
+            color: #888;
+          }
+        `}</style>
+      </div>
+    );
+  }
+}

--- a/applications/play/components/kernelUI.js
+++ b/applications/play/components/kernelUI.js
@@ -20,13 +20,9 @@ class KernelSelector extends React.Component {
         <style jsx>
           {`
             form label,
-            form select,
-            form option {
+            form select {
               font-family: inherit;
               font-size: inherit;
-            }
-            :global(form span.kernelOption) {
-              text-align: center;
             }
           `}
         </style>

--- a/applications/play/components/kernelUI.js
+++ b/applications/play/components/kernelUI.js
@@ -3,21 +3,35 @@ import * as React from "react";
 class KernelOption extends React.Component {
   render() {
     const { kernelName } = this.props;
-    return <span>{kernelName}</span>;
+    return <option value={kernelName}>{kernelName}</option>;
   }
 }
 
-// TODO: Make a generic little console for some of the styled container pieces,
-//       then make this component inject the binder specific bits
+class KernelSelector extends React.Component {
+  render() {
+    const { kernelspecs, currentKernel, onChange } = this.props;
+    return (
+      <form>
+        <label>
+          Current Kernel:
+          <select value={currentKernel} onChange={onChange}>
+            {Object.keys(kernelspecs).map((kernelName, index) => {
+              return <KernelOption kernelName={kernelName} key={kernelName} />;
+            })}
+          </select>
+        </label>
+      </form>
+    );
+  }
+}
+
 export class KernelUI extends React.Component {
   render() {
-    const { status } = this.props;
+    const { status, ...otherprops } = this.props;
     return (
       <div className="kernel-data">
         <div className="kernelInfo">
-          {Object.keys(this.props.kernelspecs).map((kernelName, index) => {
-            return <KernelOption kernelName={kernelName} key={kernelName} />;
-          })}
+          <KernelSelector {...otherprops} />
           <span className="kernel">Runtime: </span>
           {this.props.status}
         </div>

--- a/applications/play/components/kernelUI.js
+++ b/applications/play/components/kernelUI.js
@@ -1,5 +1,12 @@
 import * as React from "react";
 
+class KernelOption extends React.Component {
+  render() {
+    const { kernelName } = this.props;
+    return <span>{kernelName}</span>;
+  }
+}
+
 // TODO: Make a generic little console for some of the styled container pieces,
 //       then make this component inject the binder specific bits
 export class KernelUI extends React.Component {
@@ -8,6 +15,9 @@ export class KernelUI extends React.Component {
     return (
       <div className="kernel-data">
         <div className="kernelInfo">
+          {Object.keys(this.props.kernelspecs).map((kernelName, index) => {
+            return <KernelOption kernelName={kernelName} key={kernelName} />;
+          })}
           <span className="kernel">Runtime: </span>
           {this.props.status}
         </div>

--- a/applications/play/components/kernelUI.js
+++ b/applications/play/components/kernelUI.js
@@ -20,6 +20,19 @@ class KernelSelector extends React.Component {
             })}
           </select>
         </label>
+        <style jsx>
+          {`
+            form label,
+            form select,
+            form option {
+              font-family: inherit;
+              font-size: inherit;
+            }
+            :global(form span.kernelOption) {
+              text-align: center;
+            }
+          `}
+        </style>
       </form>
     );
   }
@@ -30,25 +43,36 @@ export class KernelUI extends React.Component {
     const { status, ...otherprops } = this.props;
     return (
       <div className="kernel-data">
-        <div className="kernelInfo">
+        <div className="kernelSelector">
           <KernelSelector {...otherprops} />
-          <span className="kernel">Runtime: </span>
+        </div>
+        <div className="kernelInfo">
+          <span className="kernelStatus">Runtime: </span>
           {this.props.status}
         </div>
         <style jsx>{`
           .kernelInfo {
             color: #f1f1f1;
             line-height: var(--header-height);
-            font-family: Monaco, monospace, system-ui;
-            font-size: 12px;
             white-space: pre-wrap;
             word-wrap: break-word;
             vertical-align: middle;
             display: table-cell;
             padding-right: 20px;
           }
-          .kernel {
+          .kernel-data {
+            font-family: Monaco, monospace;
+            font-size: 12px;
+          }
+          .kernelStatus {
             color: #888;
+          }
+          .kernelSelector {
+            display: table-cell;
+            vertical-align: middle;
+            padding-right: 10px;
+            font-family: inherit;
+            font-size: inherit;
           }
         `}</style>
       </div>

--- a/applications/play/pages/index.js
+++ b/applications/play/pages/index.js
@@ -24,10 +24,10 @@ const {
 
 import { BinderConsole } from "../components/consoles";
 import { KernelUI } from "../components/kernelUI";
-import { kernelspecs } from "rx-jupyter";
+import { kernels, shutdown, kernelspecs } from "rx-jupyter";
+import { binder } from "rx-binder";
 
 const { binder } = require("rx-binder");
-const { kernels, shutdown } = require("rx-jupyter");
 
 const {
   filter,

--- a/applications/play/pages/index.js
+++ b/applications/play/pages/index.js
@@ -417,6 +417,7 @@ div(
             height: calc(var(--header-height) - 16px);
             width: 80px;
             margin-left: 10px;
+            padding: 0px 20px 0px 10px;
           }
 
           header img,
@@ -433,6 +434,7 @@ div(
             background-color: rgba(0, 0, 0, 0);
             color: white;
             height: var(--header-height);
+            font-family: Monaco, monospace;
           }
 
           header button:active,
@@ -448,25 +450,6 @@ div(
           header button:disabled {
             background-color: rgba(255, 255, 255, 0.1);
             color: rgba(255, 255, 255, 0.1);
-          }
-
-          header img {
-            padding: 0px 20px 0px 10px;
-          }
-
-          .kernelInfo {
-            color: #f1f1f1;
-            line-height: var(--header-height);
-            font-family: Monaco, monospace, system-ui;
-            font-size: 12px;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            vertical-align: middle;
-            display: table-cell;
-            padding-right: 20px;
-          }
-          .kernel {
-            color: #888;
           }
 
           .play-editor {

--- a/applications/play/pages/index.js
+++ b/applications/play/pages/index.js
@@ -129,10 +129,9 @@ div(
   }
 
   async handleKernelChange(event) {
-    this.setState({
-      kernelName: event.target.value
-    });
-    await this.updateKernel();
+    this.state.kernelName !== event.target.value
+      ? await this.updateKernel(event.target.value)
+      : null;
   }
 
   async killKernel(serverConfig, kernelID) {
@@ -147,7 +146,7 @@ div(
     return deadkernel;
   }
 
-  async updateKernel() {
+  async updateKernel(kernelName) {
     const deadkernel = await this.killKernel(
       this.state.serverConfig,
       this.state.kernel.id

--- a/applications/play/pages/index.js
+++ b/applications/play/pages/index.js
@@ -82,9 +82,9 @@ export default class App extends React.Component {
       kernelMessages: [],
       serverConfig: null,
       kernel: null,
-      kernelName: "python3",
+      kernelName: "",
       kernelStatus: "provisioning",
-      kernelspec: null,
+      kernelspecs: null,
       error: null,
       repo: "binder-examples/jupyter-stacks",
       gitref: "master",
@@ -274,7 +274,7 @@ div(
     this.setState({ serverConfig });
     const kernelspec = await this.kernelList(this.state.serverConfig);
     this.setState({
-      kernelspec,
+      kernelspecs: kernelspec.kernelspecs,
       kernelName: kernelspec.default
     });
     const kernel = await this.getKernel(serverConfig, this.state.kernelName);
@@ -323,9 +323,8 @@ div(
 
           <KernelUI
             status={this.state.kernelStatus}
-            kernelspecs={
-              this.state.kernelspec ? this.state.kernelspec.kernelspecs : {}
-            }
+            kernelspecs={this.state.kernelspecs ? this.state.kernelspecs : {}}
+            currentKernel={this.state.kernelName}
             onChange={this.handleKernelChange}
           />
         </header>

--- a/applications/play/pages/index.js
+++ b/applications/play/pages/index.js
@@ -75,7 +75,7 @@ export default class App extends React.Component {
     this.handleFormSubmit = this.handleFormSubmit.bind(this);
     this.handleGitrefChange = this.handleGitrefChange.bind(this);
     this.handleRepoChange = this.handleRepoChange.bind(this);
-    this.kernelList = this.kernelList.bind(this);
+    this.handleKernelChange = this.handleKernelChange.bind(this);
 
     this.state = {
       binderMessages: [],
@@ -125,6 +125,12 @@ div(
   handleGitrefChange(event) {
     this.setState({
       gitref: event.target.value
+    });
+  }
+
+  handleKernelChange(event) {
+    this.setState({
+      kernelName: event.target.value
     });
   }
 
@@ -315,7 +321,13 @@ div(
             </button>
           </div>
 
-          <KernelUI status={this.state.kernelStatus} />
+          <KernelUI
+            status={this.state.kernelStatus}
+            kernelspecs={
+              this.state.kernelspec ? this.state.kernelspec.kernelspecs : {}
+            }
+            onChange={this.handleKernelChange}
+          />
         </header>
 
         {this.state.showPanel ? (

--- a/packages/rx-jupyter/__tests__/kernel-spec.js
+++ b/packages/rx-jupyter/__tests__/kernel-spec.js
@@ -38,7 +38,7 @@ describe("kernels", () => {
       });
       expect(request.method).toBe("POST");
       expect(request.body.path).toBe("/tmp");
-      expect(request.body.kernel_name).toBe("python3000");
+      expect(request.body.name).toBe("python3000");
     });
   });
 

--- a/packages/rx-jupyter/src/kernels.js
+++ b/packages/rx-jupyter/src/kernels.js
@@ -55,7 +55,7 @@ export function start(
     method: "POST",
     body: {
       path,
-      kernel_name: name
+      name
     }
   });
   return ajax(startSettings);


### PR DESCRIPTION
This is really a WIP, but at the point of submitting this PR we're getting the kernelspecs and then dumping the kernel names to the left of the Kernel status area. 

My current plan is to put a selector there from which we can choose different kernels and on switching kernels it handles the kernel lifecycle startup and closure.

Unfortunately I might not have a chance to work on this again until next week at the sprint, but it seems like it's a good start.