### PR TITLE
[play] Kill old server

### DIFF
--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -52,7 +52,7 @@ class Main extends React.Component<*, *> {
     restartKernel({ serverId, kernelName });
   };
   handleFormSubmit = event => {
-    const { serverId: oldServerId, activateServer } = this.props;
+    const { currentServerId: oldServerId, activateServer } = this.props;
     const { gitrefValue: gitref, repoValue: repo } = this.state;
     event.preventDefault();
     const serverId = utils.makeServerId({ gitref, repo });

--- a/applications/play/redux/epics.js
+++ b/applications/play/redux/epics.js
@@ -56,6 +56,20 @@ const activateServerEpic = action$ =>
     })
   );
 
+const killServerEpic = (action$, store) =>
+  action$.pipe(
+    ofType(actionTypes.KILL_SERVER),
+    mergeMap(({ payload: { serverId } }) => {
+      const { config } = store.getState().entities.serversById[serverId].server;
+      return shutdown(config).pipe(
+        mergeMap(data => {
+          return of(actions.killServerFulfilled({ serverId }));
+        }),
+        catchError(error => of(actions.killServerFailed({ serverId, error })))
+      );
+    })
+  );
+
 const fetchKernelSpecsEpic = (action$, store) =>
   action$.pipe(
     ofType(actionTypes.FETCH_KERNEL_SPECS),

--- a/applications/play/redux/epics.js
+++ b/applications/play/redux/epics.js
@@ -234,6 +234,7 @@ const runSourceEpic = (action$, store) =>
 
 const epics = combineEpics(
   activateServerEpic,
+  killServerEpic,
   fetchKernelSpecsEpic,
   setActiveKernelEpic,
   activateKernelEpic,

--- a/applications/play/redux/epics.js
+++ b/applications/play/redux/epics.js
@@ -60,7 +60,15 @@ const killServerEpic = (action$, store) =>
   action$.pipe(
     ofType(actionTypes.KILL_SERVER),
     mergeMap(({ payload: { serverId } }) => {
-      const { config } = store.getState().entities.serversById[serverId].server;
+      const oldServer = store.getState().entities.serversById[serverId];
+      if (!oldServer)
+        return of(
+          actions.killServerFailed({
+            serverId,
+            error: `server with id ${serverId} does not exist in store.`
+          })
+        );
+      const { config } = oldServer.server;
       return shutdown(config).pipe(
         mergeMap(data => {
           return of(actions.killServerFulfilled({ serverId }));

--- a/applications/play/redux/reducer.js
+++ b/applications/play/redux/reducer.js
@@ -1,5 +1,6 @@
 // @flow
 import { combineReducers } from "redux";
+import { omit } from "lodash";
 import * as actionTypes from "./actionTypes";
 import * as utils from "../utils";
 import objectPath from "object-path";
@@ -300,10 +301,18 @@ const serverEnvelope = combineReducers({
   server
 });
 
-const serversById = utils.createObjectReducer({
-  getKey: action => objectPath.get(action, "payload.serverId"),
-  valueReducer: serverEnvelope
-});
+const serversById = (state = {}, action) => {
+  switch (action.type) {
+    case actionTypes.KILL_SERVER_FULFILLED: {
+      return omit(state, action.payload.serverId);
+    }
+    default:
+      return utils.createObjectReducer({
+        getKey: action => objectPath.get(action, "payload.serverId"),
+        valueReducer: serverEnvelope
+      })(state, action);
+  }
+};
 
 const ui = combineReducers({
   repo,


### PR DESCRIPTION
Adds a new epic to kill the oldServer if you change to a new server.

Also needed to adjust the handler to properly destructure the props. 

I used mergeMap because it's possible that you do this repeatedly if you keep changing the server… but map might be sufficient (wasn't sure if it was needed but this seemed safer).