### PR TITLE
transpile @nteract/core and rx-* in webpack build

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -23,13 +23,22 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" },
+      {
+        test: /\.js$/,
+        exclude: /node_modules\/(?!(@nteract|rx-jupyter|rx-binder))/,
+        loader: "babel-loader"
+      },
       { test: /\.json$/, loader: "json-loader" }
     ]
   },
   resolve: {
-    mainFields: ["nteractDesktop", "main"],
-    extensions: [".js", ".jsx"]
+    mainFields: ["nteractDesktop", "module", "main"],
+    extensions: [".js", ".jsx"],
+    alias: {
+      "@nteract/core": "@nteract/core/src",
+      "rx-jupyter": "rx-jupyter/src",
+      "rx-binder": "rx-binder/src"
+    }
   },
   plugins: [
     new LodashModuleReplacementPlugin(),


### PR DESCRIPTION
This sets the jupyter extension up to load `@nteract/core`, `rx-jupyter`, and `rx-binder` from `src`, while also transpiling it on demand.

Ideally we'd have a shared webpack config (or functions) that would make resolution of our packages from applications work in general. I'm not up to that task just yet though. For now I just want to ease some pain.