### PR TITLE
Bring execution epic into core

### DIFF
--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -13,7 +13,7 @@ import {
   newKernelByNameEpic
 } from "./kernel-launch";
 
-import { executeCellEpic, updateDisplayEpic } from "./execute";
+import { executeCellEpic, updateDisplayEpic } from "@nteract/core/epics";
 
 import { publishEpic } from "./github-publish";
 

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -1,3 +1,4 @@
+// @flow
 import { ActionsObservable } from "redux-observable";
 import {
   EXECUTE_CELL,
@@ -16,7 +17,7 @@ import {
   executeCellEpic,
   updateDisplayEpic,
   createExecuteCellStream
-} from "../../../src/notebook/epics/execute";
+} from "../../src/epics/execute";
 
 const Immutable = require("immutable");
 

--- a/packages/core/epics.js
+++ b/packages/core/epics.js
@@ -1,0 +1,2 @@
+// @flow
+module.exports = require("./").epics;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "@nteract/dropdown-menu": "^0.0.6",
     "@nteract/editor": "^5.0.7",
     "@nteract/octicons": "^0.0.6",
+    "@nteract/messaging": "^3.0.5",
     "@nteract/transforms": "^3.1.5",
     "@nteract/types": "^1.0.4",
     "commonmark": "^0.28.0",

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -42,7 +42,7 @@ import {
   updateCellPagers,
   updateCellStatus,
   clearOutputs
-} from "@nteract/core/actions";
+} from "../actions";
 
 import type { Subject } from "rxjs/Subject";
 import type { ActionsObservable } from "redux-observable";
@@ -53,7 +53,7 @@ import {
   ABORT_EXECUTION,
   ERROR_EXECUTING,
   ERROR_UPDATE_DISPLAY
-} from "@nteract/core/constants";
+} from "../constants";
 
 const Immutable = require("immutable");
 

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { executeCellEpic, updateDisplayEpic } from "./execute";

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -6,6 +6,7 @@ import * as reducers from "./reducers";
 import * as components from "./components";
 import * as providers from "./providers";
 import * as themes from "./themes";
+import * as epics from "./epics";
 
 export {
   actions,
@@ -14,5 +15,6 @@ export {
   reducers,
   components,
   providers,
-  themes
+  themes,
+  epics
 };


### PR DESCRIPTION
This begins the migration of epics into the `@nteract/core` package, starting with execute. Only non-desktop specific epics will end up in core.