### PR TITLE
[jext] epic for saving notebooks in the web app

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -27,9 +27,7 @@ describe("saveEpic", () => {
     // TODO: This should be testing that the mocks for fs were called with the
     // filename and notebook from the state tree
 
-    expect(responses).toEqual([
-      { type: "DONE_SAVING", notebook: expect.anything() }
-    ]);
+    expect(responses).toEqual([{ type: "DONE_SAVING" }]);
   });
 });
 

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -14,85 +14,39 @@ import {
 import { saveEpic, saveAsEpic } from "../../../src/notebook/epics/saving";
 
 import { of } from "rxjs/observable/of";
-import { catchError } from "rxjs/operators";
-
-describe("save", () => {
-  test("creates a SAVE action", () => {
-    expect(save("test/test-save.ipynb", dummyCommutable)).toEqual({
-      type: SAVE,
-      filename: "test/test-save.ipynb",
-      notebook: dummyCommutable
-    });
-  });
-});
-
-describe("saveAs", () => {
-  test("creates a SAVE_AS action", () => {
-    expect(saveAs("test/test-saveas.ipynb", dummyCommutable)).toEqual({
-      type: SAVE_AS,
-      filename: "test/test-saveas.ipynb",
-      notebook: dummyCommutable
-    });
-  });
-});
+import { catchError, toArray } from "rxjs/operators";
 
 describe("saveEpic", () => {
-  test("throws an error when no filename provided", done => {
-    const input$ = of({ type: SAVE });
-    const action$ = new ActionsObservable(input$);
-    const actionBuffer = [];
+  test("saves the file using the notebook in the state tree", async function() {
     const store = dummyStore();
-    const responseActions = saveEpic(action$, store).pipe(
-      catchError(error => {
-        expect(error.message).toBe("save needs a filename");
-        return of({ type: SAVE });
-      })
-    );
-    responseActions.subscribe(
-      // Every action that goes through should get stuck on an array
-      x => actionBuffer.push(x.type),
-      err => done.fail(err),
-      () => {
-        // It should not error in the stream
-        expect(actionBuffer).toEqual([SAVE]);
-        done();
-      }
-    );
-  });
-  test("works when passed filename and notebook", done => {
-    const input$ = of(save("filename", dummyCommutable));
-    const action$ = new ActionsObservable(input$);
-    const actionBuffer = [];
-    const store = dummyStore();
-    const responseActions = saveEpic(action$, store);
-    responseActions.subscribe(
-      // Every action that goes through should get stuck on an array
-      x => actionBuffer.push(x.type),
-      err => done.fail(err),
-      () => {
-        // It should not error in the stream
-        expect(actionBuffer).toEqual([DONE_SAVING]);
-        done();
-      }
-    );
+
+    const responses = await saveEpic(ActionsObservable.of(save()), store)
+      .pipe(toArray())
+      .toPromise();
+
+    // TODO: This should be testing that the mocks for fs were called with the
+    // filename and notebook from the state tree
+
+    expect(responses).toEqual([
+      { type: "DONE_SAVING", notebook: expect.anything() }
+    ]);
   });
 });
 
 describe("saveAsEpic", () => {
-  test("works when passed actions of type SAVE_AS", done => {
-    const input$ = of(saveAs("filename", dummyCommutable));
-    const action$ = new ActionsObservable(input$);
-    const actionBuffer = [];
-    const responseActions = saveAsEpic(action$);
-    responseActions.subscribe(
-      // Every action that goes through should get stuck on an array
-      x => actionBuffer.push(x.type),
-      () => done.fail(err),
-      () => {
-        // It should not error in the stream
-        expect(actionBuffer).toEqual([CHANGE_FILENAME, SAVE]);
-        done();
-      }
-    );
+  test("works when passed actions of type SAVE_AS", async function() {
+    const store = dummyStore();
+
+    const responses = await saveAsEpic(
+      ActionsObservable.of(saveAs("great-filename")),
+      store
+    )
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responses).toEqual([
+      { type: "CHANGE_FILENAME", filename: "great-filename" },
+      { type: "SAVE" }
+    ]);
   });
 });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -325,9 +325,7 @@ describe("menu", () => {
       menu.dispatchSave(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: "SAVE",
-        filename: store.getState().document.get("filename"),
-        notebook: store.getState().document.get("notebook")
+        type: "SAVE"
       });
     });
   });
@@ -340,8 +338,7 @@ describe("menu", () => {
       menu.dispatchSaveAs(store, {}, "test-ipynb.ipynb");
       expect(store.dispatch).toHaveBeenCalledWith({
         type: "SAVE_AS",
-        filename: "test-ipynb.ipynb",
-        notebook: store.getState().document.get("notebook")
+        filename: "test-ipynb.ipynb"
       });
     });
   });
