### PR TITLE
instead of erroring the stream, log bad messages

### DIFF
--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -66,7 +66,8 @@ describe("childOf", () => {
       .then(val => {
         expect(val).toEqual(3);
       }));
-  it("throws an error if msg_id is not present", done =>
+  // They now get logged instead if bad messages, instead of bombing the stream
+  it.skip("throws an error if msg_id is not present", done =>
     from([
       { parent_header: { msg_id_bad: "100" } },
       { parent_header: { msg_id_test: "100" } },

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -52,7 +52,7 @@ export const childOf = (parentMessage: JupyterMessage<*, *>) => (
     source.subscribe(
       msg => {
         if (!msg.parent_header || !msg.parent_header.msg_id) {
-          subscriber.error(new Error("no parent_header.msg_id on message"));
+          console.error("no parent_header.msg_id on message", msg);
           return;
         }
 


### PR DESCRIPTION
An attempt at figuring out how the parent header is missing from some messages. Doesn't completely fix #2356, worth a cleanup though I think.