### PR TITLE
More actionable

### DIFF
--- a/applications/desktop/src/notebook/epics/kernel-launch.js
+++ b/applications/desktop/src/notebook/epics/kernel-launch.js
@@ -177,13 +177,7 @@ export const kernelSpecsObservable = Observable.create(observer => {
 export const acquireKernelInfoEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
     ofType(NEW_KERNEL),
-    switchMap(action => {
-      /* istanbul ignore if -- used for interactive debugging */
-      if (process.env.DEBUG) {
-        window.channels = action.channels;
-      }
-      return acquireKernelInfo(action.channels);
-    })
+    switchMap(action => acquireKernelInfo(action.channels))
   );
 
 export const newKernelByNameEpic = (action$: ActionsObservable<*>) =>

--- a/packages/commutable/src/index.js
+++ b/packages/commutable/src/index.js
@@ -101,7 +101,8 @@ module.exports = {
   removeCell,
   appendCell,
   appendCellToNotebook,
-  createImmutableOutput: v4.createImmutableOutput
+  createImmutableOutput: v4.createImmutableOutput,
+  createImmutableMimeBundle: v4.createImmutableMimeBundle
 };
 
 export type { ImmutableNotebook };

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -916,8 +916,8 @@ describe("updateDisplay", () => {
       },
       {
         type: actionTypes.UPDATE_DISPLAY,
-        output: {
-          output_type: "display_data",
+        content: {
+          output_type: "update_display_data",
           data: { "text/html": "<marquee>WOO</marquee>" },
           transient: { display_id: "1234" }
         }
@@ -928,17 +928,16 @@ describe("updateDisplay", () => {
       (s, action) => reducers(s, action),
       originalState
     );
-    expect(
-      is(
-        state.getIn(["notebook", "cellMap", id, "outputs"]),
-        Immutable.fromJS([
-          {
-            output_type: "display_data",
-            data: { "text/html": "<marquee>WOO</marquee>" }
-          }
-        ])
-      )
-    ).toBe(true);
+
+    expect(state.getIn(["notebook", "cellMap", id, "outputs"])).toEqual(
+      Immutable.fromJS([
+        {
+          output_type: "display_data",
+          data: { "text/html": "<marquee>WOO</marquee>" },
+          metadata: {}
+        }
+      ])
+    );
   });
 });
 

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -197,7 +197,7 @@ describe("executeCellEpic", () => {
 });
 
 describe("updateDisplayEpic", () => {
-  test("creates an epic that handles update_display_data messages", done => {
+  test("handles update_display_data messages", done => {
     const messages = [
       // Should be processed
       {
@@ -243,16 +243,14 @@ describe("updateDisplayEpic", () => {
         expect(responseActions).toEqual([
           {
             type: UPDATE_DISPLAY,
-            output: {
-              output_type: "display_data",
+            content: {
               data: { "text/html": "<marquee>wee</marquee>" },
               transient: { display_id: "1234" }
             }
           },
           {
             type: UPDATE_DISPLAY,
-            output: {
-              output_type: "display_data",
+            content: {
               data: { "text/plain": "i am text" },
               transient: { display_id: "here" }
             }

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -4,13 +4,9 @@ import type { Channels } from "@nteract/types/channels";
 import type { ChildProcess } from "child_process"; // eslint-disable-line no-unused-vars
 
 import type {
-  ImmutableCell,
   ImmutableNotebook,
   CellID,
   CellType,
-  ImmutableCellOrder,
-  ImmutableOutput,
-  ImmutableOutputs,
   ImmutableJSONType,
   MimeBundle,
   JSONObject

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -12,7 +12,8 @@ import type {
   ImmutableOutput,
   ImmutableOutputs,
   ImmutableJSONType,
-  MimeBundle
+  MimeBundle,
+  JSONObject
 } from "@nteract/types/commutable";
 
 import type {
@@ -81,7 +82,14 @@ export type AppendOutputAction = {
 };
 
 export const UPDATE_DISPLAY = "UPDATE_DISPLAY";
-export type UpdateDisplayAction = { type: "UPDATE_DISPLAY", output: Output };
+export type UpdateDisplayAction = {
+  type: "UPDATE_DISPLAY",
+  content: {
+    data: MimeBundle,
+    metadata: JSONObject,
+    transient: { display_id: string }
+  }
+};
 
 export const TOGGLE_CELL_OUTPUT_VISIBILITY = "TOGGLE_CELL_OUTPUT_VISIBILITY";
 export type ToggleCellOutputVisibilityAction = {

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -3,6 +3,8 @@ import * as actionTypes from "./actionTypes";
 
 import type { Notebook } from "@nteract/commutable";
 
+import type { JSONObject } from "@nteract/types/commutable";
+
 import type {
   ImmutableCell,
   ImmutableNotebook,
@@ -14,6 +16,8 @@ import type {
   MimeBundle
 } from "@nteract/commutable/src/types";
 
+import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
+
 import type {
   PasteCellAction,
   ChangeFilenameAction,
@@ -23,13 +27,17 @@ import type {
   CopyCellAction,
   DeleteMetadataFieldAction,
   OverwriteMetadataFieldAction,
+  // TODO: Not here...
   AcceptPayloadMessageAction,
   SetNotebookAction,
   NewCellAfterAction,
   NewCellBeforeAction,
   ClearOutputsAction,
+  // TODO: Not here...
   AppendOutputAction,
+  // TODO: Not here...
   SetNotebookCheckpointAction,
+  // TODO: Not here...
   UpdateDisplayAction,
   FocusNextCellAction,
   FocusCellEditorAction,
@@ -43,21 +51,30 @@ import type {
   ToggleStickyCellAction,
   FocusPreviousCellAction,
   SetKernelInfoAction,
+  // TODO: Not here...
   SetLanguageInfoAction,
   UpdateCellStatusAction,
   ToggleCellInputVisibilityAction,
   ToggleCellOutputVisibilityAction,
   SetInCellAction,
   SendExecuteMessageAction,
+  // TODO: Not here...
   NewKernelAction,
   SetGithubTokenAction,
   SetNotificationSystemAction,
+  // TODO: Not here...
   SetExecutionStateAction,
+  // TODO: Not here...
   ExitAction,
+  // TODO: Not here...
   StartSavingAction,
+  // TODO: Not here...
   InterruptKernelAction,
+  // TODO: Not here...
   KillKernelAction,
+  // TODO: Not here...
   DoneSavingAction,
+  // TODO: Not here...
   DoneSavingConfigAction,
   SetConfigAction
 } from "../actionTypes";
@@ -515,5 +532,35 @@ export function commMessageAction(message: any) {
     // NOTE: Naming inconsistent between jupyter notebook and jmp
     //       see https://github.com/n-riesco/jmp/issues/14
     //       We just expect either one
+  };
+}
+
+export function appendOutput(id: CellID, output: Output): AppendOutputAction {
+  return {
+    type: actionTypes.APPEND_OUTPUT,
+    id,
+    output
+  };
+}
+
+export function acceptPayloadMessage(
+  id: CellID,
+  payload: *
+): AcceptPayloadMessageAction {
+  return {
+    type: actionTypes.ACCEPT_PAYLOAD_MESSAGE_ACTION,
+    id,
+    payload
+  };
+}
+
+export function updateDisplay(content: {
+  data: MimeBundle,
+  metadata: JSONObject,
+  transient: { display_id: string }
+}): UpdateDisplayAction {
+  return {
+    type: actionTypes.UPDATE_DISPLAY,
+    content
   };
 }

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -259,19 +259,26 @@ function appendOutput(state: DocumentRecord, action: AppendOutputAction) {
 }
 
 function updateDisplay(state: DocumentRecord, action: UpdateDisplayAction) {
-  const { output } = action;
-  if (!(output && output.transient && output.transient.display_id)) {
+  const { content } = action;
+  if (!(content && content.transient && content.transient.display_id)) {
     return state;
   }
-  const displayID = output.transient.display_id;
-  const immOutput: ImmutableOutput = createImmutableOutput(output);
+  const displayID = content.transient.display_id;
 
   const keyPaths: KeyPaths = state.getIn(
     ["transient", "keyPathsForDisplays", displayID],
     new Immutable.List()
   );
   return keyPaths.reduce(
-    (currState: DocumentRecord, kp: KeyPath) => currState.setIn(kp, immOutput),
+    (currState: DocumentRecord, kp: KeyPath) =>
+      currState.updateIn(kp, output => {
+        return {
+          output_type: output.output_type,
+          data: content.data,
+          metadata: content.metadata,
+          transient: content.transient
+        };
+      }),
     state
   );
 }

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -60,7 +60,8 @@ import {
   insertCellAt,
   insertCellAfter,
   removeCell,
-  createImmutableOutput
+  createImmutableOutput,
+  createImmutableMimeBundle
 } from "@nteract/commutable";
 
 import type {
@@ -269,15 +270,15 @@ function updateDisplay(state: DocumentRecord, action: UpdateDisplayAction) {
     ["transient", "keyPathsForDisplays", displayID],
     new Immutable.List()
   );
+  const updatedContent = {
+    data: createImmutableMimeBundle(content.data || {}),
+    metadata: Immutable.fromJS(content.metadata || {})
+  };
+
   return keyPaths.reduce(
     (currState: DocumentRecord, kp: KeyPath) =>
       currState.updateIn(kp, output => {
-        return {
-          output_type: output.output_type,
-          data: content.data,
-          metadata: content.metadata,
-          transient: content.transient
-        };
+        return output.merge(updatedContent);
       }),
     state
   );


### PR DESCRIPTION
* [x] rely directly on more action creators (that didn't exist prior)
* [x] made update display more spec compliant -- the output type sticks around so that our updating displays can now work with `execute_result`