### PR TITLE
make nb-next default /edit/ open a 1-cell notebook

### DIFF
--- a/applications/notebook-on-next/pages/edit.js
+++ b/applications/notebook-on-next/pages/edit.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import fetch from "isomorphic-fetch";
-import { emptyNotebook, fromJS, toJS } from "@nteract/commutable";
+import { monocellNotebook, fromJS, toJS } from "@nteract/commutable";
 import { NotebookApp } from "@nteract/core/providers";
 import { Provider } from "react-redux";
 import { List as ImmutableList, Map as ImmutableMap } from "immutable";
@@ -27,7 +27,7 @@ async function fetchFromGist(gistId): ?Object {
         }
       }
     })
-    .catch(err => toJS(emptyNotebook));
+    .catch(err => toJS(monocellNotebook));
 }
 
 const Error = () => (
@@ -55,8 +55,7 @@ export default class Edit extends React.Component<*> {
     }
 
     if (!serverNotebook) {
-      // TODO: make this a notebook with one cell
-      serverNotebook = toJS(emptyNotebook);
+      serverNotebook = toJS(monocellNotebook);
     }
 
     store.dispatch({


### PR DESCRIPTION
Quick fix, switches `emptyNotebook` for `monocellNotebook` to make app.nteract.io more of a visually useable notebook at the start.