### PR TITLE
Ensure we are not trying to edit anonymous gists.

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/github-publish-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/github-publish-spec.js
@@ -110,17 +110,23 @@ describe("publishNotebookObservable", () => {
       notebook,
       "./test.ipynb",
       notificationSystem,
-      false,
+      true,
       store
     );
     const edit = jest.spyOn(github.gists, "edit");
+    let types = [];
     publishNotebookObs.subscribe(
       x => {
-        expect(x.type).toBe("OVERWRITE_METADATA_FIELD");
+        types.push(x.type);
       },
       done.fail,
       () => {
         expect(edit).toHaveBeenCalled();
+        expect(types).toMatchObject([
+          "OVERWRITE_METADATA_FIELD",
+          "DELETE_METADATA_FIELD",
+          "OVERWRITE_METADATA_FIELD"
+        ]);
         done();
       }
     );

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -126,9 +126,10 @@ export function publishNotebookObservable(
     });
     // Already in a gist belonging to the user, update the gist
 
-    const gistRequest = notebook.hasIn(["metadata", "gist_id"])
-      ? { files, id: notebook.getIn(["metadata", "gist_id"]), public: false }
-      : { files, public: false };
+    const gistRequest =
+      notebook.hasIn(["metadata", "gist_id"]) && publishAsUser
+        ? { files, id: notebook.getIn(["metadata", "gist_id"]), public: false }
+        : { files, public: false };
     if (gistRequest.id) {
       github.gists.edit(
         gistRequest,


### PR DESCRIPTION
This prevents an error when uploading as a user and then uploading anonymously.