### PR TITLE
remove bad tests from menu suite

### DIFF
--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -409,13 +409,6 @@ describe("menu", () => {
     });
   });
 
-  describe("showSaveAsDialog", () => {
-    test("returns a promise", () => {
-      const dialog = menu.showSaveAsDialog();
-      expect(dialog).toEqual(expect.any(Promise));
-    });
-  });
-
   describe("triggerWindowRefresh", () => {
     test("does nothing if no filename is given", () => {
       const store = dummyStore();
@@ -451,9 +444,6 @@ describe("menu", () => {
         level: "success"
       });
     });
-  });
-  describe("triggerSaveAsPDF", () => {
-    test("does something", () => {});
   });
 
   describe("storeToPDF", () => {

--- a/scripts/test-shim.js
+++ b/scripts/test-shim.js
@@ -27,3 +27,10 @@ global.window.document.createRange = function createRange() {
 
 // HACK: To test index.js
 document.querySelector = () => document.createElement("div");
+
+process.on("unhandledRejection", (error, promise) => {
+  console.error("Unhandled promise rejection somewhere in tests");
+  console.error(error);
+  console.error(error.stack);
+  promise.catch(err => console.error("promise rejected", err));
+});


### PR DESCRIPTION
This removes an empty test, removes a useless test (it only verified a data type, that flow was already covering for us), and sets up some deeper unhandled promise rejections.