### PR TITLE
publish should still occur when apps change

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,15 +6,5 @@
     "applications/jupyter-extension/nteract_on_jupyter"
   ],
   "version": "independent",
-  "npmClient": "npm",
-  "commands": {
-    "publish": {
-      "ignore": [
-        "packages/desktop/*",
-        "packages/jupyter-extension/*",
-        "applications/desktop/**",
-        "applications/play/**"
-      ]
-    }
-  }
+  "npmClient": "npm"
 }


### PR DESCRIPTION
I _completely_ misunderstood what lerna's `commands.publish.ignore` was doing. I _thought_ it was supposed to make it so I wouldn't _publish_ these packages, when it's really just using the commits to decide if it _can_ publish them. Super silly. We need the _right_ hook for saying "hey X is not a real package, don't actually publish it. For now, this refines our current setup.