### PR TITLE
clarify use of SyntaxHighlighter in our <Editor />

### DIFF
--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -241,6 +241,9 @@ export class Editor extends React.Component<EditorProps> {
 
   render() {
     // Build in a default renderer when they pass a plain string
+    // This is primarily for use with non-editable contexts (notebook-preview)
+    // to make rendering much faster (compared to codemirror)
+    // Ref: https://github.com/nteract/notebook-preview/issues/20
     if (typeof this.props.children === "string") {
       return (
         <SyntaxHighlighter


### PR DESCRIPTION
@mpacer asked a bit ago about why we use react syntax highligther rather than `CodeMirror` inside of the `<Editor />` component. The reason is performance for non-interactive views. It's also nice for server rendering. This is a just a comment update to clarify things.