### PR TITLE
create an octicons package from core + commuter

### DIFF
--- a/packages/commuter-frontend/components/contents/directory-listing.js
+++ b/packages/commuter-frontend/components/contents/directory-listing.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 
-import octicons from "../../icons/octicons";
+import { Book, FileText, FileDirectory } from "@nteract/octicons";
 
 import Link from "next/link";
 
@@ -98,11 +98,11 @@ const DirectoryListing = (props: DirectoryListingProps) => {
 
               const icon =
                 row.type === "notebook" ? (
-                  <octicons.Book />
+                  <Book />
                 ) : row.type === "directory" ? (
-                  <octicons.FileDirectory />
+                  <FileDirectory />
                 ) : (
-                  <octicons.FileText />
+                  <FileText />
                 );
 
               return (

--- a/packages/commuter-frontend/package.json
+++ b/packages/commuter-frontend/package.json
@@ -29,9 +29,11 @@
   "dependencies": {
     "@nteract/core": "^0.0.8",
     "@nteract/notebook-preview": "^4.1.5",
+    "@nteract/timeago": "^3.4.3",
     "@nteract/transform-dataresource": "^2.0.2",
     "@nteract/transform-vega": "^3.0.1",
     "@nteract/transforms": "^3.0.3",
+    "@nteract/octicons": "^0.0.1",
     "babel-preset-flow": "^6.23.0",
     "d3-dsv": "^1.0.7",
     "isomorphic-fetch": "^2.2.1",
@@ -39,11 +41,9 @@
     "mathjax-electron": "^2.0.1",
     "next": "^4.1.4",
     "nprogress": "^0.2.0",
-    "octicons": "^6.0.1",
     "prop-types": "^15.5.10",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "@nteract/timeago": "^3.4.3",
     "styled-jsx": "^2.1.3"
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@nteract/display-area": "^3.1.0",
     "@nteract/editor": "^4.2.2",
     "@nteract/transforms": "^3.0.3",
+    "@nteract/octicons": "^0.0.1",
     "commonmark": "^0.28.0",
     "commonmark-react-renderer": "^4.3.3",
     "date-fns": "^1.28.5",

--- a/packages/core/src/components/cell-creator.js
+++ b/packages/core/src/components/cell-creator.js
@@ -7,7 +7,11 @@ type Props = {
   mergeCell: () => void
 };
 
-import { CodeOcticon, MarkdownOcticon, DownArrowOcticon } from "./octicons";
+import {
+  CodeOcticon,
+  MarkdownOcticon,
+  DownArrowOcticon
+} from "@nteract/octicons";
 
 export default (props: Props) => (
   <div className="creator-hover-mask">

--- a/packages/core/src/components/notebook.js
+++ b/packages/core/src/components/notebook.js
@@ -22,7 +22,7 @@ import {
   executeCell
 } from "../actions";
 
-import { LinkExternalOcticon } from "./octicons";
+import { LinkExternalOcticon } from "@nteract/octicons";
 
 // NOTE: PropTypes are required for the sake of contextTypes
 const PropTypes = require("prop-types");

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -17,7 +17,7 @@ import {
   TrashOcticon,
   ChevronDownOcticon,
   TriangleRightOcticon
-} from "./octicons";
+} from "@nteract/octicons";
 
 declare type ToolbarProps = {|
   type: string,

--- a/packages/octicons/package.json
+++ b/packages/octicons/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@nteract/octicons",
+  "version": "0.0.1",
+  "description": "octicon react components, styled for use within nteract packages",
+  "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "build:clean": "rimraf lib",
+    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow",
+    "test:watch": "npm run test -- --watch"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {
+    "react": "^16.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": ["octicons", "react"],
+  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "license": "BSD-3-Clause"
+}

--- a/packages/octicons/src/index.js
+++ b/packages/octicons/src/index.js
@@ -23,16 +23,14 @@ export const SVGWrapper = (props: WrapperProps<*>) => {
         height={props.height}
         viewBox={props.viewBox}
         {...outerProps}
+        style={{
+          fill: "currentColor",
+          display: "inline-block",
+          verticalAlign: "text-bottom"
+        }}
       >
         {props.children}
       </svg>
-      <style jsx>{`
-        svg {
-          fill: currentColor;
-          display: inline-block;
-          vertical-align: text-bottom;
-        }
-      `}</style>
     </span>
   );
 };
@@ -96,6 +94,39 @@ export const LinkExternalOcticon = (props: any) => (
     <path
       fillRule="evenodd"
       d="M11 10h1v3c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h3v1H1v10h10v-3zM6 2l2.25 2.25L5 7.5 6.5 9l3.25-3.25L12 8V2H6z"
+    />
+  </SVGWrapper>
+);
+
+export const FileText = (props: any) => (
+  <SVGWrapper width={12} height={16} viewBox="0 0 12 16" outerProps={props}>
+    <path d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z" />
+  </SVGWrapper>
+);
+
+export const Book = (props: any) => (
+  <SVGWrapper width={16} height={16} viewBox="0 0 16 16" outerProps={props}>
+    <path
+      fillRule="evenodd"
+      d="M3 5h4v1H3V5zm0 3h4V7H3v1zm0 2h4V9H3v1zm11-5h-4v1h4V5zm0 2h-4v1h4V7zm0 2h-4v1h4V9zm2-6v9c0 .55-.45 1-1 1H9.5l-1 1-1-1H2c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h5.5l1 1 1-1H15c.55 0 1 .45 1 1zm-8 .5L7.5 3H2v9h6V3.5zm7-.5H9.5l-.5.5V12h6V3z"
+    />
+  </SVGWrapper>
+);
+
+export const FileDirectory = (props: any) => (
+  <SVGWrapper width={14} height={16} viewBox="0 0 14 16" outerProps={props}>
+    <path
+      fillRule="evenodd"
+      d="M13 4H7V3c0-.66-.31-1-1-1H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zM6 4H1V3h5v1z"
+    />
+  </SVGWrapper>
+);
+
+export const CloudDownload = (props: any) => (
+  <SVGWrapper width={16} height={16} viewBox="0 0 16 16" outerProps={props}>
+    <path
+      fillRule="evenodd"
+      d="M9 12h2l-3 3-3-3h2V7h2v5zm3-8c0-.44-.91-3-4.5-3C5.08 1 3 2.92 3 5 1.02 5 0 6.52 0 8c0 1.53 1 3 3 3h3V9.7H3C1.38 9.7 1.3 8.28 1.3 8c0-.17.05-1.7 1.7-1.7h1.3V5c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V11h2c2.08 0 4-1.16 4-3.5C16 5.06 14.08 4 12 4z"
     />
   </SVGWrapper>
 );


### PR DESCRIPTION
Follow on from #2162, unifying our octicon SVG React components.

Note that I switched it to inline styles here. We may want to go back to styled-jsx at some point, I just didn't want to add in the babel setup for this little package and for so few styles.