@@ -424,7 +421,6 @@ describe("menu", () => {
 
       expect(store.dispatch).toHaveBeenCalledWith({
         type: "SAVE_AS",
-        notebook: store.getState().document.get("notebook"),
         filename
       });
     });

--- a/applications/desktop/__tests__/renderer/reducers/app-spec.js
+++ b/applications/desktop/__tests__/renderer/reducers/app-spec.js
@@ -46,66 +46,6 @@ describe("setNotificationSystem", () => {
   });
 });
 
-describe("startSaving", () => {
-  test("should set isSaving to false", () => {
-    const originalState = {
-      app: makeAppRecord({
-        kernel: makeLocalKernelRecord({
-          channels: false,
-          spawn: false,
-          connectionFile: false
-        })
-      })
-    };
-
-    const action = { type: actionTypes.START_SAVING };
-
-    const state = reducers(originalState, action);
-    expect(state.app.isSaving).toBe(true);
-  });
-});
-
-describe("doneSaving", () => {
-  test("should set isSaving to false", () => {
-    const originalState = {
-      app: makeAppRecord({
-        kernel: makeLocalKernelRecord({
-          channels: false,
-          spawn: false,
-          connectionFile: false
-        })
-      })
-    };
-
-    const action = { type: actionTypes.DONE_SAVING };
-
-    const state = reducers(originalState, action);
-    expect(state.app.isSaving).toBe(false);
-  });
-});
-
-describe("setExecutionState", () => {
-  test("should set the exeuction state to the given value", () => {
-    const originalState = {
-      app: makeAppRecord({
-        kernel: makeLocalKernelRecord({
-          channels: false,
-          spawn: false,
-          connectionFile: false
-        })
-      })
-    };
-
-    const action = {
-      type: actionTypes.SET_EXECUTION_STATE,
-      kernelStatus: "idle"
-    };
-
-    const state = reducers(originalState, action);
-    expect(state.app.kernel.status).toBe("idle");
-  });
-});
-
 describe("interruptKernel", () => {
   test("sends a SIGINT and clears the kernel", () => {
     const originalState = {

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -25,25 +25,22 @@ export function saveEpic(
 ) {
   return action$.pipe(
     ofType(SAVE),
-    map(action => {
+    mergeMap(action => {
       const state = store.getState();
-      const notebook = state.document.get("notebook");
-      const filename = state.document.get("filename");
-
-      return {
-        filename,
-        notebook: stringifyNotebook(
-          toJS(
-            notebook.setIn(
+      const notebook = stringifyNotebook(
+        toJS(
+          state.document
+            .get("notebook")
+            .setIn(
               ["metadata", "nteract", "version"],
               state.app.get("version", "0.0.0-beta")
             )
-          )
         )
-      };
-    }),
-    mergeMap(action =>
-      writeFileObservable(action.filename, action.notebook).pipe(
+      );
+
+      const filename = state.document.get("filename");
+
+      return writeFileObservable(filename, notebook).pipe(
         map(() => {
           if (process.platform !== "darwin") {
             const state = store.getState();
@@ -63,8 +60,8 @@ export function saveEpic(
             error: true
           })
         )
-      )
-    )
+      );
+    })
   );
 }
 

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -38,8 +38,7 @@ export function saveEpic(
           toJS(
             notebook.setIn(
               ["metadata", "nteract", "version"],
-              // TODO: set this in the state tree once on startup
-              remote.app.getVersion()
+              state.app.get("version", "0.0.0-beta")
             )
           )
         )

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -11,8 +11,6 @@ import { changeFilename, save, doneSaving } from "@nteract/core/actions";
 
 import { toJS, stringifyNotebook } from "@nteract/commutable";
 
-import { remote } from "electron";
-
 import { of } from "rxjs/observable/of";
 import { tap, mergeMap, catchError, map } from "rxjs/operators";
 

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from "react";
 import ReactDOM from "react-dom";
-import { ipcRenderer as ipc } from "electron";
+import { ipcRenderer as ipc, remote } from "electron";
 
 import { Provider } from "react-redux";
 
@@ -23,6 +23,7 @@ import { initGlobalHandlers } from "./global-events";
 
 import {
   makeAppRecord,
+  makeDesktopHostRecord,
   makeDocumentRecord,
   CommsRecord
 } from "@nteract/types/core/records";
@@ -30,7 +31,10 @@ import {
 import "./main.css";
 
 const store = configureStore({
-  app: makeAppRecord(),
+  app: makeAppRecord({
+    host: makeDesktopHostRecord(),
+    version: remote.app.getVersion()
+  }),
   document: makeDocumentRecord(),
   comms: CommsRecord(),
   config: ImmutableMap({

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -34,9 +34,7 @@ import {
 import { defaultPathFallback, cwdKernelFallback } from "./path";
 
 export function dispatchSaveAs(store, evt, filename) {
-  const state = store.getState();
-  const notebook = state.document.get("notebook");
-  store.dispatch(saveAs(filename, notebook));
+  store.dispatch(saveAs(filename));
 }
 
 const dialog = remote.dialog;
@@ -67,9 +65,7 @@ export function triggerWindowRefresh(store, filename) {
   if (!filename) {
     return;
   }
-  const state = store.getState();
-  const notebook = state.document.get("notebook");
-  store.dispatch(saveAs(filename, notebook));
+  store.dispatch(saveAs(filename));
 }
 
 export function dispatchRestartKernel(store) {
@@ -146,12 +142,11 @@ export function triggerSaveAs(store) {
 
 export function dispatchSave(store) {
   const state = store.getState();
-  const notebook = state.document.get("notebook");
   const filename = state.document.get("filename");
   if (!filename) {
     triggerSaveAs(store);
   } else {
-    store.dispatch(save(filename, notebook));
+    store.dispatch(save());
   }
 }
 

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -1,6 +1,8 @@
 // @flow
 import { shutdownKernel } from "../kernel/shutdown";
 
+import { app } from "@nteract/core/reducers";
+
 import {
   makeAppRecord,
   makeLocalKernelRecord,
@@ -48,18 +50,6 @@ function interruptKernel(state: AppRecord) {
   return state;
 }
 
-function startSaving(state: AppRecord) {
-  return state.set("isSaving", true);
-}
-
-function setExecutionState(state: AppRecord, action: SetExecutionStateAction) {
-  return state.setIn(["kernel", "status"], action.kernelStatus);
-}
-
-function doneSaving(state: AppRecord) {
-  return state.set("isSaving", false).set("lastSaved", new Date());
-}
-
 function doneSavingConfig(state: AppRecord) {
   return state.set("configLastSaved", new Date());
 }
@@ -95,6 +85,9 @@ export default function handleApp(
   action: AppAction
 ) {
   switch (action.type) {
+    // This action is _also_ handled in @nteract/core's app
+    // however, the desktop one still has some kernel cleanup logic
+    // that needs to be refactored into an epic
     case "LAUNCH_KERNEL_SUCCESSFUL":
       return launchKernel(state, action);
     case "EXIT":
@@ -103,12 +96,6 @@ export default function handleApp(
       return cleanupKernel(state);
     case "INTERRUPT_KERNEL":
       return interruptKernel(state);
-    case "START_SAVING":
-      return startSaving(state);
-    case "SET_EXECUTION_STATE":
-      return setExecutionState(state, action);
-    case "DONE_SAVING":
-      return doneSaving(state);
     case "DONE_SAVING_CONFIG":
       return doneSavingConfig(state);
     case "SET_NOTIFICATION_SYSTEM":
@@ -116,6 +103,7 @@ export default function handleApp(
     case "SET_GITHUB_TOKEN":
       return setGithubToken(state, action);
     default:
-      return state;
+      // We defer to core for the rest as we move more into @nteract/core
+      return app(state, action);
   }
 }

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -1,6 +1,8 @@
 // @flow
 import { shutdownKernel } from "../kernel/shutdown";
 
+import { remote } from "electron";
+
 import { app } from "@nteract/core/reducers";
 
 import {
@@ -80,7 +82,8 @@ type AppAction =
 
 export default function handleApp(
   state: AppRecord = makeAppRecord({
-    host: makeDesktopHostRecord()
+    host: makeDesktopHostRecord(),
+    version: remote.app.getVersion()
   }),
   action: AppAction
 ) {

--- a/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
@@ -9,7 +9,8 @@ import {
   launchWebSocketKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
-  launchKernelWhenNotebookSetEpic
+  launchKernelWhenNotebookSetEpic,
+  saveContentEpic
 } from "@nteract/core/epics";
 
 // TODO: Bring desktop's wrapEpic over to @nteract/core so we can use it here
@@ -23,7 +24,8 @@ const epics = [
   setNotebookEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
-  launchKernelWhenNotebookSetEpic
+  launchKernelWhenNotebookSetEpic,
+  saveContentEpic
 ];
 
 export default epics;

--- a/applications/jupyter-extension/nteract_on_jupyter/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/store.js
@@ -62,7 +62,8 @@ export default function configureStore({
         token: config.token,
         // TODO: Use URL join, even though we know these are right
         serverUrl: location.origin + config.baseUrl
-      })
+      }),
+      version: `nteract-on-jupyter@${config.appVersion}`
     }),
     document: makeDocumentRecord(),
     comms: CommsRecord(),

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -408,24 +408,19 @@ describe("toggleOutputExpansion", () => {
 
 describe("save", () => {
   test("creates a SAVE action", () => {
-    const fakeNotebook = { nbformat: "eh" };
-    expect(actions.save("foo.ipynb", fakeNotebook)).toEqual({
-      type: actionTypes.SAVE,
-      filename: "foo.ipynb",
-      notebook: fakeNotebook
+    expect(actions.save()).toEqual({
+      type: actionTypes.SAVE
     });
   });
 
   test("creates a SAVE_AS action", () => {
-    const fakeNotebook = { nbformat: "eh" };
-    expect(actions.saveAs("foo.ipynb", fakeNotebook)).toEqual({
+    expect(actions.saveAs("foo.ipynb")).toEqual({
       type: actionTypes.SAVE_AS,
-      filename: "foo.ipynb",
-      notebook: fakeNotebook
+      filename: "foo.ipynb"
     });
   });
 
-  test("creates a SAVE_AS action", () => {
+  test("creates a DONE_SAVING action", () => {
     const fakeNotebook = { nbformat: "eh" };
     expect(actions.doneSaving(fakeNotebook)).toEqual({
       type: actionTypes.DONE_SAVING,

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -422,9 +422,8 @@ describe("save", () => {
 
   test("creates a DONE_SAVING action", () => {
     const fakeNotebook = { nbformat: "eh" };
-    expect(actions.doneSaving(fakeNotebook)).toEqual({
-      type: actionTypes.DONE_SAVING,
-      notebook: fakeNotebook
+    expect(actions.doneSaving()).toEqual({
+      type: actionTypes.DONE_SAVING
     });
   });
 });

--- a/packages/core/__tests__/app-spec.js
+++ b/packages/core/__tests__/app-spec.js
@@ -1,0 +1,61 @@
+import * as actionTypes from "@nteract/core/actionTypes";
+import { app } from "@nteract/core/reducers";
+import {
+  AppRecord,
+  makeAppRecord,
+  makeLocalKernelRecord
+} from "@nteract/types/core/records";
+
+describe("startSaving", () => {
+  test("should set isSaving to false", () => {
+    const originalState = makeAppRecord({
+      kernel: makeLocalKernelRecord({
+        channels: false,
+        spawn: false,
+        connectionFile: false
+      })
+    });
+
+    const action = { type: actionTypes.START_SAVING };
+
+    const state = app(originalState, action);
+    expect(state.isSaving).toBe(true);
+  });
+});
+
+describe("doneSaving", () => {
+  test("should set isSaving to false", () => {
+    const originalState = makeAppRecord({
+      kernel: makeLocalKernelRecord({
+        channels: false,
+        spawn: false,
+        connectionFile: false
+      })
+    });
+
+    const action = { type: actionTypes.DONE_SAVING };
+
+    const state = app(originalState, action);
+    expect(state.isSaving).toBe(false);
+  });
+});
+
+describe("setExecutionState", () => {
+  test("should set the exeuction state to the given value", () => {
+    const originalState = makeAppRecord({
+      kernel: makeLocalKernelRecord({
+        channels: false,
+        spawn: false,
+        connectionFile: false
+      })
+    });
+
+    const action = {
+      type: actionTypes.SET_EXECUTION_STATE,
+      kernelStatus: "idle"
+    };
+
+    const state = app(originalState, action);
+    expect(state.kernel.status).toBe("idle");
+  });
+});

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -44,6 +44,7 @@ describe("PureNotebookMenu ", () => {
         setCellTypeCode: jest.fn(),
         setCellTypeMarkdown: jest.fn(),
         setTheme: jest.fn(),
+        saveNotebook: jest.fn(),
 
         // document state (we mock out the implementation, so these are just
         // dummy variables.
@@ -175,6 +176,13 @@ describe("PureNotebookMenu ", () => {
       setThemeDarkItem.simulate("click");
       expect(props.setTheme).toHaveBeenCalledTimes(1);
       expect(props.setTheme).toHaveBeenCalledWith("dark");
+
+      const saveNotebookItem = wrapper
+        .find({ eventKey: MENU_ITEM_ACTIONS.SAVE_NOTEBOOK })
+        .first();
+      expect(props.saveNotebook).not.toHaveBeenCalled();
+      saveNotebookItem.simulate("click");
+      expect(props.saveNotebook).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -176,10 +176,7 @@ describe("setNotebookCheckpoint", () => {
       type: actionTypes.DONE_SAVING,
       notebook: dummyCommutable
     });
-    expect(is(state.get("notebook"), initialDocument.get("notebook"))).toBe(
-      true
-    );
-    expect(is(state.get("savedNotebook"), dummyCommutable)).toBe(true);
+    expect(state.get("notebook")).toEqual(state.get("savedNotebook"));
   });
 });
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -346,10 +346,6 @@ export type SetNotificationSystemAction = {
 // TODO: Determine the "right" name for this action creator (?)
 export const DONE_SAVING = "DONE_SAVING";
 export type DoneSavingAction = { type: "DONE_SAVING" };
-export type SetNotebookCheckpointAction = {
-  type: "DONE_SAVING",
-  notebook: ImmutableNotebook
-};
 
 // TODO: Make this action JSON serializable (don't use the Immutable.js version
 //       of the notebook in this action)

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -504,19 +504,16 @@ export function changeFilename(filename: string): ChangeFilenameAction {
   };
 }
 
-export function save(filename: string, notebook: any) {
+export function save() {
   return {
-    type: actionTypes.SAVE,
-    filename,
-    notebook
+    type: actionTypes.SAVE
   };
 }
 
-export function saveAs(filename: string, notebook: any) {
+export function saveAs(filename: string) {
   return {
     type: actionTypes.SAVE_AS,
-    filename,
-    notebook
+    filename
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -517,10 +517,9 @@ export function saveAs(filename: string) {
   };
 }
 
-export function doneSaving(notebook: any) {
+export function doneSaving() {
   return {
-    type: actionTypes.DONE_SAVING,
-    notebook
+    type: actionTypes.DONE_SAVING
   };
 }
 

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -3,6 +3,7 @@
 // These actions map to a case in a switch handler. They are meant to cause a
 // unique action from the menu.
 export const MENU_ITEM_ACTIONS = {
+  SAVE_NOTEBOOK: "save-notebook",
   DOWNLOAD_NOTEBOOK: "download-notebook",
   EXECUTE_ALL_CELLS: "execute-all-cells",
   EXECUTE_ALL_CELLS_BELOW: "execute-all-cells-below",

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -20,6 +20,7 @@ type Props = {
   cellFocused: ?string,
   cellMap: Immutable.Map<string, *>,
   cellOrder: Immutable.List<string>,
+  saveNotebook: ?() => void,
   executeCell: ?(cellId: ?string) => void,
   cutCell: ?(cellId: ?string) => void,
   copyCell: ?(cellId: ?string) => void,
@@ -39,6 +40,7 @@ class PureNotebookMenu extends React.Component<Props> {
     cellFocused: null,
     cellMap: Immutable.Map(),
     cellOrder: Immutable.List(),
+    saveNotebook: null,
     executeCell: null,
     cutCell: null,
     copyCell: null,
@@ -53,6 +55,7 @@ class PureNotebookMenu extends React.Component<Props> {
   };
   handleClick = ({ key }: { key: string }) => {
     const {
+      saveNotebook,
       cellFocused,
       cellMap,
       cellOrder,
@@ -71,6 +74,11 @@ class PureNotebookMenu extends React.Component<Props> {
     } = this.props;
     const [action, ...args] = parseActionKey(key);
     switch (action) {
+      case MENU_ITEM_ACTIONS.SAVE_NOTEBOOK:
+        if (saveNotebook) {
+          saveNotebook();
+        }
+        break;
       case MENU_ITEM_ACTIONS.DOWNLOAD_NOTEBOOK:
         // This gets us around a Flow fail on document.body.
         const body = document.body;
@@ -154,6 +162,9 @@ class PureNotebookMenu extends React.Component<Props> {
           selectable={false}
         >
           <SubMenu key={MENUS.FILE} title="File">
+            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.SAVE_NOTEBOOK)}>
+              Save
+            </MenuItem>
             <MenuItem
               key={createActionKey(MENU_ITEM_ACTIONS.DOWNLOAD_NOTEBOOK)}
             >
@@ -253,6 +264,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  saveNotebook: () => dispatch(actions.save()),
   executeCell: cellId => dispatch(actions.executeCell(cellId)),
   cutCell: cellId => dispatch(actions.cutCell(cellId)),
   copyCell: cellId => dispatch(actions.copyCell(cellId)),

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import { fromJS } from "@nteract/commutable";
-
 import { of } from "rxjs/observable/of";
 import {
   tap,
@@ -27,7 +25,7 @@ import type { ActionsObservable } from "redux-observable";
 
 import { contents } from "rx-jupyter";
 
-import { toJS, stringifyNotebook } from "@nteract/commutable";
+import { fromJS, toJS, stringifyNotebook } from "@nteract/commutable";
 
 import { FETCH_CONTENT, SAVE } from "../actionTypes";
 import type { FetchContent } from "../actionTypes";

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -80,22 +80,19 @@ export function saveContentEpic(
 ) {
   return action$.pipe(
     ofType(SAVE),
-    map(action => {
+    mergeMap(action => {
       const state = store.getState();
-      const notebook = state.document.get("notebook");
-      const filename = state.document.get("filename");
 
+      const filename = state.document.get("filename");
       const version = state.app.get("version", "0.0.0-beta");
 
-      return {
-        filename,
-        // contents API takes notebook as raw JSON
-        notebook: toJS(
-          notebook.setIn(["metadata", "nteract", "version"], version)
-        )
-      };
-    }),
-    mergeMap(({ filename, notebook }) => {
+      // contents API takes notebook as raw JSON
+      const notebook = toJS(
+        state.document
+          .get("notebook")
+          .setIn(["metadata", "nteract", "version"], version)
+      );
+
       // TODO: Use the selector from the kernelspecs work
       const host = store.getState().app.host;
       const serverConfig = {

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -47,7 +47,7 @@ export function fetchContentEpic(
       const serverConfig = {
         endpoint: host.serverUrl,
         token: host.token,
-        crossDomain: false
+        crossDomain: host.crossDomain
       };
 
       return contents
@@ -101,7 +101,7 @@ export function saveContentEpic(
       const serverConfig = {
         endpoint: host.serverUrl,
         token: host.token,
-        crossDomain: false
+        crossDomain: host.crossDomain
       };
 
       const model = {

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -11,4 +11,4 @@ export {
 
 export { fetchKernelspecsEpic } from "./kernelspecs";
 
-export { fetchContentEpic, setNotebookEpic } from "./contents";
+export { fetchContentEpic, setNotebookEpic, saveContentEpic } from "./contents";

--- a/packages/core/src/reducers/app.js
+++ b/packages/core/src/reducers/app.js
@@ -12,6 +12,14 @@ import * as actionTypes from "../actionTypes";
 
 import type { NewKernelAction, SetExecutionStateAction } from "../actionTypes";
 
+function startSaving(state: AppRecord) {
+  return state.set("isSaving", true);
+}
+
+function doneSaving(state: AppRecord) {
+  return state.set("isSaving", false).set("lastSaved", new Date());
+}
+
 export function launchKernelSuccessful(
   state: AppRecord,
   action: NewKernelAction
@@ -56,6 +64,10 @@ export default function handleApp(
       return launchKernelSuccessful(state, action);
     case actionTypes.SET_EXECUTION_STATE:
       return setExecutionState(state, action);
+    case actionTypes.START_SAVING:
+      return startSaving(state);
+    case actionTypes.DONE_SAVING:
+      return doneSaving(state);
     default:
       return state;
   }

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -24,7 +24,7 @@ import type {
   NewCellBeforeAction,
   ClearOutputsAction,
   AppendOutputAction,
-  SetNotebookCheckpointAction,
+  DoneSavingAction,
   UpdateDisplayAction,
   FocusNextCellAction,
   FocusCellEditorAction,
@@ -170,9 +170,10 @@ function setNotebook(state: DocumentRecord, action: SetNotebookAction) {
 
 function setNotebookCheckpoint(
   state: DocumentRecord,
-  action: SetNotebookCheckpointAction
+  action: DoneSavingAction
 ) {
-  return state.set("savedNotebook", action.notebook);
+  // Use the current version of the notebook document
+  return state.set("savedNotebook", state.get("notebook"));
 }
 
 function focusCell(state: DocumentRecord, action: FocusCellAction) {
@@ -700,9 +701,9 @@ type DocumentAction =
   | PasteCellAction
   | ChangeCellTypeAction
   | ToggleCellExpansionAction
-  | SetNotebookCheckpointAction
   | AcceptPayloadMessageAction
   | SendExecuteMessageAction
+  | DoneSavingAction
   | SetInCellAction<*>;
 
 const defaultDocument: DocumentRecord = makeDocumentRecord();

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -8,6 +8,8 @@ import type {
   RemoteKernelProps
 } from "./hosts";
 
+const version = require("../../package.json").version;
+
 import { List, Map, Record, Set } from "immutable";
 
 export type { HostRef, KernelRef, KernelspecsRef } from "./refs";
@@ -155,7 +157,9 @@ type AppRecordProps = {
   isSaving: boolean,
   lastSaved: ?Date,
   configLastSaved: ?Date,
-  error: any
+  error: any,
+  // The version number should be provided by an app on boot
+  version: string
 };
 
 export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
@@ -166,7 +170,9 @@ export const makeAppRecord: RecordFactory<AppRecordProps> = Record({
   isSaving: false, // All -- ?
   lastSaved: null, // All
   configLastSaved: null, // ?
-  error: null // All
+  error: null, // All
+  // set the default version to @nteract/core's version
+  version: `@nteract/core@${version}`
 });
 
 export type AppRecord = RecordOf<AppRecordProps>;


### PR DESCRIPTION
Closes #2429. This PR accomplished all the following:

* [x] create a File -> Save menu item and menu action
* [x] Refactor `SAVE` and `SAVE_AS` actions to not require passing a filename and the raw notebook structure
  * [x] Action creators
  * [x] Desktop Epic
* [x] Refactor `DONE_SAVING` action to not pass back a notebook file
* [x] Store version information in the `app` state, for both desktop and web app
* [x] Create an epic that uses rx-jupyter and matches the style for how we do loading
* [x] Move save related reducers and tests from desktop to core