### PR TITLE
ensure sockets are connected before usage

### DIFF
--- a/applications/desktop/__mocks__/enchannel-zmq-backend.js
+++ b/applications/desktop/__mocks__/enchannel-zmq-backend.js
@@ -12,7 +12,7 @@ class HokeySocket extends EventEmitter {
 }
 
 module.exports = {
-  createMainChannel: () => {
+  createMainChannel: async function() {
     const shellSocket = new HokeySocket();
     const iopubSocket = new HokeySocket();
     const sockets = {
@@ -20,7 +20,7 @@ module.exports = {
       iopub: iopubSocket
     };
 
-    const channels = createMainChannelFromSockets(sockets, {
+    const channels = await createMainChannelFromSockets(sockets, {
       session: "spinning",
       username: "dj"
     });

--- a/applications/desktop/__mocks__/spawnteract.js
+++ b/applications/desktop/__mocks__/spawnteract.js
@@ -11,7 +11,11 @@ module.exports = {
     }
     return writeConnectionFile("config").then(c => {
       return {
-        spawn: { on: () => {} },
+        spawn: {
+          on: () => {},
+          stdout: { on: () => {} },
+          stderr: { on: () => {} }
+        },
         connectionFile: c.connectionFile,
         config: c.config,
         kernelSpec: kernelSpec.name

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/nteract/nteract",
   "scripts": {
     "postinstall": "npm run lerna",
-    "//lerna bootstrap": "builds packages",
+    "//lerna bootstrap": "links and builds packages",
     "lerna": "lerna bootstrap",
     "build:apps": "lerna run build --scope nteract --scope @nteract/play --scope @nteract/commuter --scope @nteract/notebook-on-next --scope @nteract/showcase --parallel --stream",
     "app:desktop": "lerna run start --scope nteract --stream",
@@ -49,8 +49,6 @@
     "test:conformance": "node scripts/conformance.js",
     "test:lint": "npm run lint",
     "test:flow": "npm run flow",
-    "// pretest": "ensure that zeromq is built for node",
-    "pretest": "lerna exec --scope enchannel-zmq-backend -- npm rebuild",
     "test:desktop": "lerna run test:unit --scope nteract --stream",
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",

--- a/packages/core/src/middlewares.js
+++ b/packages/core/src/middlewares.js
@@ -9,9 +9,10 @@ type Action = {
 // Get the type
 type Console = typeof console;
 
-export const errorMiddleware = (store: any, console: Console = console) => (
-  next: any
-) => (action: Action) => {
+export const errorMiddleware = (
+  store: any,
+  console: Console = global.console
+) => (next: any) => (action: Action) => {
   if (!action.type.includes("ERROR")) {
     return next(action);
   }

--- a/packages/enchannel-zmq-backend/__mocks__/jmp.js
+++ b/packages/enchannel-zmq-backend/__mocks__/jmp.js
@@ -1,0 +1,32 @@
+const EventEmitter = require("events");
+class Socket extends EventEmitter {
+  constructor(zmqType, scheme, key) {
+    super();
+    this.type = zmqType;
+    this.scheme = scheme;
+    this.key = key;
+  }
+
+  monitor() {}
+  unmonitor() {}
+  connect() {
+    if (this.throttle) {
+      setTimeout(() => this.emit("connect"), 0);
+    } else {
+      this.emit("connect");
+    }
+  }
+  close() {}
+}
+
+module.exports = {
+  Message: msg => ({
+    header: { ...msg.header },
+    parent_header: { ...msg.parent_header },
+    content: { ...msg.content },
+    metadata: { ...msg.metadata },
+    buffers: [],
+    idents: []
+  }),
+  Socket
+};

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -193,10 +193,10 @@ export function createMainChannelFromSockets(
         const jMessage = new jmp.Message({
           // Fold in the setup header to ease usage of messages on channels
           header: { ...message.header, ...header },
-          parent_header: { ...message.parent_header },
-          content: { ...message.content },
-          metadata: { ...message.metadata },
-          buffers: [...message.buffers]
+          parent_header: message.parent_header,
+          content: message.content,
+          metadata: message.metadata,
+          buffers: message.buffers
         });
         socket.send(jMessage);
       },


### PR DESCRIPTION
closes #2156 (thankfully)

I've made the interface to `enchannel-zmq-backend`'s channel creation to be a promise that resolves when all the sockets have been properly connected. This does use the monitoring that was suggested by @lgeiger.

With this, I think we've finished off the last release blocker (that I can recall).