### PR TITLE
Kernel lifecycles for @nteract/core

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -3,7 +3,6 @@ import { ActionsObservable } from "redux-observable";
 import * as actionTypes from "@nteract/core/actionTypes";
 
 import {
-  setLanguageInfo,
   acquireKernelInfo,
   watchExecutionStateEpic,
   launchKernelObservable,
@@ -11,65 +10,8 @@ import {
   launchKernelByNameEpic
 } from "../../../src/notebook/epics/kernel-launch";
 
-import { createMessage } from "@nteract/messaging";
-
-import { Subject } from "rxjs/Subject";
 import { of } from "rxjs/observable/of";
 import { toArray, share } from "rxjs/operators";
-
-describe("acquireKernelInfo", () => {
-  test("sends a kernel_info_request and processes kernel_info_reply", done => {
-    const sent = new Subject();
-    const received = new Subject();
-
-    const mockSocket = Subject.create(sent, received);
-
-    sent.subscribe(msg => {
-      expect(msg.header.msg_type).toEqual("kernel_info_request");
-
-      const response = createMessage("kernel_info_reply");
-      response.parent_header = msg.header;
-      response.content = { language_info: { language: "python" } };
-
-      // TODO: Get the Rx handling proper here
-      setTimeout(() => received.next(response), 100);
-    });
-
-    const obs = acquireKernelInfo(mockSocket);
-
-    obs.subscribe(langAction => {
-      expect(langAction).toEqual({
-        langInfo: { language: "python" },
-        type: "SET_LANGUAGE_INFO"
-      });
-      done();
-    });
-  });
-});
-
-describe("watchExecutionStateEpic", () => {
-  test("returns an Observable with an initial state of idle", done => {
-    const action$ = ActionsObservable.of({
-      type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-      kernel: {
-        channels: of({
-          header: { msg_type: "status" },
-          content: { execution_state: "idle" }
-        })
-      }
-    });
-    const obs = watchExecutionStateEpic(action$);
-    obs.pipe(toArray()).subscribe(
-      // Every action that goes through should get stuck on an array
-      actions => {
-        const types = actions.map(({ type }) => type);
-        expect(types).toEqual([actionTypes.SET_EXECUTION_STATE]);
-      },
-      err => done.fail(err), // It should not error in the stream
-      () => done()
-    );
-  });
-});
 
 describe("launchKernelObservable", () => {
   test("returns an observable", () => {

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -6,12 +6,12 @@ import { loadEpic, newNotebookEpic } from "./loading";
 
 import type { ActionsObservable, Epic } from "redux-observable";
 
+import { launchKernelEpic, launchKernelByNameEpic } from "./kernel-launch";
+
 import {
-  launchKernelEpic,
   acquireKernelInfoEpic,
-  watchExecutionStateEpic,
-  launchKernelByNameEpic
-} from "./kernel-launch";
+  watchExecutionStateEpic
+} from "@nteract/core/epics";
 
 import {
   executeCellEpic,

--- a/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
@@ -7,7 +7,9 @@ import {
   executeCellEpic,
   updateDisplayEpic,
   commListenEpic,
-  launchWebSocketKernelEpic
+  launchWebSocketKernelEpic,
+  acquireKernelInfoEpic,
+  watchExecutionStateEpic
 } from "@nteract/core/epics";
 
 // TODO: Bring desktop's wrapEpic over to @nteract/core so we can use it here
@@ -18,7 +20,9 @@ const epics = [
   launchWebSocketKernelEpic,
   loadEpic,
   listKernelSpecsEpic,
-  setNotebookEpic
+  setNotebookEpic,
+  acquireKernelInfoEpic,
+  watchExecutionStateEpic
 ];
 
 export default epics;

--- a/packages/core/__tests__/epics/kernel-lifecycle-spec.js
+++ b/packages/core/__tests__/epics/kernel-lifecycle-spec.js
@@ -1,0 +1,69 @@
+import { ActionsObservable } from "redux-observable";
+
+import * as actionTypes from "@nteract/core/actionTypes";
+
+import { createMessage } from "@nteract/messaging";
+
+import { Subject } from "rxjs/Subject";
+
+import {
+  acquireKernelInfo,
+  watchExecutionStateEpic
+} from "../../src/epics/kernel-lifecycle";
+
+import { of } from "rxjs/observable/of";
+import { toArray, share } from "rxjs/operators";
+
+describe("acquireKernelInfo", () => {
+  test("sends a kernel_info_request and processes kernel_info_reply", done => {
+    const sent = new Subject();
+    const received = new Subject();
+
+    const mockSocket = Subject.create(sent, received);
+
+    sent.subscribe(msg => {
+      expect(msg.header.msg_type).toEqual("kernel_info_request");
+
+      const response = createMessage("kernel_info_reply");
+      response.parent_header = msg.header;
+      response.content = { language_info: { language: "python" } };
+
+      // TODO: Get the Rx handling proper here
+      setTimeout(() => received.next(response), 100);
+    });
+
+    const obs = acquireKernelInfo(mockSocket);
+
+    obs.subscribe(langAction => {
+      expect(langAction).toEqual({
+        langInfo: { language: "python" },
+        type: "SET_LANGUAGE_INFO"
+      });
+      done();
+    });
+  });
+});
+
+describe("watchExecutionStateEpic", () => {
+  test("returns an Observable with an initial state of idle", done => {
+    const action$ = ActionsObservable.of({
+      type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
+      kernel: {
+        channels: of({
+          header: { msg_type: "status" },
+          content: { execution_state: "idle" }
+        })
+      }
+    });
+    const obs = watchExecutionStateEpic(action$);
+    obs.pipe(toArray()).subscribe(
+      // Every action that goes through should get stuck on an array
+      actions => {
+        const types = actions.map(({ type }) => type);
+        expect(types).toEqual([actionTypes.SET_EXECUTION_STATE]);
+      },
+      err => done.fail(err), // It should not error in the stream
+      () => done()
+    );
+  });
+});

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -2,3 +2,8 @@
 export { executeCellEpic, updateDisplayEpic } from "./execute";
 export { commListenEpic } from "./comm";
 export { launchWebSocketKernelEpic } from "./websocket-kernel";
+
+export {
+  acquireKernelInfoEpic,
+  watchExecutionStateEpic
+} from "./kernel-lifecycle";

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -1,0 +1,89 @@
+/* @flow */
+
+import { Observable } from "rxjs/Observable";
+import { of } from "rxjs/observable/of";
+import { merge } from "rxjs/observable/merge";
+
+import { createMessage, childOf, ofMessageType } from "@nteract/messaging";
+
+import {
+  filter,
+  map,
+  tap,
+  mergeMap,
+  catchError,
+  first,
+  pluck,
+  switchMap
+} from "rxjs/operators";
+
+import { ActionsObservable, ofType } from "redux-observable";
+
+import * as uuid from "uuid";
+
+import type { Channels } from "@nteract/types/channels";
+
+import type { NewKernelAction } from "../actionTypes";
+
+import type { KernelInfo, LocalKernelProps } from "@nteract/types/core/records";
+
+import {
+  setExecutionState,
+  setNotebookKernelInfo,
+  launchKernelSuccessful,
+  launchKernel,
+  setLanguageInfo
+} from "../actions";
+
+import { LAUNCH_KERNEL_SUCCESSFUL } from "../actionTypes";
+
+/**
+ * Sets the execution state after a kernel has been launched.
+ *
+ * @oaram  {ActionObservable}  action$ ActionObservable for LAUNCH_KERNEL_SUCCESSFUL action
+ */
+export const watchExecutionStateEpic = (action$: ActionsObservable<*>) =>
+  action$.pipe(
+    ofType(LAUNCH_KERNEL_SUCCESSFUL),
+    switchMap((action: NewKernelAction) =>
+      action.kernel.channels.pipe(
+        filter(msg => msg.header.msg_type === "status"),
+        map(msg => setExecutionState(msg.content.execution_state))
+      )
+    )
+  );
+
+/**
+ * Send a kernel_info_request to the kernel.
+ *
+ * @param  {Object}  channels  A object containing the kernel channels
+ * @returns  {Observable}  The reply from the server
+ */
+export function acquireKernelInfo(channels: Channels) {
+  const message = createMessage("kernel_info_request");
+
+  const obs = channels.pipe(
+    childOf(message),
+    ofMessageType("kernel_info_reply"),
+    first(),
+    pluck("content", "language_info"),
+    map(setLanguageInfo)
+  );
+
+  return Observable.create(observer => {
+    const subscription = obs.subscribe(observer);
+    channels.next(message);
+    return subscription;
+  });
+}
+
+/**
+ * Gets information about newly launched kernel.
+ *
+ * @param  {ActionObservable}  The action type
+ */
+export const acquireKernelInfoEpic = (action$: ActionsObservable<*>) =>
+  action$.pipe(
+    ofType(LAUNCH_KERNEL_SUCCESSFUL),
+    switchMap(action => acquireKernelInfo(action.kernel.channels))
+  );


### PR DESCRIPTION
Brings over the kernel lifecycle methods (and tests!) from desktop.

* [x] acquire kernel info when a new kernel is launched
* [x] watch kernel status