### PR TITLE
Token switch out

### DIFF
--- a/applications/desktop/__mocks__/github.js
+++ b/applications/desktop/__mocks__/github.js
@@ -1,0 +1,5 @@
+class GitHub {
+  authenticate() {}
+}
+
+module.exports = GitHub;

--- a/applications/desktop/__tests__/renderer/epics/execute-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/execute-spec.js
@@ -151,7 +151,7 @@ describe("executeCellEpic", () => {
         executionState: "idle",
         channels: "errorInExecuteCellObservable",
         notificationSystem: { addNotification: jest.fn() },
-        token: "blah"
+        githubToken: "blah"
       }
     }
   };

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -185,7 +185,7 @@ describe("setGithubToken", () => {
     const originalState = {
       app: makeAppRecord({
         github: new Github(),
-        token: null
+        githubToken: null
       })
     };
 
@@ -194,7 +194,7 @@ describe("setGithubToken", () => {
     const state = reducers(originalState, action);
     // this is a crappy way of testing this
     expect(state.app.github).not.toBeNull();
-    expect(state.app.token).not.toBeNull();
+    expect(state.app.githubToken).not.toBeNull();
   });
 });
 

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -166,7 +166,7 @@ export function handleGistAction(store: any, action: any) {
   const notificationSystem = state.app.get("notificationSystem");
   let publishAsUser = false;
   if (action.type === "PUBLISH_USER_GIST") {
-    const githubToken = state.app.get("token");
+    const githubToken = state.app.get("githubToken");
     github.authenticate({ type: "oauth", token: githubToken });
     publishAsUser = true;
   }

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -8,6 +8,7 @@ import { makeAppRecord } from "@nteract/types/core/records";
 
 import type { Channels } from "@nteract/types/channels";
 
+// TODO: This should be coming from @nteract/types/core/records
 declare class AppState {
   channels: Channels;
   spawn: ChildProcess;
@@ -16,7 +17,7 @@ declare class AppState {
   kernelSpecDisplayName: string;
   kernelSpec: Object;
   executionState: string;
-  token: string;
+  githubToken: string;
   notificationSystem: Object;
   set(string, any): AppState;
   withMutations(any): AppState;
@@ -106,7 +107,7 @@ function setNotificationsSystem(
 type SetGithubTokenAction = { type: "SET_GITHUB_TOKEN", githubToken: string };
 function setGithubToken(state: AppState, action: SetGithubTokenAction) {
   const { githubToken } = action;
-  return state.set("token", githubToken);
+  return state.set("githubToken", githubToken);
 }
 
 type ExitAction = { type: "EXIT" };

--- a/packages/core/src/dummy/index.js
+++ b/packages/core/src/dummy/index.js
@@ -105,7 +105,7 @@ export function dummyStore(config: *) {
       notificationSystem: {
         addNotification: () => {} // most of the time you'll want to mock this
       },
-      token: "TOKEN",
+      githubToken: "TOKEN",
       channels: "channelInfo"
     }),
     config: Immutable.Map({

--- a/packages/core/src/records.js
+++ b/packages/core/src/records.js
@@ -124,7 +124,7 @@ export type Notebook = {
 export const AppRecord = Immutable.Record({
   executionState: "not connected",
 
-  token: null, // Electron specific (ish...)
+  githubToken: null, // Belongs in a separate state tree
   channels: null, // Electron, though we hope to adapt these...
   spawn: null, // Very Electron
   connectionFile: null, // Electron

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -126,7 +126,7 @@ export type Notebook = {
 // Basically, anything that's only for desktop should have its own record & reducers
 type AppRecordProps = {
   executionState: "not connected" | "busy" | "idle" | "starting",
-  token: ?string,
+  githubToken: ?string,
   channels: ?Channels,
   spawn: ?ChildProcess,
   connectionFile: ?string,
@@ -141,7 +141,7 @@ type AppRecordProps = {
 };
 export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
   executionState: "not connected",
-  token: null, // Electron specific (ish...)
+  githubToken: null, // Electron specific (ish...)
   channels: null, // Electron, though we hope to adapt these...
   spawn: null, // Very Electron
   connectionFile: null, // Electron


### PR DESCRIPTION
Since the name token appears all over our code base (primarily in jupyter), having a top level `token` in our core app record was unclear. I've changed it to `githubToken`. While I was at it I mocked `github` because I noticed that it was making requests to github.com in our tests, causing a slow down and is possibly why we were getting stalled out sometimes.