### PR TITLE
Add transforms for vega 3 and vega-lite 2

### DIFF
--- a/applications/desktop/__tests__/renderer/__snapshots__/index-spec.js.snap
+++ b/applications/desktop/__tests__/renderer/__snapshots__/index-spec.js.snap
@@ -16,7 +16,9 @@ exports[`App renders app 1`] = `
     <Connect(DragDropContext(NotebookApp))
       displayOrder={
         Array [
+          "application/vnd.vega.v3+json",
           "application/vnd.vega.v2+json",
+          "application/vnd.vegalite.v2+json",
           "application/vnd.vegalite.v1+json",
           "application/geo+json",
           "application/vnd.plotly.v1+json",
@@ -45,7 +47,9 @@ exports[`App renders app 1`] = `
           "application/vnd.dataresource+json": [Function],
           "application/vnd.plotly.v1+json": [Function],
           "application/vnd.vega.v2+json": [Function],
+          "application/vnd.vega.v3+json": [Function],
           "application/vnd.vegalite.v1+json": [Function],
+          "application/vnd.vegalite.v2+json": [Function],
           "application/x-nteract-model-debug+json": [Function],
           "image/gif": [Function],
           "image/jpeg": [Function],

--- a/applications/desktop/webpack.common.js
+++ b/applications/desktop/webpack.common.js
@@ -4,7 +4,8 @@ const path = require("path");
 
 const nodeModules = {
   jmp: "commonjs jmp",
-  canvas: "commonjs canvas"
+  canvas: "commonjs canvas",
+  "canvas-prebuilt": "commonjs canvas-prebuilt"
 };
 
 const mainConfig = {

--- a/applications/jupyter-extension/nteract_on_jupyter/components/notebook.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/components/notebook.js
@@ -12,7 +12,7 @@ import React, { PropTypes as T } from "react";
 import NotebookPreview from "@nteract/notebook-preview";
 import { MarkdownTransform } from "@nteract/transforms";
 import DataResourceTransform from "@nteract/transform-dataresource";
-import { VegaLite, Vega } from "@nteract/transform-vega";
+import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 
 import {
   standardTransforms,
@@ -23,8 +23,10 @@ import {
 // Order is important here. The last transform in the array will have order `0`.
 const { transforms, displayOrder } = [
   DataResourceTransform,
-  VegaLite,
-  Vega
+  VegaLite1,
+  VegaLite2,
+  Vega2,
+  Vega3
 ].reduce(registerTransform, {
   transforms: standardTransforms,
   displayOrder: standardDisplayOrder

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/nteract/nteract",
   "scripts": {
     "postinstall": "npm run lerna",
-    "lerna": "lerna bootstrap --hoist --loglevel verbose --nohoist='{electron-builder,electron-updater,lodash,ijavascript,zeromq,nteract-assets,mathjax-electron,github,jmp}'",
+    "lerna": "lerna bootstrap --hoist --loglevel verbose --nohoist='{electron-builder,electron-updater,lodash,ijavascript,zeromq,nteract-assets,mathjax-electron,github,jmp,canvas,canvas-prebuilt}'",
     "app:desktop": "lerna run start --scope nteract --stream",
     "app:play": "lerna run dev --scope @nteract/play --stream",
     "app:showcase": "lerna run dev --scope @nteract/showcase --stream",

--- a/packages/commuter-frontend/components/contents/index.js
+++ b/packages/commuter-frontend/components/contents/index.js
@@ -21,7 +21,7 @@ import type { Content } from "./types";
 
 import DataResourceTransform from "@nteract/transform-dataresource";
 
-import { VegaLite, Vega } from "@nteract/transform-vega";
+import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 
 import { PlotlyNullTransform, PlotlyTransform } from "../../transforms";
 
@@ -30,8 +30,10 @@ const { transforms, displayOrder } = [
   DataResourceTransform,
   PlotlyNullTransform,
   PlotlyTransform,
-  VegaLite,
-  Vega
+  VegaLite1,
+  VegaLite2,
+  Vega2,
+  Vega3
 ].reduce(registerTransform, {
   transforms: standardTransforms,
   displayOrder: standardDisplayOrder

--- a/packages/transform-vega/__tests__/vega.test.js
+++ b/packages/transform-vega/__tests__/vega.test.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { shallow, mount } from "enzyme";
 
-import { Vega, VegaLite, VegaEmbed } from "../src/";
+import { Vega2, Vega3, VegaLite1, VegaLite2, VegaEmbed } from "../src/";
 
 const cars = require("vega-lite/data/cars.json");
 
@@ -20,21 +20,43 @@ const spec = {
   }
 };
 
-describe("Vega", () => {
+describe("Vega2", () => {
   it("renders VegaEmbed with embedMode vega", () => {
-    const wrapper = shallow(<Vega data={spec} />);
+    const wrapper = shallow(<Vega2 data={spec} />);
 
     expect(wrapper.name()).toEqual("VegaEmbed");
     expect(wrapper.props().embedMode).toEqual("vega");
+    expect(wrapper.props().version).toEqual("vega2");
   });
 });
 
-describe("VegaLite", () => {
+describe("Vega3", () => {
+  it("renders VegaEmbed with embedMode vega", () => {
+    const wrapper = shallow(<Vega3 data={spec} />);
+
+    expect(wrapper.name()).toEqual("VegaEmbed");
+    expect(wrapper.props().embedMode).toEqual("vega");
+    expect(wrapper.props().version).toEqual("vega3");
+  });
+});
+
+describe("VegaLite1", () => {
   it("renders VegaEmbed with embedMode vega-lite", () => {
-    const wrapper = shallow(<VegaLite data={spec} />);
+    const wrapper = shallow(<VegaLite1 data={spec} />);
 
     expect(wrapper.name()).toEqual("VegaEmbed");
     expect(wrapper.props().embedMode).toEqual("vega-lite");
+    expect(wrapper.props().version).toEqual("vega2");
+  });
+});
+
+describe("VegaLite2", () => {
+  it("renders VegaEmbed with embedMode vega-lite", () => {
+    const wrapper = shallow(<VegaLite2 data={spec} />);
+
+    expect(wrapper.name()).toEqual("VegaEmbed");
+    expect(wrapper.props().embedMode).toEqual("vega-lite");
+    expect(wrapper.props().version).toEqual("vega3");
   });
 });
 

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "d3": "^3.5.17",
     "lodash": "^4.17.4",
-    "@nteract/vega-embed2": "^1.0.0"
+    "@nteract/vega-embed2": "^1.0.0",
+    "vega-embed": "^3.0.0-rc7"
   },
   "peerDependencies": {
     "react": "^16.2.0"

--- a/packages/transform-vega/src/index.js
+++ b/packages/transform-vega/src/index.js
@@ -3,10 +3,13 @@ import * as React from "react";
 
 const merge = require("lodash").merge;
 
-const vegaEmbed = require("@nteract/vega-embed2");
+const vegaEmbed2 = require("@nteract/vega-embed2");
+import vegaEmbed3 from "vega-embed";
 
-const MIMETYPE_VEGA = "application/vnd.vega.v2+json";
-const MIMETYPE_VEGALITE = "application/vnd.vegalite.v1+json";
+const MIMETYPE_VEGA2 = "application/vnd.vega.v2+json";
+const MIMETYPE_VEGA3 = "application/vnd.vega.v3+json";
+const MIMETYPE_VEGALITE1 = "application/vnd.vegalite.v1+json";
+const MIMETYPE_VEGALITE2 = "application/vnd.vegalite.v2+json";
 
 const DEFAULT_WIDTH = 500;
 const DEFAULT_HEIGHT = DEFAULT_WIDTH / 1.5;
@@ -14,6 +17,7 @@ const DEFAULT_HEIGHT = DEFAULT_WIDTH / 1.5;
 type EmbedProps = {
   data: Object,
   embedMode: string,
+  version: string,
   renderedCallback: (err: any, result: any) => any
 };
 
@@ -23,26 +27,49 @@ function embed(
   el: HTMLElement,
   spec: Object,
   mode: string,
+  version: string,
   cb: (err: any, result: any) => any
 ) {
-  const embedSpec = {
-    mode,
-    spec: Object.assign({}, spec)
-  };
+  if (version == "vega2") {
+    const embedSpec = {
+      mode,
+      spec: Object.assign({}, spec)
+    };
 
-  if (mode === "vega-lite") {
-    embedSpec.spec.config = merge(
-      {
-        cell: {
-          width: DEFAULT_WIDTH,
-          height: DEFAULT_HEIGHT
-        }
-      },
-      embedSpec.spec.config
-    );
+    if (mode === "vega-lite") {
+      embedSpec.spec.config = merge(
+        {
+          cell: {
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT
+          }
+        },
+        embedSpec.spec.config
+      );
+    }
+
+    vegaEmbed2(el, embedSpec, cb);
+  } else {
+    spec = Object.assign({}, spec);
+    if (mode === "vega-lite") {
+      spec.config = merge(
+        {
+          cell: {
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT
+          }
+        },
+        spec.config
+      );
+    }
+
+    vegaEmbed3(el, spec, {
+      mode: mode,
+      actions: false
+    })
+      .then(result => cb(null, result))
+      .catch(cb);
   }
-
-  vegaEmbed(el, embedSpec, cb);
 }
 
 export class VegaEmbed extends React.Component<EmbedProps> {
@@ -50,7 +77,8 @@ export class VegaEmbed extends React.Component<EmbedProps> {
 
   static defaultProps = {
     renderedCallback: defaultCallback,
-    embedMode: "vega-lite"
+    embedMode: "vega-lite",
+    version: "vega2"
   };
 
   componentDidMount(): void {
@@ -59,6 +87,7 @@ export class VegaEmbed extends React.Component<EmbedProps> {
         this.el,
         this.props.data,
         this.props.embedMode,
+        this.props.version,
         this.props.renderedCallback
       );
     }
@@ -74,6 +103,7 @@ export class VegaEmbed extends React.Component<EmbedProps> {
         this.el,
         this.props.data,
         this.props.embedMode,
+        this.props.version,
         this.props.renderedCallback
       );
     }
@@ -81,6 +111,8 @@ export class VegaEmbed extends React.Component<EmbedProps> {
 
   render(): ?React$Element<any> {
     // Note: We hide vega-actions since they won't work in our environment
+    // (this is only needed for vega2, since vega-embed v3 supports hiding
+    // actions via options)
     return (
       <React.Fragment>
         <style>{".vega-actions{ display: none; }"}</style>
@@ -98,14 +130,29 @@ type Props = {
   data: Object
 };
 
-export function VegaLite(props: Props) {
-  return <VegaEmbed data={props.data} embedMode="vega-lite" />;
+export function VegaLite1(props: Props) {
+  return <VegaEmbed data={props.data} embedMode="vega-lite" version="vega2" />;
 }
 
-VegaLite.MIMETYPE = MIMETYPE_VEGALITE;
+VegaLite1.MIMETYPE = MIMETYPE_VEGALITE1;
 
-export function Vega(props: Props) {
-  return <VegaEmbed data={props.data} embedMode="vega" />;
+export function Vega2(props: Props) {
+  return <VegaEmbed data={props.data} embedMode="vega" version="vega2" />;
 }
 
-Vega.MIMETYPE = MIMETYPE_VEGA;
+Vega2.MIMETYPE = MIMETYPE_VEGA2;
+
+// For backwards compatibility
+export { VegaLite1 as VegaLite, Vega2 as Vega };
+
+export function VegaLite2(props: Props) {
+  return <VegaEmbed data={props.data} embedMode="vega-lite" version="vega3" />;
+}
+
+VegaLite2.MIMETYPE = MIMETYPE_VEGALITE2;
+
+export function Vega3(props: Props) {
+  return <VegaEmbed data={props.data} embedMode="vega" version="vega3" />;
+}
+
+Vega3.MIMETYPE = MIMETYPE_VEGA3;

--- a/packages/transforms-full/src/index.js
+++ b/packages/transforms-full/src/index.js
@@ -11,7 +11,7 @@ import ModelDebug from "@nteract/transform-model-debug";
 
 import DataResourceTransform from "@nteract/transform-dataresource";
 
-import { VegaLite, Vega } from "@nteract/transform-vega";
+import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 
 import {
   standardTransforms,
@@ -26,8 +26,10 @@ const additionalTransforms = [
   PlotlyNullTransform,
   PlotlyTransform,
   GeoJSONTransform,
-  VegaLite,
-  Vega
+  VegaLite1,
+  VegaLite2,
+  Vega2,
+  Vega3
 ];
 
 const { transforms, displayOrder } = additionalTransforms.reduce(


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

This adds transforms for the latest version of Vega.

(I couldn't get tests to run locally, but hopefully there's some CI bot in place to catch errors)