### PR TITLE
Remove useless top-level elements

### DIFF
--- a/applications/desktop/__tests__/renderer/__snapshots__/index-spec.js.snap
+++ b/applications/desktop/__tests__/renderer/__snapshots__/index-spec.js.snap
@@ -12,9 +12,7 @@ exports[`App renders app 1`] = `
     }
   }
 >
-  <div
-    className="jsx-825914725 jsx-825914725"
-  >
+  <React.Fragment>
     <Connect(DragDropContext(NotebookApp))
       displayOrder={
         Array [
@@ -70,6 +68,6 @@ exports[`App renders app 1`] = `
       css="body{font-family:\\"Source Sans Pro\\";font-size:16px;line-height:22px;background-color:var(--main-bg-color);color:var(--main-fg-color);line-height:1.3 !important;}#app{padding-top:20px;}@-webkit-keyframes fadeOut{from{opacity:1;}to{opacity:0;}}@keyframes fadeOut{from{opacity:1;}to{opacity:0;}}div#loading{-webkit-animation-name:fadeOut;animation-name:fadeOut;-webkit-animation-duration:0.25s;animation-duration:0.25s;-webkit-animation-fill-mode:forwards;animation-fill-mode:forwards;}"
       styleId="825914725"
     />
-  </div>
+  </React.Fragment>
 </Provider>
 `;

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import ReactDOM from "react-dom";
 import { ipcRenderer as ipc } from "electron";
 
@@ -57,7 +57,7 @@ export default class App extends React.PureComponent<Object, Object> {
     // eslint-disable-line class-methods-use-this
     return (
       <Provider store={store}>
-        <div>
+        <React.Fragment>
           <NotebookApp transforms={transforms} displayOrder={displayOrder} />
           <NotificationSystem
             ref={notificationSystem => {
@@ -94,7 +94,7 @@ export default class App extends React.PureComponent<Object, Object> {
               animation-fill-mode: forwards;
             }
           `}</style>
-        </div>
+        </React.Fragment>
       </Provider>
     );
   }

--- a/applications/jupyter-extension/nteract_on_jupyter/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import ReactDOM from "react-dom";
 
 import { Provider } from "react-redux";
