### PR TITLE
create epic for launching a jupyter ws kernel

### DIFF
--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -33,6 +33,7 @@ function launchKernel(state: AppRecord, action: NewKernelAction) {
   }
   return cleanupKernel(state).set("kernel", kernel);
 }
+
 function exit(state: AppRecord) {
   return cleanupKernel(state);
 }

--- a/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
@@ -3,6 +3,22 @@ import { loadEpic } from "./contents";
 import { listKernelSpecsEpic } from "./kernelspecs";
 import { setNotebookEpic } from "./notebook";
 
-const epics = [loadEpic, listKernelSpecsEpic, setNotebookEpic];
+import {
+  executeCellEpic,
+  updateDisplayEpic,
+  commListenEpic,
+  launchWebSocketKernelEpic
+} from "@nteract/core/epics";
+
+// TODO: Bring desktop's wrapEpic over to @nteract/core so we can use it here
+const epics = [
+  executeCellEpic,
+  updateDisplayEpic,
+  commListenEpic,
+  launchWebSocketKernelEpic,
+  loadEpic,
+  listKernelSpecsEpic,
+  setNotebookEpic
+];
 
 export default epics;

--- a/applications/jupyter-extension/nteract_on_jupyter/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/store.js
@@ -6,7 +6,7 @@ import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-import { document, comms, config } from "@nteract/core/reducers";
+import { document, comms, config, app } from "@nteract/core/reducers";
 
 import {
   makeAppRecord,
@@ -36,7 +36,7 @@ export type AppState = {
 };
 
 const rootReducer = combineReducers({
-  app: (state = {}) => state,
+  app,
   document,
   comms,
   config
@@ -66,9 +66,7 @@ export default function configureStore({
   const middlewares = [createEpicMiddleware(rootEpic)];
 
   return createStore(
-    // $FlowFixMe: Types incompatible, we've got to align what our app stores will be like
     rootReducer,
-    // $FlowFixMe: Types incompatible, we've got to align what our app stores will be like
     initialState,
     composeEnhancers(applyMiddleware(...middlewares))
   );

--- a/packages/core/__mocks__/rx-jupyter.js
+++ b/packages/core/__mocks__/rx-jupyter.js
@@ -1,0 +1,9 @@
+import { of } from "rxjs/observable/of";
+import { Subject } from "rxjs/Subject";
+
+module.exports = {
+  kernels: {
+    start: (config, kernelSpecName, cwd) => of({ response: { id: "0" } }),
+    connect: (config, id, session) => new Subject()
+  }
+};

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -1,0 +1,64 @@
+// @flow
+import { ActionsObservable } from "redux-observable";
+import { launchKernelByName } from "../../src/actions";
+import { launchWebSocketKernelEpic } from "../../src/epics";
+
+import { toArray } from "rxjs/operators";
+
+import { Subject } from "rxjs/Subject";
+
+import * as Immutable from "immutable";
+
+describe("launchWebSocketKernelEpic", () => {
+  test("", async function() {
+    const store = {
+      getState() {
+        return this.state;
+      },
+      state: {
+        app: {
+          host: {
+            type: "jupyter",
+            token: "eh",
+            serverUrl: "http://localhost:8888/"
+          },
+          kernel: null,
+          notificationSystem: { addNotification: jest.fn() }
+        },
+        document: Immutable.fromJS({
+          notebook: {
+            cellMap: {
+              first: {
+                source: "woo",
+                cell_type: "code"
+              },
+              second: {
+                source: "eh",
+                cell_type: "code"
+              }
+            },
+            cellOrder: ["first", "second"]
+          }
+        })
+      }
+    };
+
+    const action$ = ActionsObservable.of(launchKernelByName("fancy", "/"));
+
+    const responseActions = await launchWebSocketKernelEpic(action$, store)
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responseActions).toEqual([
+      {
+        type: "LAUNCH_KERNEL_SUCCESSFUL",
+        kernel: {
+          type: "websocket",
+          channels: expect.any(Subject),
+          kernelSpecName: "fancy",
+          id: "0"
+        }
+      }
+    ]);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,8 @@
     "redux": "^3.7.2",
     "redux-immutable": "^4.0.0",
     "rxjs": "^5.5.6",
+    "rx-binder": "^1.0.9",
+    "rx-jupyter": "^2.3.4",
     "uuid": "^3.1.0"
   },
   "peerDependencies": {

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -1,3 +1,4 @@
 // @flow
 export { executeCellEpic, updateDisplayEpic } from "./execute";
 export { commListenEpic } from "./comm";
+export { launchWebSocketKernelEpic } from "./websocket-kernel";

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -1,0 +1,60 @@
+// @flow
+
+import { ofType } from "redux-observable";
+
+import { catchError, map, mergeMap, switchMap, filter } from "rxjs/operators";
+import { of } from "rxjs/observable/of";
+import { from } from "rxjs/observable/from";
+import { merge } from "rxjs/observable/merge";
+
+import { launchKernelSuccessful } from "../actions";
+
+import type { AppState, RemoteKernelProps } from "@nteract/types/core/records";
+
+import { kernels, shutdown, kernelspecs } from "rx-jupyter";
+import { v4 as uuid } from "uuid";
+
+import {
+  LAUNCH_KERNEL,
+  LAUNCH_KERNEL_BY_NAME,
+  LAUNCH_KERNEL_SUCCESSFUL
+} from "../actionTypes";
+
+import { executeRequest, kernelInfoRequest } from "@nteract/messaging";
+
+export const launchWebSocketKernelEpic = (action$: *, store: *) =>
+  action$.pipe(
+    ofType(LAUNCH_KERNEL_BY_NAME),
+    map(action => {
+      const state: AppState = store.getState();
+      return { host: state.app.host, ...action };
+    }),
+    // Only accept jupyter servers for the host with this epic
+    filter(({ host }) => host && host.type === "jupyter" && host.serverUrl),
+    // TODO: When a switchMap happens, we need to close down the originating
+    // kernel, likely by sending a different action. Right now this gets
+    // coordinated in a different way.
+    switchMap(({ kernelSpecName, host, cwd }) => {
+      const config = {
+        crossDomain: host.crossDomain,
+        token: host.token,
+        endpoint: host.serverUrl
+      };
+
+      return kernels.start(config, kernelSpecName, cwd).pipe(
+        mergeMap(data => {
+          const session = uuid();
+
+          const kernel = Object.assign({}, data.response, {
+            type: "websocket",
+            channels: kernels.connect(config, data.response.id, session),
+            kernelSpecName
+          });
+
+          kernel.channels.next(kernelInfoRequest());
+
+          return of(launchKernelSuccessful(kernel));
+        })
+      );
+    })
+  );

--- a/packages/core/src/reducers/app.js
+++ b/packages/core/src/reducers/app.js
@@ -1,0 +1,46 @@
+// @flow
+import {
+  makeAppRecord,
+  makeLocalKernelRecord,
+  makeRemoteKernelRecord,
+  makeDesktopHostRecord,
+  makeJupyterHostRecord,
+  AppRecord
+} from "@nteract/types/core/records";
+
+import * as actionTypes from "../actionTypes";
+
+import type { NewKernelAction, SetExecutionStateAction } from "../actionTypes";
+
+export function launchKernelSuccessful(
+  state: AppRecord,
+  action: NewKernelAction
+) {
+  const kernel = makeRemoteKernelRecord(action.kernel);
+
+  // TODO: implement cleanup kernel within an epic
+  //       our old practice was to do the cleanup in the reducer which is an
+  //       anti-pattern, _especially_ because it's really something that's async
+  return state.set("kernel", kernel);
+}
+
+export function setExecutionState(
+  state: AppRecord,
+  action: SetExecutionStateAction
+) {
+  return state.setIn(["kernel", "status"], action.kernelStatus);
+}
+
+export default function handleApp(
+  state: AppRecord = makeAppRecord(),
+  action: *
+) {
+  switch (action.type) {
+    case actionTypes.LAUNCH_KERNEL_SUCCESSFUL:
+      return launchKernelSuccessful(state, action);
+    case actionTypes.SET_EXECUTION_STATE:
+      return setExecutionState(state, action);
+    default:
+      return state;
+  }
+}

--- a/packages/core/src/reducers/index.js
+++ b/packages/core/src/reducers/index.js
@@ -2,6 +2,6 @@
 import document from "./document";
 import comms from "./comms";
 import config from "./config";
+import app from "./app";
 
-// We'll export our specific reducers here
-export { document, comms, config };
+export { document, comms, config, app };

--- a/packages/rx-jupyter/src/kernels.js
+++ b/packages/rx-jupyter/src/kernels.js
@@ -9,6 +9,7 @@ import { Subscriber } from "rxjs/Subscriber";
 
 import { createAJAXSettings } from "./base";
 
+const urljoin = require("url-join");
 const URLSearchParams = require("url-search-params");
 
 /**
@@ -123,9 +124,10 @@ export function formWebSocketURL(
   const q = params.toString();
   const suffix = q !== "" ? `?${q}` : "";
 
-  const url = `${
-    serverConfig.endpoint
-  }/api/kernels/${kernelID}/channels${suffix}`;
+  const url = urljoin(
+    serverConfig.endpoint,
+    `/api/kernels/${kernelID}/channels${suffix}`
+  );
 
   return url.replace(/^http(s)?/, "ws$1");
 }


### PR DESCRIPTION
This sets up a kernel launching epic that launches kernels on jupyter hosts.

🎉  Connections to remote kernels, ready for desktop, play, and the nteract web app. Connecting this up to Desktop is not a focus for this PR, nor is the UI/config for doing so. The first target is the jupyter extension.

TODO:

* [x] Match semantics of the zeromq kernel launch
* [x] Adapt either the jupyter extension or `rx-jupyter` to adapt the URL based on `location.origin` as necessary
* [x] Integrate into the jupyter extension app
* [x] Tests