### PR TITLE
move the comm epic to @nteract/core

### DIFF
--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -13,11 +13,13 @@ import {
   newKernelByNameEpic
 } from "./kernel-launch";
 
-import { executeCellEpic, updateDisplayEpic } from "@nteract/core/epics";
+import {
+  executeCellEpic,
+  updateDisplayEpic,
+  commListenEpic
+} from "@nteract/core/epics";
 
 import { publishEpic } from "./github-publish";
-
-import { commListenEpic } from "./comm";
 
 import {
   loadConfigEpic,

--- a/packages/core/__tests__/epics/comm-spec.js
+++ b/packages/core/__tests__/epics/comm-spec.js
@@ -1,13 +1,14 @@
+// @flow
 import {
   createCommMessage,
   createCommCloseMessage,
   createCommOpenMessage,
   commActionObservable
-} from "../../../src/notebook/epics/comm";
+} from "../../src/epics/comm";
 
-import { commOpenAction, commMessageAction } from "@nteract/core/actions";
+import { commOpenAction, commMessageAction } from "../../src/actions";
 
-import { COMM_OPEN, COMM_MESSAGE, COMM_ERROR } from "@nteract/core/actionTypes";
+import { COMM_OPEN, COMM_MESSAGE, COMM_ERROR } from "../../src/actionTypes";
 
 import { of } from "rxjs/observable/of";
 import { toArray } from "rxjs/operators";

--- a/packages/core/src/epics/comm.js
+++ b/packages/core/src/epics/comm.js
@@ -4,13 +4,13 @@ import { merge } from "rxjs/observable/merge";
 import { map, retry, switchMap } from "rxjs/operators";
 import { ofType } from "redux-observable";
 
-import { commOpenAction, commMessageAction } from "@nteract/core/actions";
+import { commOpenAction, commMessageAction } from "../actions";
 
 import { createMessage, ofMessageType, childOf } from "@nteract/messaging";
 
 import type { ActionsObservable } from "redux-observable";
 
-import { NEW_KERNEL } from "@nteract/core/actionTypes";
+import { NEW_KERNEL } from "../actionTypes";
 
 /**
  * creates a comm open message

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -1,2 +1,3 @@
 // @flow
 export { executeCellEpic, updateDisplayEpic } from "./execute";
+export { commListenEpic } from "./comm";


### PR DESCRIPTION
An easy epic to migrate, now we can "support" comm messages in `@nteract/core`