### PR TITLE
fix: fix flow typing (missing // @flow)

### DIFF
--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -1,14 +1,10 @@
 // @flow
 import type { ChildProcess } from "child_process";
-import type { Id } from "./id";
+import type { Id } from "./ids";
 import type { RecordFactory, RecordOf } from "immutable";
-import type { Ref } from "./ref";
-import type { KernelspecsRef } from "./kernelspecs";
+import type { HostRef, KernelRef, KernelspecsRef } from "./refs";
 
 import { Record, List } from "immutable";
-
-export opaque type KernelRef = Ref;
-export opaque type HostRef = Ref;
 
 export type BaseHostProps = {
   id: ?Id,

--- a/packages/types/src/core/ids.js
+++ b/packages/types/src/core/ids.js
@@ -1,3 +1,5 @@
+// @flow
+
 // The Id type is for external resources, e.g. with /api/kernels/9092-7679-9978-8822,
 // 9092-7679-9978-8822 is the Id
 export opaque type Id = string;

--- a/packages/types/src/core/kernelspecs.js
+++ b/packages/types/src/core/kernelspecs.js
@@ -1,8 +1,11 @@
+// @flow
 import type { RecordFactory, RecordOf } from "immutable";
-import type { Ref } from "./ref";
 import { List, Map, Record } from "immutable";
+import { v4 as uuid } from "uuid";
 
-export opaque type KernelspecsRef = Ref;
+export opaque type KernelspecsRef = string;
+
+export const createKernelspecsRef = (): KernelspecsRef => uuid();
 
 type CommunicationKernelspecsProps = {
   loading: boolean,
@@ -21,7 +24,7 @@ export const makeCommunicationKernelspecs: RecordFactory<
 type KernelspecProps = {
   language: ?string,
   argv: List<string>,
-  env: Map
+  env: Map<string, *>
 };
 
 export type Kernelspec = RecordOf<KernelspecProps>;
@@ -34,7 +37,7 @@ export const makeKernelspec: RecordFactory<KernelspecProps> = Record({
 
 type KernelspecsProps = {
   name: ?string,
-  resources: Map,
+  resources: Map<string, *>,
   spec: RecordOf<KernelspecProps>
 };
 

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -10,8 +10,9 @@ import type {
 
 import { List, Map, Record, Set } from "immutable";
 
+export type { HostRef, KernelspecsRef } from "./refs";
+
 export {
-  HostRef,
   makeLocalKernelRecord,
   makeDesktopHostRecord,
   makeJupyterHostRecord,
@@ -19,7 +20,6 @@ export {
 } from "./hosts";
 
 export {
-  KernelspecsRef,
   makeCommunicationKernelspecs,
   makeKernelspec,
   makeKernelspecs

--- a/packages/types/src/core/ref.js
+++ b/packages/types/src/core/ref.js
@@ -1,2 +1,0 @@
-// A ref is an internal Id, used for kernels, hosts, kernelspec collections, etc.
-export opaque type Ref = string;

--- a/packages/types/src/core/refs.js
+++ b/packages/types/src/core/refs.js
@@ -1,6 +1,10 @@
 // @flow
 import { v4 as uuid } from "uuid";
 
+// Note that within this file, these can all be used as `string`.
+// However, _outside_ this file, they are no longer `string`, but actually the
+// opaque types that we've set.
+// See https://flow.org/en/docs/types/opaque-types/#toc-within-the-defining-file
 export opaque type HostRef = string;
 export opaque type KernelRef = string;
 export opaque type KernelspecsRef = string;

--- a/packages/types/src/core/refs.js
+++ b/packages/types/src/core/refs.js
@@ -1,0 +1,10 @@
+// @flow
+import { v4 as uuid } from "uuid";
+
+export opaque type HostRef = string;
+export opaque type KernelRef = string;
+export opaque type KernelspecsRef = string;
+
+export const createHostRef = (): HostRef => uuid();
+export const createKernelRef = (): KernelRef => uuid();
+export const createKernelspecsRef = (): KernelspecsRef => uuid();


### PR DESCRIPTION
Missed some `// @flow` annotations :(

We also figured out how to actually handle the `opaque` types in here. There's a bit of trickiness to get them to work properly. _Within_ the file, the types can be used as `string`, but outside the files (i.e., when you import them), they are no longer `string`, but actually a new type that you've defined.