### PR TITLE
switch to kernel record props

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -51,10 +51,12 @@ describe("watchExecutionStateEpic", () => {
   test("returns an Observable with an initial state of idle", done => {
     const action$ = ActionsObservable.of({
       type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-      channels: of({
-        header: { msg_type: "status" },
-        content: { execution_state: "idle" }
-      })
+      kernel: {
+        channels: of({
+          header: { msg_type: "status" },
+          content: { execution_state: "idle" }
+        })
+      }
     });
     const obs = watchExecutionStateEpic(action$);
     obs.pipe(toArray()).subscribe(

--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -63,10 +63,7 @@ describe("watchExecutionStateEpic", () => {
       // Every action that goes through should get stuck on an array
       actions => {
         const types = actions.map(({ type }) => type);
-        expect(types).toEqual([
-          actionTypes.SET_EXECUTION_STATE,
-          actionTypes.SET_EXECUTION_STATE
-        ]);
+        expect(types).toEqual([actionTypes.SET_EXECUTION_STATE]);
       },
       err => done.fail(err), // It should not error in the stream
       () => done()

--- a/applications/desktop/__tests__/renderer/native-window-spec.js
+++ b/applications/desktop/__tests__/renderer/native-window-spec.js
@@ -37,7 +37,7 @@ describe("setTitleFromAttributes", () => {
 
     const titleObject = {
       fullpath: "/tmp/test.ipynb",
-      executionState: "busy",
+      kernelStatus: "busy",
       modified: true
     };
     nativeWindow.setTitleFromAttributes(titleObject);
@@ -58,7 +58,7 @@ describe("createTitleFeed", () => {
         filename: "titled.ipynb"
       }),
       app: makeAppRecord({
-        executionState: "not connected"
+        kernelStatus: "not connected"
       })
     };
 
@@ -75,7 +75,7 @@ describe("createTitleFeed", () => {
           {
             modified: process.platform === "darwin" ? true : false,
             fullpath: "titled.ipynb",
-            executionState: "not connected"
+            kernelStatus: "not connected"
           }
         ]);
         done();
@@ -95,7 +95,7 @@ describe("createTitleFeed", () => {
         filename: "titled.ipynb"
       }),
       app: makeAppRecord({
-        executionState: "not connected"
+        kernelStatus: "not connected"
       })
     };
 
@@ -112,7 +112,7 @@ describe("createTitleFeed", () => {
           {
             modified: false,
             fullpath: "titled.ipynb",
-            executionState: "not connected"
+            kernelStatus: "not connected"
           }
         ]);
         done();

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -8,25 +8,6 @@ import {
 
 const Github = require("github");
 
-describe("cleanupKernel", () => {
-  test("nullifies entries for the kernel in originalState", () => {
-    const originalState = {
-      app: makeAppRecord({
-        kernel: makeLocalKernelRecord({
-          channels: false,
-          spawn: false,
-          connectionFile: false
-        })
-      })
-    };
-
-    const action = { type: actionTypes.KILL_KERNEL };
-
-    const state = reducers(originalState, action);
-    expect(state.app.kernel).toBeNull();
-  });
-});
-
 describe("setNotificationSystem", () => {
   test("returns the same originalState if notificationSystem is undefined", () => {
     const originalState = {
@@ -121,26 +102,7 @@ describe("setExecutionState", () => {
     };
 
     const state = reducers(originalState, action);
-    expect(state.app.executionState).toBe("idle");
-  });
-});
-
-describe("killKernel", () => {
-  test("clears out kernel configuration", () => {
-    const originalState = {
-      app: makeAppRecord({
-        kernel: makeLocalKernelRecord({
-          channels: false,
-          spawn: false,
-          connectionFile: false
-        })
-      })
-    };
-
-    const action = { type: actionTypes.KILL_KERNEL };
-
-    const state = reducers(originalState, action);
-    expect(state.app.kernel).toBeNull();
+    expect(state.app.kernel.status).toBe("idle");
   });
 });
 
@@ -183,12 +145,12 @@ describe("launchKernel", () => {
         channels: "test_channels",
         spawn: "test_spawn",
         kernelSpecName: "test_name",
-        executionState: "starting"
+        status: "starting"
       }
     };
 
     const state = reducers(originalState, action);
-    expect(state.app.executionState).toBe("starting");
+    expect(state.app.kernel.status).toBe("starting");
     expect(state.app.kernel.kernelSpecName).toBe("test_name");
     expect(state.app.kernel.spawn).toBe("test_spawn");
     expect(state.app.kernel.channels).toBe("test_channels");
@@ -210,27 +172,6 @@ describe("setGithubToken", () => {
     // this is a crappy way of testing this
     expect(state.app.github).not.toBeNull();
     expect(state.app.githubToken).not.toBeNull();
-  });
-});
-
-describe("exit", () => {
-  test("calls cleanupKernel", () => {
-    const originalState = {
-      app: makeAppRecord({
-        kernel: makeLocalKernelRecord({
-          channels: false,
-          spawn: false,
-          connectionFile: false
-        })
-      })
-    };
-
-    const action = { type: actionTypes.EXIT };
-
-    const state = reducers(originalState, action);
-    expect(state.app.kernel).toBeNull();
-    expect(state.app.kernelSpecName).toBeNull();
-    expect(state.app.executionState).toBe("not connected");
   });
 });
 

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -98,7 +98,7 @@ describe("setExecutionState", () => {
 
     const action = {
       type: actionTypes.SET_EXECUTION_STATE,
-      executionState: "idle"
+      kernelStatus: "idle"
     };
 
     const state = reducers(originalState, action);

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -179,20 +179,17 @@ describe("launchKernel", () => {
 
     const action = {
       type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-      channels: "test_channels",
-      spawn: "test_spawn",
-      kernelSpecName: "test_name",
-      kernelSpec: { spec: { display_name: "Test Name" } },
-      executionState: "starting"
+      kernel: {
+        channels: "test_channels",
+        spawn: "test_spawn",
+        kernelSpecName: "test_name",
+        executionState: "starting"
+      }
     };
 
     const state = reducers(originalState, action);
     expect(state.app.executionState).toBe("starting");
-    expect(state.app.kernelSpecName).toBe("test_name");
-    expect(state.app.kernelSpec).toEqual({
-      spec: { display_name: "Test Name" }
-    });
-    expect(state.app.kernelSpecDisplayName).toBe("Test Name");
+    expect(state.app.kernel.kernelSpecName).toBe("test_name");
     expect(state.app.kernel.spawn).toBe("test_spawn");
     expect(state.app.kernel.channels).toBe("test_channels");
   });

--- a/applications/desktop/src/notebook/epics/kernel-launch.js
+++ b/applications/desktop/src/notebook/epics/kernel-launch.js
@@ -26,9 +26,12 @@ import { ipcRenderer as ipc } from "electron";
 import { createMainChannel } from "enchannel-zmq-backend";
 import * as jmp from "jmp";
 
+import type { NewKernelAction } from "@nteract/core/actionTypes";
+
 import type {
   LanguageInfoMetadata,
-  KernelInfo
+  KernelInfo,
+  LocalKernelProps
 } from "@nteract/types/core/records";
 
 import type { Channels } from "@nteract/types/channels";
@@ -89,7 +92,6 @@ export function launchKernelObservable(kernelSpec: KernelInfo, cwd: string) {
   return Observable.create(observer => {
     launchSpec(spec, { cwd, stdio: ["ignore", "pipe", "pipe"] }).then(c => {
       const { config, spawn, connectionFile } = c;
-      const kernelSpecName = kernelSpec.name;
 
       spawn.stdout.on("data", data => {
         const action = { type: KERNEL_RAW_STDOUT, payload: data.toString() };
@@ -105,15 +107,16 @@ export function launchKernelObservable(kernelSpec: KernelInfo, cwd: string) {
         .then(channels => {
           observer.next(setNotebookKernelInfo(kernelSpec));
 
-          observer.next(
-            launchKernelSuccessful({
-              channels,
-              connectionFile,
-              spawn,
-              kernelSpecName,
-              kernelSpec
-            })
-          );
+          const kernel: LocalKernelProps = {
+            // TODO: Include the ref when we need it here
+            channels,
+            connectionFile,
+            spawn,
+            kernelSpecName: kernelSpec.name,
+            status: "launched" // TODO: Determine our taxonomy
+          };
+
+          observer.next(launchKernelSuccessful(kernel));
         })
         .catch(error => {
           observer.error({ type: "ERROR", payload: error, err: true });
@@ -142,9 +145,9 @@ export function launchKernelObservable(kernelSpec: KernelInfo, cwd: string) {
 export const watchExecutionStateEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
     ofType(LAUNCH_KERNEL_SUCCESSFUL),
-    switchMap(action =>
+    switchMap((action: NewKernelAction) =>
       merge(
-        action.channels.pipe(
+        action.kernel.channels.pipe(
           filter(msg => msg.header.msg_type === "status"),
           map(msg => setExecutionState(msg.content.execution_state))
         ),
@@ -173,7 +176,7 @@ export const kernelSpecsObservable = Observable.create(observer => {
 export const acquireKernelInfoEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
     ofType(LAUNCH_KERNEL_SUCCESSFUL),
-    switchMap(action => acquireKernelInfo(action.channels))
+    switchMap(action => acquireKernelInfo(action.kernel.channels))
   );
 
 export const launchKernelByNameEpic = (action$: ActionsObservable<*>) =>
@@ -187,6 +190,7 @@ export const launchKernelByNameEpic = (action$: ActionsObservable<*>) =>
     mergeMap(action =>
       kernelSpecsObservable.pipe(
         mergeMap(specs =>
+          // Defer to a LAUNCH_KERNEL action to _actually_ launch
           of(launchKernel(specs[action.kernelSpecName], action.cwd))
         )
       )

--- a/applications/desktop/src/notebook/epics/kernel-launch.js
+++ b/applications/desktop/src/notebook/epics/kernel-launch.js
@@ -146,12 +146,9 @@ export const watchExecutionStateEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
     ofType(LAUNCH_KERNEL_SUCCESSFUL),
     switchMap((action: NewKernelAction) =>
-      merge(
-        action.kernel.channels.pipe(
-          filter(msg => msg.header.msg_type === "status"),
-          map(msg => setExecutionState(msg.content.execution_state))
-        ),
-        of(setExecutionState("idle"))
+      action.kernel.channels.pipe(
+        filter(msg => msg.header.msg_type === "status"),
+        map(msg => setExecutionState(msg.content.execution_state))
       )
     )
   );

--- a/applications/desktop/src/notebook/native-window.js
+++ b/applications/desktop/src/notebook/native-window.js
@@ -34,7 +34,7 @@ export function tildify(p) {
 
 export function setTitleFromAttributes(attributes) {
   const filename = tildify(attributes.fullpath);
-  const { executionState } = attributes;
+  const { kernelStatus } = attributes;
 
   try {
     const win = remote.getCurrentWindow();
@@ -42,7 +42,7 @@ export function setTitleFromAttributes(attributes) {
       win.setRepresentedFilename(attributes.fullpath);
       win.setDocumentEdited(attributes.modified);
     }
-    const title = `${filename} - ${executionState}`;
+    const title = `${filename} - ${kernelStatus}`;
     win.setTitle(title);
   } catch (e) {
     /* istanbul ignore next */
@@ -74,7 +74,7 @@ export function createTitleFeed(state$) {
     map(state => state.document.get("filename") || "Untitled")
   );
 
-  const executionState$ = state$.pipe(
+  const kernelStatus$ = state$.pipe(
     map(state => state.app.getIn(["kernel", "status"], "not connected")),
     debounceTime(200)
   );
@@ -82,11 +82,11 @@ export function createTitleFeed(state$) {
   return combineLatest(
     modified$,
     fullpath$,
-    executionState$,
-    (modified, fullpath, executionState) => ({
+    kernelStatus$,
+    (modified, fullpath, kernelStatus) => ({
       modified,
       fullpath,
-      executionState
+      kernelStatus
     })
   ).pipe(distinctUntilChanged(), switchMap(i => of(i)));
 }

--- a/applications/desktop/src/notebook/native-window.js
+++ b/applications/desktop/src/notebook/native-window.js
@@ -75,7 +75,7 @@ export function createTitleFeed(state$) {
   );
 
   const executionState$ = state$.pipe(
-    map(state => state.app.get("executionState")),
+    map(state => state.app.getIn(["kernel", "status"], "not connected")),
     debounceTime(200)
   );
 

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -52,7 +52,7 @@ function startSaving(state: AppRecord) {
 }
 
 function setExecutionState(state: AppRecord, action: SetExecutionStateAction) {
-  return state.setIn(["kernel", "status"], action.executionState);
+  return state.setIn(["kernel", "status"], action.kernelStatus);
 }
 
 function doneSaving(state: AppRecord) {

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -23,20 +23,15 @@ import type {
 
 function cleanupKernel(state: AppRecord): AppRecord {
   shutdownKernel(state.kernel);
-
-  return state.withMutations((ctx: AppRecord) =>
-    ctx.set("kernel", null).set("executionState", "not connected")
-  );
+  return state;
 }
 
 function launchKernel(state: AppRecord, action: NewKernelAction) {
   const kernel = makeLocalKernelRecord(action.kernel);
-
-  return cleanupKernel(state).withMutations((ctx: AppRecord) =>
-    // TODO: set the executionState inside the kernel (?)
-    //       was that what the status field was for?
-    ctx.set("kernel", kernel).set("executionState", "starting")
-  );
+  if (!kernel) {
+    return state.set("kernel", kernel);
+  }
+  return cleanupKernel(state).set("kernel", kernel);
 }
 function exit(state: AppRecord) {
   return cleanupKernel(state);
@@ -57,7 +52,7 @@ function startSaving(state: AppRecord) {
 }
 
 function setExecutionState(state: AppRecord, action: SetExecutionStateAction) {
-  return state.set("executionState", action.executionState);
+  return state.setIn(["kernel", "status"], action.executionState);
 }
 
 function doneSaving(state: AppRecord) {

--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -201,11 +201,11 @@ class Main extends React.Component<*, *> {
             focusAbove={() => {}}
             focusBelow={() => {}}
             // END TODO for notebook leakage
-            // TODO: executionState should be allowed to be null or undefined,
+            // TODO: kernelStatus should be allowed to be null or undefined,
             //       resulting in thought of as either idle or not connected by
             //       default. This is primarily used for determining if code
             //       completion should be enabled
-            executionState={
+            kernelStatus={
               currentKernel ? currentKernel.status : "not connected"
             }
             options={{

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -97,7 +97,7 @@ describe("setExecutionState", () => {
   test("creates a SET_EXECUTION_STATE action", () => {
     expect(actions.setExecutionState("idle")).toEqual({
       type: actionTypes.SET_EXECUTION_STATE,
-      executionState: "idle"
+      kernelStatus: "idle"
     });
   });
 });

--- a/packages/core/__tests__/epics/comm-spec.js
+++ b/packages/core/__tests__/epics/comm-spec.js
@@ -88,7 +88,9 @@ describe("commActionObservable", () => {
     };
 
     const launchKernelAction = {
-      channels: of(commOpenMessage, commMessage)
+      kernel: {
+        channels: of(commOpenMessage, commMessage)
+      }
     };
 
     commActionObservable(launchKernelAction)

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -231,7 +231,9 @@ describe("updateDisplayEpic", () => {
     const channels = from(messages);
     const action$ = ActionsObservable.of({
       type: LAUNCH_KERNEL_SUCCESSFUL,
-      channels
+      kernel: {
+        channels
+      }
     });
 
     const epic = updateDisplayEpic(action$);

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -59,9 +59,9 @@ describe("createExecuteCellStream", () => {
       },
       state: {
         app: {
-          executionState: "not connected",
           kernel: {
-            channels
+            channels,
+            status: "not connected"
           },
           notificationSystem: { addNotification: jest.fn() }
         }
@@ -91,9 +91,9 @@ describe("createExecuteCellStream", () => {
       },
       state: {
         app: {
-          executionState: "connected",
           kernel: {
-            channels
+            channels,
+            status: "connected"
           },
           notificationSystem: { addNotification: jest.fn() }
         }
@@ -137,9 +137,9 @@ describe("executeCellEpic", () => {
     },
     state: {
       app: {
-        executionState: "idle",
         kernel: {
-          channels: "errorInExecuteCellObservable"
+          channels: "errorInExecuteCellObservable",
+          status: "idle"
         },
         notificationSystem: { addNotification: jest.fn() },
         githubToken: "blah"

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -15,7 +15,9 @@ import type {
 import type {
   LanguageInfoMetadata,
   KernelInfo,
-  DocumentRecord
+  DocumentRecord,
+  LocalKernelProps,
+  RemoteKernelProps
 } from "@nteract/types/core/records";
 
 import type { ExecuteRequest } from "@nteract/types/messaging";
@@ -255,11 +257,7 @@ export type ChangeCellTypeAction = {
 export const LAUNCH_KERNEL_SUCCESSFUL = "LAUNCH_KERNEL_SUCCESSFUL";
 export type NewKernelAction = {
   type: "LAUNCH_KERNEL_SUCCESSFUL",
-  channels: Channels,
-  connectionFile: string,
-  spawn: ChildProcess,
-  kernelSpecName: string,
-  kernelSpec: Object
+  kernel: LocalKernelProps | RemoteKernelProps
 };
 
 export const SET_EXECUTION_STATE = "SET_EXECUTION_STATE";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -263,7 +263,7 @@ export type NewKernelAction = {
 export const SET_EXECUTION_STATE = "SET_EXECUTION_STATE";
 export type SetExecutionStateAction = {
   type: "SET_EXECUTION_STATE",
-  executionState: string
+  kernelStatus: string
 };
 
 export const SET_NOTIFICATION_SYSTEM = "SET_NOTIFICATION_SYSTEM";

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -116,11 +116,11 @@ export function setNotebookKernelInfo(kernelInfo: any): SetKernelInfoAction {
 }
 
 export function setExecutionState(
-  executionState: string
+  kernelStatus: string
 ): SetExecutionStateAction {
   return {
     type: actionTypes.SET_EXECUTION_STATE,
-    executionState
+    kernelStatus
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -83,7 +83,6 @@ import { createExecuteRequest } from "@nteract/messaging";
 export function launchKernelSuccessful(
   kernel: LocalKernelProps | RemoteKernelProps
 ): NewKernelAction {
-  // TODO: Use our new kernel types instead of only matching the old setup
   return {
     type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
     kernel

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -7,7 +7,9 @@ import type { JSONObject } from "@nteract/types/commutable";
 
 import type {
   LanguageInfoMetadata,
-  KernelInfo
+  KernelInfo,
+  LocalKernelProps,
+  RemoteKernelProps
 } from "@nteract/types/core/records";
 
 import type {
@@ -78,11 +80,13 @@ import type {
 
 import { createExecuteRequest } from "@nteract/messaging";
 
-export function launchKernelSuccessful(payload: *): NewKernelAction {
+export function launchKernelSuccessful(
+  kernel: LocalKernelProps | RemoteKernelProps
+): NewKernelAction {
   // TODO: Use our new kernel types instead of only matching the old setup
   return {
     type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-    ...payload
+    kernel
   };
 }
 

--- a/packages/core/src/components/status-bar.js
+++ b/packages/core/src/components/status-bar.js
@@ -5,14 +5,14 @@ import distanceInWordsToNow from "date-fns/distance_in_words_to_now";
 type Props = {
   lastSaved: Date,
   kernelSpecDisplayName: string,
-  executionState: string
+  kernelStatus: string
 };
 
 export default class StatusBar extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     if (
       this.props.lastSaved !== nextProps.lastSaved ||
-      this.props.executionState !== nextProps.executionState
+      this.props.kernelStatus !== nextProps.kernelStatus
     ) {
       return true;
     }
@@ -33,7 +33,7 @@ export default class StatusBar extends React.Component<Props> {
         </span>
         <span className="pull-left">
           <p>
-            {name} | {this.props.executionState}
+            {name} | {this.props.kernelStatus}
           </p>
         </span>
         <style jsx>{`

--- a/packages/core/src/dummy/index.js
+++ b/packages/core/src/dummy/index.js
@@ -101,12 +101,14 @@ export function dummyStore(config: *) {
       filename: config && config.noFilename ? "" : "dummy-store-nb.ipynb"
     }),
     app: makeAppRecord({
-      executionState: "not connected",
       notificationSystem: {
         addNotification: () => {} // most of the time you'll want to mock this
       },
       githubToken: "TOKEN",
-      channels: "channelInfo"
+      kernel: {
+        channels: "channelInfo",
+        status: "not connected"
+      }
     }),
     config: Immutable.Map({
       theme: "light"

--- a/packages/core/src/epics/comm.js
+++ b/packages/core/src/epics/comm.js
@@ -74,13 +74,13 @@ export function createCommCloseMessage(
  * @param  {Object} launchKernelAction a LAUNCH_KERNEL_SUCCESSFUL action
  * @return {ActionsObservable}          all actions resulting from comm messages on this kernel
  */
-export function commActionObservable({ channels }: NewKernelAction) {
-  const commOpenAction$ = channels.pipe(
+export function commActionObservable({ kernel }: NewKernelAction) {
+  const commOpenAction$ = kernel.channels.pipe(
     ofMessageType("comm_open"),
     map(commOpenAction)
   );
 
-  const commMessageAction$ = channels.pipe(
+  const commMessageAction$ = kernel.channels.pipe(
     ofMessageType("comm_msg"),
     map(commMessageAction)
   );

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -7,7 +7,7 @@ import {
   updatedOutputs,
   outputs,
   payloads,
-  executionStates,
+  kernelStatuses,
   executionCounts
 } from "@nteract/messaging";
 
@@ -95,7 +95,7 @@ export function executeCellStream(
 
     // All actions for updating cell status
     cellMessages.pipe(
-      executionStates(),
+      kernelStatuses(),
       map(status => updateCellStatus(id, status))
     ),
 

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -127,14 +127,14 @@ export function createExecuteCellStream(
   id: string
 ) {
   const state = store.getState();
-  const channels = state.app.kernel ? state.app.kernel.channels : null;
+
+  const kernel = state.app.kernel;
+  const channels = kernel ? kernel.channels : null;
 
   const kernelConnected =
+    kernel &&
     channels &&
-    !(
-      state.app.executionState === "starting" ||
-      state.app.executionState === "not connected"
-    );
+    !(kernel.status === "starting" || kernel.status === "not connected");
 
   if (!kernelConnected) {
     return of({

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -59,6 +59,8 @@ import {
   SEND_EXECUTE_REQUEST
 } from "../actionTypes";
 
+import type { NewKernelAction } from "../actionTypes";
+
 const Immutable = require("immutable");
 
 /**
@@ -188,8 +190,8 @@ export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
   // Global message watcher so we need to set up a feed for each new kernel
   action$.pipe(
     ofType(LAUNCH_KERNEL_SUCCESSFUL),
-    switchMap(({ channels }) =>
-      channels.pipe(
+    switchMap((action: NewKernelAction) =>
+      action.kernel.channels.pipe(
         ofMessageType("update_display_data"),
         map(msg => updateDisplay(msg.content)),
         catchError(err =>

--- a/packages/core/src/providers/editor.js
+++ b/packages/core/src/providers/editor.js
@@ -13,7 +13,7 @@ type Props = CodeMirrorEditorProps & {
   id: string,
   cellFocused: boolean,
   channels: any,
-  executionState: string,
+  kernelStatus: string,
   options: Object
 };
 
@@ -28,7 +28,7 @@ function mapStateToProps(
         })
       : { cursorBlinkRate: state.config.get("cursorBlinkRate") },
     channels: state.app.kernel ? state.app.kernel.channels : null,
-    executionState: state.app.getIn(["kernel", "status"], "not connected")
+    kernelStatus: state.app.getIn(["kernel", "status"], "not connected")
   };
 }
 

--- a/packages/core/src/providers/editor.js
+++ b/packages/core/src/providers/editor.js
@@ -13,7 +13,7 @@ type Props = CodeMirrorEditorProps & {
   id: string,
   cellFocused: boolean,
   channels: any,
-  executionState: "idle" | "starting" | "not connected",
+  executionState: string,
   options: Object
 };
 
@@ -28,7 +28,7 @@ function mapStateToProps(
         })
       : { cursorBlinkRate: state.config.get("cursorBlinkRate") },
     channels: state.app.kernel ? state.app.kernel.channels : null,
-    executionState: state.app.executionState
+    executionState: state.app.getIn(["kernel", "status"], "not connected")
   };
 }
 

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -106,7 +106,7 @@ const mapStateToProps = (state: Object, ownProps: Props): Props => {
     cellFocused: state.document.get("cellFocused"),
     editorFocused: state.document.get("editorFocused"),
     stickyCells: state.document.get("stickyCells"),
-    executionState: state.app.get("executionState"),
+    executionState: state.app.getIn(["kernel", "status"], "not connected"),
     models: state.comms.get("models"),
     languageDisplayName: state.document.getIn(
       ["notebook", "metadata", "kernelspec", "display_name"],

--- a/packages/core/src/providers/notebook-app.js
+++ b/packages/core/src/providers/notebook-app.js
@@ -65,7 +65,7 @@ type Props = {
   theme: string,
   lastSaved: Date,
   languageDisplayName: string,
-  executionState: string,
+  kernelStatus: string,
   models: ImmutableMap<string, any>,
   codeMirrorMode: string | ImmutableMap<string, *>
 };
@@ -106,7 +106,7 @@ const mapStateToProps = (state: Object, ownProps: Props): Props => {
     cellFocused: state.document.get("cellFocused"),
     editorFocused: state.document.get("editorFocused"),
     stickyCells: state.document.get("stickyCells"),
-    executionState: state.app.getIn(["kernel", "status"], "not connected"),
+    kernelStatus: state.app.getIn(["kernel", "status"], "not connected"),
     models: state.comms.get("models"),
     languageDisplayName: state.document.getIn(
       ["notebook", "metadata", "kernelspec", "display_name"],
@@ -423,7 +423,7 @@ export class NotebookApp extends React.Component<Props> {
         <StatusBar
           lastSaved={this.props.lastSaved}
           kernelSpecDisplayName={this.props.languageDisplayName}
-          executionState={this.props.executionState}
+          kernelStatus={this.props.kernelStatus}
         />
         <style jsx>{`
           .cells {

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -40,7 +40,7 @@ export type CodeMirrorEditorProps = {
   focusBelow: () => void,
   theme: string,
   channels: any,
-  executionState: string,
+  kernelStatus: string,
   onChange: (value: string, change: EditorChange) => void,
   onFocusChange: (focused: boolean) => void,
   onScroll: (scrollInfo: ScrollInfo) => any,
@@ -116,12 +116,7 @@ class CodeMirrorEditor extends React.Component<
   }
 
   componentDidMount(): void {
-    const {
-      editorFocused,
-      executionState,
-      focusAbove,
-      focusBelow
-    } = this.props;
+    const { editorFocused, kernelStatus, focusAbove, focusBelow } = this.props;
 
     require("codemirror/addon/hint/show-hint");
     require("codemirror/addon/hint/anyword-hint");
@@ -182,7 +177,7 @@ class CodeMirrorEditor extends React.Component<
           token.string === " " ||
           token.string === "<" ||
           token.string === "/") &&
-        executionState === "idle"
+        kernelStatus === "idle"
       ) {
         editor.execCommand("autocomplete", { completeSingle: false });
       }

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -40,7 +40,7 @@ export type CodeMirrorEditorProps = {
   focusBelow: () => void,
   theme: string,
   channels: any,
-  executionState: "idle" | "starting" | "not connected",
+  executionState: string,
   onChange: (value: string, change: EditorChange) => void,
   onFocusChange: (focused: boolean) => void,
   onScroll: (scrollInfo: ScrollInfo) => any,

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -10,7 +10,7 @@ import {
   outputs,
   payloads,
   executionCounts,
-  executionStates
+  kernelStatuses
 } from "../";
 
 import {
@@ -273,7 +273,7 @@ describe("executionCounts", () => {
   });
 });
 
-describe("executionStates", () => {
+describe("kernelStatuses", () => {
   it("extracts all the execution states from status messages", () => {
     return of(
       status("starting"),
@@ -283,7 +283,7 @@ describe("executionStates", () => {
       displayData({ data: { "text/plain": "hoo" } }),
       status("idle")
     )
-      .pipe(executionStates(), toArray())
+      .pipe(kernelStatuses(), toArray())
       .toPromise()
       .then(arr => {
         expect(arr).toEqual(["starting", "idle", "busy", "idle"]);

--- a/packages/messaging/src/index.js
+++ b/packages/messaging/src/index.js
@@ -174,7 +174,7 @@ export const executionCounts = () => (
     pluck("content", "execution_count")
   );
 
-export const executionStates = () => (
+export const kernelStatuses = () => (
   source: rxjs$Observable<JupyterMessage<*, *>>
 ): rxjs$Observable<JupyterMessage<*, *>> =>
   source.pipe(ofMessageType("status"), pluck("content", "execution_state"));

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -78,7 +78,11 @@ export type BaseKernelProps = {
   kernelSpecName: ?string,
   lastActivity: ?Date,
   channels: ?rxjs$Subject<*, *>,
-  // TODO: Determine what stauses we'll set here
+  // Canonically: idle, busy, starting
+  // Xref: http://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-status
+  //
+  // We also use this for other bits of lifecycle, including: launching,
+  //   shutting down, not connected.
   status: ?string
 };
 

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -78,6 +78,7 @@ export type BaseKernelProps = {
   kernelSpecName: ?string,
   lastActivity: ?Date,
   channels: ?rxjs$Subject<*, *>,
+  // TODO: Determine what stauses we'll set here
   status: ?string
 };
 

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -141,12 +141,8 @@ export type Notebook = {
 type AppRecordProps = {
   kernel: ?RecordOf<RemoteKernelProps | LocalKernelProps>,
   host: ?RecordOf<DesktopHostRecordProps | JupyterHostRecordProps>,
-  executionState: "not connected" | "busy" | "idle" | "starting",
   githubToken: ?string,
   notificationSystem: ?Object,
-  kernelSpecName: ?string,
-  kernelSpecDisplayName: ?string,
-  kernelSpec: ?Object,
   isSaving: boolean,
   lastSaved: ?Date,
   configLastSaved: ?Date,
@@ -156,12 +152,8 @@ type AppRecordProps = {
 export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
   kernel: null,
   host: null,
-  executionState: "not connected",
   githubToken: null, // Electron specific (ish...)
   notificationSystem: null, // Should be available for all I assume
-  kernelSpecName: null, // All
-  kernelSpecDisplayName: null, // All
-  kernelSpec: null, // All
   isSaving: false, // All -- ?
   lastSaved: null, // All
   configLastSaved: null, // ?


### PR DESCRIPTION
This is the kernel type unification of #2367. Primary benefits here are that the `LAUNCH_KERNEL_SUCCESSFUL` action emits either the jupyter websocket kernels ("remote") or local kernels ("zeromq"). I'm definitely seeing more bits to clean up in our app record, including what/where we have kernel status.