### PR TITLE
pull kernelDisplayName from the notebook metadata

### DIFF
--- a/packages/core/__tests__/providers/notebook-spec.js
+++ b/packages/core/__tests__/providers/notebook-spec.js
@@ -7,7 +7,10 @@ import { shallow, mount } from "enzyme";
 import renderer from "react-test-renderer";
 
 import { displayOrder, transforms } from "@nteract/transforms";
-import { NotebookApp, getLanguageMode } from "../../src/providers/notebook-app";
+import {
+  NotebookApp,
+  getCodeMirrorMode
+} from "../../src/providers/notebook-app";
 
 import { dummyStore, dummyCommutable } from "../../src/dummy";
 
@@ -44,17 +47,17 @@ describe("NotebookApp", () => {
     expect(component).not.toBeNull();
   });
 
-  describe("getLanguageMode", () => {
-    test("determines the right language from the notebook metadata", () => {
-      const lang = getLanguageMode(dummyCommutable.get("metadata"));
-      expect(lang).toBe("ipython");
+  describe("getCodeMirrorMode", () => {
+    test("determines the right mode from the notebook metadata", () => {
+      const mode = getCodeMirrorMode(dummyCommutable.get("metadata"));
+      expect(mode).toEqual(Immutable.fromJS({ name: "ipython", version: 3 }));
 
-      const lang2 = getLanguageMode(
+      const lang2 = getCodeMirrorMode(
         dummyCommutable
           .setIn(["metadata", "language_info", "codemirror_mode", "name"], "r")
           .get("metadata")
       );
-      expect(lang2).toBe("r");
+      expect(lang2).toEqual(Immutable.fromJS({ name: "r", version: 3 }));
     });
   });
 

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -448,5 +448,4 @@ export class NotebookApp extends React.Component<Props> {
 }
 
 export const ConnectedNotebook = dragDropContext(HTML5Backend)(NotebookApp);
-// $FlowFixMe: Flow can't figure out what to do with connect with one param.
 export default connect(mapStateToProps)(ConnectedNotebook);

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -81,8 +81,8 @@ export function getLanguageMode(languageInfo: ImmutableMap<*, *>): string {
   return language;
 }
 
-const mapStateToProps = (state: Object): Props => {
-  const language_info = state.document.getIn(
+const mapStateToProps = (state: Object, ownProps: Props): Props => {
+  const languageInfo = state.document.getIn(
     ["notebook", "metadata", "language_info"],
     ImmutableMap()
   );
@@ -103,7 +103,9 @@ const mapStateToProps = (state: Object): Props => {
     languageDisplayName: state.document.getIn(
       ["notebook", "metadata", "kernelspec", "display_name"],
       ""
-    )
+    ),
+    transforms: ownProps.transforms || transforms,
+    displayOrder: ownProps.displayOrder || displayOrder
   };
 };
 
@@ -402,7 +404,7 @@ export class NotebookApp extends React.Component<Props> {
         </div>
         <StatusBar
           lastSaved={this.props.lastSaved}
-          kernelSpecDisplayName={this.props.kernelSpecDisplayName}
+          kernelSpecDisplayName={this.props.languageDisplayName}
           executionState={this.props.executionState}
         />
         <style jsx>{`

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -63,41 +63,49 @@ type Props = {
   editorFocused: string,
   theme: string,
   lastSaved: Date,
-  kernelSpecDisplayName: string,
+  languageDisplayName: string,
   executionState: string,
   models: ImmutableMap<string, any>,
   language: string
 };
 
-export function getLanguageMode(metadata: ImmutableMap<*, *>): string {
+export function getLanguageMode(languageInfo: ImmutableMap<*, *>): string {
   // First try codemirror_mode, then name, and fallback to 'text'
-  const language = metadata.getIn(
-    ["language_info", "codemirror_mode", "name"],
-    metadata.getIn(
-      ["language_info", "codemirror_mode"],
-      metadata.getIn(["language_info", "name"], "text")
+  const language = languageInfo.getIn(
+    ["codemirror_mode", "name"],
+    languageInfo.getIn(
+      ["codemirror_mode"],
+      languageInfo.getIn(["name"], "text")
     )
   );
   return language;
 }
 
-const mapStateToProps = (state: Object) => ({
-  theme: state.config.get("theme"),
-  lastSaved: state.app.get("lastSaved"),
-  kernelSpecDisplayName: state.app.get("kernelSpecDisplayName"),
-  cellOrder: state.document.getIn(["notebook", "cellOrder"], ImmutableList()),
-  cellMap: state.document.getIn(["notebook", "cellMap"], ImmutableMap()),
-  transient: state.document.get("transient"),
-  cellPagers: state.document.get("cellPagers", ImmutableMap()),
-  cellFocused: state.document.get("cellFocused"),
-  editorFocused: state.document.get("editorFocused"),
-  stickyCells: state.document.get("stickyCells"),
-  executionState: state.app.get("executionState"),
-  models: state.comms.get("models"),
-  language: getLanguageMode(
-    state.document.getIn(["notebook", "metadata"], ImmutableMap())
-  )
-});
+const mapStateToProps = (state: Object): Props => {
+  const language_info = state.document.getIn(
+    ["notebook", "metadata", "language_info"],
+    ImmutableMap()
+  );
+
+  return {
+    theme: state.config.get("theme"),
+    lastSaved: state.app.get("lastSaved"),
+    cellOrder: state.document.getIn(["notebook", "cellOrder"], ImmutableList()),
+    cellMap: state.document.getIn(["notebook", "cellMap"], ImmutableMap()),
+    transient: state.document.get("transient"),
+    cellPagers: state.document.get("cellPagers", ImmutableMap()),
+    cellFocused: state.document.get("cellFocused"),
+    editorFocused: state.document.get("editorFocused"),
+    stickyCells: state.document.get("stickyCells"),
+    executionState: state.app.get("executionState"),
+    models: state.comms.get("models"),
+    language: getLanguageMode(languageInfo),
+    languageDisplayName: state.document.getIn(
+      ["notebook", "metadata", "kernelspec", "display_name"],
+      ""
+    )
+  };
+};
 
 export class NotebookApp extends React.Component<Props> {
   static defaultProps = {


### PR DESCRIPTION
Part of the ongoing remote kernel work. I was trying to figure out why our `AppRecord` needed kernel info since it was part of the document. This was the only place `app.kernelSpecDisplayName` was used.

* [x] Fix tests
* [x] Rebase against #2370, since that will use the explicit codemirror mode prop