### PR TITLE
Fix styling for initial codemirror text area

### DIFF
--- a/packages/editor/src/styles.js
+++ b/packages/editor/src/styles.js
@@ -222,7 +222,7 @@ export default css`
     font-size: 14px;
     line-height: 20px;
 
-    height: auto;
+    height: inherit;
 
     background: none;
 


### PR DESCRIPTION
This fixes a issue where the serverside rendered textarea was truncated:

master | PR
----|---
![master](https://user-images.githubusercontent.com/13285808/34501661-3fbfc876-f010-11e7-9917-27ccce9b4bc4.gif) | ![pr](https://user-images.githubusercontent.com/13285808/34501669-468bd118-f010-11e7-94a2-f92bbae78e50.gif)
