### PR TITLE
fix: use defaultKeys/openKeys correctly in rc-menu

### DIFF
--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -50,7 +50,7 @@ describe("PureNotebookMenu ", () => {
         cellOrder: Immutable.List(["a", "b", "c", "d"]),
 
         // menu props, note that we force all menus to be open to click.
-        openKeys: Object.values(MENUS)
+        defaultOpenKeys: Object.values(MENUS)
       };
       const wrapper = mount(<PureNotebookMenu {...props} />);
 

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -14,7 +14,8 @@ const createActionKey = (action, ...args) => [action, ...args].join(":");
 const parseActionKey = key => key.split(":");
 
 type Props = {
-  openKeys: ?Array<string>,
+  defaultOpenKeys?: Array<string>,
+  openKeys?: Array<string>,
   cellFocused: ?string,
   cellMap: Immutable.Map<string, *>,
   cellOrder: Immutable.List<string>,
@@ -30,7 +31,6 @@ type Props = {
 
 class PureNotebookMenu extends React.Component<Props> {
   static defaultProps = {
-    openKeys: null,
     cellFocused: null,
     cellMap: Immutable.Map(),
     cellOrder: Immutable.List(),
@@ -117,13 +117,13 @@ class PureNotebookMenu extends React.Component<Props> {
     }
   };
   render() {
-    const { openKeys } = this.props;
+    const { defaultOpenKeys } = this.props;
     return (
       <div>
         <Menu
           mode="horizontal"
           onClick={this.handleClick}
-          openKeys={openKeys}
+          defaultOpenKeys={defaultOpenKeys}
           selectable={false}
         >
           <SubMenu key={MENUS.EDIT} title="Edit">


### PR DESCRIPTION
These *cannot* be `null`. I thought this was sort-of odd behavior at
first for the `rc-menu` comp, but it makes sense since `defaultProps`
will only target `undefined`. Allowing `null` is actually a bit of a
pain to implement in `rc-menu`.

I always get confused about the `undefined` vs `nil-y` types in Flow:

`type foo?: string // string or undefined (i.e., optional)`
`type foo: ?string // string or undefined or null`