### PR TITLE
Revert "Update dependency react-syntax-highlighter to ^6.0.0"

### DIFF
--- a/applications/showcase/package.json
+++ b/applications/showcase/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^16.0.0",
     "react-markdown": "^2.5.0",
     "react-redux": "^5.0.5",
-    "react-syntax-highlighter": "^6.0.0",
+    "react-syntax-highlighter": "^5.8.0",
     "rxjs": "^5.5.0",
     "styled-jsx": "^2.1.3",
     "uuid": "^3.1.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "react-dnd-html5-backend": "^2.4.1",
     "react-redux": "^5.0.5",
     "react-simple-dropdown": "^3.0.0",
-    "react-syntax-highlighter": "^6.0.0",
+    "react-syntax-highlighter": "^5.8.0",
     "redux": "^3.7.0",
     "rxjs": "^5.5.0",
     "styled-jsx": "^2.1.3",


### PR DESCRIPTION
Reverts nteract/nteract#2200

Should fix `master`