### PR TITLE
include global styles for nteract_on_jupyter

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -12,6 +12,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title}}{% endblock %}</title>
 
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Source+Code+Pro|Source+Sans+Pro|Source+Serif+Pro" rel="stylesheet">
   <script src="https://cdn.plot.ly/plotly-latest.min.js" type="text/javascript" charset="utf-8"></script>
 
   <script id="jupyter-config-data" type="application/json">{

--- a/applications/jupyter-extension/nteract_on_jupyter/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.js
@@ -41,6 +41,36 @@ function createApp(jupyterConfigData: JupyterConfigData) {
                 this.notificationSystem = notificationSystem;
               }}
             />
+            <style jsx global>{`
+              body {
+                font-family: "Source Sans Pro";
+                font-size: 16px;
+                line-height: 22px;
+                background-color: var(--main-bg-color);
+                color: var(--main-fg-color);
+                /* All the old theme setups declared this, putting it back for consistency */
+                line-height: 1.3 !important;
+              }
+
+              #app {
+                padding-top: 20px;
+              }
+
+              @keyframes fadeOut {
+                from {
+                  opacity: 1;
+                }
+                to {
+                  opacity: 0;
+                }
+              }
+
+              div#loading {
+                animation-name: fadeOut;
+                animation-duration: 0.25s;
+                animation-fill-mode: forwards;
+              }
+            `}</style>
           </div>
         </Provider>
       );

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -41,8 +41,7 @@
     ]
   },
   "devDependencies": {
-    "css-loader": "^0.28.7",
     "next": "^4.2.1",
-    "style-loader": "^0.19.1"
+    "styled-jsx": "^2.2.1"
   }
 }

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -23,7 +23,6 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.css$/, use: ["style-loader", "css-loader"] },
       { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" },
       { test: /\.json$/, loader: "json-loader" }
     ]


### PR DESCRIPTION
Makes sure the jupyter extension looks as good (typographically) as the desktop app.