### PR TITLE
Add menu to nteract-on-jupyter

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.js
@@ -14,6 +14,8 @@ import { NotebookApp } from "@nteract/core/providers";
 
 import { fetchKernelspecs, fetchContent } from "@nteract/core/actions";
 
+import { NotebookMenu } from "@nteract/core/components";
+
 function createApp(jupyterConfigData: JupyterConfigData) {
   const store = configureStore({ config: jupyterConfigData });
   window.store = store;
@@ -35,6 +37,7 @@ function createApp(jupyterConfigData: JupyterConfigData) {
       return (
         <Provider store={store}>
           <div>
+            <NotebookMenu />
             <NotebookApp />
             <NotificationSystem
               ref={notificationSystem => {

--- a/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
+++ b/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PureNotebookMenu  snapshots renders the default 1`] = `
+<div
+  className="jsx-2223146628 jsx-2223146628"
+>
+  <ul
+    aria-activedescendant=""
+    className="rc-menu  rc-menu-root rc-menu-horizontal"
+    onKeyDown={[Function]}
+    role="menu"
+    style={Object {}}
+    tabIndex="0"
+  >
+    <li
+      className="rc-menu-submenu rc-menu-submenu-horizontal"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={undefined}
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-owns="edit$Menu"
+        className="rc-menu-submenu-title"
+        onBlur={undefined}
+        onClick={[Function]}
+        onContextMenu={undefined}
+        onFocus={undefined}
+        onMouseDown={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={undefined}
+        style={Object {}}
+        title="Edit"
+      >
+        Edit
+        <i
+          className="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+    <li
+      className="rc-menu-submenu rc-menu-submenu-horizontal"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={undefined}
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-owns="cell$Menu"
+        className="rc-menu-submenu-title"
+        onBlur={undefined}
+        onClick={[Function]}
+        onContextMenu={undefined}
+        onFocus={undefined}
+        onMouseDown={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={undefined}
+        style={Object {}}
+        title="Cell"
+      >
+        Cell
+        <i
+          className="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -1,0 +1,127 @@
+// @flow
+import React from "react";
+import renderer from "react-test-renderer";
+import * as Immutable from "immutable";
+
+import { shallow, mount } from "enzyme";
+
+import { PureNotebookMenu } from "../../src/components/notebook-menu";
+import { ACTIONS, MENUS } from "../../src/components/notebook-menu/constants";
+
+describe("PureNotebookMenu ", () => {
+  describe("snapshots", () => {
+    test("renders the default", () => {
+      const component = renderer.create(<PureNotebookMenu />);
+      let tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+  describe("shallow", () => {
+    test("renders the default", () => {
+      const wrapper = shallow(<PureNotebookMenu />);
+      expect(wrapper).not.toBeNull();
+    });
+  });
+  describe("mount", () => {
+    test("renders the default", () => {
+      const wrapper = mount(<PureNotebookMenu />);
+      expect(wrapper).not.toBeNull();
+    });
+    test("calls appropriate handlers on click", () => {
+      const props = {
+        // action functions
+        executeCell: jest.fn(),
+        cutCell: jest.fn(),
+        copyCell: jest.fn(),
+        pasteCell: jest.fn(),
+        createCodeCell: jest.fn(),
+        createMarkdownCell: jest.fn(),
+        setCellTypeCode: jest.fn(),
+        setCellTypeMarkdown: jest.fn(),
+
+        // document state
+        cellFocused: "b",
+        cellMap: Immutable.Map({
+          a: Immutable.Map({ cell_type: "code" }),
+          b: Immutable.Map({ cell_type: "code" }),
+          c: Immutable.Map({ cell_type: "markdown" }),
+          d: Immutable.Map({ cell_type: "code" })
+        }),
+        cellOrder: Immutable.List(["a", "b", "c", "d"]),
+
+        // menu props, note that we force all menus to be open to click.
+        openKeys: Object.values(MENUS)
+      };
+      const wrapper = mount(<PureNotebookMenu {...props} />);
+
+      // Test that we call executeAllCells
+      const executeAllCellsItem = wrapper
+        .find({ eventKey: ACTIONS.EXECUTE_ALL_CELLS })
+        .first();
+      expect(props.executeCell).not.toHaveBeenCalled();
+      executeAllCellsItem.simulate("click");
+      expect(props.executeCell).toHaveBeenCalledTimes(3);
+      expect(props.executeCell).toHaveBeenCalledWith("a");
+      expect(props.executeCell).toHaveBeenCalledWith("b");
+      expect(props.executeCell).toHaveBeenCalledWith("d");
+      props.executeCell.mockClear();
+
+      const executeAllCellsBelowItem = wrapper
+        .find({ eventKey: ACTIONS.EXECUTE_ALL_CELLS_BELOW })
+        .first();
+      expect(props.executeCell).not.toHaveBeenCalled();
+      executeAllCellsBelowItem.simulate("click");
+      expect(props.executeCell).toHaveBeenCalledTimes(2);
+      expect(props.executeCell).toHaveBeenCalledWith("b");
+      expect(props.executeCell).toHaveBeenCalledWith("d");
+      props.executeCell.mockClear();
+
+      const cutCellItem = wrapper.find({ eventKey: ACTIONS.CUT_CELL }).first();
+      expect(props.cutCell).not.toHaveBeenCalled();
+      cutCellItem.simulate("click");
+      expect(props.cutCell).toHaveBeenCalled();
+
+      const copyCellItem = wrapper
+        .find({ eventKey: ACTIONS.COPY_CELL })
+        .first();
+      expect(props.copyCell).not.toHaveBeenCalled();
+      copyCellItem.simulate("click");
+      expect(props.copyCell).toHaveBeenCalled();
+
+      const pasteCellItem = wrapper
+        .find({ eventKey: ACTIONS.PASTE_CELL })
+        .first();
+      expect(props.pasteCell).not.toHaveBeenCalled();
+      pasteCellItem.simulate("click");
+      expect(props.pasteCell).toHaveBeenCalled();
+
+      const createMarkdownCellItem = wrapper
+        .find({ eventKey: ACTIONS.CREATE_MARKDOWN_CELL })
+        .first();
+      expect(props.createMarkdownCell).not.toHaveBeenCalled();
+      createMarkdownCellItem.simulate("click");
+      expect(props.createMarkdownCell).toHaveBeenCalled();
+
+      const createCodeCellItem = wrapper
+        .find({ eventKey: ACTIONS.CREATE_CODE_CELL })
+        .first();
+      expect(props.createCodeCell).not.toHaveBeenCalled();
+      createCodeCellItem.simulate("click");
+      expect(props.createCodeCell).toHaveBeenCalled();
+
+      const setCellTypeCodeItem = wrapper
+        .find({ eventKey: ACTIONS.SET_CELL_TYPE_CODE })
+        .first();
+      expect(props.setCellTypeCode).not.toHaveBeenCalled();
+      setCellTypeCodeItem.simulate("click");
+      expect(props.setCellTypeCode).toHaveBeenCalled();
+
+      const setCellTypeMarkdownItem = wrapper
+        .find({ eventKey: ACTIONS.SET_CELL_TYPE_MARKDOWN })
+        .first();
+      expect(props.setCellTypeMarkdown).not.toHaveBeenCalled();
+      setCellTypeMarkdownItem.simulate("click");
+      expect(props.setCellTypeMarkdown).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "escape-carriage": "^1.2.0",
     "mathjax-electron": "^2.0.1",
     "prop-types": "^15.5.10",
+    "rc-menu": "6.2.6",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
     "react-redux": "^5.0.6",

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -4,6 +4,8 @@ import * as React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import syntax from "../themes/syntax-highlighting";
 
+export { default as NotebookMenu } from "./notebook-menu";
+
 export type PagersProps = {
   children: React.Node,
   hidden: boolean

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -1,0 +1,26 @@
+// Note, we can reuse keys, but all paths need to be unique in the menu.
+
+// These actions map to a case in a switch handler. They are meant to cause a
+// unique action from the menu.
+export const ACTIONS = {
+  EXECUTE_ALL_CELLS: "execute-all-cells",
+  EXECUTE_ALL_CELLS_BELOW: "execute-all-cells-below",
+  CLEAR_ALL_OUTPUTS: "clear-all-outputs",
+  CREATE_CODE_CELL: "create-code-cell",
+  CREATE_MARKDOWN_CELL: "create-markdown-cell",
+  SET_CELL_TYPE_CODE: "set-cell-type-code",
+  SET_CELL_TYPE_MARKDOWN: "set-cell-type-markdown",
+  COPY_CELL: "copy-cell",
+  CUT_CELL: "cut-cell",
+  PASTE_CELL: "paste-cell"
+};
+
+// These are top-level-menu or sub-menu keys in case we need interim look-ups
+// when users hover over sub-menu titles.
+export const MENUS = {
+  EDIT: "edit",
+  EDIT_SET_CELL_TYPE: "cell-set-cell-type",
+  INSERT: "insert",
+  CELL: "cell",
+  CELL_CREATE_CELL: "cell-create-cell"
+};

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -1,0 +1,212 @@
+// @flow
+import * as React from "react";
+import Menu, { SubMenu, Divider, MenuItem } from "rc-menu";
+import { localCss } from "./styles";
+import { connect } from "react-redux";
+import * as Immutable from "immutable";
+import * as actions from "../../actions";
+import { ACTIONS, MENUS } from "./constants";
+
+// To allow actions that can take dynamic arguments (like selecting a kernel
+// based on the host's kernelspecs), we have some simple utility functions to
+// stringify/parse actions/arguments.
+const createActionKey = (action, ...args) => [action, ...args].join(":");
+const parseActionKey = key => key.split(":");
+
+type Props = {
+  openKeys: ?Array<string>,
+  cellFocused: ?string,
+  cellMap: Immutable.Map<string, *>,
+  cellOrder: Immutable.List<string>,
+  executeCell: ?(cellId: ?string) => void,
+  cutCell: ?(cellId: ?string) => void,
+  copyCell: ?(cellId: ?string) => void,
+  pasteCell: ?() => void,
+  createCodeCell: ?(cellId: ?string) => void,
+  createMarkdownCell: ?(cellId: ?string) => void,
+  setCellTypeCode: ?(cellId: ?string) => void,
+  setCellTypeMarkdown: ?(cellId: ?string) => void
+};
+
+class PureNotebookMenu extends React.Component<Props> {
+  static defaultProps = {
+    openKeys: null,
+    cellFocused: null,
+    cellMap: Immutable.Map(),
+    cellOrder: Immutable.List(),
+    executeCell: null,
+    cutCell: null,
+    copyCell: null,
+    pasteCell: null,
+    createCodeCell: null,
+    createMarkdownCell: null,
+    setCellTypeCode: null,
+    setCellTypeMarkdown: null
+  };
+  executeCells = (cellIds: Immutable.List<string>) => {
+    const { executeCell } = this.props;
+    if (executeCell) {
+      cellIds.forEach(cellId => executeCell(cellId));
+    }
+  };
+  executeAllCellsBelow = () => {
+    const { cellFocused, cellMap, cellOrder } = this.props;
+    if (!cellFocused) {
+      this.executeAllCells();
+    } else {
+      const cellIds = cellOrder
+        .skip(cellOrder.indexOf(cellFocused))
+        .filter(cellId => cellMap.getIn([cellId, "cell_type"]) === "code");
+      this.executeCells(cellIds);
+    }
+  };
+  executeAllCells = () => {
+    const { cellMap, cellOrder } = this.props;
+    const cellIds = cellOrder.filter(
+      cellId => cellMap.getIn([cellId, "cell_type"]) === "code"
+    );
+    this.executeCells(cellIds);
+  };
+
+  handleClick = ({ key }: { key: string }) => {
+    const [action, ...args] = parseActionKey(key);
+    switch (action) {
+      case ACTIONS.COPY_CELL:
+        if (this.props.copyCell) {
+          this.props.copyCell(this.props.cellFocused);
+        }
+        break;
+      case ACTIONS.CUT_CELL:
+        if (this.props.cutCell) {
+          this.props.cutCell(this.props.cellFocused);
+        }
+        break;
+      case ACTIONS.PASTE_CELL:
+        if (this.props.pasteCell) {
+          this.props.pasteCell();
+        }
+        break;
+      case ACTIONS.CREATE_CODE_CELL:
+        if (this.props.createCodeCell) {
+          this.props.createCodeCell(this.props.cellFocused);
+        }
+        break;
+      case ACTIONS.CREATE_MARKDOWN_CELL:
+        if (this.props.createMarkdownCell) {
+          this.props.createMarkdownCell(this.props.cellFocused);
+        }
+        break;
+      case ACTIONS.SET_CELL_TYPE_CODE:
+        if (this.props.setCellTypeCode) {
+          this.props.setCellTypeCode(this.props.cellFocused);
+        }
+        break;
+      case ACTIONS.SET_CELL_TYPE_MARKDOWN:
+        if (this.props.setCellTypeMarkdown) {
+          this.props.setCellTypeMarkdown(this.props.cellFocused);
+        }
+        break;
+      case ACTIONS.EXECUTE_ALL_CELLS:
+        this.executeAllCells();
+        break;
+      case ACTIONS.EXECUTE_ALL_CELLS_BELOW:
+        this.executeAllCellsBelow();
+        break;
+      default:
+        console.log(`unhandled action: ${action}`);
+    }
+  };
+  render() {
+    const { openKeys } = this.props;
+    return (
+      <div>
+        <Menu
+          mode="horizontal"
+          onClick={this.handleClick}
+          openKeys={openKeys}
+          selectable={false}
+        >
+          <SubMenu key={MENUS.EDIT} title="Edit">
+            <MenuItem key={createActionKey(ACTIONS.CUT_CELL)}>
+              Cut Cell
+            </MenuItem>
+            <MenuItem key={createActionKey(ACTIONS.COPY_CELL)}>
+              Copy Cell
+            </MenuItem>
+            <MenuItem key={createActionKey(ACTIONS.PASTE_CELL)}>
+              Paste Cell Below
+            </MenuItem>
+            <Divider />
+            <SubMenu key={MENUS.EDIT_SET_CELL_TYPE} title="Cell Type">
+              <MenuItem key={createActionKey(ACTIONS.SET_CELL_TYPE_CODE)}>
+                Code
+              </MenuItem>
+              <MenuItem key={createActionKey(ACTIONS.SET_CELL_TYPE_MARKDOWN)}>
+                Markdown
+              </MenuItem>
+            </SubMenu>
+          </SubMenu>
+          <SubMenu key={MENUS.CELL} title="Cell">
+            <MenuItem key={createActionKey(ACTIONS.EXECUTE_ALL_CELLS)}>
+              Run All Cells
+            </MenuItem>
+            <MenuItem key={createActionKey(ACTIONS.EXECUTE_ALL_CELLS_BELOW)}>
+              Run All Cells Below
+            </MenuItem>
+            <Divider />
+            <SubMenu key={MENUS.CELL_CREATE_CELL} title="New Cell">
+              <MenuItem key={createActionKey(ACTIONS.CREATE_CODE_CELL)}>
+                Code
+              </MenuItem>
+              <MenuItem key={createActionKey(ACTIONS.CREATE_MARKDOWN_CELL)}>
+                Markdown
+              </MenuItem>
+            </SubMenu>
+          </SubMenu>
+        </Menu>
+        <style global jsx>
+          {localCss}
+        </style>
+        <style jsx>{`
+          position: sticky;
+          top: 0;
+          // TODO: this is getting ridiculous...
+          z-index: 10000;
+        `}</style>
+      </div>
+    );
+  }
+}
+
+// TODO: this forces the menu to re-render on cell focus. The better option is
+// to alter how the actions work to just target the currently focused cell.
+// That said, we *may* not have a great way of getting around this as we'll need
+// information about the current document to decide which menu items are
+// available...
+const mapStateToProps = state => ({
+  cellFocused: state.document.cellFocused,
+  cellMap: state.document.getIn(["notebook", "cellMap"]),
+  cellOrder: state.document.getIn(["notebook", "cellOrder"])
+});
+
+const mapDispatchToProps = dispatch => ({
+  executeCell: cellId => dispatch(actions.executeCell(cellId)),
+  cutCell: cellId => dispatch(actions.cutCell(cellId)),
+  copyCell: cellId => dispatch(actions.copyCell(cellId)),
+  pasteCell: () => dispatch(actions.pasteCell()),
+  createCodeCell: cellId => dispatch(actions.createCellAfter("code", cellId)),
+  createMarkdownCell: cellId =>
+    dispatch(actions.createCellAfter("markdown", cellId)),
+  setCellTypeCode: cellId => dispatch(actions.changeCellType(cellId, "code")),
+  setCellTypeMarkdown: cellId =>
+    dispatch(actions.changeCellType(cellId, "markdown"))
+});
+
+const NotebookMenu = connect(mapStateToProps, mapDispatchToProps)(
+  PureNotebookMenu
+);
+
+// We export this for testing purposes.
+export { PureNotebookMenu };
+
+export default NotebookMenu;

--- a/packages/core/src/components/notebook-menu/styles.js
+++ b/packages/core/src/components/notebook-menu/styles.js
@@ -1,0 +1,283 @@
+// @flow
+import css from "styled-jsx/css";
+
+export const localCss = css`
+  /* completions styles */
+  .rc-menu {
+    outline: none;
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+    border: 1px solid var(--primary-border);
+    box-shadow: 0 0 4px var(--primary-border);
+    border-radius: 3px;
+    color: var(--main-fg-color);
+  }
+  .rc-menu-hidden {
+    display: none;
+  }
+  .rc-menu-collapse {
+    overflow: hidden;
+  }
+  .rc-menu-collapse-active {
+    transition: height 0.3s ease-out;
+  }
+  .rc-menu-item-group-list {
+    margin: 0;
+    padding: 0;
+  }
+  .rc-menu-item-group-title {
+    color: #999;
+    line-height: 1.5;
+    padding: 8px 10px;
+    border-bottom: 1px solid #dedede;
+  }
+  .rc-menu-item-active,
+  .rc-menu-submenu-active > .rc-menu-submenu-title {
+    background-color: var(--cell-bg-focus);
+  }
+  .rc-menu-item-selected {
+    background-color: var(--cell-bg-focus);
+    transform: translateZ(0);
+  }
+  .rc-menu-submenu-selected {
+    background-color: var(--cell-bg-focus);
+  }
+  .rc-menu > li.rc-menu-submenu {
+    padding: 0;
+  }
+  .rc-menu-horizontal.rc-menu-sub,
+  .rc-menu-vertical.rc-menu-sub,
+  .rc-menu-vertical-left.rc-menu-sub,
+  .rc-menu-vertical-right.rc-menu-sub {
+    min-width: 160px;
+    margin-top: 0;
+  }
+  .rc-menu-item,
+  .rc-menu-submenu-title {
+    margin: 0;
+    position: relative;
+    display: block;
+    padding: 7px 7px 7px 16px;
+    white-space: nowrap;
+    font-size: 12px;
+    user-select: none;
+  }
+  .rc-menu-item.rc-menu-item-disabled,
+  .rc-menu-submenu-title.rc-menu-item-disabled,
+  .rc-menu-item.rc-menu-submenu-disabled,
+  .rc-menu-submenu-title.rc-menu-submenu-disabled {
+    color: #777 !important;
+  }
+  .rc-menu > .rc-menu-item-divider {
+    height: 1px;
+    margin: 1px 0;
+    overflow: hidden;
+    padding: 0;
+    line-height: 0;
+    background-color: #e5e5e5;
+  }
+  .rc-menu-submenu-popup {
+    position: absolute;
+  }
+  .rc-menu-submenu > .rc-menu {
+    background-color: #fff;
+  }
+  .rc-menu .rc-menu-submenu-title .anticon,
+  .rc-menu .rc-menu-item .anticon {
+    width: 14px;
+    height: 14px;
+    margin-right: 8px;
+    top: -1px;
+  }
+  .rc-menu-submenu,
+  .rc-menu-item,
+  .rc-menu-submenu-title {
+    // TODO: the app should be structured in such a way that a separate stacking
+    // context is created and we don't need to battle it out for z-index in this
+    // way...
+    z-index: 1000;
+  }
+  .rc-menu-horizontal {
+    background-color: var(--status-bar);
+    border: none;
+    border-bottom: 1px solid var(--primary-border);
+    box-shadow: none;
+  }
+  .rc-menu-horizontal > .rc-menu-item,
+  .rc-menu-horizontal > .rc-menu-submenu > .rc-menu-submenu-title {
+    padding: 8px 15px;
+  }
+  .rc-menu-horizontal > .rc-menu-submenu,
+  .rc-menu-horizontal > .rc-menu-item {
+    float: left;
+  }
+  .rc-menu-horizontal > .rc-menu-submenu-active,
+  .rc-menu-horizontal > .rc-menu-item-active {
+    background-color: #f3f5f7;
+  }
+  .rc-menu-horizontal:after {
+    content: "\\20";
+    display: block;
+    height: 0;
+    clear: both;
+  }
+  .rc-menu-vertical,
+  .rc-menu-vertical-left,
+  .rc-menu-vertical-right,
+  .rc-menu-inline {
+    padding: 12px 0;
+  }
+  .rc-menu-vertical > .rc-menu-item,
+  .rc-menu-vertical-left > .rc-menu-item,
+  .rc-menu-vertical-right > .rc-menu-item,
+  .rc-menu-inline > .rc-menu-item,
+  .rc-menu-vertical > .rc-menu-submenu > .rc-menu-submenu-title,
+  .rc-menu-vertical-left > .rc-menu-submenu > .rc-menu-submenu-title,
+  .rc-menu-vertical-right > .rc-menu-submenu > .rc-menu-submenu-title,
+  .rc-menu-inline > .rc-menu-submenu > .rc-menu-submenu-title {
+    padding: 8px 40px 8px 10px;
+  }
+  .rc-menu-vertical .rc-menu-submenu-arrow,
+  .rc-menu-vertical-left .rc-menu-submenu-arrow,
+  .rc-menu-vertical-right .rc-menu-submenu-arrow,
+  .rc-menu-inline .rc-menu-submenu-arrow {
+    display: inline-block;
+    font: normal normal normal 14px/1 FontAwesome;
+    font-size: inherit;
+    vertical-align: baseline;
+    text-align: center;
+    text-transform: none;
+    text-rendering: auto;
+    position: absolute;
+    right: 16px;
+    line-height: 1.5em;
+  }
+  .rc-menu-vertical .rc-menu-submenu-arrow:before,
+  .rc-menu-vertical-left .rc-menu-submenu-arrow:before,
+  .rc-menu-vertical-right .rc-menu-submenu-arrow:before,
+  .rc-menu-inline .rc-menu-submenu-arrow:before {
+    content: "\\f0da";
+  }
+  .rc-menu-inline .rc-menu-submenu-arrow {
+    transform: rotate(90deg);
+    transition: transform 0.3s;
+  }
+  .rc-menu-inline
+    .rc-menu-submenu-open
+    > .rc-menu-submenu-title
+    .rc-menu-submenu-arrow {
+    transform: rotate(-90deg);
+  }
+  .rc-menu-vertical.rc-menu-sub,
+  .rc-menu-vertical-left.rc-menu-sub,
+  .rc-menu-vertical-right.rc-menu-sub {
+    padding: 0;
+  }
+  .rc-menu-sub.rc-menu-inline {
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  .rc-menu-sub.rc-menu-inline > .rc-menu-item,
+  .rc-menu-sub.rc-menu-inline > .rc-menu-submenu > .rc-menu-submenu-title {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-right: 0;
+  }
+  .rc-menu-open-slide-up-enter,
+  .rc-menu-open-slide-up-appear {
+    animation-duration: 0.3s;
+    animation-fill-mode: both;
+    transform-origin: 0 0;
+    opacity: 0;
+    animation-timing-function: cubic-bezier(0.08, 0.82, 0.17, 1);
+    animation-play-state: paused;
+  }
+  .rc-menu-open-slide-up-leave {
+    animation-duration: 0.3s;
+    animation-fill-mode: both;
+    transform-origin: 0 0;
+    opacity: 1;
+    animation-timing-function: cubic-bezier(0.6, 0.04, 0.98, 0.34);
+    animation-play-state: paused;
+  }
+  .rc-menu-open-slide-up-enter.rc-menu-open-slide-up-enter-active,
+  .rc-menu-open-slide-up-appear.rc-menu-open-slide-up-appear-active {
+    animation-name: rcMenuOpenSlideUpIn;
+    animation-play-state: running;
+  }
+  .rc-menu-open-slide-up-leave.rc-menu-open-slide-up-leave-active {
+    animation-name: rcMenuOpenSlideUpOut;
+    animation-play-state: running;
+  }
+  @keyframes rcMenuOpenSlideUpIn {
+    0% {
+      opacity: 0;
+      transform-origin: 0% 0%;
+      transform: scaleY(0);
+    }
+    100% {
+      opacity: 1;
+      transform-origin: 0% 0%;
+      transform: scaleY(1);
+    }
+  }
+  @keyframes rcMenuOpenSlideUpOut {
+    0% {
+      opacity: 1;
+      transform-origin: 0% 0%;
+      transform: scaleY(1);
+    }
+    100% {
+      opacity: 0;
+      transform-origin: 0% 0%;
+      transform: scaleY(0);
+    }
+  }
+  .rc-menu-open-zoom-enter,
+  .rc-menu-open-zoom-appear {
+    opacity: 0;
+    animation-duration: 0.3s;
+    animation-fill-mode: both;
+    transform-origin: 0 0;
+    animation-timing-function: cubic-bezier(0.08, 0.82, 0.17, 1);
+    animation-play-state: paused;
+  }
+  .rc-menu-open-zoom-leave {
+    animation-duration: 0.3s;
+    animation-fill-mode: both;
+    transform-origin: 0 0;
+    animation-timing-function: cubic-bezier(0.6, 0.04, 0.98, 0.34);
+    animation-play-state: paused;
+  }
+  .rc-menu-open-zoom-enter.rc-menu-open-zoom-enter-active,
+  .rc-menu-open-zoom-appear.rc-menu-open-zoom-appear-active {
+    animation-name: rcMenuOpenZoomIn;
+    animation-play-state: running;
+  }
+  .rc-menu-open-zoom-leave.rc-menu-open-zoom-leave-active {
+    animation-name: rcMenuOpenZoomOut;
+    animation-play-state: running;
+  }
+  @keyframes rcMenuOpenZoomIn {
+    0% {
+      opacity: 0;
+      transform: scale(0, 0);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1, 1);
+    }
+  }
+  @keyframes rcMenuOpenZoomOut {
+    0% {
+      transform: scale(1, 1);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(0, 0);
+    }
+  }
+`;


### PR DESCRIPTION
🎉 first pass at some minimal menu functionality

I went with code-completeness > feature completeness. I.e., there's much more to flesh out here, but I tried my best to get this code right on the first pass so that we can easily extend.

TODO:

- [x] create `notebook-menu` presentation component (i made it a dir with`index.js` so it matches other components there)
- [x] connect presentation component to redux
- [x] snapshot test
- [x] test that we can mount and then assert that the appropriate actions are being called