### PR TITLE
Add kernelspecs record

### DIFF
--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -1,24 +1,20 @@
 // @flow
 import type { ChildProcess } from "child_process";
+import type { Id } from "./id";
+import type { RecordFactory, RecordOf } from "immutable";
+import type { Ref } from "./ref";
+import type { KernelspecsRef } from "./kernelspecs";
 
-// The Id type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
-// 9092-7679-9978-8822 is the Id
-export opaque type Id = string;
-// A ref is an internal Id, used for kernels, hosts, kernelspec collections, etc.
-export opaque type Ref = string;
+import { Record, List } from "immutable";
 
 export opaque type KernelRef = Ref;
 export opaque type HostRef = Ref;
-export opaque type KernelSpecsRef = Ref;
-
-import type { RecordFactory, RecordOf } from "immutable";
-import { Record, List } from "immutable";
 
 export type BaseHostProps = {
   id: ?Id,
   ref: ?HostRef,
   selectedKernelRef: ?KernelRef,
-  kernelSpecsRef: ?KernelSpecsRef, // reference to a collection of kernelspecs
+  kernelspecsRef: ?KernelspecsRef, // reference to a collection of kernelspecs
   defaultKernelName: ?string,
   // In the desktop case, this _should_ be only one, pending
   // kernel cleanup
@@ -39,7 +35,7 @@ export const makeJupyterHostRecord: RecordFactory<
   ref: null,
   id: null,
   selectedKernelRef: null,
-  kernelSpecsRef: null,
+  kernelspecsRef: null,
   defaultKernelName: null,
   activeKernelRefs: List(),
   token: null,
@@ -65,7 +61,7 @@ export const makeDesktopHostRecord: RecordFactory<
   ref: null,
   id: null,
   selectedKernelRef: null,
-  kernelSpecsRef: null,
+  kernelspecsRef: null,
   defaultKernelName: null,
   activeKernelRefs: List()
 });

--- a/packages/types/src/core/id.js
+++ b/packages/types/src/core/id.js
@@ -1,0 +1,3 @@
+// The Id type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
+// 9092-7679-9978-8822 is the Id
+export opaque type Id = string;

--- a/packages/types/src/core/kernelspecs.js
+++ b/packages/types/src/core/kernelspecs.js
@@ -1,3 +1,55 @@
+import type { RecordFactory, RecordOf } from "immutable";
 import type { Ref } from "./ref";
+import { List, Map, Record } from "immutable";
 
 export opaque type KernelspecsRef = Ref;
+
+type CommunicationKernelspecsProps = {
+  loading: boolean,
+  error: ?Object
+};
+
+export type CommunicationKernelspecsRecord = RecordOf<
+  CommunicationKernelspecsProps
+>;
+
+export const communicationKernelspecsFactory: RecordFactory<
+  CommunicationKernelspecsProps
+> = Record({
+  loading: false,
+  error: null
+});
+
+type EntitiesKernelspecsSpecProps = {
+  language: string,
+  argv: List<string>,
+  env: Map
+};
+
+export type EntitiesKernelspecsSpecRecord = RecordOf<
+  EntitiesKernelspecsSpecProps
+>;
+
+export const entitiesKernelspecsSpecFactory: RecordFactory<
+  EntitiesKernelspecsSpecProps
+> = Record({
+  language: "", // TODO: what's a reasonable default?
+  argv: List(),
+  env: Map()
+});
+
+type EntitiesKernelspecsProps = {
+  name: string,
+  resources: Map,
+  spec: RecordOf<EntitiesKernelspecsSpecProps>
+};
+
+export type EntitiesKernelspecsRecord = RecordOf<EntitiesKernelspecsProps>;
+
+export const entitiesKernelspecsFactory: RecordFactory<
+  EntitiesKernelspecsProps
+> = Record({
+  name: "", // TODO: what's a reasonable default?
+  resources: Map(),
+  spec: entitiesKernelspecsSpecFactory()
+});

--- a/packages/types/src/core/kernelspecs.js
+++ b/packages/types/src/core/kernelspecs.js
@@ -1,0 +1,3 @@
+import type { Ref } from "./ref";
+
+export opaque type KernelspecsRef = Ref;

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -1,24 +1,14 @@
 /* @flow */
-
-import type { Subject } from "rxjs";
-
-const Immutable = require("immutable");
 import type { RecordFactory, RecordOf } from "immutable";
-import type { ChildProcess } from "child_process";
-import { Record } from "immutable";
-import type { Channels } from "../channels";
-
+import type { Subject } from "rxjs";
 import type {
-  Id,
-  Ref,
-  KernelRef,
-  KernelSpecsRef,
-  HostRef,
-  RemoteKernelProps,
-  LocalKernelProps,
+  DesktopHostRecordProps,
   JupyterHostRecordProps,
-  DesktopHostRecordProps
+  LocalKernelProps,
+  RemoteKernelProps
 } from "./hosts";
+
+import { List, Map, Record, Set } from "immutable";
 
 export { makeLocalKernelRecord, makeDesktopHostRecord } from "./hosts";
 
@@ -40,12 +30,14 @@ export type ImmutableJSON =
   | null
   | ImmutableJSONMap
   | ImmutableJSONList; // eslint-disable-line no-use-before-define
