### PR TITLE
ensure styles are encoded properly by force

### DIFF
--- a/applications/notebook-on-next/pages/edit.js
+++ b/applications/notebook-on-next/pages/edit.js
@@ -69,7 +69,9 @@ export default class Edit extends React.Component<*> {
     if (!this.props.serverNotebook) return <Error />;
     return (
       <div>
-        <style>{`@media print {
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `@media print {
           * {
             box-shadow: none !important;
           }
@@ -117,7 +119,9 @@ export default class Edit extends React.Component<*> {
             "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji",
             "Segoe UI Emoji", "Segoe UI Symbol";
           font-size: 1em;
-        }`}</style>
+        }`
+          }}
+        />
         <Provider store={store}>
           <div>
             <NotebookApp />;

--- a/applications/notebook-on-next/pages/index.js
+++ b/applications/notebook-on-next/pages/index.js
@@ -25,7 +25,16 @@ class Input extends React.Component {
 
   render() {
     return (
-      <div className="centering">
+      <div>
+        <div className="centering">
+          <input
+            placeholder="Gist ID"
+            value={this.state.gistid}
+            onChange={this.handleChange}
+            onKeyDown={this.handleKeydown}
+          />
+          <button onClick={this.handleConfirm}>Launch Notebook</button>
+        </div>
         <style jsx>{`
           .centering {
             position: absolute;
@@ -64,13 +73,6 @@ class Input extends React.Component {
             outline: none;
           }
         `}</style>
-        <input
-          placeholder="Gist ID"
-          value={this.state.gistid}
-          onChange={this.handleChange}
-          onKeyDown={this.handleKeydown}
-        />
-        <button onClick={this.handleConfirm}>Launch Notebook</button>
       </div>
     );
   }

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -392,7 +392,16 @@ export class NotebookApp extends React.PureComponent<Props> {
             padding-right: 10px;
           }
         `}</style>
-        <style>{`:root { ${themes[this.props.theme]} } `}</style>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+:root {
+  ${themes[this.props.theme]};
+}`
+          }}
+        >
+          {}
+        </style>
       </div>
     );
   }


### PR DESCRIPTION
This fixes up an issue where the `"` in the style were being turned into `&quot;`. There's one other-ssr related issue here where an extra (or missing) `<div />` is causing an error on client side render.