### PR TITLE
provide nicer ways to work with jupyter-extension

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "build": "webpack",
     "build:watch": "webpack --watch",
-    "prepare": "npm run build",
-    "prepublish": "echo wat",
-    "copy-static": "cp"
+    "dev": "echo 'run a notebook server with this' && npm run build:watch",
+    "prepublishOnly": "npm run build"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "app:showcase": "lerna run dev --scope @nteract/showcase --stream",
     "app:commuter": "lerna run dev --scope @nteract/commuter --stream",
     "app:notebook-on-next": "lerna run dev --scope @nteract/notebook-on-next --stream",
+    "app:jupyter-extension": "lerna run dev --scope nteract-on-jupyter --stream",
     "start": "npm run app:desktop",
     "spawn": "lerna run spawn --scope nteract",
     "showcase": "lerna run dev --scope @nteract/showcase --stream",


### PR DESCRIPTION
* `npm run app:jupyter-extension` runs the jupyter extension webpack build in watch mode 👀 
* fixes erroneous build on `prepare` of the jupyter extension, should be `prepublishOnly` ✅ 