### PR TITLE
begin migrating last vega release to new package

### DIFF
--- a/packages/transform-vega/src/index.js
+++ b/packages/transform-vega/src/index.js
@@ -2,7 +2,8 @@
 import * as React from "react";
 
 const merge = require("lodash").merge;
-const vegaEmbed = require("vega-embed");
+
+const vegaEmbed = require("@nteract/vega-embed2");
 
 const MIMETYPE_VEGA = "application/vnd.vega.v2+json";
 const MIMETYPE_VEGALITE = "application/vnd.vegalite.v1+json";

--- a/packages/vega-embed2/.npmrc
+++ b/packages/vega-embed2/.npmrc
@@ -1,0 +1,2 @@
+package-lock = false
+optional = false

--- a/packages/vega-embed2/package.json
+++ b/packages/vega-embed2/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@nteract/transform-vega",
-  "version": "3.0.6",
-  "description": "Vega Transform",
+  "name": "@nteract/vega-embed2",
+  "version": "1.0.0",
+  "description": "Direct vega2 and vega-lite 1 embed",
   "main": "lib/",
   "nteractDesktop": "src/index.js",
   "scripts": {
@@ -20,12 +20,9 @@
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-vega",
   "dependencies": {
-    "d3": "^3.5.17",
-    "lodash": "^4.17.4",
-    "@nteract/vega-embed2": "^1.0.0"
-  },
-  "peerDependencies": {
-    "react": "^16.2.0"
+    "vega": "^2.6.5",
+    "vega-embed": "^2.2.0",
+    "vega-lite": "^1.3.1"
   },
   "license": "BSD-3-Clause"
 }

--- a/packages/vega-embed2/package.json
+++ b/packages/vega-embed2/package.json
@@ -18,7 +18,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-vega",
+  "repository": "https://github.com/nteract/nteract/tree/master/packages/vega-embed2",
   "dependencies": {
     "vega": "^2.6.5",
     "vega-embed": "^2.2.0",

--- a/packages/vega-embed2/src/index.js
+++ b/packages/vega-embed2/src/index.js
@@ -1,0 +1,1 @@
+module.exports = require("vega-embed");


### PR DESCRIPTION
Sets up a new package handle the old version of vega-embed separately.

/cc @nikitakit