### PR TITLE
fix(index): fix YERROR in notebook index.js

### DIFF
--- a/applications/desktop/src/main/index.js
+++ b/applications/desktop/src/main/index.js
@@ -43,7 +43,7 @@ const path = require("path");
 
 const yargs = require("yargs/yargs");
 const argv = yargs()
-  .version(() => require("./../../package.json").version)
+  .version((() => require("./../../package.json").version)())
   .usage("Usage: nteract <notebooks> [options]")
   .example("nteract notebook1.ipynb notebook2.ipynb", "Open notebooks")
   .example("nteract --kernel javascript", "Launch a kernel")


### PR DESCRIPTION
The yargs.version() method was being sent a function when it needed to be sent result of that function which is the version.

This addresses part of #2369  
This addresses #2371 
