### PR TITLE
hook up app reducer + epics to notebook-on-next

### DIFF
--- a/applications/notebook-on-next/pages/edit.js
+++ b/applications/notebook-on-next/pages/edit.js
@@ -48,11 +48,25 @@ export default class Edit extends React.Component<*> {
   static async getInitialProps(context: Object) {
     const query = context.query;
     const isServer = context.isServer;
-    const serverNotebook = await fetchFromGist(query.gistid);
-    if (!serverNotebook) return {};
+
+    let serverNotebook;
+    if (query.gistid) {
+      serverNotebook = await fetchFromGist(query.gistid);
+    }
+
+    if (!serverNotebook) {
+      // TODO: make this a notebook with one cell
+      serverNotebook = toJS(emptyNotebook);
+    }
+
     store.dispatch({
+      // TODO: This action _will_ set off a kernel kick off with our current
+      //       setup so as we start activating servers and kernels we'll want
+      //       to change how we do "SET_NOTEBOOK"
       type: "SET_NOTEBOOK",
-      notebook: serverNotebook ? fromJS(serverNotebook) : null
+      // TODO: We still need to adapt this action to use a raw json notebook
+      //       object
+      notebook: fromJS(serverNotebook)
     });
     return { serverNotebook, isServer };
   }

--- a/applications/notebook-on-next/routes.js
+++ b/applications/notebook-on-next/routes.js
@@ -2,4 +2,4 @@
 const nextRoutes = require("next-routes");
 const routes = (module.exports = nextRoutes());
 
-routes.add("edit", "/edit/:gistid");
+routes.add("edit", "/edit/:gistid?");

--- a/applications/notebook-on-next/store.js
+++ b/applications/notebook-on-next/store.js
@@ -4,8 +4,7 @@ import { createEpicMiddleware, combineEpics } from "redux-observable";
 
 import { Map as ImmutableMap } from "immutable";
 
-import { document, comms, config } from "@nteract/core/reducers";
-import { emptyNotebook, fromJS } from "@nteract/commutable";
+import { app, document, comms, config } from "@nteract/core/reducers";
 
 import type { AppState } from "@nteract/types/core/records";
 
@@ -17,8 +16,27 @@ import {
   CommsRecord
 } from "@nteract/types/core/records";
 
+import {
+  executeCellEpic,
+  updateDisplayEpic,
+  commListenEpic,
+  launchWebSocketKernelEpic,
+  acquireKernelInfoEpic,
+  watchExecutionStateEpic
+} from "@nteract/core/epics";
+
+// TODO: Bring desktop's wrapEpic over to @nteract/core so we can use it here
+const epics = [
+  executeCellEpic,
+  updateDisplayEpic,
+  commListenEpic,
+  launchWebSocketKernelEpic,
+  acquireKernelInfoEpic,
+  watchExecutionStateEpic
+];
+
 const rootReducer = combineReducers({
-  app: (state = {}) => state,
+  app,
   document,
   comms,
   config
@@ -39,7 +57,7 @@ const composeEnhancers =
   compose;
 
 export default function configureStore() {
-  const rootEpic = combineEpics(...[]);
+  const rootEpic = combineEpics(...epics);
   const middlewares = [createEpicMiddleware(rootEpic)];
 
   return createStore(


### PR DESCRIPTION
This hooks up execution / kernel launch logic to notebook-on-next.

We're a very short amount of work away from a full binder backed app on the web here.