### PR TITLE
rely solely on core for action type constants

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -8,12 +8,11 @@ import {
   notebookLoaded,
   extractNewKernel,
   convertRawNotebook,
-  LOAD,
   loadEpic,
-  NEW_NOTEBOOK,
-  SET_NOTEBOOK,
   newNotebookEpic
 } from "../../../src/notebook/epics/loading";
+
+import { LOAD, NEW_NOTEBOOK, SET_NOTEBOOK } from "@nteract/core/constants";
 
 import { toArray } from "rxjs/operators";
 

--- a/applications/desktop/src/notebook/epics/config.js
+++ b/applications/desktop/src/notebook/epics/config.js
@@ -4,7 +4,9 @@ import { remote } from "electron";
 import {
   MERGE_CONFIG,
   SET_CONFIG_KEY,
-  DONE_SAVING_CONFIG
+  DONE_SAVING_CONFIG,
+  LOAD_CONFIG,
+  SAVE_CONFIG
 } from "@nteract/core/constants";
 
 import { readFileObservable, writeFileObservable } from "fs-observable";
@@ -15,10 +17,7 @@ import type { ActionsObservable } from "redux-observable";
 
 const path = require("path");
 
-export const LOAD_CONFIG = "LOAD_CONFIG";
 export const loadConfig = () => ({ type: LOAD_CONFIG });
-
-export const SAVE_CONFIG = "SAVE_CONFIG";
 export const saveConfig = () => ({ type: SAVE_CONFIG });
 export const doneSavingConfig = () => ({ type: DONE_SAVING_CONFIG });
 

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -165,7 +165,7 @@ export function handleGistAction(store: any, action: any) {
   const filename = state.document.get("filename");
   const notificationSystem = state.app.get("notificationSystem");
   let publishAsUser = false;
-  if (action.type === "PUBLISH_USER_GIST") {
+  if (action.type === PUBLISH_USER_GIST) {
     const githubToken = state.app.get("githubToken");
     github.authenticate({ type: "oauth", token: githubToken });
     publishAsUser = true;

--- a/applications/desktop/src/notebook/epics/kernel-launch.js
+++ b/applications/desktop/src/notebook/epics/kernel-launch.js
@@ -46,7 +46,9 @@ import {
   LAUNCH_KERNEL,
   LAUNCH_KERNEL_BY_NAME,
   SET_LANGUAGE_INFO,
-  ERROR_KERNEL_LAUNCH_FAILED
+  ERROR_KERNEL_LAUNCH_FAILED,
+  KERNEL_RAW_STDOUT,
+  KERNEL_RAW_STDERR
 } from "@nteract/core/constants";
 
 export function setLanguageInfo(langInfo: LanguageInfoMetadata) {
@@ -95,11 +97,11 @@ export function newKernelObservable(kernelSpec: KernelInfo, cwd: string) {
       const kernelSpecName = kernelSpec.name;
 
       spawn.stdout.on("data", data => {
-        const action = { type: "RAW_STDOUT", payload: data.toString() };
+        const action = { type: KERNEL_RAW_STDOUT, payload: data.toString() };
         observer.next(action);
       });
       spawn.stderr.on("data", data => {
-        const action = { type: "RAW_STDERR", payload: data.toString() };
+        const action = { type: KERNEL_RAW_STDERR, payload: data.toString() };
         observer.next(action);
       });
 

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -14,9 +14,7 @@ const path = require("path");
 import { of } from "rxjs/observable/of";
 import { map, tap, mergeMap, switchMap, catchError } from "rxjs/operators";
 
-export const LOAD = "LOAD";
-export const SET_NOTEBOOK = "SET_NOTEBOOK";
-export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
+import { LOAD, SET_NOTEBOOK, NEW_NOTEBOOK } from "@nteract/core/constants";
 
 export function load(filename: string) {
   return {
@@ -122,7 +120,7 @@ export const newNotebookEpic = (action$: ActionsObservable<*>) =>
     switchMap(action =>
       of(
         {
-          type: "SET_NOTEBOOK",
+          type: SET_NOTEBOOK,
           notebook: monocellNotebook
         },
         newKernel(action.kernelSpec, action.cwd)

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -101,3 +101,11 @@ export const TOGGLE_OUTPUT_EXPANSION = "TOGGLE_OUTPUT_EXPANSION";
 
 export const SAVE = "SAVE";
 export const SAVE_AS = "SAVE_AS";
+
+export const LOAD = "LOAD";
+
+export const LOAD_CONFIG = "LOAD_CONFIG";
+export const SAVE_CONFIG = "SAVE_CONFIG";
+
+export const KERNEL_RAW_STDOUT = "KERNEL_RAW_STDOUT";
+export const KERNEL_RAW_STDERR = "KERNEL_RAW_STDERR";

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -50,6 +50,7 @@ import type { ActionsObservable } from "redux-observable";
 import {
   NEW_KERNEL,
   REMOVE_CELL,
+  EXECUTE_CELL,
   ABORT_EXECUTION,
   ERROR_EXECUTING,
   ERROR_UPDATE_DISPLAY
@@ -180,7 +181,7 @@ export function createExecuteCellStream(
  */
 export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
   return action$.pipe(
-    ofType("EXECUTE_CELL"),
+    ofType(EXECUTE_CELL),
     tap(action => {
       if (!action.id) {
         throw new Error("execute cell needs an id");


### PR DESCRIPTION
Cleaned up all the spread out constants. I just noticed a few more, I'll get those cleaned up too.

* [x] Finish finding epics that declare their own constants
  