### PR TITLE
Resolve flow types from src

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,6 +5,30 @@ types
 [options]
 module.ignore_non_literal_requires=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+module.name_mapper='^ansi-to-react$' -> '<PROJECT_ROOT>/packages/ansi-to-react/src/'
+module.name_mapper='^@nteract/commutable$' -> '<PROJECT_ROOT>/packages/commutable/src/'
+module.name_mapper='^@nteract/commuter-frontend$' -> '<PROJECT_ROOT>/packages/commuter-frontend/src/'
+module.name_mapper='^@nteract/core$' -> '<PROJECT_ROOT>/packages/core'
+module.name_mapper='^@nteract/display-area$' -> '<PROJECT_ROOT>/packages/display-area/src/'
+module.name_mapper='^@nteract/editor$' -> '<PROJECT_ROOT>/packages/editor/src/'
+module.name_mapper='^enchannel-zmq-backend$' -> '<PROJECT_ROOT>/packages/enchannel-zmq-backend/src/'
+module.name_mapper='^fs-observable$' -> '<PROJECT_ROOT>/packages/fs-observable/src/'
+module.name_mapper='^@nteract/messaging$' -> '<PROJECT_ROOT>/packages/messaging/src/'
+module.name_mapper='^@nteract/notebook-preview$' -> '<PROJECT_ROOT>/packages/notebook-preview/src/'
+module.name_mapper='^@nteract/octicons$' -> '<PROJECT_ROOT>/packages/octicons/src/'
+module.name_mapper='^rx-binder$' -> '<PROJECT_ROOT>/packages/rx-binder/src/'
+module.name_mapper='^rx-jupyter$' -> '<PROJECT_ROOT>/packages/rx-jupyter/src/'
+module.name_mapper='^@nteract/timeago$' -> '<PROJECT_ROOT>/packages/timeago/src/'
+module.name_mapper='^@nteract/transform-dataresource$' -> '<PROJECT_ROOT>/packages/transform-dataresource/src/'
+module.name_mapper='^@nteract/transform-geojson$' -> '<PROJECT_ROOT>/packages/transform-geojson/src/'
+module.name_mapper='^@nteract/transform-model-debug$' -> '<PROJECT_ROOT>/packages/transform-model-debug/src/'
+module.name_mapper='^@nteract/transform-plotly$' -> '<PROJECT_ROOT>/packages/transform-plotly/src/'
+module.name_mapper='^@nteract/transform-vdom$' -> '<PROJECT_ROOT>/packages/transform-vdom/src/'
+module.name_mapper='^@nteract/transform-vega$' -> '<PROJECT_ROOT>/packages/transform-vega/src/'
+module.name_mapper='^@nteract/transforms$' -> '<PROJECT_ROOT>/packages/transforms/src/'
+module.name_mapper='^@nteract/transforms-full$' -> '<PROJECT_ROOT>/packages/transforms-full/src/'
+include_warnings=true
+emoji=true
 
 [ignore]
 .*/node_modules/eslint-plugin-jsx-a11y/src/.*

--- a/applications/commuter/src/content-providers/local/fs.js
+++ b/applications/commuter/src/content-providers/local/fs.js
@@ -48,7 +48,6 @@ function createContentResponse(
     path.join(parsedFilePath.dir, parsedFilePath.base)
   );
   const writable = Boolean(fs.constants.W_OK & stat.mode);
-  // $FlowFixMe: See https://github.com/facebook/flow/pull/3767
   const created: Date = stat.birthtime;
   const last_modified = stat.mtime;
 
