### PR TITLE
unify styled-jsxes as peerDeps

### DIFF
--- a/packages/commuter-frontend/package.json
+++ b/packages/commuter-frontend/package.json
@@ -43,7 +43,9 @@
     "nprogress": "^0.2.0",
     "prop-types": "^15.5.10",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react-dom": "^16.2.0"
+  },
+  "peerDependencies": {
     "styled-jsx": "^2.1.3"
   },
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,10 +34,10 @@
     "react-syntax-highlighter": "^6.0.0",
     "redux": "^3.7.0",
     "rxjs": "^5.5.0",
-    "styled-jsx": "^2.1.3",
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
+    "styled-jsx": "^2.1.3",
     "immutable": "^3.8.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -31,13 +31,13 @@
     "@nteract/types": "^1.0.0",
     "codemirror": "5.33.0",
     "lodash": "^4.17.4",
-    "rxjs": "^5.5.0",
-    "styled-jsx": "^2.1.3"
+    "rxjs": "^5.5.0"
   },
   "peerDependencies": {
     "immutable": "^3.8.1",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react-dom": "^16.0.0",
+    "styled-jsx": "^2.1.3"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -26,10 +26,10 @@
     "@nteract/transforms": "^3.0.3",
     "commonmark": "^0.28.0",
     "commonmark-react-renderer": "^4.3.3",
-    "mathjax-electron": "^2.0.1",
-    "styled-jsx": "^2.1.3"
+    "mathjax-electron": "^2.0.1"
   },
   "peerDependencies": {
+    "styled-jsx": "^2.1.3",
     "immutable": "^3.8.1",
     "react": "^16.0.0"
   },


### PR DESCRIPTION
Set up `styled-jsx` as a peer dependency to help prevent the flash of unstyled content ([FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)).