### PR TITLE
feat: add download notebook option to file menu

### DIFF
--- a/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
+++ b/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
@@ -21,6 +21,34 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
       <div
         aria-expanded={false}
         aria-haspopup="true"
+        aria-owns="file$Menu"
+        className="rc-menu-submenu-title"
+        onBlur={undefined}
+        onClick={[Function]}
+        onContextMenu={undefined}
+        onFocus={undefined}
+        onMouseDown={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={undefined}
+        style={Object {}}
+        title="File"
+      >
+        File
+        <i
+          className="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+    <li
+      className="rc-menu-submenu rc-menu-submenu-horizontal"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={undefined}
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="true"
         aria-owns="edit$Menu"
         className="rc-menu-submenu-title"
         onBlur={undefined}

--- a/packages/core/__tests__/components/notebook-menu-extra-handlers-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-extra-handlers-spec.js
@@ -1,75 +1,88 @@
 // @flow
+jest.mock("file-saver");
+
+import FileSaver from "file-saver";
 import React from "react";
-import * as Immutable from "immutable";
 import * as extraHandlers from "../../src/components/notebook-menu/extra-handlers";
+import { bigDummyJSON, bigDummyCommutable } from "../../src/dummy/dummy-nb";
 
 describe("utils", () => {
   describe("executeCells", () => {
     it("doesn't flake if not provided executeCells function", () => {
       expect(() =>
-        extraHandlers.executeCells(null, Immutable.Map(), Immutable.List())
+        extraHandlers.executeCells(
+          null,
+          bigDummyCommutable.get("cellMap"),
+          bigDummyCommutable.get("cellOrder")
+        )
       ).not.toThrow();
     });
     it("executes only non-code cells", () => {
       const executeCell = jest.fn();
-      const cellMap = Immutable.Map({
-        a: Immutable.Map({ cell_type: "code" }),
-        b: Immutable.Map({ cell_type: "cruft" }),
-        c: Immutable.Map({ cell_type: "markdown" }),
-        d: Immutable.Map({ cell_type: "code" })
-      });
-      const cellIds = Immutable.List(["a", "b", "c", "d"]);
+      const cellMap = bigDummyCommutable.get("cellMap");
+      const cellIds = bigDummyCommutable.get("cellOrder");
+      const codeCellIds = cellIds.filter(
+        id => cellMap.getIn([id, "cell_type"]) === "code"
+      );
       extraHandlers.executeCells(executeCell, cellMap, cellIds);
-      expect(executeCell).toHaveBeenCalledTimes(2);
-      expect(executeCell).toHaveBeenCalledWith("a");
-      expect(executeCell).toHaveBeenCalledWith("d");
-    });
-    it("handles missing cell ids", () => {
-      const executeCell = jest.fn();
-      const cellMap = Immutable.Map({});
-      const cellIds = Immutable.List(["a", "b", "c", "d"]);
-      extraHandlers.executeCells(executeCell, cellMap, cellIds);
-      expect(executeCell).not.toHaveBeenCalled();
+      expect(executeCell).toHaveBeenCalledTimes(codeCellIds.size);
+      codeCellIds.forEach(id => expect(executeCell).toHaveBeenCalledWith(id));
     });
   });
   describe("executeAllCellsBelow", () => {
     it("executes all cells if index isn't found", () => {
       const executeCell = jest.fn();
-      const cellMap = Immutable.Map({
-        a: Immutable.Map({ cell_type: "code" }),
-        b: Immutable.Map({ cell_type: "code" })
-      });
-      const cellIds = Immutable.List(["a", "b"]);
-      extraHandlers.executeAllCellsBelow(executeCell, cellMap, cellIds, "DNE");
-      expect(executeCell).toHaveBeenCalledTimes(2);
-      expect(executeCell).toHaveBeenCalledWith("a");
-      expect(executeCell).toHaveBeenCalledWith("b");
-    });
-    it("executes all cells if index isn't given", () => {
-      const executeCell = jest.fn();
-      const cellMap = Immutable.Map({
-        a: Immutable.Map({ cell_type: "code" }),
-        b: Immutable.Map({ cell_type: "code" })
-      });
-      const cellIds = Immutable.List(["a", "b"]);
+      const cellMap = bigDummyCommutable.get("cellMap");
+      const cellIds = bigDummyCommutable.get("cellOrder");
+      const codeCellIds = cellIds.filter(
+        id => cellMap.getIn([id, "cell_type"]) === "code"
+      );
       extraHandlers.executeAllCellsBelow(executeCell, cellMap, cellIds, null);
-      expect(executeCell).toHaveBeenCalledTimes(2);
-      expect(executeCell).toHaveBeenCalledWith("a");
-      expect(executeCell).toHaveBeenCalledWith("b");
+      expect(executeCell).toHaveBeenCalledTimes(codeCellIds.size);
+      codeCellIds.forEach(id => expect(executeCell).toHaveBeenCalledWith(id));
     });
     it("executes all cells including and after index", () => {
       const executeCell = jest.fn();
-      const cellMap = Immutable.Map({
-        a: Immutable.Map({ cell_type: "code" }),
-        b: Immutable.Map({ cell_type: "code" }),
-        c: Immutable.Map({ cell_type: "markdown" }),
-        d: Immutable.Map({ cell_type: "code" })
+      const cellMap = bigDummyCommutable.get("cellMap");
+      const cellIds = bigDummyCommutable.get("cellOrder");
+      const codeCellIds = cellIds.filter(
+        id => cellMap.getIn([id, "cell_type"]) === "code"
+      );
+      const index = 2;
+      const cellId = codeCellIds.get(index);
+      const cellIdsToRun = codeCellIds.skip(index);
+      extraHandlers.executeAllCellsBelow(executeCell, cellMap, cellIds, cellId);
+      expect(executeCell).toHaveBeenCalledTimes(cellIdsToRun.size);
+      cellIdsToRun.forEach(id => expect(executeCell).toHaveBeenCalledWith(id));
+    });
+  });
+  describe("downloadNotebook", () => {
+    beforeEach(() => {
+      FileSaver.saveAs.mockClear();
+      global.Blob = (content, options) => ({ content, options });
+    });
+    it("doesn't fail if notebook is null", () => {
+      expect(() => extraHandlers.downloadNotebook(null, null)).not.toThrow();
+    });
+    it("calls FileSaver.saveAs with notebook and filename", () => {
+      const filename = "/here/there/awesome.ipynb";
+      const expectedData = bigDummyJSON;
+      expect(FileSaver.saveAs).not.toHaveBeenCalled();
+      extraHandlers.downloadNotebook(bigDummyCommutable, filename);
+      expect(FileSaver.saveAs).toHaveBeenCalledTimes(1);
+      const actualMockBlobResponse = FileSaver.saveAs.mock.calls[0][0];
+      const actualFilename = FileSaver.saveAs.mock.calls[0][1];
+      expect(actualMockBlobResponse).toEqual({
+        content: [JSON.stringify(expectedData, undefined, 2)],
+        options: { type: "text/json" }
       });
-      const cellIds = Immutable.List(["a", "b", "c", "d"]);
-      extraHandlers.executeAllCellsBelow(executeCell, cellMap, cellIds, "b");
-      expect(executeCell).toHaveBeenCalledTimes(2);
-      expect(executeCell).toHaveBeenCalledWith("b");
-      expect(executeCell).toHaveBeenCalledWith("d");
+      expect(actualFilename).toBe("awesome.ipynb");
+    });
+    it("calls FileSaver.saveAs with default filename if none provided", () => {
+      expect(FileSaver.saveAs).not.toHaveBeenCalled();
+      extraHandlers.downloadNotebook(bigDummyCommutable, null);
+      expect(FileSaver.saveAs).toHaveBeenCalledTimes(1);
+      expect(FileSaver.saveAs.mock.calls[0][1]).toBe("notebook.ipynb");
     });
   });
 });

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -48,6 +48,8 @@ describe("PureNotebookMenu ", () => {
         cellFocused: "fake",
         cellMap: Immutable.Map(),
         cellOrder: Immutable.List(),
+        notebook: Immutable.Map(),
+        filename: "fake.ipynb",
 
         // menu props, note that we force all menus to be open to click.
         defaultOpenKeys: Object.values(MENUS)
@@ -72,12 +74,23 @@ describe("PureNotebookMenu ", () => {
         .first();
       expect(extraHandlers.executeAllCellsBelow).not.toHaveBeenCalled();
       executeAllCellsBelowItem.simulate("click");
-      expect(extraHandlers.executeAllCells).toHaveBeenCalledTimes(1);
+      expect(extraHandlers.executeAllCellsBelow).toHaveBeenCalledTimes(1);
       expect(extraHandlers.executeAllCellsBelow).toHaveBeenCalledWith(
         props.executeCell,
         props.cellMap,
         props.cellOrder,
         props.cellFocused
+      );
+
+      const downloadNotebookItem = wrapper
+        .find({ eventKey: MENU_ITEM_ACTIONS.DOWNLOAD_NOTEBOOK })
+        .first();
+      expect(extraHandlers.downloadNotebook).not.toHaveBeenCalled();
+      downloadNotebookItem.simulate("click");
+      expect(extraHandlers.downloadNotebook).toHaveBeenCalledTimes(1);
+      expect(extraHandlers.downloadNotebook).toHaveBeenCalledWith(
+        props.notebook,
+        props.filename
       );
 
       const cutCellItem = wrapper

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "commonmark-react-renderer": "^4.3.3",
     "date-fns": "^1.29.0",
     "escape-carriage": "^1.2.0",
+    "file-saver": "^1.3.3",
     "mathjax-electron": "^2.0.1",
     "prop-types": "^15.5.10",
     "rc-menu": "6.2.6",

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -3,6 +3,7 @@
 // These actions map to a case in a switch handler. They are meant to cause a
 // unique action from the menu.
 export const MENU_ITEM_ACTIONS = {
+  DOWNLOAD_NOTEBOOK: "download-notebook",
   EXECUTE_ALL_CELLS: "execute-all-cells",
   EXECUTE_ALL_CELLS_BELOW: "execute-all-cells-below",
   CLEAR_ALL_OUTPUTS: "clear-all-outputs",
@@ -18,6 +19,7 @@ export const MENU_ITEM_ACTIONS = {
 // These are top-level-menu or sub-menu keys in case we need interim look-ups
 // when users hover over sub-menu titles.
 export const MENUS = {
+  FILE: "file",
   EDIT: "edit",
   EDIT_SET_CELL_TYPE: "cell-set-cell-type",
   INSERT: "insert",

--- a/packages/core/src/components/notebook-menu/extra-handlers.js
+++ b/packages/core/src/components/notebook-menu/extra-handlers.js
@@ -1,14 +1,20 @@
 // @flow
 import * as Immutable from "immutable";
+import FileSaver from "file-saver";
+import type { ImmutableNotebook, Notebook } from "@nteract/commutable";
+import * as commutable from "@nteract/commutable";
 
 // Adding a level of indirection here to make it trivial to mock these out in
 // tests to ensure they're getting called as we expect. It also prevents the
 // NotebookMenu component from bloating too much.
 
+// TODO: these exist in commutable/types. We should use export/use those.
 type FocusedCellId = ?string;
 type CellIds = Immutable.List<string>;
 type CellMap = Immutable.Map<string, *>;
 type CellIdFn = ?(string) => void;
+
+const DEFAULT_NOTEBOOK_FILENAME = "notebook.ipynb";
 
 export const executeCells = (
   executeCell: CellIdFn,
@@ -42,5 +48,18 @@ export const executeAllCellsBelow = (
     executeCells(executeCell, cellMap, cellIds.skip(skipToIndex));
   } else {
     executeCells(executeCell, cellMap, cellIds);
+  }
+};
+
+export const downloadNotebook = (
+  immutableNotebook: ?ImmutableNotebook,
+  path: ?string
+) => {
+  if (immutableNotebook) {
+    const notebook = commutable.toJS(immutableNotebook);
+    const filename = (path || DEFAULT_NOTEBOOK_FILENAME).split("/").pop();
+    const data = commutable.stringifyNotebook(notebook);
+    const blob = new Blob([data], { type: "text/json" });
+    FileSaver.saveAs(blob, filename);
   }
 };

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -23,6 +23,8 @@ type Props = {
   executeCell: ?(cellId: ?string) => void,
   cutCell: ?(cellId: ?string) => void,
   copyCell: ?(cellId: ?string) => void,
+  filename: ?string,
+  notebook: Immutable.Map<string, *>,
   pasteCell: ?() => void,
   createCodeCell: ?(cellId: ?string) => void,
   createMarkdownCell: ?(cellId: ?string) => void,
@@ -38,6 +40,7 @@ class PureNotebookMenu extends React.Component<Props> {
     executeCell: null,
     cutCell: null,
     copyCell: null,
+    notebook: null,
     pasteCell: null,
     createCodeCell: null,
     createMarkdownCell: null,
@@ -54,12 +57,21 @@ class PureNotebookMenu extends React.Component<Props> {
       createMarkdownCell,
       cutCell,
       executeCell,
+      filename,
+      notebook,
       pasteCell,
       setCellTypeCode,
       setCellTypeMarkdown
     } = this.props;
     const [action, ...args] = parseActionKey(key);
     switch (action) {
+      case MENU_ITEM_ACTIONS.DOWNLOAD_NOTEBOOK:
+        // This gets us around a Flow fail on document.body.
+        const body = document.body;
+        if (body) {
+          extraHandlers.downloadNotebook(notebook, filename);
+        }
+        break;
       case MENU_ITEM_ACTIONS.COPY_CELL:
         if (copyCell) {
           copyCell(cellFocused);
@@ -120,6 +132,13 @@ class PureNotebookMenu extends React.Component<Props> {
           defaultOpenKeys={defaultOpenKeys}
           selectable={false}
         >
+          <SubMenu key={MENUS.FILE} title="File">
+            <MenuItem
+              key={createActionKey(MENU_ITEM_ACTIONS.DOWNLOAD_NOTEBOOK)}
+            >
+              Download (.ipynb)
+            </MenuItem>
+          </SubMenu>
           <SubMenu key={MENUS.EDIT} title="Edit">
             <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.CUT_CELL)}>
               Cut Cell
@@ -192,7 +211,9 @@ class PureNotebookMenu extends React.Component<Props> {
 const mapStateToProps = state => ({
   cellFocused: state.document.cellFocused,
   cellMap: state.document.getIn(["notebook", "cellMap"]),
-  cellOrder: state.document.getIn(["notebook", "cellOrder"])
+  cellOrder: state.document.getIn(["notebook", "cellOrder"]),
+  filename: state.document.get("filename"),
+  notebook: state.document.get("notebook")
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/core/src/dummy/dummy-nb.js
+++ b/packages/core/src/dummy/dummy-nb.js
@@ -19,3 +19,134 @@ export const dummy =
 export const dummyJSON = JSON.parse(dummy);
 
 export const dummyCommutable = fromJS(dummyJSON);
+
+export const bigDummyJSON = {
+  cells: [
+    {
+      cell_type: "markdown",
+      source: [
+        "# This is an example notebook\n",
+        "\n",
+        "## Used for test purposes...\n",
+        "\nThe idea is to have enough real data in here to make a non-trivial NB."
+      ],
+      metadata: {
+        trusted: false
+      }
+    },
+    {
+      cell_type: "code",
+      source: ["import math\n", "import IPython.display"],
+      outputs: [],
+      execution_count: 17,
+      metadata: {
+        trusted: false
+      }
+    },
+    {
+      cell_type: "markdown",
+      source: [
+        "Here, we intersperse markdown to make sure it isn't simply a bunch of consecutive code blocks."
+      ],
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "code",
+      source: [
+        "data = [round(math.sin(i*2*math.pi/10)*100) + 100 for i in range(0, 10)]"
+      ],
+      outputs: [],
+      execution_count: 23,
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "markdown",
+      source: [
+        "Finally, we even display some HTML in the output to ensure that we have more than simple text output."
+      ],
+      metadata: {}
+    },
+    {
+      cell_type: "code",
+      source: [
+        'bars = "".join([\'<div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: {}px;"></div>\'.format(datum) for datum in data])\n',
+        "IPython.display.HTML(bars)"
+      ],
+      outputs: [
+        {
+          output_type: "execute_result",
+          execution_count: 33,
+          data: {
+            "text/plain": ["<IPython.core.display.HTML object>"],
+            "text/html": [
+              '<div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 100px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 159px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 195px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 195px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 159px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 100px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 41px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 5px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 5px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 41px;"></div>'
+            ]
+          },
+          metadata: {}
+        }
+      ],
+      execution_count: 33,
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "code",
+      source: [],
+      outputs: [],
+      execution_count: 28,
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "markdown",
+      source: [
+        "^^ Add an empty code cell above and an empty markdown cell below for kicks. Et, voila."
+      ],
+      metadata: {}
+    },
+    {
+      cell_type: "markdown",
+      source: [],
+      metadata: {}
+    }
+  ],
+  metadata: {
+    kernelspec: {
+      display_name: "Python 3",
+      language: "python",
+      name: "python3"
+    },
+    language_info: {
+      name: "python",
+      version: "3.6.0",
+      mimetype: "text/x-python",
+      codemirror_mode: {
+        name: "ipython",
+        version: 3
+      },
+      pygments_lexer: "ipython3",
+      nbconvert_exporter: "python",
+      file_extension: ".py"
+    }
+  },
+  nbformat: 4,
+  nbformat_minor: 2
+};
+
+export const bigDummyCommutable = fromJS(bigDummyJSON);
+
+export const bigDummy = JSON.stringify(bigDummyJSON);

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -197,7 +197,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
   >
     <Cell
       isSelected={false}
-      key="5"
+      key="14"
     >
       <div
         className="jsx-2299737332 jsx-2299737332 content-margin"
@@ -229,7 +229,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
     </Cell>
     <Cell
       isSelected={false}
-      key="6"
+      key="15"
     >
       <PapermillView />
       <Input


### PR DESCRIPTION
I ended up using a 3rd party file downloader. I did also find this while looking around: https://github.com/jimmywarting/StreamSaver.js

If notebooks are quite large (which i imagine they could be), it'd be cool to flesh this out and alternatively stream the notebook to disk if we hit a limit on the blob size. Thoughts?

Chrome's blobs cap out at 500MiB according to https://stackoverflow.com/questions/28307789/is-there-any-limitation-on-javascript-max-blob-size. Any concern there?