### PR TITLE
switch to launchKernel over newKernel naming

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -6,9 +6,9 @@ import {
   setLanguageInfo,
   acquireKernelInfo,
   watchExecutionStateEpic,
-  newKernelObservable,
-  newKernelEpic,
-  newKernelByNameEpic
+  launchKernelObservable,
+  launchKernelEpic,
+  launchKernelByNameEpic
 } from "../../../src/notebook/epics/kernel-launch";
 
 import { createMessage } from "@nteract/messaging";
@@ -72,20 +72,20 @@ describe("watchExecutionStateEpic", () => {
   });
 });
 
-describe("newKernelObservable", () => {
+describe("launchKernelObservable", () => {
   test("returns an observable", () => {
-    const obs = newKernelObservable("python3", process.cwd());
+    const obs = launchKernelObservable("python3", process.cwd());
     expect(obs.subscribe).toBeTruthy();
   });
 });
 
-describe("newKernelEpic", () => {
+describe("launchKernelEpic", () => {
   test("throws an error if given a bad action", done => {
     const actionBuffer = [];
     const action$ = ActionsObservable.of({
       type: actionTypes.LAUNCH_KERNEL
     }).pipe(share());
-    const obs = newKernelEpic(action$);
+    const obs = launchKernelEpic(action$);
     obs.subscribe(
       x => {
         expect(x.type).toEqual(actionTypes.ERROR_KERNEL_LAUNCH_FAILED);
@@ -95,14 +95,14 @@ describe("newKernelEpic", () => {
       err => done.fail(err)
     );
   });
-  test("calls newKernelObservable if given the correct action", done => {
+  test("calls launchKernelObservable if given the correct action", done => {
     const actionBuffer = [];
     const action$ = ActionsObservable.of({
       type: actionTypes.LAUNCH_KERNEL,
       kernelSpec: { spec: "hokey" },
       cwd: "~"
     });
-    const obs = newKernelEpic(action$);
+    const obs = launchKernelEpic(action$);
     obs.subscribe(
       x => {
         actionBuffer.push(x.type);
@@ -119,14 +119,14 @@ describe("newKernelEpic", () => {
   });
 });
 
-describe("newKernelByNameEpic", () => {
+describe("launchKernelByNameEpic", () => {
   test("creates a LAUNCH_KERNEL action in response to a LAUNCH_KERNEL_BY_NAME action", done => {
     const action$ = ActionsObservable.of({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
       kernelSpecName: "python3",
       cwd: "~"
     });
-    const obs = newKernelByNameEpic(action$);
+    const obs = launchKernelByNameEpic(action$);
     obs.pipe(toArray()).subscribe(
       actions => {
         const types = actions.map(({ type }) => type);

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -165,7 +165,7 @@ describe("interruptKernel", () => {
   });
 });
 
-describe("newKernel", () => {
+describe("launchKernel", () => {
   test("creates a new kernel", () => {
     const originalState = {
       app: makeAppRecord({

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -7,10 +7,10 @@ import { loadEpic, newNotebookEpic } from "./loading";
 import type { ActionsObservable, Epic } from "redux-observable";
 
 import {
-  newKernelEpic,
+  launchKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
-  newKernelByNameEpic
+  launchKernelByNameEpic
 } from "./kernel-launch";
 
 import {
@@ -43,8 +43,8 @@ const epics = [
   newNotebookEpic,
   executeCellEpic,
   updateDisplayEpic,
-  newKernelEpic,
-  newKernelByNameEpic,
+  launchKernelEpic,
+  launchKernelByNameEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
   loadConfigEpic,

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -7,7 +7,11 @@ import { monocellNotebook, fromJS, parseNotebook } from "@nteract/commutable";
 import type { Notebook, ImmutableNotebook } from "@nteract/commutable";
 
 import { readFileObservable } from "fs-observable";
-import { newKernelByName, newKernel, setNotebook } from "@nteract/core/actions";
+import {
+  launchKernelByName,
+  launchKernel,
+  setNotebook
+} from "@nteract/core/actions";
 
 const path = require("path");
 
@@ -78,7 +82,7 @@ export const loadEpic = (actions: ActionsObservable<*>) =>
             // Find kernel based on kernel name
             // NOTE: Conda based kernels and remote kernels will need
             // special handling
-            newKernelByName(kernelSpecName, cwd)
+            launchKernelByName(kernelSpecName, cwd)
           );
         }),
         catchError(err => of({ type: "ERROR", payload: err, error: true }))
@@ -100,7 +104,7 @@ export const newNotebookEpic = (action$: ActionsObservable<*>) =>
           type: SET_NOTEBOOK,
           notebook: monocellNotebook
         },
-        newKernel(action.kernelSpec, action.cwd)
+        launchKernel(action.kernelSpec, action.cwd)
       )
     )
   );

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -20,7 +20,7 @@ import {
   executeCell,
   interruptKernel,
   killKernel,
-  newKernel,
+  launchKernel,
   pasteCell,
   save,
   saveAs,
@@ -81,7 +81,7 @@ export function dispatchRestartKernel(store) {
   }
 
   store.dispatch(killKernel);
-  store.dispatch(newKernel(state.app.kernelSpec, cwd));
+  store.dispatch(launchKernel(state.app.kernelSpec, cwd));
 
   notificationSystem.addNotification({
     title: "Kernel Restarted",
@@ -140,7 +140,7 @@ export function dispatchNewKernel(store, evt, spec) {
   if (state && state.document && state.document.get("filename")) {
     cwd = path.dirname(path.resolve(state.document.get("filename")));
   }
-  store.dispatch(newKernel(spec, cwd));
+  store.dispatch(launchKernel(spec, cwd));
 }
 
 export function dispatchPublishAnonGist(store) {

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -34,7 +34,7 @@ function cleanupKernel(state: AppRecord): AppRecord {
   );
 }
 
-function newKernel(state: AppRecord, action: NewKernelAction) {
+function launchKernel(state: AppRecord, action: NewKernelAction) {
   const kernel = makeLocalKernelRecord({
     channels: action.channels,
     spawn: action.spawn,
@@ -107,7 +107,7 @@ export default function handleApp(
 ) {
   switch (action.type) {
     case "NEW_KERNEL":
-      return newKernel(state, action);
+      return launchKernel(state, action);
     case "EXIT":
       return exit(state);
     case "KILL_KERNEL":

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -102,9 +102,9 @@ describe("setExecutionState", () => {
   });
 });
 
-describe("newKernel", () => {
+describe("launchKernel", () => {
   test("creates a LAUNCH_KERNEL action", () => {
-    expect(actions.newKernel({ spec: "hokey" }, ".")).toEqual({
+    expect(actions.launchKernel({ spec: "hokey" }, ".")).toEqual({
       type: actionTypes.LAUNCH_KERNEL,
       kernelSpec: { spec: "hokey" },
       cwd: "."
@@ -112,9 +112,9 @@ describe("newKernel", () => {
   });
 });
 
-describe("newKernelByName", () => {
+describe("launchKernelByName", () => {
   test("creates a LAUNCH_KERNEL_BY_NAME action", () => {
-    expect(actions.newKernelByName("python2", ".")).toEqual({
+    expect(actions.launchKernelByName("python2", ".")).toEqual({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
       kernelSpecName: "python2",
       cwd: "."

--- a/packages/core/__tests__/epics/comm-spec.js
+++ b/packages/core/__tests__/epics/comm-spec.js
@@ -87,11 +87,11 @@ describe("commActionObservable", () => {
       buffers: new Uint8Array()
     };
 
-    const newKernelAction = {
+    const launchKernelAction = {
       channels: of(commOpenMessage, commMessage)
     };
 
-    commActionObservable(newKernelAction)
+    commActionObservable(launchKernelAction)
       .pipe(toArray())
       .subscribe(
         actions => {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -253,7 +253,7 @@ export type ChangeCellTypeAction = {
 };
 
 export const NEW_KERNEL = "NEW_KERNEL";
-type NewKernelAction = {
+export type NewKernelAction = {
   type: "NEW_KERNEL",
   channels: Channels,
   connectionFile: string,
@@ -263,13 +263,13 @@ type NewKernelAction = {
 };
 
 export const SET_EXECUTION_STATE = "SET_EXECUTION_STATE";
-type SetExecutionStateAction = {
+export type SetExecutionStateAction = {
   type: "SET_EXECUTION_STATE",
   executionState: string
 };
 
 export const SET_NOTIFICATION_SYSTEM = "SET_NOTIFICATION_SYSTEM";
-type SetNotificationSystemAction = {
+export type SetNotificationSystemAction = {
   type: "SET_NOTIFICATION_SYSTEM",
   notificationSystem: Object
 };
@@ -312,6 +312,20 @@ export type SetGithubTokenAction = {
   githubToken: string
 };
 
+export const LAUNCH_KERNEL = "LAUNCH_KERNEL";
+export type LaunchKernelAction = {
+  type: "LAUNCH_KERNEL",
+  kernelSpec: Object,
+  cwd: string
+};
+
+export const LAUNCH_KERNEL_BY_NAME = "LAUNCH_KERNEL_BY_NAME";
+export type LaunchKernelByNameAction = {
+  type: "LAUNCH_KERNEL_BY_NAME",
+  kernelSpecName: string,
+  cwd: string
+};
+
 // TODO: This action needs a proper flow type, its from desktop's github store
 export const PUBLISH_USER_GIST = "PUBLISH_USER_GIST";
 // TODO: This action needs a proper flow type, its from desktop's github store
@@ -331,10 +345,7 @@ export const KERNEL_RAW_STDERR = "KERNEL_RAW_STDERR";
 
 // TODO: Properly type this action type, which is consumed only by epics
 export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
-// TODO: Properly type this action type, which is consumed only by epics
-export const LAUNCH_KERNEL = "LAUNCH_KERNEL";
-// TODO: Properly type this action type, which is consumed only by epics
-export const LAUNCH_KERNEL_BY_NAME = "LAUNCH_KERNEL_BY_NAME";
+
 // TODO: This needs a proper flow type, is only consumed by the epics
 export const ABORT_EXECUTION = "ABORT_EXECUTION";
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -57,28 +57,36 @@ import type {
   ToggleCellOutputVisibilityAction,
   SetInCellAction,
   SendExecuteMessageAction,
-  // TODO: Not here...
   NewKernelAction,
   SetGithubTokenAction,
   SetNotificationSystemAction,
   SetExecutionStateAction,
   SetConfigAction,
+  LaunchKernelAction,
+  LaunchKernelByNameAction,
   InterruptKernelAction,
   KillKernelAction,
-  // TODO: Not here...
+  // TODO: Needs an action creator
   StartSavingAction,
-  // TODO: Not here...
+  // TODO: Needs an action creator
   DoneSavingAction,
-  // TODO: Not here...
+  // TODO: Needs an action creator
   DoneSavingConfigAction,
-  // TODO: Not here...
+  // TODO: Needs an action creator
   SetNotebookCheckpointAction
 } from "../actionTypes";
 
 import { createExecuteRequest } from "@nteract/messaging";
 
-// TODO: This is one of the untyped actions currently
-export function newKernel(kernelSpec: any, cwd: string) {
+export function launchKernelSuccessful(payload: *): NewKernelAction {
+  // TODO: Use our new kernel types instead of only matching the old setup
+  return {
+    type: actionTypes.NEW_KERNEL,
+    ...payload
+  };
+}
+
+export function launchKernel(kernelSpec: any, cwd: string): LaunchKernelAction {
   return {
     type: actionTypes.LAUNCH_KERNEL,
     kernelSpec,
@@ -86,8 +94,10 @@ export function newKernel(kernelSpec: any, cwd: string) {
   };
 }
 
-// TODO: This is one of the untyped actions currently
-export function newKernelByName(kernelSpecName: any, cwd: string) {
+export function launchKernelByName(
+  kernelSpecName: any,
+  cwd: string
+): LaunchKernelByNameAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_BY_NAME,
     kernelSpecName,

--- a/packages/core/src/epics/comm.js
+++ b/packages/core/src/epics/comm.js
@@ -10,6 +10,7 @@ import { createMessage, ofMessageType, childOf } from "@nteract/messaging";
 
 import type { ActionsObservable } from "redux-observable";
 
+import type { NewKernelAction } from "../actionTypes";
 import { NEW_KERNEL } from "../actionTypes";
 
 /**
@@ -70,16 +71,16 @@ export function createCommCloseMessage(
 
 /**
  * creates all comm related actions given a new kernel action
- * @param  {Object} newKernelAction a NEW_KERNEL action
+ * @param  {Object} launchKernelAction a NEW_KERNEL action
  * @return {ActionsObservable}          all actions resulting from comm messages on this kernel
  */
-export function commActionObservable(newKernelAction: any) {
-  const commOpenAction$ = newKernelAction.channels.pipe(
+export function commActionObservable({ channels }: NewKernelAction) {
+  const commOpenAction$ = channels.pipe(
     ofMessageType("comm_open"),
     map(commOpenAction)
   );
 
-  const commMessageAction$ = newKernelAction.channels.pipe(
+  const commMessageAction$ = channels.pipe(
     ofMessageType("comm_msg"),
     map(commMessageAction)
   );


### PR DESCRIPTION
Making sure our naming is consistent for kernel launching, a re-visitation of #2367.