### PR TITLE
Only prettify staged code in precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",
     "precommit": "lint-staged",
-    "prettier": "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
+    "prettify": "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
     "dist": "lerna run dist --scope nteract --stream",
     "pack": "lerna run pack --scope nteract --stream",
     "publish": "lerna run publish --scope nteract --stream",


### PR DESCRIPTION
`lint-staged` was conflicting with with the `npm` script and therefor prettifying all files on precommit which can take a long time.

Commits are now fast again 🚀
Still no support for partially staged files though.