### PR TITLE
mock plotly explicitly without invoking plotly

### DIFF
--- a/packages/transform-plotly/__mocks__/@nteract/plotly.js
+++ b/packages/transform-plotly/__mocks__/@nteract/plotly.js
@@ -1,0 +1,4 @@
+module.exports = {
+  newPlot: jest.fn(),
+  redraw: jest.fn()
+};

--- a/packages/transform-plotly/__tests__/plotly.test.js
+++ b/packages/transform-plotly/__tests__/plotly.test.js
@@ -5,11 +5,7 @@ import { mount } from "enzyme";
 
 import PlotlyTransform from "../src";
 
-jest.mock("@nteract/plotly");
 const plotly = require("@nteract/plotly");
-
-plotly.newPlot.mockImplementation(() => {});
-plotly.redraw.mockImplementation(() => {});
 
 function deepFreeze(obj) {
   // Retrieve the property names defined on obj


### PR DESCRIPTION
The previous plotly mock was calling out to plotly itself, which required canvas, and was showing as a warning in our test runs. Here I've just made the mock apply to our plotly package.