@@ -84,11 +84,11 @@ function main(rootEl: Element, dataEl: Node | null) {
   // When the data element isn't there, provide an error message
   // Primarily for development usage
   const ErrorPage = (props: { error?: Error }) => (
-    <div>
+    <React.Fragment>
       <h1>ERROR</h1>
       <pre>Unable to parse / process the jupyter config data.</pre>
       {props.error ? props.error.message : null}
-    </div>
+    </React.Fragment>
   );
 
   if (!dataEl) {

--- a/applications/notebook-on-next/pages/edit.js
+++ b/applications/notebook-on-next/pages/edit.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import * as React from "react";
 import fetch from "isomorphic-fetch";
 import { emptyNotebook, fromJS } from "@nteract/commutable";
 import { NotebookApp } from "@nteract/core/providers";
@@ -30,7 +30,7 @@ async function fetchFromGist(gistId): ?Object {
 }
 
 const Error = () => (
-  <div>
+  <React.Fragment>
     <style jsx>{`
       position: absolute;
       top: 50%;
@@ -40,7 +40,7 @@ const Error = () => (
       font-family: Source Sans Pro, Helvetica, sans-serif;
     `}</style>
     Could not fetch notebook.
-  </div>
+  </React.Fragment>
 );
 
 export default class Edit extends React.Component<*> {
@@ -68,7 +68,7 @@ export default class Edit extends React.Component<*> {
   render() {
     if (!this.props.serverNotebook) return <Error />;
     return (
-      <div>
+      <React.Fragment>
         <style
           dangerouslySetInnerHTML={{
             __html: `@media print {
@@ -127,7 +127,7 @@ export default class Edit extends React.Component<*> {
             <NotebookApp />;
           </div>
         </Provider>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/applications/notebook-on-next/pages/index.js
+++ b/applications/notebook-on-next/pages/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Router } from "../routes";
 
 class Input extends React.Component {
@@ -25,7 +25,7 @@ class Input extends React.Component {
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <div className="centering">
           <input
             placeholder="Gist ID"
@@ -73,7 +73,7 @@ class Input extends React.Component {
             outline: none;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -78,7 +78,7 @@ class Main extends React.Component<*, *> {
     } = this.props;
     const { repoValue, gitrefValue, sourceValue } = this.state;
     return (
-      <div>
+      <React.Fragment>
         <Head>
           <link rel="dns-prefetch" href="https://mybinder.org" />
           <link
@@ -285,7 +285,7 @@ class Main extends React.Component<*, *> {
             margin: 0;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/applications/play/components/consoles.js
+++ b/applications/play/components/consoles.js
@@ -4,7 +4,7 @@ import * as React from "react";
 class BinderLogo extends React.Component<*, *> {
   render() {
     return (
-      <div>
+      <React.Fragment>
         <a className="anchor" href="https://mybinder.org" target="_blank">
           <img
             src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
@@ -18,7 +18,7 @@ class BinderLogo extends React.Component<*, *> {
             margin: 0 0 7px 0px;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -28,7 +28,7 @@ class BinderTextInput extends React.Component<*, *> {
     const { onChange, value, id, labelText, name } = this.props;
 
     return (
-      <div>
+      <React.Fragment>
         <fieldset className="binder">
           <label htmlFor={id}>
             <span>{labelText}</span>
@@ -53,7 +53,7 @@ class BinderTextInput extends React.Component<*, *> {
             display: inline-block;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -62,7 +62,7 @@ class BinderForm extends React.Component<*, *> {
   render() {
     const { onSubmit } = this.props;
     return (
-      <div className="binder-ui-wrapper">
+      <React.Fragment>
         <form onSubmit={onSubmit} className="form">
           {this.props.children}
           <fieldset className="binder">
@@ -95,7 +95,7 @@ class BinderForm extends React.Component<*, *> {
             margin-left: 0px;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/applications/showcase/pages/index.js
+++ b/applications/showcase/pages/index.js
@@ -9,6 +9,8 @@ import {
   Cells
 } from "@nteract/core/components";
 
+import * as React from "react";
+
 import ReactMarkdown from "react-markdown";
 
 import SyntaxHighlighter from "react-syntax-highlighter";
@@ -50,7 +52,7 @@ const cells: CellsStructure = {
   abc: {
     code: "from hogwarts import characters;\ndisplay(characters)",
     outputs: (
-      <div>
+      <React.Fragment>
         <table>
           <thead>
             <tr>
@@ -129,7 +131,7 @@ const cells: CellsStructure = {
             vertical-align: middle;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     ),
     running: false,
     queued: false,

--- a/applications/showcase/pages/notebook-preview.js
+++ b/applications/showcase/pages/notebook-preview.js
@@ -78,7 +78,7 @@ class StaticNotebookApp extends React.Component<
   render() {
     if (this.state.notebook) {
       return (
-        <div>
+        <React.Fragment>
           <button onClick={() => this.toggleTheme()} className="theme-toggle">
             Toggle Theme
           </button>
@@ -130,10 +130,10 @@ class StaticNotebookApp extends React.Component<
               background-color: "black";
             }
           `}</style>
-        </div>
+        </React.Fragment>
       );
     }
-    return <div>loading...</div>;
+    return "loading...";
   }
 }
 

--- a/packages/commuter-frontend/components/body.js
+++ b/packages/commuter-frontend/components/body.js
@@ -8,11 +8,7 @@ type BodyProps = {
 };
 
 const Body = (props: BodyProps) => {
-  return (
-    <div>
-      <div className="main-container">{props.children}</div>
-    </div>
-  );
+  return props.children;
 };
 
 export default Body;

--- a/packages/commuter-frontend/components/browse-header.js
+++ b/packages/commuter-frontend/components/browse-header.js
@@ -76,7 +76,7 @@ class BrowseHeader extends React.Component<*> {
           })}
         </ul>
         {this.props.type === "directory" ? null : (
-          <div>
+          <React.Fragment>
             {this.props.commuterExecuteLink && viewingNotebook ? (
               <a
                 href={`${this.props.commuterExecuteLink}/${path}`}
@@ -88,7 +88,7 @@ class BrowseHeader extends React.Component<*> {
             <a href={filePath} download className="ops">
               Download
             </a>
-          </div>
+          </React.Fragment>
         )}
         <style jsx>{`
           nav {

--- a/packages/commuter-frontend/components/contents/csv.js
+++ b/packages/commuter-frontend/components/contents/csv.js
@@ -11,10 +11,6 @@ export default class CSVView extends React.Component<*> {
 
   render() {
     const data = d3.csvParse(this.props.entry.content);
-    return (
-      <div>
-        <DataTransform data={{ data }} theme="light" />
-      </div>
-    );
+    return <DataTransform data={{ data }} theme="light" />;
   }
 }

--- a/packages/commuter-frontend/components/contents/directory-listing.js
+++ b/packages/commuter-frontend/components/contents/directory-listing.js
@@ -51,7 +51,7 @@ const GroupedDirectoryListings = (props: DirectoryListingProps) => {
   ));
 
   return (
-    <div>
+    <React.Fragment>
       <div className="letters">
         {groupNames.map(x => (
           <a href={`#group-${x}`} key={x}>
@@ -71,7 +71,7 @@ const GroupedDirectoryListings = (props: DirectoryListingProps) => {
           padding-left: 6px;
         }
       `}</style>
-    </div>
+    </React.Fragment>
   );
 };
 
@@ -82,7 +82,7 @@ const DirectoryListing = (props: DirectoryListingProps) => {
   const contents = props.contents.filter(row => !row.name.startsWith("."));
 
   return (
-    <div>
+    <React.Fragment>
       <div className="directory-listing">
         <table>
           <tbody>
@@ -208,7 +208,7 @@ const DirectoryListing = (props: DirectoryListingProps) => {
           }
         `}
       </style>
-    </div>
+    </React.Fragment>
   );
 };
 

--- a/packages/commuter-frontend/components/contents/index.js
+++ b/packages/commuter-frontend/components/contents/index.js
@@ -62,11 +62,7 @@ class File extends React.Component<*> {
       case "md":
       case "markdown":
       case "rmd":
-        return (
-          <div>
-            <MarkdownTransform data={this.props.entry.content} />
-          </div>
-        );
+        return <MarkdownTransform data={this.props.entry.content} />;
       case "gif":
       case "jpeg":
       case "jpg":

--- a/packages/commuter-frontend/components/contents/json.js
+++ b/packages/commuter-frontend/components/contents/json.js
@@ -24,11 +24,11 @@ export default props => {
     );
   } catch (e) {
     return (
-      <div>
+      <React.Fragment>
         <h1>Failed to parse Zeppelin Notebook</h1>
         <pre>{e.toString()}</pre>
         <code>{this.props.entry.content}</code>
-      </div>
+      </React.Fragment>
     );
   }
 };

--- a/packages/commuter-frontend/components/contents/zeppelin.js
+++ b/packages/commuter-frontend/components/contents/zeppelin.js
@@ -8,20 +8,83 @@ import { Editor } from "@nteract/core/components";
 const d3 = Object.assign({}, require("d3-dsv"));
 
 const Text = (props: { data: string }) => (
-  <div>
+  <React.Fragment>
     <code>{props.data}</code>
     <style jsx>{`
       code {
         white-space: pre;
       }
     `}</style>
-  </div>
+  </React.Fragment>
 );
 
 const HokeyTable = props => (
-  <div>
-    <style jsx>
-      {`
+  <React.Fragment>
+    <style jsx>{`
+      table {
+        border-collapse: collapse;
+        border-spacing: 0;
+        border-collapse: collapse;
+        border-spacing: 0;
+        empty-cells: show;
+        border: 1px solid #cbcbcb;
+        max-height: 200px;
+        overflow-y: scroll;
+      }
+
+      td,
+      th {
+        padding: 0;
+        border-left: 1px solid #cbcbcb; /*  inner column border */
+        border-width: 0 0 0 1px;
+        font-size: inherit;
+        margin: 0;
+        overflow: visible; /*to make ths where the title is really long work*/
+        padding: 0.5em 1em; /* cell padding */
+      }
+
+      td:first-child,
+      th:first-child {
+        border-left-width: 0;
+      }
+
+      thead {
+        background-color: #e0e0e0;
+        color: #000;
+        text-align: left;
+        vertical-align: bottom;
+      }
+    `}</style>
+    <table>
+      <thead>
+        <tr>
+          {props.columnNames.map(column => (
+            <th key={column.index}>{column.name}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {props.rows.map((row, idx) => (
+          <tr key={idx}>
+            {row.map((item, colIdx) => <td key={colIdx}>{item}</td>)}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </React.Fragment>
+);
+
+const DSVTable = (props: { data: Array<Object> }) => {
+  if (!Array.isArray(props.data) || props.data.length <= 0) {
+    return null;
+  }
+
+  const columnNames = Object.keys(props.data[0]);
+  const rows = props.data;
+
+  return (
+    <React.Fragment>
+      <style jsx>{`
         table {
           border-collapse: collapse;
           border-spacing: 0;
@@ -55,74 +118,7 @@ const HokeyTable = props => (
           text-align: left;
           vertical-align: bottom;
         }
-      `}
-    </style>
-    <table>
-      <thead>
-        <tr>
-          {props.columnNames.map(column => (
-            <th key={column.index}>{column.name}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {props.rows.map((row, idx) => (
-          <tr key={idx}>
-            {row.map((item, colIdx) => <td key={colIdx}>{item}</td>)}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </div>
-);
-
-const DSVTable = (props: { data: Array<Object> }) => {
-  if (!Array.isArray(props.data) || props.data.length <= 0) {
-    return null;
-  }
-
-  const columnNames = Object.keys(props.data[0]);
-  const rows = props.data;
-
-  return (
-    <div>
-      <style jsx>
-        {`
-          table {
-            border-collapse: collapse;
-            border-spacing: 0;
-            border-collapse: collapse;
-            border-spacing: 0;
-            empty-cells: show;
-            border: 1px solid #cbcbcb;
-            max-height: 200px;
-            overflow-y: scroll;
-          }
-
-          td,
-          th {
-            padding: 0;
-            border-left: 1px solid #cbcbcb; /*  inner column border */
-            border-width: 0 0 0 1px;
-            font-size: inherit;
-            margin: 0;
-            overflow: visible; /*to make ths where the title is really long work*/
-            padding: 0.5em 1em; /* cell padding */
-          }
-
-          td:first-child,
-          th:first-child {
-            border-left-width: 0;
-          }
-
-          thead {
-            background-color: #e0e0e0;
-            color: #000;
-            text-align: left;
-            vertical-align: bottom;
-          }
-        `}
-      </style>
+      `}</style>
       <table>
         <thead>
           <tr>
@@ -137,12 +133,12 @@ const DSVTable = (props: { data: Array<Object> }) => {
           ))}
         </tbody>
       </table>
-    </div>
+    </React.Fragment>
   );
 };
 
 const UnsupportedResult = props => (
-  <div>
+  <React.Fragment>
     <h1>UNSUPPORTED ZEPPELIN RESULT</h1>
     <p>
       Post an issue to{" "}
@@ -152,7 +148,7 @@ const UnsupportedResult = props => (
       to let us know about it
     </p>
     <JSONTransform data={props.result} />
-  </div>
+  </React.Fragment>
 );
 
 // Old style Zeppelin
@@ -242,11 +238,9 @@ const Paragraph = props => {
   if (props.result) {
     resultView = <Result result={props.result} />;
   } else if (props.results && Array.isArray(props.results.msg)) {
-    resultView = (
-      <div>
-        {props.results.msg.map((item, idx) => <Message {...item} key={idx} />)}
-      </div>
-    );
+    resultView = props.results.msg.map((item, idx) => (
+      <Message {...item} key={idx} />
+    ));
   }
 
   if (lang === "markdown") {
@@ -263,7 +257,7 @@ const Paragraph = props => {
   }
 
   return (
-    <div>
+    <React.Fragment>
       <Editor language={lang}>{props.text}</Editor>
       <div
         style={{
@@ -273,7 +267,7 @@ const Paragraph = props => {
       >
         {resultView}
       </div>
-    </div>
+    </React.Fragment>
   );
 };
 

--- a/packages/commuter-frontend/pages/discover.js
+++ b/packages/commuter-frontend/pages/discover.js
@@ -152,41 +152,39 @@ class DiscoveryGrid extends React.Component<*> {
   render() {
     if (this.props.discovered.length === 0) {
       return (
-        <div>
+        <React.Fragment>
           <Header />
           <Body>
             <h1>No discoveries...</h1>
           </Body>
-        </div>
+        </React.Fragment>
       );
     }
 
     return (
-      <div>
+      <React.Fragment>
         <Header active="discover" />
         <Body>
-          <div>
-            <div className="discoveries">
-              {this.props.discovered
-                ? this.props.discovered.map(item => (
-                    <DiscoveryItem key={item.path} {...item} />
-                  ))
-                : null}
-            </div>
-            <style jsx>{`
-              .discoveries {
-                margin-top: 1rem;
-                margin-left: 1rem;
-                margin-right: 1rem;
-              }
-
-              .discoveries > * {
-                display: block;
-              }
-            `}</style>
+          <div className="discoveries">
+            {this.props.discovered
+              ? this.props.discovered.map(item => (
+                  <DiscoveryItem key={item.path} {...item} />
+                ))
+              : null}
           </div>
+          <style jsx>{`
+            .discoveries {
+              margin-top: 1rem;
+              margin-left: 1rem;
+              margin-right: 1rem;
+            }
+
+            .discoveries > * {
+              display: block;
+            }
+          `}</style>
         </Body>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/commuter-frontend/pages/index.js
+++ b/packages/commuter-frontend/pages/index.js
@@ -17,12 +17,12 @@ class IndexPage extends React.Component<*> {
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         Redirecting to{" "}
         <Link href="/view">
           <a>/view</a>
         </Link>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/commuter-frontend/pages/view.js
+++ b/packages/commuter-frontend/pages/view.js
@@ -83,11 +83,11 @@ class ViewPage extends React.Component<ViewPageProps, ViewPageState> {
 
   render() {
     if (this.props.statusCode) {
-      return <div>{`Nothing found for ${this.props.viewPath}`}</div>;
+      return `Nothing found for ${this.props.viewPath}`;
     }
 
     return (
-      <div>
+      <React.Fragment>
         <Header />
         <BrowseHeader
           basepath={"/view"}
@@ -110,7 +110,7 @@ class ViewPage extends React.Component<ViewPageProps, ViewPageState> {
             `}</style>
           </div>
         </Body>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/core/__tests__/components/__snapshots__/pinned-cell-spec.js.snap
+++ b/packages/core/__tests__/components/__snapshots__/pinned-cell-spec.js.snap
@@ -32,12 +32,10 @@ exports[`PinnedPlaceHolderCell has a snapshot test at least 1`] = `
 `;
 
 exports[`Sticky Cell Container creates a container when there are children 1`] = `
-<div
-  className="jsx-719937883 jsx-1455849675"
->
+Array [
   <div
     className="jsx-719937883 jsx-1455849675 sticky-cells-placeholder"
-  />
+  />,
   <div
     className="jsx-719937883 jsx-1455849675 sticky-cell-container"
   >
@@ -47,8 +45,8 @@ exports[`Sticky Cell Container creates a container when there are children 1`] =
     <div>
       cell two
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Sticky Cell Container returns null when there are no children 1`] = `null`;

--- a/packages/core/__tests__/views/__snapshots__/toolbar-spec.js.snap
+++ b/packages/core/__tests__/views/__snapshots__/toolbar-spec.js.snap
@@ -10,132 +10,120 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
     <div
       className="jsx-3867617067 jsx-3867617067 cell-toolbar"
     >
-      <div
-        className="jsx-3867617067 jsx-3867617067"
+      <button
+        className="jsx-3867617067 jsx-3867617067 executeButton"
+        title="execute cell"
       >
-        <button
-          className="jsx-3867617067 jsx-3867617067 executeButton"
-          title="execute cell"
+        <span
+          className="jsx-3867617067 jsx-3867617067 octicon"
         >
-          <span
-            className="jsx-3867617067 jsx-3867617067 octicon"
-          >
-            <TriangleRightOcticon>
-              <SVGWrapper
-                height={16}
-                outerProps={Object {}}
-                viewBox="0 0 6 16"
-                width={6}
-              >
-                <span>
-                  <svg
-                    height={16}
-                    style={
-                      Object {
-                        "display": "inline-block",
-                        "fill": "currentColor",
-                        "verticalAlign": "text-bottom",
-                      }
+          <TriangleRightOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 6 16"
+              width={6}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
                     }
-                    viewBox="0 0 6 16"
-                    width={6}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 14l6-6-6-6z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </SVGWrapper>
-            </TriangleRightOcticon>
-          </span>
-        </button>
-      </div>
-      <div
-        className="jsx-3867617067 jsx-3867617067"
+                  }
+                  viewBox="0 0 6 16"
+                  width={6}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 14l6-6-6-6z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </TriangleRightOcticon>
+        </span>
+      </button>
+      <button
+        className="jsx-3867617067 jsx-3867617067 stickyButton"
+        title="pin cell"
       >
-        <button
-          className="jsx-3867617067 jsx-3867617067 stickyButton"
-          title="pin cell"
+        <span
+          className="jsx-3867617067 jsx-3867617067 octicon"
         >
-          <span
-            className="jsx-3867617067 jsx-3867617067 octicon"
-          >
-            <PinOcticon>
-              <SVGWrapper
-                height={16}
-                outerProps={Object {}}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <span>
-                  <svg
-                    height={16}
-                    style={
-                      Object {
-                        "display": "inline-block",
-                        "fill": "currentColor",
-                        "verticalAlign": "text-bottom",
-                      }
+          <PinOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 16 16"
+              width={16}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
                     }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 0 0 .86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 0 0-.86.34z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </SVGWrapper>
-            </PinOcticon>
-          </span>
-        </button>
-      </div>
-      <div
-        className="jsx-3867617067 jsx-3867617067"
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 0 0 .86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 0 0-.86.34z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </PinOcticon>
+        </span>
+      </button>
+      <button
+        className="jsx-3867617067 jsx-3867617067 deleteButton"
+        title="delete cell"
       >
-        <button
-          className="jsx-3867617067 jsx-3867617067 deleteButton"
-          title="delete cell"
+        <span
+          className="jsx-3867617067 jsx-3867617067 octicon"
         >
-          <span
-            className="jsx-3867617067 jsx-3867617067 octicon"
-          >
-            <TrashOcticon>
-              <SVGWrapper
-                height={16}
-                outerProps={Object {}}
-                viewBox="0 0 12 16"
-                width={12}
-              >
-                <span>
-                  <svg
-                    height={16}
-                    style={
-                      Object {
-                        "display": "inline-block",
-                        "fill": "currentColor",
-                        "verticalAlign": "text-bottom",
-                      }
+          <TrashOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 12 16"
+              width={12}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
                     }
-                    viewBox="0 0 12 16"
-                    width={12}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </SVGWrapper>
-            </TrashOcticon>
-          </span>
-        </button>
-      </div>
+                  }
+                  viewBox="0 0 12 16"
+                  width={12}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </TrashOcticon>
+        </span>
+      </button>
       <DropdownMenu>
         <div
           className="jsx-2673522894 dropdown"
@@ -217,132 +205,120 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
     <div
       className="jsx-3867617067 jsx-3867617067 cell-toolbar"
     >
-      <div
-        className="jsx-3867617067 jsx-3867617067"
+      <button
+        className="jsx-3867617067 jsx-3867617067 executeButton"
+        title="execute cell"
       >
-        <button
-          className="jsx-3867617067 jsx-3867617067 executeButton"
-          title="execute cell"
+        <span
+          className="jsx-3867617067 jsx-3867617067 octicon"
         >
-          <span
-            className="jsx-3867617067 jsx-3867617067 octicon"
-          >
-            <TriangleRightOcticon>
-              <SVGWrapper
-                height={16}
-                outerProps={Object {}}
-                viewBox="0 0 6 16"
-                width={6}
-              >
-                <span>
-                  <svg
-                    height={16}
-                    style={
-                      Object {
-                        "display": "inline-block",
-                        "fill": "currentColor",
-                        "verticalAlign": "text-bottom",
-                      }
+          <TriangleRightOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 6 16"
+              width={6}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
                     }
-                    viewBox="0 0 6 16"
-                    width={6}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0 14l6-6-6-6z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </SVGWrapper>
-            </TriangleRightOcticon>
-          </span>
-        </button>
-      </div>
-      <div
-        className="jsx-3867617067 jsx-3867617067"
+                  }
+                  viewBox="0 0 6 16"
+                  width={6}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 14l6-6-6-6z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </TriangleRightOcticon>
+        </span>
+      </button>
+      <button
+        className="jsx-3867617067 jsx-3867617067 stickyButton"
+        title="pin cell"
       >
-        <button
-          className="jsx-3867617067 jsx-3867617067 stickyButton"
-          title="pin cell"
+        <span
+          className="jsx-3867617067 jsx-3867617067 octicon"
         >
-          <span
-            className="jsx-3867617067 jsx-3867617067 octicon"
-          >
-            <PinOcticon>
-              <SVGWrapper
-                height={16}
-                outerProps={Object {}}
-                viewBox="0 0 16 16"
-                width={16}
-              >
-                <span>
-                  <svg
-                    height={16}
-                    style={
-                      Object {
-                        "display": "inline-block",
-                        "fill": "currentColor",
-                        "verticalAlign": "text-bottom",
-                      }
+          <PinOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 16 16"
+              width={16}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
                     }
-                    viewBox="0 0 16 16"
-                    width={16}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 0 0 .86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 0 0-.86.34z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </SVGWrapper>
-            </PinOcticon>
-          </span>
-        </button>
-      </div>
-      <div
-        className="jsx-3867617067 jsx-3867617067"
+                  }
+                  viewBox="0 0 16 16"
+                  width={16}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 1.2V2l.5 1L6 6H2.2c-.44 0-.67.53-.34.86L5 10l-4 5 5-4 3.14 3.14a.5.5 0 0 0 .86-.34V10l3-4.5 1 .5h.8c.44 0 .67-.53.34-.86L10.86.86a.5.5 0 0 0-.86.34z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </PinOcticon>
+        </span>
+      </button>
+      <button
+        className="jsx-3867617067 jsx-3867617067 deleteButton"
+        title="delete cell"
       >
-        <button
-          className="jsx-3867617067 jsx-3867617067 deleteButton"
-          title="delete cell"
+        <span
+          className="jsx-3867617067 jsx-3867617067 octicon"
         >
-          <span
-            className="jsx-3867617067 jsx-3867617067 octicon"
-          >
-            <TrashOcticon>
-              <SVGWrapper
-                height={16}
-                outerProps={Object {}}
-                viewBox="0 0 12 16"
-                width={12}
-              >
-                <span>
-                  <svg
-                    height={16}
-                    style={
-                      Object {
-                        "display": "inline-block",
-                        "fill": "currentColor",
-                        "verticalAlign": "text-bottom",
-                      }
+          <TrashOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 12 16"
+              width={12}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
                     }
-                    viewBox="0 0 12 16"
-                    width={12}
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </span>
-              </SVGWrapper>
-            </TrashOcticon>
-          </span>
-        </button>
-      </div>
+                  }
+                  viewBox="0 0 12 16"
+                  width={12}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </TrashOcticon>
+        </span>
+      </button>
       <DropdownMenu>
         <div
           className="jsx-2673522894 dropdown"

--- a/packages/core/src/components/pinned-cell.js
+++ b/packages/core/src/components/pinned-cell.js
@@ -44,7 +44,7 @@ export class StickyCellContainer extends React.Component<*, *> {
     }
 
     return (
-      <div>
+      <React.Fragment>
         <div
           className="sticky-cells-placeholder"
           ref={ref => {
@@ -86,7 +86,7 @@ export class StickyCellContainer extends React.Component<*, *> {
             margin: 20px;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -80,40 +80,34 @@ export default class Toolbar extends PureComponent<ToolbarProps> {
       <div className="cell-toolbar-mask">
         <div className="cell-toolbar">
           {type !== "markdown" && (
-            <div>
-              <button
-                onClick={executeCell}
-                title="execute cell"
-                className="executeButton"
-              >
-                <span className="octicon">
-                  <TriangleRightOcticon />
-                </span>
-              </button>
-            </div>
+            <button
+              onClick={executeCell}
+              title="execute cell"
+              className="executeButton"
+            >
+              <span className="octicon">
+                <TriangleRightOcticon />
+              </span>
+            </button>
           )}
-          <div>
-            <button
-              onClick={toggleStickyCell}
-              title="pin cell"
-              className="stickyButton"
-            >
-              <span className="octicon">
-                <PinOcticon />
-              </span>
-            </button>
-          </div>
-          <div>
-            <button
-              onClick={removeCell}
-              title="delete cell"
-              className="deleteButton"
-            >
-              <span className="octicon">
-                <TrashOcticon />
-              </span>
-            </button>
-          </div>
+          <button
+            onClick={toggleStickyCell}
+            title="pin cell"
+            className="stickyButton"
+          >
+            <span className="octicon">
+              <PinOcticon />
+            </span>
+          </button>
+          <button
+            onClick={removeCell}
+            title="delete cell"
+            className="deleteButton"
+          >
+            <span className="octicon">
+              <TrashOcticon />
+            </span>
+          </button>
           <DropdownMenu>
             <DropdownTrigger>
               <button title="show additional actions">

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -243,7 +243,7 @@ export class NotebookApp extends React.PureComponent<Props> {
         const outputExpanded = cell.getIn(["metadata", "outputExpanded"]);
 
         element = (
-          <div>
+          <React.Fragment>
             <Input hidden={sourceHidden}>
               <Prompt counter={cell.get("execution_count")} running={running} />
               <Editor>
@@ -290,7 +290,7 @@ export class NotebookApp extends React.PureComponent<Props> {
                 />
               </Outputs>
             </LatexRenderer>
-          </div>
+          </React.Fragment>
         );
 
         break;
@@ -372,7 +372,7 @@ export class NotebookApp extends React.PureComponent<Props> {
 
   render(): ?React$Element<any> {
     return (
-      <div>
+      <React.Fragment>
         {/* Sticky cells */}
         {this.renderStickyCells()}
         {/* Actual cells! */}
@@ -402,7 +402,7 @@ export class NotebookApp extends React.PureComponent<Props> {
         >
           {}
         </style>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/notebook-preview/src/papermill.js
+++ b/packages/notebook-preview/src/papermill.js
@@ -12,7 +12,7 @@ export const PapermillView = (props: PapermillMetadata) => {
 
   if (props.status === "running") {
     return (
-      <div>
+      <React.Fragment>
         <div className="papermill">Executing with Papermill...</div>
         <style jsx>{`
           .papermill {
@@ -26,7 +26,7 @@ export const PapermillView = (props: PapermillMetadata) => {
             box-sizing: border-box;
           }
         `}</style>
-      </div>
+      </React.Fragment>
     );
   }
   return null;

--- a/packages/transform-geojson/src/index.js
+++ b/packages/transform-geojson/src/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 /* eslint class-methods-use-this: 0 */
-import React from "react";
+import * as React from "react";
 import L from "leaflet";
 
 type Props = {
@@ -109,7 +109,7 @@ export class GeoJSONTransform extends React.Component<Props> {
 
   render(): ?React$Element<any> {
     return (
-      <div>
+      <React.Fragment>
         <link
           rel="stylesheet"
           href="../node_modules/leaflet/dist/leaflet.css"
@@ -120,7 +120,7 @@ export class GeoJSONTransform extends React.Component<Props> {
           }}
           style={{ height: 600, width: "100%" }}
         />
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/transform-model-debug/src/index.js
+++ b/packages/transform-model-debug/src/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React from "react";
+import * as React from "react";
 
 type Props = {
   data: string,
@@ -21,10 +21,10 @@ class ModelDebug extends React.Component<Props> {
     // show all the models
     const model = models.modelID || models;
     return (
-      <div>
+      <React.Fragment>
         <h1>{JSON.stringify(data, null, 2)}</h1>
         <pre>{model ? JSON.stringify(model, null, 2) : null}</pre>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React from "react";
+import * as React from "react";
 
 import { objectToReactElement } from "./object-to-react";
 import { cloneDeep } from "lodash";
@@ -25,7 +25,7 @@ export default class VDOM extends React.Component<Props> {
       return objectToReactElement(obj);
     } catch (err) {
       return (
-        <div>
+        <React.Fragment>
           <pre
             style={{
               backgroundColor: "ghostwhite",
@@ -39,7 +39,7 @@ export default class VDOM extends React.Component<Props> {
             There was an error rendering VDOM data from the kernel or notebook
           </pre>
           <code>{err.toString()}</code>
-        </div>
+        </React.Fragment>
       );
     }
   }

--- a/packages/transform-vega/src/index.js
+++ b/packages/transform-vega/src/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React from "react";
+import * as React from "react";
 
 const merge = require("lodash").merge;
 const vegaEmbed = require("vega-embed");
@@ -81,14 +81,14 @@ export class VegaEmbed extends React.Component<EmbedProps> {
   render(): ?React$Element<any> {
     // Note: We hide vega-actions since they won't work in our environment
     return (
-      <div>
+      <React.Fragment>
         <style>{".vega-actions{ display: none; }"}</style>
         <div
           ref={el => {
             this.el = el;
           }}
         />
-      </div>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
Since we're on React 16.2, I've taken the liberty of switching a bunch of our app to using either `React.Fragment`, raw arrays, or strings where possible.

I was trying to figure out some styling differences and it was much easier to reason about without all the extra divs (or spans). I'm going to keep at this and verify all the apps. A finetooth comb should probably be applied.

* [x] switch from wrapper divs to `<React.Fragment>`s
* [x] rely on raw strings and arrays where appropriate
* [x] update jest snapshots to match
  