### PR TITLE
allow unfocusing the editor for markdown preview

### DIFF
--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -195,7 +195,7 @@ export function focusPreviousCell(id: string) {
   };
 }
 
-export function focusCellEditor(id: string) {
+export function focusCellEditor(id: string | null) {
   return {
     type: constants.FOCUS_CELL_EDITOR,
     id

--- a/packages/core/src/components/markdown-preview.js
+++ b/packages/core/src/components/markdown-preview.js
@@ -1,6 +1,7 @@
 // @flow
 
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
+/* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
 
 import React from "react";
 import CommonMark from "commonmark";
@@ -12,10 +13,10 @@ import { Outputs, PromptBuffer, Input } from "./";
 
 type Props = {
   source: string,
-  focusAbove: () => void,
-  focusBelow: () => void,
   focusEditor: () => void,
   unfocusEditor: () => void,
+  focusAbove: () => void,
+  focusBelow: () => void,
   cellFocused: boolean,
   editorFocused: boolean,
   children: React$Element<*>
@@ -33,6 +34,8 @@ const parser = new CommonMark.Parser();
 const renderer = new MarkdownRenderer();
 const mdRender: MDRender = input => renderer.render(parser.parse(input));
 
+const noop = function() {};
+
 // TODO: Consider whether this component is really something like two components:
 //
 //       * a behavioral component that tracks focus (possibly already covered elsewhere)
@@ -48,10 +51,10 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
   static defaultProps = {
     cellFocused: false,
     editorFocused: false,
-    focusAbove: () => {},
-    focusBelow: () => {},
-    focusEditor: () => {},
-    unfocusEditor: () => {},
+    focusAbove: noop,
+    focusBelow: noop,
+    focusEditor: noop,
+    unfocusEditor: noop,
     source: ""
   };
 
@@ -98,11 +101,6 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
    * Handles when a keydown event occurs on the unrendered MD cell
    */
   editorKeyDown(e: SyntheticKeyboardEvent<*>): void {
-    // TODO: ctrl-enter will set the state view mode, _however_
-    //       the focus is still set from above the editor
-    //       Suggestion: we need a `this.props.unfocusEditor`
-    //       It's either that or we should be setting `view` from
-    //       the outside
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === "Enter") {
@@ -132,16 +130,16 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
     }
 
     switch (e.key) {
+      case "Enter":
+        this.openEditor();
+        e.preventDefault();
+        return;
       case "ArrowUp":
         this.props.focusAbove();
         break;
       case "ArrowDown":
         this.props.focusBelow();
         break;
-      case "Enter":
-        this.openEditor();
-        e.preventDefault();
-        return;
       default:
     }
     return;
@@ -156,6 +154,10 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
         onKeyDown={this.renderedKeyDown}
         ref={rendered => {
           this.rendered = rendered;
+        }}
+        tabIndex={this.props.cellFocused ? 0 : null}
+        style={{
+          outline: "none"
         }}
       >
         <Outputs>

--- a/packages/core/src/components/markdown-preview.js
+++ b/packages/core/src/components/markdown-preview.js
@@ -125,6 +125,10 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === "Enter") {
+      if (this.state.view) {
+        return;
+      }
+      // This likely isn't even possible, as we _should_ be in view mode
       this.closeEditor();
       return;
     }

--- a/packages/core/src/components/markdown-preview.js
+++ b/packages/core/src/components/markdown-preview.js
@@ -14,7 +14,8 @@ type Props = {
   source: string,
   focusAbove: () => void,
   focusBelow: () => void,
-  focusEditor: Function,
+  focusEditor: () => void,
+  unfocusEditor: () => void,
   cellFocused: boolean,
   editorFocused: boolean,
   children: React$Element<*>
@@ -50,6 +51,7 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
     focusAbove: () => {},
     focusBelow: () => {},
     focusEditor: () => {},
+    unfocusEditor: () => {},
     source: ""
   };
 
@@ -61,6 +63,7 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
     (this: any).openEditor = this.openEditor.bind(this);
     (this: any).editorKeyDown = this.editorKeyDown.bind(this);
     (this: any).renderedKeyDown = this.renderedKeyDown.bind(this);
+    (this: any).closeEditor = this.closeEditor.bind(this);
   }
 
   componentDidMount(): void {
@@ -103,8 +106,13 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === "Enter") {
-      this.setState({ view: true });
+      this.closeEditor();
     }
+  }
+
+  closeEditor(): void {
+    this.setState({ view: true });
+    this.props.unfocusEditor();
   }
 
   openEditor(): void {
@@ -115,12 +123,12 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
   /**
    * Handles when a keydown event occurs on the rendered MD cell
    */
-  renderedKeyDown(e: SyntheticKeyboardEvent<*>): boolean {
+  renderedKeyDown(e: SyntheticKeyboardEvent<*>) {
     const shift = e.shiftKey;
     const ctrl = e.ctrlKey;
     if ((shift || ctrl) && e.key === "Enter") {
-      this.setState({ view: true });
-      return false;
+      this.closeEditor();
+      return;
     }
 
     switch (e.key) {
@@ -133,10 +141,10 @@ export default class MarkdownCell extends React.PureComponent<any, State> {
       case "Enter":
         this.openEditor();
         e.preventDefault();
-        return false;
+        return;
       default:
     }
-    return true;
+    return;
   }
 
   render(): ?React$Element<any> {

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -222,6 +222,11 @@ export class NotebookApp extends React.PureComponent<Props> {
     const focusEditor = () => {
       this.context.store.dispatch(focusCellEditor(id));
     };
+
+    const unfocusEditor = () => {
+      this.context.store.dispatch(focusCellEditor(null));
+    };
+
     const focusAboveCell = () => {
       this.context.store.dispatch(focusPreviousCell(id));
       this.context.store.dispatch(focusPreviousCellEditor(id));
@@ -302,6 +307,7 @@ export class NotebookApp extends React.PureComponent<Props> {
             focusEditor={focusEditor}
             cellFocused={cellFocused}
             editorFocused={editorFocused}
+            unfocusEditor={unfocusEditor}
             source={cell.get("source", "")}
           >
             <Editor>

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -306,7 +306,7 @@ function focusPreviousCell(
   return state.set("cellFocused", cellOrder.get(nextIndex));
 }
 
-type FocusCellEditorAction = { type: "FOCUS_CELL_EDITOR", id: CellID };
+type FocusCellEditorAction = { type: "FOCUS_CELL_EDITOR", id: CellID | null };
 function focusCellEditor(state: DocumentState, action: FocusCellEditorAction) {
   return state.set("editorFocused", action.id);
 }


### PR DESCRIPTION
This closes #1735 by allowing the markdown cell to trigger an unfocusCellEditor callback. For the connected notebook app, this uses the `focusCellEditor` action, setting the id to `null` so no editor has focus.

I went the path of creating an `unfocusCellEditor` action then I realized how silly that was when it could be done with `focusCellEditor` and an `id`. I can still go back to that if people would prefer separate actions. LMK.