### PR TITLE
extract getServerConfig to 🆕 core selectors

### DIFF
--- a/flow-typed/npm/reselect_v3.x.x.js
+++ b/flow-typed/npm/reselect_v3.x.x.js
@@ -1,0 +1,893 @@
+// flow-typed signature: 7242133add1d3bd16fc3e9d648152c63
+// flow-typed version: 00301f0d29/reselect_v3.x.x/flow_>=v0.47.x
+
+// flow-typed signature: 0199525b667f385f2e61dbeae3215f21
+// flow-typed version: b43dff3e0e/reselect_v3.x.x/flow_>=v0.28.x
+
+declare module "reselect" {
+  declare type Selector<-TState, TProps, TResult> = (
+    state: TState,
+    props: TProps,
+    ...rest: any[]
+  ) => TResult;
+
+  declare type SelectorCreator = {
+    <TState, TProps, TResult, T1>(
+      selector1: Selector<TState, TProps, T1>,
+      resultFunc: (arg1: T1) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1>(
+      selectors: [Selector<TState, TProps, T1>],
+      resultFunc: (arg1: T1) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2>(
+      selectors: [Selector<TState, TProps, T1>, Selector<TState, TProps, T2>],
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selector1: Selector<TState, TProps, T1>,
+      selector2: Selector<TState, TProps, T2>,
+      selector3: Selector<TState, TProps, T3>,
+      selector4: Selector<TState, TProps, T4>,
+      selector5: Selector<TState, TProps, T5>,
+      selector6: Selector<TState, TProps, T6>,
+      selector7: Selector<TState, TProps, T7>,
+      selector8: Selector<TState, TProps, T8>,
+      selector9: Selector<TState, TProps, T9>,
+      selector10: Selector<TState, TProps, T10>,
+      selector11: Selector<TState, TProps, T11>,
+      selector12: Selector<TState, TProps, T12>,
+      selector13: Selector<TState, TProps, T13>,
+      selector14: Selector<TState, TProps, T14>,
+      selector15: Selector<TState, TProps, T15>,
+      selector16: Selector<TState, TProps, T16>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): Selector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selectors: [
+        Selector<TState, TProps, T1>,
+        Selector<TState, TProps, T2>,
+        Selector<TState, TProps, T3>,
+        Selector<TState, TProps, T4>,
+        Selector<TState, TProps, T5>,
+        Selector<TState, TProps, T6>,
+        Selector<TState, TProps, T7>,
+        Selector<TState, TProps, T8>,
+        Selector<TState, TProps, T9>,
+        Selector<TState, TProps, T10>,
+        Selector<TState, TProps, T11>,
+        Selector<TState, TProps, T12>,
+        Selector<TState, TProps, T13>,
+        Selector<TState, TProps, T14>,
+        Selector<TState, TProps, T15>,
+        Selector<TState, TProps, T16>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): Selector<TState, TProps, TResult>
+  };
+
+  declare type Reselect = {
+    createSelector: SelectorCreator,
+
+    defaultMemoize: <TFunc: Function>(
+      func: TFunc,
+      equalityCheck?: (a: any, b: any) => boolean
+    ) => TFunc,
+
+    createSelectorCreator: (
+      memoize: Function,
+      ...memoizeOptions: any[]
+    ) => SelectorCreator,
+
+    createStructuredSelector: <TState, TProps>(
+      inputSelectors: {
+        [k: string | number]: Selector<TState, TProps, any>
+      },
+      selectorCreator?: SelectorCreator
+    ) => Selector<TState, TProps, any>
+  };
+
+  declare module.exports: Reselect;
+}

--- a/package.json
+++ b/package.json
@@ -90,8 +90,9 @@
     "immutable": "^4.0.0-rc.9",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "styled-jsx": "^2.2.1",
-    "rxjs": "^5.5.6"
+    "reselect": "^3.0.1",
+    "rxjs": "^5.5.6",
+    "styled-jsx": "^2.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "react-syntax-highlighter": "^7.0.0",
     "redux": "^3.7.2",
     "redux-immutable": "^4.0.0",
+    "reselect": "^3.0.1",
     "rx-binder": "^1.0.9",
     "rx-jupyter": "^2.3.5",
     "rxjs": "^5.5.6",

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -21,6 +21,8 @@ import {
 
 import { FETCH_CONTENT_FULFILLED } from "../actionTypes";
 
+import { getServerConfig } from "../selectors";
+
 import type { ActionsObservable } from "redux-observable";
 
 import { contents } from "rx-jupyter";
@@ -42,13 +44,7 @@ export function fetchContentEpic(
       }
     }),
     switchMap((action: FetchContent) => {
-      // TODO: Use the selector from the kernelspecs work
-      const host = store.getState().app.host;
-      const serverConfig = {
-        endpoint: host.serverUrl,
-        token: host.token,
-        crossDomain: host.crossDomain
-      };
+      const serverConfig = getServerConfig(store.getState());
 
       return contents
         .get(serverConfig, action.payload.path, action.payload.params)
@@ -93,13 +89,7 @@ export function saveContentEpic(
           .setIn(["metadata", "nteract", "version"], version)
       );
 
-      // TODO: Use the selector from the kernelspecs work
-      const host = store.getState().app.host;
-      const serverConfig = {
-        endpoint: host.serverUrl,
-        token: host.token,
-        crossDomain: host.crossDomain
-      };
+      const serverConfig = getServerConfig(state);
 
       const model = {
         content: notebook,

--- a/packages/core/src/epics/kernelspecs.js
+++ b/packages/core/src/epics/kernelspecs.js
@@ -8,13 +8,7 @@ import { ofType } from "redux-observable";
 import type { ActionsObservable } from "redux-observable";
 import type { KernelspecProps, Kernelspecs } from "@nteract/types/core/records";
 
-// TODO: this should also be immutable.
-// TODO: this assumes a jupyter host for now.
-const getServerConfig = state => ({
-  endpoint: state.app.host.serverUrl,
-  crossDomain: state.app.host.crossDomain,
-  token: state.app.host.token
-});
+import { getServerConfig } from "../selectors";
 
 export const fetchKernelspecsEpic = (
   action$: ActionsObservable<*>,

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -3,10 +3,15 @@ import type { AppState } from "@nteract/types/core/records";
 
 import { createSelector } from "reselect";
 
-export const getHost = (state: AppState) => state.app.host;
+const serverUrl = (state: AppState) => state.app.host.serverUrl;
+const crossDomain = (state: AppState) => state.app.host.crossDomain;
+const token = (state: AppState) => state.app.host.token;
 
-export const getServerConfig = createSelector(getHost, host => ({
-  endpoint: host.serverUrl,
-  crossDomain: host.crossDomain,
-  token: host.token
-}));
+export const getServerConfig = createSelector(
+  [serverUrl, crossDomain, token],
+  (serverUrl, crossDomain, token) => ({
+    endpoint: serverUrl,
+    crossDomain,
+    token
+  })
+);

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -1,9 +1,12 @@
 // @flow
 import type { AppState } from "@nteract/types/core/records";
 
-// TODO: This assumes a jupyter host for now
-export const getServerConfig = (state: AppState) => ({
-  endpoint: state.app.host.serverUrl,
-  crossDomain: state.app.host.crossDomain,
-  token: state.app.host.token
-});
+import { createSelector } from "reselect";
+
+export const getHost = (state: AppState) => state.app.host;
+
+export const getServerConfig = createSelector(getHost, host => ({
+  endpoint: host.serverUrl,
+  crossDomain: host.crossDomain,
+  token: host.token
+}));

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -1,0 +1,9 @@
+// @flow
+import type { AppState } from "@nteract/types/core/records";
+
+// TODO: This assumes a jupyter host for now
+export const getServerConfig = (state: AppState) => ({
+  endpoint: state.app.host.serverUrl,
+  crossDomain: state.app.host.crossDomain,
+  token: state.app.host.token
+});

--- a/packages/types/src/core/records.js
+++ b/packages/types/src/core/records.js
@@ -16,6 +16,10 @@ export type { HostRef, KernelRef, KernelspecsRef } from "./refs";
 
 export { createHostRef, createKernelRef, createKernelspecsRef } from "./refs";
 
+export type HostRecord = RecordOf<
+  DesktopHostRecordProps | JupyterHostRecordProps
+>;
+
 export {
   makeLocalKernelRecord,
   makeDesktopHostRecord,
@@ -151,7 +155,7 @@ export type Notebook = {
 // Basically, anything that's only for desktop should have its own record & reducers
 type AppRecordProps = {
   kernel: ?RecordOf<RemoteKernelProps | LocalKernelProps>,
-  host: ?RecordOf<DesktopHostRecordProps | JupyterHostRecordProps>,
+  host: ?HostRecord,
   githubToken: ?string,
   notificationSystem: ?Object,
   isSaving: boolean,


### PR DESCRIPTION
Probably about time we create general selectors! This `getServerConfig` selector comes from kernelspecs and is now applied to all the `rx-jupyter`-using epics.

I've also gone ahead and introduced `reselect` to memoize this one. This is my first time _actually_ using `reselect` rather than just knowing about it. 😄 