### PR TITLE
Disable semantic commits for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "semanticCommits": false
 }


### PR DESCRIPTION
This will shorten/simplify PR titles and commit messages, as you don't seem to be using semantic commits otherwise.