### PR TITLE
switch from NEW_KERNEL to LAUNCH_KERNEL_SUCCESSFUL

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -50,7 +50,7 @@ describe("acquireKernelInfo", () => {
 describe("watchExecutionStateEpic", () => {
   test("returns an Observable with an initial state of idle", done => {
     const action$ = ActionsObservable.of({
-      type: actionTypes.NEW_KERNEL,
+      type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
       channels: of({
         header: { msg_type: "status" },
         content: { execution_state: "idle" }
@@ -109,7 +109,7 @@ describe("launchKernelEpic", () => {
         if (actionBuffer.length === 2) {
           expect(actionBuffer).toEqual([
             actionTypes.SET_KERNEL_INFO,
-            actionTypes.NEW_KERNEL
+            actionTypes.LAUNCH_KERNEL_SUCCESSFUL
           ]);
           done();
         }

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -158,7 +158,7 @@ describe("menu", () => {
   });
 
   describe("dispatchRestartKernel", () => {
-    test("dispatches KILL_KERNEL and NEW_KERNEL actions", () => {
+    test("dispatches KILL_KERNEL and LAUNCH_KERNEL_SUCCESSFUL actions", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
 

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -178,7 +178,7 @@ describe("launchKernel", () => {
     };
 
     const action = {
-      type: actionTypes.NEW_KERNEL,
+      type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
       channels: "test_channels",
       spawn: "test_spawn",
       kernelSpecName: "test_name",

--- a/applications/desktop/src/notebook/epics/kernel-launch.js
+++ b/applications/desktop/src/notebook/epics/kernel-launch.js
@@ -44,7 +44,7 @@ import {
 } from "@nteract/core/actions";
 
 import {
-  NEW_KERNEL,
+  LAUNCH_KERNEL_SUCCESSFUL,
   LAUNCH_KERNEL,
   LAUNCH_KERNEL_BY_NAME,
   SET_LANGUAGE_INFO,
@@ -137,11 +137,11 @@ export function launchKernelObservable(kernelSpec: KernelInfo, cwd: string) {
 /**
  * Sets the execution state after a kernel has been launched.
  *
- * @oaram  {ActionObservable}  action$ ActionObservable for NEW_KERNEL action
+ * @oaram  {ActionObservable}  action$ ActionObservable for LAUNCH_KERNEL_SUCCESSFUL action
  */
 export const watchExecutionStateEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
-    ofType(NEW_KERNEL),
+    ofType(LAUNCH_KERNEL_SUCCESSFUL),
     switchMap(action =>
       merge(
         action.channels.pipe(
@@ -172,7 +172,7 @@ export const kernelSpecsObservable = Observable.create(observer => {
  */
 export const acquireKernelInfoEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
-    ofType(NEW_KERNEL),
+    ofType(LAUNCH_KERNEL_SUCCESSFUL),
     switchMap(action => acquireKernelInfo(action.channels))
   );
 

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -26,7 +26,7 @@ import { LOAD, SET_NOTEBOOK, NEW_NOTEBOOK } from "@nteract/core/actionTypes";
  * @param  {String}  filename  The filename of the notebook being loaded
  * @param  {Immutable<Map>}  notebook  The notebook to extract langauge info from
  *
- * @returns  {ActionObservable}  ActionObservable for a NEW_KERNEL action
+ * @returns  {ActionObservable}  ActionObservable for a LAUNCH_KERNEL_SUCCESSFUL action
  */
 export const extractNewKernel = (
   filename: string,

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -106,7 +106,7 @@ export default function handleApp(
   action: AppAction
 ) {
   switch (action.type) {
-    case "NEW_KERNEL":
+    case "LAUNCH_KERNEL_SUCCESSFUL":
       return launchKernel(state, action);
     case "EXIT":
       return exit(state);

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -7,7 +7,7 @@ import {
   CLEAR_OUTPUTS,
   UPDATE_CELL_STATUS,
   UPDATE_DISPLAY,
-  NEW_KERNEL
+  LAUNCH_KERNEL_SUCCESSFUL
 } from "@nteract/core/actionTypes";
 
 import { createExecuteRequest } from "@nteract/messaging";
@@ -229,7 +229,10 @@ describe("updateDisplayEpic", () => {
     ];
 
     const channels = from(messages);
-    const action$ = ActionsObservable.of({ type: NEW_KERNEL, channels });
+    const action$ = ActionsObservable.of({
+      type: LAUNCH_KERNEL_SUCCESSFUL,
+      channels
+    });
 
     const epic = updateDisplayEpic(action$);
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -252,9 +252,9 @@ export type ChangeCellTypeAction = {
   to: string
 };
 
-export const NEW_KERNEL = "NEW_KERNEL";
+export const LAUNCH_KERNEL_SUCCESSFUL = "LAUNCH_KERNEL_SUCCESSFUL";
 export type NewKernelAction = {
-  type: "NEW_KERNEL",
+  type: "LAUNCH_KERNEL_SUCCESSFUL",
   channels: Channels,
   connectionFile: string,
   spawn: ChildProcess,

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -81,7 +81,7 @@ import { createExecuteRequest } from "@nteract/messaging";
 export function launchKernelSuccessful(payload: *): NewKernelAction {
   // TODO: Use our new kernel types instead of only matching the old setup
   return {
-    type: actionTypes.NEW_KERNEL,
+    type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
     ...payload
   };
 }

--- a/packages/core/src/epics/comm.js
+++ b/packages/core/src/epics/comm.js
@@ -11,7 +11,7 @@ import { createMessage, ofMessageType, childOf } from "@nteract/messaging";
 import type { ActionsObservable } from "redux-observable";
 
 import type { NewKernelAction } from "../actionTypes";
-import { NEW_KERNEL } from "../actionTypes";
+import { LAUNCH_KERNEL_SUCCESSFUL } from "../actionTypes";
 
 /**
  * creates a comm open message
@@ -71,7 +71,7 @@ export function createCommCloseMessage(
 
 /**
  * creates all comm related actions given a new kernel action
- * @param  {Object} launchKernelAction a NEW_KERNEL action
+ * @param  {Object} launchKernelAction a LAUNCH_KERNEL_SUCCESSFUL action
  * @return {ActionsObservable}          all actions resulting from comm messages on this kernel
  */
 export function commActionObservable({ channels }: NewKernelAction) {
@@ -95,4 +95,7 @@ export function commActionObservable({ channels }: NewKernelAction) {
  * @return {ActionsObservable}         Comm actions
  */
 export const commListenEpic = (action$: ActionsObservable<*>) =>
-  action$.pipe(ofType(NEW_KERNEL), switchMap(commActionObservable)); // We have a new channel
+  action$.pipe(
+    ofType(LAUNCH_KERNEL_SUCCESSFUL),
+    switchMap(commActionObservable)
+  ); // We have a new channel

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -51,7 +51,7 @@ import type { Subject } from "rxjs/Subject";
 import type { ActionsObservable } from "redux-observable";
 
 import {
-  NEW_KERNEL,
+  LAUNCH_KERNEL_SUCCESSFUL,
   REMOVE_CELL,
   ABORT_EXECUTION,
   ERROR_EXECUTING,
@@ -187,7 +187,7 @@ export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
 export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
   // Global message watcher so we need to set up a feed for each new kernel
   action$.pipe(
-    ofType(NEW_KERNEL),
+    ofType(LAUNCH_KERNEL_SUCCESSFUL),
     switchMap(({ channels }) =>
       channels.pipe(
         ofMessageType("update_display_data"),


### PR DESCRIPTION
This is mostly to disambiguate what is requesting to create a
new kernel (launch kernel) and what's the result of the created
kernel.