### PR TITLE
Create new types, for Hosts and Kernels

### DIFF
--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -1,6 +1,10 @@
 import * as constants from "@nteract/core/constants";
 import reducers from "../../../src/notebook/reducers";
-import { AppRecord, makeAppRecord } from "@nteract/types/core/records";
+import {
+  AppRecord,
+  makeAppRecord,
+  makeLocalKernelRecord
+} from "@nteract/types/core/records";
 
 const Github = require("github");
 
@@ -8,18 +12,18 @@ describe("cleanupKernel", () => {
   test("nullifies entries for the kernel in originalState", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
     const action = { type: constants.KILL_KERNEL };
 
     const state = reducers(originalState, action);
-    expect(state.app.channels).toBeNull();
-    expect(state.app.spawn).toBeNull();
-    expect(state.app.connectionFile).toBeNull();
+    expect(state.app.kernel).toBeNull();
   });
 });
 
@@ -27,9 +31,11 @@ describe("setNotificationSystem", () => {
   test("returns the same originalState if notificationSystem is undefined", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
@@ -41,9 +47,11 @@ describe("setNotificationSystem", () => {
   test("sets the notificationSystem if given", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
@@ -61,9 +69,11 @@ describe("startSaving", () => {
   test("should set isSaving to false", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
@@ -78,9 +88,11 @@ describe("doneSaving", () => {
   test("should set isSaving to false", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
@@ -95,9 +107,11 @@ describe("setExecutionState", () => {
   test("should set the exeuction state to the given value", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
@@ -115,18 +129,18 @@ describe("killKernel", () => {
   test("clears out kernel configuration", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
     const action = { type: constants.KILL_KERNEL };
 
     const state = reducers(originalState, action);
-    expect(state.app.channels).toBeNull();
-    expect(state.app.spawn).toBeNull();
-    expect(state.app.connectionFile).toBeNull();
+    expect(state.app.kernel).toBeNull();
   });
 });
 
@@ -134,11 +148,13 @@ describe("interruptKernel", () => {
   test("sends a SIGINT and clears the kernel", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: {
-          kill: () => {}
-        },
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: {
+            kill: () => {}
+          },
+          connectionFile: false
+        })
       })
     };
 
@@ -153,9 +169,11 @@ describe("newKernel", () => {
   test("creates a new kernel", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
@@ -175,8 +193,8 @@ describe("newKernel", () => {
       spec: { display_name: "Test Name" }
     });
     expect(state.app.kernelSpecDisplayName).toBe("Test Name");
-    expect(state.app.spawn).toBe("test_spawn");
-    expect(state.app.channels).toBe("test_channels");
+    expect(state.app.kernel.spawn).toBe("test_spawn");
+    expect(state.app.kernel.channels).toBe("test_channels");
   });
 });
 
@@ -202,18 +220,18 @@ describe("exit", () => {
   test("calls cleanupKernel", () => {
     const originalState = {
       app: makeAppRecord({
-        channels: false,
-        spawn: false,
-        connectionFile: false
+        kernel: makeLocalKernelRecord({
+          channels: false,
+          spawn: false,
+          connectionFile: false
+        })
       })
     };
 
     const action = { type: constants.EXIT };
 
     const state = reducers(originalState, action);
-    expect(state.app.channels).toBeNull();
-    expect(state.app.spawn).toBeNull();
-    expect(state.app.connectionFile).toBeNull();
+    expect(state.app.kernel).toBeNull();
     expect(state.app.kernelSpecName).toBeNull();
     expect(state.app.executionState).toBe("not connected");
   });

--- a/applications/desktop/src/notebook/kernel/shutdown.js
+++ b/applications/desktop/src/notebook/kernel/shutdown.js
@@ -16,6 +16,13 @@ export type Kernel = {
 };
 
 export function cleanupKernel(kernel: Kernel, closeChannels: boolean): void {
+  if (!kernel) {
+    console.warn(
+      `Could not cleanup kernel channels, have they already
+      been completed?`
+    );
+    return;
+  }
   if (kernel.channels && closeChannels) {
     try {
       kernel.channels.complete();

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -60,7 +60,9 @@ describe("createExecuteCellStream", () => {
       state: {
         app: {
           executionState: "not connected",
-          channels,
+          kernel: {
+            channels
+          },
           notificationSystem: { addNotification: jest.fn() }
         }
       }
@@ -90,7 +92,9 @@ describe("createExecuteCellStream", () => {
       state: {
         app: {
           executionState: "connected",
-          channels,
+          kernel: {
+            channels
+          },
           notificationSystem: { addNotification: jest.fn() }
         }
       }
@@ -134,7 +138,9 @@ describe("executeCellEpic", () => {
     state: {
       app: {
         executionState: "idle",
-        channels: "errorInExecuteCellObservable",
+        kernel: {
+          channels: "errorInExecuteCellObservable"
+        },
         notificationSystem: { addNotification: jest.fn() },
         githubToken: "blah"
       }

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -131,7 +131,7 @@ export function createExecuteCellStream(
   id: string
 ) {
   const state = store.getState();
-  const channels = state.app.channels;
+  const channels = state.app.kernel ? state.app.kernel.channels : null;
 
   const kernelConnected =
     channels &&

--- a/packages/core/src/providers/editor.js
+++ b/packages/core/src/providers/editor.js
@@ -26,7 +26,7 @@ type Props = {
 function mapStateToProps(state: Object): Object {
   return {
     cursorBlinkRate: state.config.get("cursorBlinkRate"),
-    channels: state.app.channels,
+    channels: state.app.kernel ? state.app.kernel.channels : null,
     executionState: state.app.executionState
   };
 }

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -1,0 +1,67 @@
+// @flow
+// The ID type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
+// 9092-7679-9978-8822 is the ID
+opaque type ID = string;
+// A ref is an internal ID, used for kernels, hosts, kernelspec collections, etc.
+opaque type Ref = string;
+
+import type { RecordFactory, RecordOf } from "immutable";
+import { Record, List } from "immutable";
+
+type BaseHostProps = {
+  id: ?ID,
+  ref: ?Ref,
+  selectedKernelRef: ?Ref,
+  kernelSpecsRef: ?Ref, // reference to a collection of kernelspecs
+  defaultKernelName: ?string,
+  // In the desktop case, this _should_ be only one, pending
+  // kernel cleanup
+  activeKernelRefs: List<ID>
+};
+
+type JupyterHostRecordProps = BaseHostProps & {
+  type: "jupyter",
+  token: ?string,
+  serverUrl: ?string,
+  crossDomain: ?boolean
+};
+
+export const makeJupyterHostRecord: RecordFactory<
+  JupyterHostRecordProps
+> = Record({
+  type: "jupyter",
+  ref: null,
+  id: null,
+  selectedKernelRef: null,
+  kernelSpecsRef: null,
+  defaultKernelName: null,
+  activeKernelRefs: List(),
+  token: null,
+  serverUrl: null,
+  crossDomain: false
+});
+
+export type JupyterHostRecord = RecordOf<JupyterHostRecordProps>;
+
+type BinderHostRecordProps = JupyterHostRecordProps & {
+  // TODO: figure out if this belong here, it was brought over by play
+  messages: List<string>
+};
+
+type DesktopHostRecordProps = BaseHostProps & {
+  type: "local"
+};
+
+export const makeDesktopHostRecord: RecordFactory<
+  DesktopHostRecordProps
+> = Record({
+  type: "local",
+  ref: null,
+  id: null,
+  selectedKernelRef: null,
+  kernelSpecsRef: null,
+  defaultKernelName: null,
+  activeKernelRefs: List()
+});
+
+export type DesktopHostRecord = RecordOf<DesktopHostRecordProps>;

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -1,22 +1,28 @@
 // @flow
-// The ID type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
-// 9092-7679-9978-8822 is the ID
-opaque type ID = string;
-// A ref is an internal ID, used for kernels, hosts, kernelspec collections, etc.
+import type { ChildProcess } from "child_process";
+
+// The Id type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
+// 9092-7679-9978-8822 is the Id
+opaque type Id = string;
+// A ref is an internal Id, used for kernels, hosts, kernelspec collections, etc.
 opaque type Ref = string;
+
+opaque type KernelRef = Ref;
+opaque type HostRef = Ref;
+opaque type KernelSpecsRef = Ref;
 
 import type { RecordFactory, RecordOf } from "immutable";
 import { Record, List } from "immutable";
 
 type BaseHostProps = {
-  id: ?ID,
-  ref: ?Ref,
-  selectedKernelRef: ?Ref,
-  kernelSpecsRef: ?Ref, // reference to a collection of kernelspecs
+  id: ?Id,
+  ref: ?HostRef,
+  selectedKernelRef: ?KernelRef,
+  kernelSpecsRef: ?KernelSpecsRef, // reference to a collection of kernelspecs
   defaultKernelName: ?string,
   // In the desktop case, this _should_ be only one, pending
   // kernel cleanup
-  activeKernelRefs: List<ID>
+  activeKernelRefs: List<Id>
 };
 
 type JupyterHostRecordProps = BaseHostProps & {
@@ -65,3 +71,20 @@ export const makeDesktopHostRecord: RecordFactory<
 });
 
 export type DesktopHostRecord = RecordOf<DesktopHostRecordProps>;
+
+type BaseKernelProps = {
+  ref: KernelRef,
+  name: string,
+  lastActivity: Date,
+  channels: rxjs$Subject<*, *>,
+  status: string
+};
+
+type RemoteKernelProps = BaseKernelProps & {
+  id: Id
+};
+
+type LocalKernelProps = BaseKernelProps & {
+  spawn: ChildProcess,
+  connectionFile: string
+};

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -73,18 +73,30 @@ export const makeDesktopHostRecord: RecordFactory<
 export type DesktopHostRecord = RecordOf<DesktopHostRecordProps>;
 
 export type BaseKernelProps = {
-  ref: KernelRef,
-  name: string,
-  lastActivity: Date,
-  channels: rxjs$Subject<*, *>,
-  status: string
+  ref: ?KernelRef,
+  name: ?string,
+  lastActivity: ?Date,
+  channels: ?rxjs$Subject<*, *>,
+  status: ?string
 };
 
 export type RemoteKernelProps = BaseKernelProps & {
-  id: Id
+  id: ?Id
 };
 
 export type LocalKernelProps = BaseKernelProps & {
-  spawn: ChildProcess,
-  connectionFile: string
+  spawn: ?ChildProcess,
+  connectionFile: ?string
 };
+
+export const makeLocalKernelRecord: RecordFactory<LocalKernelProps> = Record({
+  ref: null,
+  name: null,
+  lastActivity: null,
+  channels: null,
+  status: null,
+  spawn: null,
+  connectionFile: null
+});
+
+export type LocalKernelRecord = RecordOf<LocalKernelProps>;

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -3,18 +3,18 @@ import type { ChildProcess } from "child_process";
 
 // The Id type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
 // 9092-7679-9978-8822 is the Id
-opaque type Id = string;
+export opaque type Id = string;
 // A ref is an internal Id, used for kernels, hosts, kernelspec collections, etc.
-opaque type Ref = string;
+export opaque type Ref = string;
 
-opaque type KernelRef = Ref;
-opaque type HostRef = Ref;
-opaque type KernelSpecsRef = Ref;
+export opaque type KernelRef = Ref;
+export opaque type HostRef = Ref;
+export opaque type KernelSpecsRef = Ref;
 
 import type { RecordFactory, RecordOf } from "immutable";
 import { Record, List } from "immutable";
 
-type BaseHostProps = {
+export type BaseHostProps = {
   id: ?Id,
   ref: ?HostRef,
   selectedKernelRef: ?KernelRef,
@@ -25,7 +25,7 @@ type BaseHostProps = {
   activeKernelRefs: List<Id>
 };
 
-type JupyterHostRecordProps = BaseHostProps & {
+export type JupyterHostRecordProps = BaseHostProps & {
   type: "jupyter",
   token: ?string,
   serverUrl: ?string,
@@ -49,12 +49,12 @@ export const makeJupyterHostRecord: RecordFactory<
 
 export type JupyterHostRecord = RecordOf<JupyterHostRecordProps>;
 
-type BinderHostRecordProps = JupyterHostRecordProps & {
+export type BinderHostRecordProps = JupyterHostRecordProps & {
   // TODO: figure out if this belong here, it was brought over by play
   messages: List<string>
 };
 
-type DesktopHostRecordProps = BaseHostProps & {
+export type DesktopHostRecordProps = BaseHostProps & {
   type: "local"
 };
 
@@ -72,7 +72,7 @@ export const makeDesktopHostRecord: RecordFactory<
 
 export type DesktopHostRecord = RecordOf<DesktopHostRecordProps>;
 
-type BaseKernelProps = {
+export type BaseKernelProps = {
   ref: KernelRef,
   name: string,
   lastActivity: Date,
@@ -80,11 +80,11 @@ type BaseKernelProps = {
   status: string
 };
 
-type RemoteKernelProps = BaseKernelProps & {
+export type RemoteKernelProps = BaseKernelProps & {
   id: Id
 };
 
-type LocalKernelProps = BaseKernelProps & {
+export type LocalKernelProps = BaseKernelProps & {
   spawn: ChildProcess,
   connectionFile: string
 };

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -18,6 +18,8 @@ import type {
   LocalKernelProps
 } from "./hosts";
 
+export { makeLocalKernelRecord } from "./hosts";
+
 /*
 
 This is the definition of JSON that Flow provides
@@ -138,9 +140,6 @@ type AppRecordProps = {
   kernel: ?RecordOf<RemoteKernelProps | LocalKernelProps>,
   executionState: "not connected" | "busy" | "idle" | "starting",
   githubToken: ?string,
-  channels: ?Channels,
-  spawn: ?ChildProcess,
-  connectionFile: ?string,
   notificationSystem: ?Object,
   kernelSpecName: ?string,
   kernelSpecDisplayName: ?string,
@@ -154,9 +153,6 @@ export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
   kernel: null,
   executionState: "not connected",
   githubToken: null, // Electron specific (ish...)
-  channels: null, // Electron, though we hope to adapt these...
-  spawn: null, // Very Electron
-  connectionFile: null, // Electron
   notificationSystem: null, // Should be available for all I assume
   kernelSpecName: null, // All
   kernelSpecDisplayName: null, // All
@@ -196,15 +192,22 @@ export const DocumentRecord = Immutable.Record({
   filename: ""
 });
 
+type CommsRecordProps = {
+  targets: Immutable.Map<any, any>,
+  info: Immutable.Map<any, any>,
+  models: Immutable.Map<any, any>
+};
+
 export const CommsRecord = Immutable.Record({
   targets: new Immutable.Map(),
   info: new Immutable.Map(),
   models: new Immutable.Map()
 });
 
+// TODO: I don't think flow is fully checking things here
 export type AppState = {
-  app: AppRecord,
-  document: DocumentRecord,
-  comms: CommsRecord,
+  app: RecordOf<AppRecordProps>,
+  document: RecordOf<DocumentState>,
+  comms: RecordOf<CommsRecordProps>,
   config: Immutable.Map<string, any>
 };

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -8,6 +8,16 @@ import type { ChildProcess } from "child_process";
 import { Record } from "immutable";
 import type { Channels } from "../channels";
 
+import type {
+  Id,
+  Ref,
+  KernelRef,
+  KernelSpecsRef,
+  HostRef,
+  RemoteKernelProps,
+  LocalKernelProps
+} from "./hosts";
+
 /*
 
 This is the definition of JSON that Flow provides
@@ -19,7 +29,6 @@ type JSONArray = Array<JSON>;
 Which we'll adapt for our use of Immutable.js
 
 */
-
 export type ImmutableJSON =
   | string
   | number
@@ -101,14 +110,15 @@ export type LanguageInfoMetadata = {
 export type NotebookMetadata = {
   kernelspec: KernelspecMetadata,
   language_info: LanguageInfoMetadata
-  // We're not currently using orig_nbformat in nteract. Based on the comment
-  // in the schema, I'm not sure we should:
+  // NOTE: We're not currently using orig_nbformat in nteract. Based on the comment
+  // in the schema, we won't:
   //
   //   > Original notebook format (major number) before converting the notebook between versions. This should never be written to a file
   //
   //   from https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L58-L61
   //
-  // It seems like an intermediate/in-memory representation that bled its way into the spec
+  // It seems like an intermediate/in-memory representation that bled its way into the spec, when it should have been
+  // handled as separate state.
   //
   // orig_nbformat?: number,
 };
@@ -125,6 +135,7 @@ export type Notebook = {
 // ElectronAppRecord
 // Basically, anything that's only for desktop should have its own record & reducers
 type AppRecordProps = {
+  kernel: ?RecordOf<RemoteKernelProps | LocalKernelProps>,
   executionState: "not connected" | "busy" | "idle" | "starting",
   githubToken: ?string,
   channels: ?Channels,
@@ -140,6 +151,7 @@ type AppRecordProps = {
   error: any
 };
 export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
+  kernel: null,
   executionState: "not connected",
   githubToken: null, // Electron specific (ish...)
   channels: null, // Electron, though we hope to adapt these...


### PR DESCRIPTION
This will be for both local "hosts" (the desktop app) and for connection to remote hosts:

* Jupyter Notebook Server
* JupyterHub
* Binders

This PR is the `HostRecord` and `KernelRecord` portion of #2338.