### PR TITLE
perform prefetching of mybinder DNS + logo

### DIFF
--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -1,5 +1,7 @@
 // @flow
 import * as React from "react";
+import Head from "next/head";
+
 import CodeMirrorEditor from "@nteract/editor";
 import { BinderConsole } from "./consoles";
 import { Display } from "@nteract/display-area";
@@ -77,6 +79,13 @@ class Main extends React.Component<*, *> {
     const { repoValue, gitrefValue, sourceValue } = this.state;
     return (
       <div>
+        <Head>
+          <link rel="dns-prefetch" href="https://mybinder.org" />
+          <link
+            rel="prefetch"
+            href="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
+          />
+        </Head>
         <header>
           <div className="left">
             <img

--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -85,6 +85,14 @@ class Main extends React.Component<*, *> {
             rel="prefetch"
             href="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
           />
+          {/*
+            prefetch our little sample graphic for an extra touch of ✨
+          */}
+          <link rel="prefetch" href="https://bit.ly/storybot-vdom" />
+          <link
+            rel="prefetch"
+            href="https://media.giphy.com/media/xUPGcguWZHRC2HyBRS/giphy.gif"
+          />
         </Head>
         <header>
           <div className="left">

--- a/applications/play/redux/getInitialState.js
+++ b/applications/play/redux/getInitialState.js
@@ -3,20 +3,27 @@ const getInitialState = () => ({
   ui: {
     repo: "binder-examples/jupyter-stacks",
     gitref: "master",
-    source: `from vdom import h1, p, img, div, b, span
-div(
-    h1('Welcome to play.nteract.io'),
+    source: `from vdom import h1, p, img, div, span
+
+def fancy(word):
+    '''component to make a simple word ✨ fancy ✨'''
+    colors = ['#FA8AAE', '#8AE7FA', '#FAFA8A', '#8AFA8A']
+
+    return [
+        span(letter, style=dict(color=colors[idx % len(colors)]))
+        for (idx, letter) in enumerate(word)
+    ]
+
+
+div(h1('Welcome to ', fancy('play'), '!'),
     p('Run Python code via Binder & Jupyter'),
     img(src="https://bit.ly/storybot-vdom"),
     p('Change the code, click ',
-        span("▶ Run", style=dict(
-            color="white",
-            backgroundColor="black",
-            padding="10px"
-        )),
-      ' Up above'
-    )
-)`,
+      span(
+          "▶ Run",
+          style=dict(color="white", backgroundColor="black", padding="10px")),
+      ' Up above'))
+`,
     showPanel: true,
     currentServerId: "",
     currentKernelName: "",


### PR DESCRIPTION
This helps prevent flicker of the binder logo and is a bit more useful if the drawer is closed on start (which we don't currently do). The amount of savings is probably not much, it's an easy thing to do this for DNS and images so the user experience is ✨ .