### PR TITLE
Disable uglify on next.js apps

### DIFF
--- a/applications/notebook-on-next/next.config.js
+++ b/applications/notebook-on-next/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  webpack(cfg) {
+    cfg.plugins = cfg.plugins.filter(
+      plugin => plugin.constructor.name !== "UglifyJsPlugin"
+    );
+    return cfg;
+  }
+};

--- a/applications/play/next.config.js
+++ b/applications/play/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  webpack(cfg) {
+    cfg.plugins = cfg.plugins.filter(
+      plugin => plugin.constructor.name !== "UglifyJsPlugin"
+    );
+    return cfg;
+  }
+};


### PR DESCRIPTION
Disable uglify on next.js apps until we find out why it's failing. This should fix our build issues for now.

Probably some dependency is not correctly transpiled.