-export type ImmutableJSONMap = Immutable.Map<string, ImmutableJSON>;
-export type ImmutableJSONList = Immutable.List<ImmutableJSON>;
+
+export type ImmutableJSONMap = Map<string, ImmutableJSON>;
+
+export type ImmutableJSONList = List<ImmutableJSON>;
 
 export type ExecutionCount = number | null;
 
-export type MimeBundle = Immutable.Map<string, ImmutableJSON>;
+export type MimeBundle = Map<string, ImmutableJSON>;
 
 export type ExecuteResult = {
   output_type: "execute_result",
@@ -70,7 +62,7 @@ export type ErrorOutput = {
   output_type: "error",
   ename: string,
   evalue: string,
-  traceback: Immutable.List<string>
+  traceback: List<string>
 };
 
 export type Output = ExecuteResult | DisplayData | StreamOutput | ErrorOutput;
@@ -80,7 +72,7 @@ export type CodeCell = {
   metadata: ImmutableJSONMap,
   execution_count: ExecutionCount,
   source: string,
-  outputs: Immutable.List<Output>
+  outputs: List<Output>
 };
 
 export type MarkdownCell = {
@@ -128,8 +120,8 @@ export type NotebookMetadata = {
 };
 
 export type Notebook = {
-  cellMap: Immutable.Map<string, Cell>,
-  cellOrder: Immutable.List<string>,
+  cellMap: Map<string, Cell>,
+  cellOrder: List<string>,
   nbformat: 4,
   nbformat_minor: 0 | 1 | 2 | 3 | 4,
   metadata: NotebookMetadata
@@ -159,52 +151,53 @@ export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
   configLastSaved: null, // ?
   error: null // All
 });
+
 export type AppRecord = RecordOf<AppRecordProps>;
 
 type DocumentRecordProps = {
   notebook: ?Notebook,
-  transient: Immutable.Map<string, any>, // has the keypaths for updating displays
+  transient: Map<string, any>, // has the keypaths for updating displays
   // transient should be more fully typed (be a record itself)
   // right now it's keypaths and then it looks like it's able to handle any per
   // cell transient data that will be deleted when the kernel is restarted
   cellPagers: any,
-  stickyCells: ?Immutable.Set<any>,
+  stickyCells: ?Set<any>,
   editorFocused: any,
   cellFocused: any,
-  copied: Immutable.Map<any, any>
+  copied: Map<any, any>
 };
 
 export const makeDocumentRecord: RecordFactory<DocumentRecordProps> = Record({
   notebook: null,
   savedNotebook: null,
   // $FlowFixMe: Immutable
-  transient: new Immutable.Map({
-    keyPathsForDisplays: new Immutable.Map()
+  transient: new Map({
+    keyPathsForDisplays: new Map()
   }),
-  cellPagers: new Immutable.Map(),
-  stickyCells: new Immutable.Set(),
+  cellPagers: new Map(),
+  stickyCells: new Set(),
   editorFocused: null,
   cellFocused: null,
-  copied: new Immutable.Map(),
+  copied: new Map(),
   filename: ""
 });
 export type DocumentRecord = RecordOf<DocumentRecordProps>;
 
 type CommsRecordProps = {
-  targets: Immutable.Map<any, any>,
-  info: Immutable.Map<any, any>,
-  models: Immutable.Map<any, any>
+  targets: Map<any, any>,
+  info: Map<any, any>,
+  models: Map<any, any>
 };
 
-export const CommsRecord = Immutable.Record({
-  targets: new Immutable.Map(),
-  info: new Immutable.Map(),
-  models: new Immutable.Map()
+export const CommsRecord = Record({
+  targets: new Map(),
+  info: new Map(),
+  models: new Map()
 });
 
 export type AppState = {
   app: RecordOf<AppRecordProps>,
   document: RecordOf<DocumentRecordProps>,
   comms: RecordOf<CommsRecordProps>,
-  config: Immutable.Map<string, any>
+  config: Map<string, any>
 };

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -11,7 +11,12 @@ import type {
 import { List, Map, Record, Set } from "immutable";
 
 export { HostRef, makeLocalKernelRecord, makeDesktopHostRecord } from "./hosts";
-export { KernelspecsRef } from "./kernelspecs";
+export {
+  KernelspecsRef,
+  communicationKernelspecsFactory,
+  entitiesKernelspecsSpecFactory,
+  entitiesKernelspecsFactory
+} from "./kernelspecs";
 
 /*
 

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -10,7 +10,8 @@ import type {
 
 import { List, Map, Record, Set } from "immutable";
 
-export { makeLocalKernelRecord, makeDesktopHostRecord } from "./hosts";
+export { HostRef, makeLocalKernelRecord, makeDesktopHostRecord } from "./hosts";
+export { KernelspecsRef } from "./kernelspecs";
 
 /*
 

--- a/packages/types/src/core/ref.js
+++ b/packages/types/src/core/ref.js
@@ -1,0 +1,2 @@
+// A ref is an internal Id, used for kernels, hosts, kernelspec collections, etc.
+export opaque type Ref = string;


### PR DESCRIPTION
Please excuse any shortcomings wrt `flow` / `immutable`, I'm far from an expert at either technology. This is a stab at getting our typings set based on our plan doc in https://github.com/nteract/nteract/pull/2338

Also, just wondering about the pattern in general here. Should we have these types in a separate package? Or, should the `core` stuff be in core? What's the common convention?