### PR TITLE
remove unused hljs styles from showcase

### DIFF
--- a/applications/showcase/pages/index.js
+++ b/applications/showcase/pages/index.js
@@ -15,8 +15,6 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 
 import idea from "react-syntax-highlighter/styles/hljs/idea";
 import agate from "react-syntax-highlighter/styles/hljs/agate";
-import androidstudio from "react-syntax-highlighter/styles/hljs/androidstudio";
-import docco from "react-syntax-highlighter/styles/hljs/docco";
 
 /** These are fake cell types for the purposes of demonstration **/
 type CodeCell = {|


### PR DESCRIPTION
Working on more CSS sync up between our light codemirror theme and our react-syntaxhighlighter and noticed these weren't really used.