### PR TITLE
switch to proper app record setup for jupyter-ext

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/epics/contents.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/epics/contents.js
@@ -61,10 +61,11 @@ export function loadEpic(
       }
     }),
     switchMap((action: LOAD_ACTION) => {
-      const config = store.getState().webApp.config;
-      // Normalizing to match rx-jupyter vs. the jupyter server config
+      const host = store.getState().app.host;
+      // Normalizing to match rx-jupyter vs. host record
       const serverConfig = {
-        endpoint: config.baseUrl,
+        endpoint: host.serverUrl,
+        token: host.token,
         crossDomain: false
       };
 

--- a/applications/jupyter-extension/nteract_on_jupyter/epics/kernelspecs.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/epics/kernelspecs.js
@@ -48,10 +48,11 @@ export function listKernelSpecsEpic(
   return action$.pipe(
     ofType("LIST_KERNELSPECS"),
     switchMap((action: LIST_KERNELSPECS) => {
-      const config = store.getState().webApp.config;
-      // Normalizing to match rx-jupyter vs. the jupyter server config
+      const host = store.getState().app.host;
+      // Normalizing to match rx-jupyter vs. host record
       const serverConfig = {
-        endpoint: config.baseUrl,
+        endpoint: host.serverUrl,
+        token: host.token,
         crossDomain: false
       };
 

--- a/applications/jupyter-extension/nteract_on_jupyter/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/store.js
@@ -27,16 +27,6 @@ export type JupyterConfigData = {
   appVersion: string
 };
 
-const webAppReducer = (state = {}, action) => {
-  switch (action.type) {
-    case "LOADED":
-      return Object.assign({}, state, { contents: action.payload });
-    case "KERNELSPECS_LISTED":
-      return Object.assign({}, state, { kernelspecs: action.payload });
-  }
-  return state;
-};
-
 export type AppState = {
   app: AppRecord,
   document: DocumentRecord,
@@ -46,7 +36,6 @@ export type AppState = {
 };
 
 const rootReducer = combineReducers({
-  webApp: webAppReducer,
   app: (state = {}) => state,
   document,
   comms,
@@ -70,8 +59,7 @@ export default function configureStore({
     comms: CommsRecord(),
     config: ImmutableMap({
       theme: "light"
-    }),
-    webApp: { config }
+    })
   };
 
   const rootEpic = combineEpics(...epics);


### PR DESCRIPTION
This deletes some of my temporary webapp bits in favor of using the proper app host records we have now.