### PR TITLE
require actions from src/actions

### DIFF
--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -1,6 +1,6 @@
 // @flow
-import * as actions from "../actions";
-import * as constants from "../constants";
+import * as actions from "../src/actions";
+import * as constants from "../src/constants";
 
 describe("setExecutionState", () => {
   test("creates a SET_EXECUTION_STATE action", () => {


### PR DESCRIPTION
Found out the _real_ reason the actions spec is taking so long to load -- it was loading up all of core because of how it was imported. Since `it` and `test` will do a fresh environment, this was ending up really large. Test run length should now be a bit less.