### PR TITLE
run coverage before app build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
 install:
 - npm install
 script:
-- npm run build:apps
 - npm run test:coverage
+- npm run build:apps
 - npm run test:lint
 - npm run test:flow
 - npm run test:conformance


### PR DESCRIPTION
I'm kind of curious if this helps our Travis timeouts by virtue of jest looking through less files / folders for available tests. Could be silly. ¯\\\_(ツ)\_/¯