### PR TITLE
Immutable redux

### DIFF
--- a/packages/core/__tests__/reducers/createImmutableMapReducer-spec.js
+++ b/packages/core/__tests__/reducers/createImmutableMapReducer-spec.js
@@ -1,0 +1,74 @@
+import createImmutableMapReducer from "../../src/reducers/createImmutableMapReducer";
+import { Map, Record } from "immutable";
+import { combineReducers } from "redux-immutable";
+
+const appRecordFactory = Record({ resourcesById: Map() });
+const resourceRecordFactory = Record({ exists: false, name: "" });
+
+describe("createImmutableMapReducer", () => {
+  it("can be used with redux-immutable's combineReducers w/ Records", () => {
+    const exists = (state, action) => {
+      if (action.type === "RESOURCE/CREATE") {
+        return true;
+      }
+      return state;
+    };
+
+    const name = (state, action) => {
+      if (action.type === "RESOURCE/NAME") {
+        return action.name;
+      }
+      return state;
+    };
+
+    const resource = combineReducers({ exists, name }, resourceRecordFactory);
+
+    const getKey = action => action.resourceId;
+    const resourcesById = createImmutableMapReducer(getKey, resource);
+    const rootReducer = combineReducers({ resourcesById }, appRecordFactory);
+
+    // Test initialization:
+    //   1. Our top-level state should be a Record instance now.
+    //   2. The resourcesById should *not* be a Record instance (should be Map).
+    //   3. Since there we now matches in getKey, we should have no resources.
+    const state0 = rootReducer(undefined, { type: "INIT" });
+    expect(Record.isRecord(state0)).toBe(true);
+    expect(Map.isMap(state0.resourcesById)).toBe(true);
+    expect(state0.resourcesById.size).toBe(0);
+
+    // Create a resource:
+    //   1. We should now have a single resource.
+    //   2. That resource should be a Record instance.
+    //   3. That resource should have been created (exists = true).
+    //   4. That resource should not have a name yet (name = "").
+    const state1 = rootReducer(state0, {
+      type: "RESOURCE/CREATE",
+      resourceId: "a"
+    });
+    expect(state1.resourcesById.size).toBe(1);
+    expect(Record.isRecord(state1.resourcesById.get("a"))).toBe(true);
+    expect(state1.resourcesById.get("a").exists).toBe(true);
+    expect(state1.resourcesById.get("a").name).toBe("");
+
+    // Name the resource:
+    //   1. No new fields should have been created.
+    //   2. Exists state should not have changed.
+    //   3. Name state should be updated.
+    const state2 = rootReducer(state1, {
+      type: "RESOURCE/NAME",
+      resourceId: "a",
+      name: "kewl"
+    });
+    expect(state2.resourcesById.size).toBe(1);
+    expect(state2.resourcesById.get("a").exists).toBe(true);
+    expect(state2.resourcesById.get("a").name).toBe("kewl");
+
+    // Failing to provide something getKey can interpret:
+    //  1. State should literally be the same since nothing changes ( === ).
+    const state3 = rootReducer(state2, {
+      type: "RESOURCE/NAME",
+      name: "does not work"
+    });
+    expect(state3).toBe(state2);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "react-redux": "^5.0.6",
     "react-syntax-highlighter": "^6.0.0",
     "redux": "^3.7.2",
+    "redux-immutable": "^4.0.0",
     "rxjs": "^5.5.6",
     "uuid": "^3.1.0"
   },

--- a/packages/core/src/reducers/createImmutableMapReducer.js
+++ b/packages/core/src/reducers/createImmutableMapReducer.js
@@ -1,0 +1,30 @@
+// @flow
+import { Map } from "immutable";
+
+type GetKeyType = (action: Object) => string | void;
+type ReducerType = (state: *, action: Object) => *;
+
+/**
+ * Similar to how combineReducers allows you to create a container reducer to
+ * delegate actions where each key maps to a reducer to handle the key's value--
+ * createObjectReducer allows you to create a container reducer to delegate
+ * actions where *all* keys use the *same* reducer, but the keys are not known
+ * ahead of time.
+ */
+const createImmutableMapReducer = (
+  getKey: GetKeyType,
+  reducer: ReducerType
+) => (state: * = Map({}), action: *) => {
+  const key = getKey(action);
+  if (typeof key !== "undefined") {
+    const previousValueState = state.get(key);
+    const nextValueState = reducer(previousValueState, action);
+    // Don't return a new object if nothing changed.
+    if (nextValueState !== previousValueState) {
+      return state.set(key, nextValueState);
+    }
+  }
+  return state;
+};
+
+export default createImmutableMapReducer;


### PR DESCRIPTION
This PR does two things:

1. brings in `redux-immutable`, which recently allowed users to pass in a `getDefaultState` function to it's `combineReducers` that we can use as a `RecordFactory`
2. defines a new reducer-creation-function to create immutable maps of `ids: values`

This is sort-of just for discussion atm, but it sets us up to become fully immutable with our state.
