### PR TITLE
impose host record setup in core AppRecord

### DIFF
--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -7,6 +7,7 @@ import { shutdownKernel } from "../kernel/shutdown";
 import {
   makeAppRecord,
   makeLocalKernelRecord,
+  makeDesktopHostRecord,
   AppRecord
 } from "@nteract/types/core/records";
 
@@ -116,7 +117,9 @@ type AppAction =
   | DoneSavingConfigAction;
 
 export default function handleApp(
-  state: AppRecord = makeAppRecord(),
+  state: AppRecord = makeAppRecord({
+    host: makeDesktopHostRecord()
+  }),
   action: AppAction
 ) {
   switch (action.type) {

--- a/applications/desktop/src/notebook/store.js
+++ b/applications/desktop/src/notebook/store.js
@@ -6,8 +6,6 @@ import type { AppState } from "@nteract/types/core/records";
 import middlewares from "./middlewares";
 import rootReducer from "./reducers";
 
-// NOTE: This is likely to be created by the apps directly using `createStore` from redux,
-//       piecing together the reducers and middlewares they want
 export default function configureStore(initialState: AppState) {
   return createStore(
     rootReducer,

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -99,4 +99,13 @@ export const makeLocalKernelRecord: RecordFactory<LocalKernelProps> = Record({
   connectionFile: null
 });
 
+export const makeRemoteKernelRecord: RecordFactory<RemoteKernelProps> = Record({
+  id: null,
+  ref: null,
+  name: null,
+  lastActivity: null,
+  channels: null,
+  status: null
+});
+
 export type LocalKernelRecord = RecordOf<LocalKernelProps>;

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -15,10 +15,12 @@ import type {
   KernelSpecsRef,
   HostRef,
   RemoteKernelProps,
-  LocalKernelProps
+  LocalKernelProps,
+  JupyterHostRecordProps,
+  DesktopHostRecordProps
 } from "./hosts";
 
-export { makeLocalKernelRecord } from "./hosts";
+export { makeLocalKernelRecord, makeDesktopHostRecord } from "./hosts";
 
 /*
 
@@ -138,6 +140,7 @@ export type Notebook = {
 // Basically, anything that's only for desktop should have its own record & reducers
 type AppRecordProps = {
   kernel: ?RecordOf<RemoteKernelProps | LocalKernelProps>,
+  host: ?RecordOf<DesktopHostRecordProps | JupyterHostRecordProps>,
   executionState: "not connected" | "busy" | "idle" | "starting",
   githubToken: ?string,
   notificationSystem: ?Object,
@@ -149,8 +152,10 @@ type AppRecordProps = {
   configLastSaved: ?Date,
   error: any
 };
+
 export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
   kernel: null,
+  host: null,
   executionState: "not connected",
   githubToken: null, // Electron specific (ish...)
   notificationSystem: null, // Should be available for all I assume


### PR DESCRIPTION
This introduces the `Host` record into the `AppRecord`, intended for switching between Desktop and Jupyter Hosts (including binder & jupyterhub in general).

* [x] Create a `host` record for the `AppRecord`
* [x] Set the desktop app up with a default "Desktop" host record