### PR TITLE
create some guided steps to ease release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,9 @@ In order to build a signed copy with working auto-update, you will need to join 
 
 ## Release Process
 
-0. Run `lerna publish` to publish all the inner packages.
+1. Run `npm run publish` to publish all the inner packages.
+
+1. Run `npm run publish:commuter` (assuming the above worked)
 
 1. Make sure the release is working by running `npm run dist` and testing the built app inside the `./applications/desktop/dist/` folder. You can build for all platforms using `npm run dist:all`.
 

--- a/applications/desktop/RELEASING.md
+++ b/applications/desktop/RELEASING.md
@@ -14,11 +14,11 @@ In order to build a signed copy with working auto-update, you will need to join 
 
 ## Release Process
 
-0. Run `lerna publish` to publish all the packages, or at the very least just this package, `nteract`.
+0. Run `lerna publish` to publish all the inner packages.
 
 1. Make sure the release is working by running `npm run dist` and testing the built app inside the `./applications/desktop/dist/` folder. You can build for all platforms using `npm run dist:all`.
 
-1. Run `npm run publish` on macOS, Windows and Linux or run `npm run publish:all` to build everything on a single machine. This will draft a new release on GitHub and will upload all necessary assets.
+1. Run `npm run publish:desktop` on macOS, Windows and Linux or run `npm run publish:desktop:all` to build everything on a single machine. This will draft a new release on GitHub and will upload all necessary assets.
 
 1. From GitHub go to [nteract's releases](https://github.com/nteract/nteract/releases), verify everything works and edit the release notes. The name should follow our [naming guidelines](https://github.com/nteract/naming), namely that we use the last name of the next scientist in the list with an adjective in front.
    Example:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "scripts": {
     "postinstall": "npm run lerna",
     "lerna": "lerna bootstrap --hoist --loglevel verbose --nohoist='{electron-builder,electron-updater,lodash,ijavascript,zeromq,nteract-assets,mathjax-electron,github,jmp}'",
-    "build:apps": "lerna run build --scope nteract --scope @nteract/play --scope @nteract/commuter --scope @nteract/notebook-on-next --parallel --stream",
     "app:desktop": "lerna run start --scope nteract --stream",
     "app:play": "lerna run dev --scope @nteract/play --stream",
     "app:showcase": "lerna run dev --scope @nteract/showcase --stream",
@@ -35,6 +34,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "npm run build:packages",
+    "build:apps": "lerna run build --scope nteract --scope @nteract/play --scope @nteract/commuter --scope @nteract/notebook-on-next --parallel --stream",
     "build:desktop": "lerna run build --scope nteract --stream",
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "lerna run build --parallel --ignore @nteract/play --ignore @nteract/showcase --ignore nteract --ignore @nteract/commuter-frontend --ignore @nteract/notebook-on-next --ignore nteract-on-jupyter",
@@ -52,12 +52,17 @@
     "flow": "flow",
     "diagnostics": "scripts/kernelspecs-diagnostics.js",
     "precommit": "lint-staged",
+    "verifyBeforePublish":  "lerna run prepublishOnly && lerna run prepare",
+    "prepublishOnly": "npm run verifyBeforePublish",
+    "publish": "lerna run publish --ignore nteract --ignore @nteract/commuter-frontend --ignore @nteract/commuter",
+    "prepublish:commuter": "npm run build:packages",
+    "publish:commuter": "lerna run publish --scope @nteract/commuter-frontend --scope @nteract/commuter",
     "prettify": "prettier --write '**/*.{js,json}' '!**/{lib,.git,.next,package.json,flow-typed}/**'",
-    "dist": "lerna run dist --scope nteract --stream",
     "pack": "lerna run pack --scope nteract --stream",
-    "publish": "lerna run publish --scope nteract --stream",
+    "dist": "lerna run dist --scope nteract --stream",
     "dist:all": "lerna run dist:all --scope nteract --stream",
-    "publish:all": "lerna run publish:all --scope nteract --stream"
+    "publish:desktop": "lerna run publish --scope nteract --stream",
+    "publish:desktop:all": "lerna run publish:all --scope nteract --stream"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Ever since #2277, I've been hoping to make the release process a bit more staged and with a few more verification steps. The new steps (and as documented in the releasing notes):

```
npm run publish
npm run publish:commuter
npm run publish:desktop:all
```

I think with it set up in this way I'd probably add in the two web apps deployed on now. No worries for now though.