### PR TITLE
Detach more functionality from the Cell provider

### DIFF
--- a/packages/core/src/components/hijack-scroll.js
+++ b/packages/core/src/components/hijack-scroll.js
@@ -1,0 +1,58 @@
+// @flow
+
+import * as React from "react";
+
+type HijackScrollProps = {
+  focused: boolean,
+  onClick: () => void,
+  children: React.Node
+};
+
+export class HijackScroll extends React.Component<HijackScrollProps, *> {
+  el: ?HTMLElement;
+
+  scrollIntoViewIfNeeded(prevFocused?: boolean): void {
+    // Check if the element is being hovered over.
+    const hovered =
+      this.el &&
+      this.el.parentElement &&
+      this.el.parentElement.querySelector(":hover") === this.el;
+
+    if (
+      this.props.focused &&
+      prevFocused !== this.props.focused &&
+      // Don't scroll into view if already hovered over, this prevents
+      // accidentally selecting text within the codemirror area
+      !hovered
+    ) {
+      if (this.el && "scrollIntoViewIfNeeded" in this.el) {
+        // $FlowFixMe: This is only valid in Chrome, WebKit
+        this.el.scrollIntoViewIfNeeded();
+      } else {
+        // TODO: Polyfill as best we can for the webapp version
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps: HijackScrollProps) {
+    this.scrollIntoViewIfNeeded(prevProps.focused);
+  }
+
+  componentDidMount(): void {
+    this.scrollIntoViewIfNeeded();
+  }
+
+  render() {
+    return (
+      <div
+        onClick={this.props.onClick}
+        role="presentation"
+        ref={el => {
+          this.el = el;
+        }}
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/packages/core/src/components/hijack-scroll.js
+++ b/packages/core/src/components/hijack-scroll.js
@@ -1,4 +1,6 @@
 // @flow
+/* eslint jsx-a11y/no-static-element-interactions: 0 */
+/* eslint jsx-a11y/click-events-have-key-events: 0 */
 
 import * as React from "react";
 

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -377,16 +377,25 @@ Cell.defaultProps = {
 };
 
 export const Cells = (props: {
-  children: React.ChildrenArray<React.Element<*>>,
+  children: React.ChildrenArray<any>,
   selected: string | null
 }) => {
   const children = React.Children.map(props.children, child => {
+    if (!child) {
+      return null;
+    }
+
+    if (!child.type) {
+      return child;
+    }
+
     if (child.type === Cell) {
       return React.cloneElement(child, {
         // If there's a selection and it matches the cell's ID, mark isSelected
         isSelected: props.selected && child.props.id === props.selected
       });
     }
+
     return child;
   });
   return (

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -318,11 +318,7 @@ export class Input extends React.Component<InputProps> {
   }
 }
 
-export const Cell = (props: {
-  isSelected: boolean,
-  children?: React.Node,
-  id?: string
-}) => {
+export const Cell = (props: { isSelected: boolean, children?: React.Node }) => {
   const children = props.children;
   return (
     <div className={`cell ${props.isSelected ? "focused" : ""}`}>
@@ -372,8 +368,7 @@ export const Cell = (props: {
 
 Cell.defaultProps = {
   isSelected: false,
-  children: null,
-  id: null
+  children: null
 };
 
 export const Cells = (props: {

--- a/packages/core/src/providers/cell.js
+++ b/packages/core/src/providers/cell.js
@@ -163,7 +163,7 @@ export default class CellView extends React.Component<CellProps, *> {
 
     return (
       <HijackScroll focused={cellFocused} onClick={this.props.selectCell}>
-        <Cell id={this.props.id} isSelected={cellFocused}>
+        <Cell isSelected={cellFocused}>
           <Toolbar type={cellType} cell={cell} id={this.props.id} />
           {element}
           <style jsx>{`

--- a/packages/core/src/providers/cell.js
+++ b/packages/core/src/providers/cell.js
@@ -3,7 +3,7 @@
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 /* eslint jsx-a11y/click-events-have-key-events: 0 */
 
-import React from "react";
+import * as React from "react";
 import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 import CodeMirror from "./editor";
 
@@ -19,6 +19,8 @@ import Toolbar from "./toolbar";
 const PropTypes = require("prop-types");
 
 import { Input, Prompt, Editor, Pagers, Outputs, Cell } from "../components";
+
+import { HijackScroll } from "../components/hijack-scroll";
 
 export type CellProps = {
   cell: any,
@@ -48,42 +50,6 @@ export default class CellView extends React.Component<CellProps, *> {
   static contextTypes = {
     store: PropTypes.object
   };
-
-  cellDiv: ?HTMLElement;
-
-  componentDidUpdate(prevProps: CellProps) {
-    this.scrollIntoViewIfNeeded(prevProps.cellFocused);
-  }
-
-  componentDidMount(): void {
-    this.scrollIntoViewIfNeeded();
-  }
-
-  scrollIntoViewIfNeeded(prevCellFocused?: string): void {
-    // If the previous cell that was focused was not us, we go ahead and scroll
-
-    // Check if the .cell div is being hovered over.
-    const hoverCell =
-      this.cellDiv &&
-      this.cellDiv.parentElement &&
-      this.cellDiv.parentElement.querySelector(":hover") === this.cellDiv;
-
-    if (
-      this.props.cellFocused &&
-      this.props.cellFocused === this.props.id &&
-      prevCellFocused !== this.props.cellFocused &&
-      // Don't scroll into view if already hovered over, this prevents
-      // accidentally selecting text within the codemirror area
-      !hoverCell
-    ) {
-      if (this.cellDiv && "scrollIntoViewIfNeeded" in this.cellDiv) {
-        // $FlowFixMe: This is only valid in Chrome, WebKit
-        this.cellDiv.scrollIntoViewIfNeeded();
-      } else {
-        // TODO: Polyfill as best we can for the webapp version
-      }
-    }
-  }
 
   render() {
     const cell = this.props.cell;
@@ -196,28 +162,22 @@ export default class CellView extends React.Component<CellProps, *> {
     }
 
     return (
-      <Cell id={this.props.id} isSelected={cellFocused}>
-        <div
-          onClick={this.props.selectCell}
-          role="presentation"
-          ref={el => {
-            this.cellDiv = el;
-          }}
-        >
+      <HijackScroll focused={cellFocused} onClick={this.props.selectCell}>
+        <Cell id={this.props.id} isSelected={cellFocused}>
           <Toolbar type={cellType} cell={cell} id={this.props.id} />
           {element}
-        </div>
-        <style jsx>{`
-          /*
+          <style jsx>{`
+            /*
            * Show the cell-toolbar-mask if hovering on cell,
            * or cell was the last clicked (has .focused class).
            */
-          :global(.cell:hover .cell-toolbar-mask),
-          :global(.cell.focused .cell-toolbar-mask) {
-            display: block;
-          }
-        `}</style>
-      </Cell>
+            :global(.cell:hover .cell-toolbar-mask),
+            :global(.cell.focused .cell-toolbar-mask) {
+              display: block;
+            }
+          `}</style>
+        </Cell>
+      </HijackScroll>
     );
   }
 }

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -14,6 +14,8 @@ import { displayOrder, transforms } from "@nteract/transforms";
 
 import CellView from "./cell";
 
+import {} from "../components";
+
 import DraggableCell from "../components/draggable-cell";
 import CellCreator from "./cell-creator";
 import StatusBar from "../components/status-bar";
@@ -89,12 +91,6 @@ const mapStateToProps = (state: Object) => ({
 });
 
 export class NotebookApp extends React.PureComponent<Props> {
-  createCellElement: (s: string) => ?React$Element<any>;
-  keyDown: (e: KeyboardEvent) => void;
-  moveCell: (source: string, dest: string, above: boolean) => void;
-  selectCell: (id: string) => void;
-  renderCell: (id: string) => React$Element<any>;
-
   static defaultProps = {
     displayOrder,
     transforms,
@@ -107,11 +103,11 @@ export class NotebookApp extends React.PureComponent<Props> {
 
   constructor(): void {
     super();
-    this.createCellElement = this.createCellElement.bind(this);
-    this.keyDown = this.keyDown.bind(this);
-    this.moveCell = this.moveCell.bind(this);
-    this.selectCell = this.selectCell.bind(this);
-    this.renderCell = this.renderCell.bind(this);
+    (this: any).createCellElement = this.createCellElement.bind(this);
+    (this: any).keyDown = this.keyDown.bind(this);
+    (this: any).moveCell = this.moveCell.bind(this);
+    (this: any).selectCell = this.selectCell.bind(this);
+    (this: any).renderCell = this.renderCell.bind(this);
   }
 
   componentDidMount(): void {
@@ -227,7 +223,7 @@ export class NotebookApp extends React.PureComponent<Props> {
     );
   }
 
-  createCellElement(id: string): ?React$Element<any> {
+  createCellElement(id: string): React$Element<*> {
     const isStickied = this.props.stickyCells.get(id);
 
     return (

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -8,7 +8,6 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
     selected={null}
   >
     <Cell
-      id={null}
       isSelected={false}
       key="3"
     >
@@ -41,7 +40,6 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
       />
     </Cell>
     <Cell
-      id={null}
       isSelected={false}
       key="4"
     >
@@ -198,7 +196,6 @@ exports[`Notebook accepts an Object of cells 1`] = `
     selected={null}
   >
     <Cell
-      id={null}
       isSelected={false}
       key="5"
     >
@@ -231,7 +228,6 @@ exports[`Notebook accepts an Object of cells 1`] = `
       />
     </Cell>
     <Cell
-      id={null}
       isSelected={false}
       key="6"
     >


### PR DESCRIPTION
More in efforts towards #2218. This PR:

* [x] creates a `HijackScroll` component that does exactly what cells were doing previously with an onClick handler and a `focused` prop. It's more of a `ScrollIntoViewIfNeeded` component.
* [x] clean up unused props from core's `<Cell />` component

This makes the current Cell component into something small and simple to bring into the `NotebookApp` provider component