@@ -206,7 +205,6 @@ function getDirectory(
 
         Promise.all(contentPromises)
           .then(contents =>
-            // $FlowFixMe
             contents.filter(x => !(x === null || x === undefined))
           )
           .then(contents => {

--- a/applications/desktop/src/notebook/epics/config.js
+++ b/applications/desktop/src/notebook/epics/config.js
@@ -69,7 +69,6 @@ export const saveConfigEpic = (actions: ActionsObservable<*>, store: any) =>
     mergeMap(() =>
       writeFileObservable(
         CONFIG_FILE_PATH,
-        // $FlowFixMe: We're totally using this argument, not sure what's up here
         JSON.stringify(store.getState().config.toJS())
       ).pipe(map(doneSavingConfig))
     )

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -36,7 +36,6 @@ export function saveEpic(
     mergeMap(action =>
       writeFileObservable(
         action.filename,
-        // $FlowFixMe: We're totally using this argument, not sure what's up here
         stringifyNotebook(
           toJS(
             action.notebook.setIn(

--- a/applications/jupyter-extension/nteract_on_jupyter/components/notebook.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/components/notebook.js
@@ -10,7 +10,7 @@ global.$ = jquery;
 import React, { PropTypes as T } from "react";
 
 import NotebookPreview from "@nteract/notebook-preview";
-import MarkdownTransform from "@nteract/transforms/lib/markdown";
+import { MarkdownTransform } from "@nteract/transforms";
 import DataResourceTransform from "@nteract/transform-dataresource";
 import { VegaLite, Vega } from "@nteract/transform-vega";
 import { PlotlyNullTransform, PlotlyTransform } from "./transforms";

--- a/packages/ansi-to-react/package.json
+++ b/packages/ansi-to-react/package.json
@@ -5,9 +5,9 @@
   "main": "lib/index.js",
   "nteractDesktop": "src/index.js",
   "scripts": {
-    "prebuild": "npm run build:clean",
-    "prepublish": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:flow": "flow-copy-source -v -i '**/tests/**' src lib",
     "build:clean": "rimraf lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/commutable/src/index.js
+++ b/packages/commutable/src/index.js
@@ -21,7 +21,7 @@ const {
   emptyMarkdownCell,
   appendCell,
   monocellNotebook,
-
+  createCodeCell,
   appendCellToNotebook,
 
   insertCellAt,
@@ -99,6 +99,7 @@ module.exports = {
   toJS,
   fromJS,
 
+  createCodeCell,
   parseNotebook,
   stringifyNotebook,
 

--- a/packages/commuter-frontend/components/contents/index.js
+++ b/packages/commuter-frontend/components/contents/index.js
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 import NotebookPreview from "@nteract/notebook-preview";
-import MarkdownTransform from "@nteract/transforms/lib/markdown";
+import { MarkdownTransform } from "@nteract/transforms";
 
 import DirectoryListing from "./directory-listing";
 
@@ -109,7 +109,6 @@ export const Entry = (props: EntryProps) => {
     case "notebook":
       return (
         <NotebookPreview
-          // $FlowFixMe COME BACK TO THIS
           notebook={props.entry.content}
           displayOrder={displayOrder}
           transforms={transforms}

--- a/packages/commuter-frontend/components/contents/zeppelin.js
+++ b/packages/commuter-frontend/components/contents/zeppelin.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from "react";
 
-import JSONTransform from "@nteract/transforms/lib/json";
-import HTML from "@nteract/transforms/lib/html";
+import { JSONTransform, HTMLTransform } from "@nteract/transforms";
 
 import { _nextgen } from "@nteract/core/components";
 
@@ -162,7 +161,7 @@ const UnsupportedResult = props => (
 const Message = props => {
   switch (props.type) {
     case "HTML":
-      return <HTML data={props.data} />;
+      return <HTMLTransform data={props.data} />;
     case "TEXT":
       return <Text data={props.data} />;
     default:
@@ -177,7 +176,7 @@ const Result = props => {
 
   switch (props.result.type) {
     case "HTML":
-      return <HTML data={props.result.msg} />;
+      return <HTMLTransform data={props.result.msg} />;
     case "TEXT":
       return <Text data={props.result.msg} />;
     case "TABLE":

--- a/packages/core/actions.js
+++ b/packages/core/actions.js
@@ -1,2 +1,1 @@
-// @flow
 module.exports = require("./").actions;

--- a/packages/core/components.js
+++ b/packages/core/components.js
@@ -1,2 +1,1 @@
-// @flow
 module.exports = require("./").components;

--- a/packages/core/constants.js
+++ b/packages/core/constants.js
@@ -1,2 +1,1 @@
-// @flow
 module.exports = require("./").constants;

--- a/packages/core/middlewares.js
+++ b/packages/core/middlewares.js
@@ -1,2 +1,1 @@
-// @flow
 module.exports = require("./").middlewares;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/core/records.js
+++ b/packages/core/records.js
@@ -1,2 +1,1 @@
-// @flow
 module.exports = require("./").records;

--- a/packages/core/reducers.js
+++ b/packages/core/reducers.js
@@ -1,2 +1,1 @@
-// @flow
 module.exports = require("./").reducers;

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -361,7 +361,6 @@ class CodeMirrorEditor extends React.Component<
       !editor.somethingSelected()
     ) {
       const CM = require("codemirror");
-      // $FlowFixMe: fix the flow definition for signal on a commonjs import
       CM.signal(editor, "bottomBoundary");
     } else {
       editor.execCommand("goLineDown");
@@ -372,7 +371,6 @@ class CodeMirrorEditor extends React.Component<
     const cursor = editor.getCursor();
     if (cursor.line === 0 && cursor.ch === 0 && !editor.somethingSelected()) {
       const CM = require("codemirror");
-      // $FlowFixMe: fix the flow definition for signal on a commonjs import
       CM.signal(editor, "topBoundary");
     } else {
       editor.execCommand("goLineUp");

--- a/packages/editor/src/styles.js
+++ b/packages/editor/src/styles.js
@@ -1,5 +1,4 @@
 // @flow
-// $FlowFixMe: this is a "fake" import from styled-jsx that gets handled by their babel setup
 import css from "styled-jsx/css";
 
 export default css`

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -6,8 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "prebuild": "npm run build:clean",
-    "build": "npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/fs-observable/package.json
+++ b/packages/fs-observable/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -13,7 +13,7 @@ import {
   appendCellToNotebook,
   fromJS
 } from "@nteract/commutable";
-import { createCodeCell } from "@nteract/commutable/lib/structures";
+import { createCodeCell } from "@nteract/commutable";
 
 import { _nextgen } from "@nteract/core/components";
 

--- a/packages/octicons/package.json
+++ b/packages/octicons/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/rx-binder/package.json
+++ b/packages/rx-binder/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/rx-jupyter/src/kernels.js
+++ b/packages/rx-jupyter/src/kernels.js
@@ -172,7 +172,6 @@ export function connect(
     // Subject.create takes a subscriber and an observable. We're only overriding
     // the subscriber here so we pass the subject on as an observable as the
     // second argument to Subject.create (since it's _also_ an observable)
-    // $FlowFixMe: update the flow definition to allow this
     wsSubject
   );
 }

--- a/packages/timeago/package.json
+++ b/packages/timeago/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -6,7 +6,8 @@
   "nteractDesktop": "src/index.js",
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && npm run build:lib && npm run build:flow",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib": "babel -d lib src --ignore '**/__tests__/**'",

--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -82,3 +82,14 @@ export function richestMimetype(
 }
 export const transforms = standardTransforms;
 export const displayOrder = standardDisplayOrder;
+export const TextTransform = TextDisplay;
+export const JSONTransform = JsonDisplay;
+export const JavaScriptTransform = JavaScriptDisplay;
+export const HTMLTransform = HTMLDisplay;
+export const MarkdownTransform = MarkdownDisplay;
+export const LaTeXTransform = LaTeXDisplay;
+export const SVGTransform = SVGDisplay;
+export const PNGTransform = PNGDisplay;
+export const JPEGTransform = JPEGDisplay;
+export const GIFTransform = GIFDisplay;
+export const VDOMTransform = VDOMDisplay;


### PR DESCRIPTION
This removes the need of copying flow types from `src/` to `lib/` during development. The flow types are now resolved direclty from `src/`. `flow-copy-source` now only executes during publishing via the `prepublishOnly` npm lifecycle script.

This adds a few exports to remove direct requires from `lib/` in order to appease flow.