### PR TITLE
Remove styled-jsx workarounds

### DIFF
--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -267,44 +267,6 @@ class Main extends React.Component<*, *> {
           body {
             margin: 0;
           }
-
-          /** In development mode, these aren't set right away so we set them
-          direct to start off. Same styled-jsx issue we typically run into with
-          our lerna app... */
-          .CodeMirror {
-            height: 100%;
-          }
-          .CodeMirror-gutters {
-            box-shadow: unset;
-          }
-
-          .initialTextAreaForCodeMirror {
-            font-family: "Source Code Pro", "Monaco", monospace;
-            font-size: 14px;
-            line-height: 20px;
-
-            height: auto;
-
-            background: none;
-
-            border: none;
-            overflow: hidden;
-
-            -webkit-scrollbar: none;
-            -webkit-box-shadow: none;
-            -moz-box-shadow: none;
-            box-shadow: none;
-            width: 100%;
-            resize: none;
-            padding: 10px 0 5px 10px;
-            letter-spacing: 0.3px;
-            word-spacing: 0px;
-          }
-
-          .initialTextAreaForCodeMirror:focus {
-            outline: none;
-            border: none;
-          }
         `}</style>
       </div>
     );

--- a/packages/octicons/src/index.js
+++ b/packages/octicons/src/index.js
@@ -12,9 +12,6 @@ type WrapperProps<T> = {
 };
 
 export const SVGWrapper = (props: WrapperProps<*>) => {
-  // TODO: revert back to {...props.outerProps} when transpilation works again.
-  // See: https://github.com/zeit/styled-jsx/issues/329
-  const outerProps = props.outerProps;
   return (
     <span>
       <svg
@@ -22,7 +19,7 @@ export const SVGWrapper = (props: WrapperProps<*>) => {
         width={props.width}
         height={props.height}
         viewBox={props.viewBox}
-        {...outerProps}
+        {...props.outerProps}
         style={{
           fill: "currentColor",
           display: "inline-block",


### PR DESCRIPTION
https://github.com/zeit/styled-jsx/issues/329 is fixed and we're hoisting our dependencies so we can remove a few workarounds.