### PR TITLE
Add notebook on next index page

### DIFF
--- a/applications/notebook-on-next/pages/edit.js
+++ b/applications/notebook-on-next/pages/edit.js
@@ -37,7 +37,7 @@ const Error = () => (
       left: 50%;
       transform: translate(-50%, -50%);
       font-size: 30px;
-      font-family: Source Sans Pro;
+      font-family: Source Sans Pro, Helvetica, sans-serif;
     `}</style>
     Could not fetch notebook.
   </div>

--- a/applications/notebook-on-next/pages/index.js
+++ b/applications/notebook-on-next/pages/index.js
@@ -1,1 +1,79 @@
-export default () => <div>Notebook on next.js</div>;
+import React from "react";
+import { Router } from "../routes";
+
+class Input extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { gistid: "" };
+  }
+
+  handleChange = e => {
+    this.setState({ gistid: e.target.value });
+  };
+
+  handleKeydown = e => {
+    if (e.key == "Enter") {
+      this.handleConfirm();
+    }
+  };
+
+  handleConfirm = () => {
+    if (this.state.gistid) {
+      Router.pushRoute("edit", { gistid: this.state.gistid });
+    }
+  };
+
+  render() {
+    return (
+      <div className="centering">
+        <style jsx>{`
+          .centering {
+            position: absolute;
+            display: flex;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 20px;
+            font-family: Source Sans Pro, Helvetica, sans-serif;
+          }
+          button {
+            margin-left: 0.5em;
+            padding: 0.5em;
+            border: none;
+            outline: none;
+            border: solid 1px black;
+            background-color: black;
+            color: white;
+            font-size: inherit;
+            white-space: nowrap;
+          }
+
+          button:hover {
+            background-color: rgba(0, 0, 0, 0.75);
+            border-color: rgba(0, 0, 0, 0.75);
+          }
+
+          input {
+            width: 25em;
+            padding: 0.5em;
+            border: solid 1px black;
+            font-size: inherit;
+          }
+
+          input:focus {
+            outline: none;
+          }
+        `}</style>
+        <input
+          placeholder="Gist ID"
+          value={this.state.gistid}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKeydown}
+        />
+        <button onClick={this.handleConfirm}>Launch Notebook</button>
+      </div>
+    );
+  }
+}
+
+export default Input;


### PR DESCRIPTION
This adds a very basic text input on the index page so users can launch notebooks from the index page by providing a gist id:
<img width="1552" alt="bildschirmfoto 2017-12-22 um 02 46 43" src="https://user-images.githubusercontent.com/13285808/34295543-bc7c5264-e6c2-11e7-8dc5-928960a02d3d.png">


