### PR TITLE
feat: add help/about to web menu.

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.js
@@ -14,7 +14,7 @@ import { NotebookApp } from "@nteract/core/providers";
 
 import { fetchKernelspecs, fetchContent } from "@nteract/core/actions";
 
-import { NotebookMenu } from "@nteract/core/components";
+import { ModalController, NotebookMenu } from "@nteract/core/components";
 
 function createApp(jupyterConfigData: JupyterConfigData) {
   const store = configureStore({ config: jupyterConfigData });
@@ -44,6 +44,7 @@ function createApp(jupyterConfigData: JupyterConfigData) {
                 this.notificationSystem = notificationSystem;
               }}
             />
+            <ModalController />
             <style jsx global>{`
               body {
                 font-family: "Source Sans Pro";

--- a/applications/jupyter-extension/nteract_on_jupyter/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/store.js
@@ -11,7 +11,8 @@ import {
   comms,
   config,
   app,
-  entitiesKernelspecsByRef
+  entitiesKernelspecsByRef,
+  modals
 } from "@nteract/core/reducers";
 
 import {
@@ -38,7 +39,8 @@ export type AppState = {
   document: DocumentRecord,
   comms: CommsRecord,
   config: ImmutableMap<string, any>,
-  contents: any
+  contents: any,
+  modals: any
 };
 
 const rootReducer = combineReducers({
@@ -46,6 +48,7 @@ const rootReducer = combineReducers({
   document,
   comms,
   config,
+  modals,
   entities: combineReducers({
     kernelspecsByRef: entitiesKernelspecsByRef
   })

--- a/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
+++ b/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
@@ -124,6 +124,34 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
         />
       </div>
     </li>
+    <li
+      className="rc-menu-submenu rc-menu-submenu-horizontal"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={undefined}
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-owns="help$Menu"
+        className="rc-menu-submenu-title"
+        onBlur={undefined}
+        onClick={[Function]}
+        onContextMenu={undefined}
+        onFocus={undefined}
+        onMouseDown={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={undefined}
+        style={Object {}}
+        title="Help"
+      >
+        Help
+        <i
+          className="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
   </ul>
 </div>
 `;

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -45,6 +45,7 @@ describe("PureNotebookMenu ", () => {
         setCellTypeMarkdown: jest.fn(),
         setTheme: jest.fn(),
         saveNotebook: jest.fn(),
+        openAboutModal: jest.fn(),
 
         // document state (we mock out the implementation, so these are just
         // dummy variables.
@@ -183,6 +184,13 @@ describe("PureNotebookMenu ", () => {
       expect(props.saveNotebook).not.toHaveBeenCalled();
       saveNotebookItem.simulate("click");
       expect(props.saveNotebook).toHaveBeenCalledTimes(1);
+
+      const openAboutItem = wrapper
+        .find({ eventKey: MENU_ITEM_ACTIONS.OPEN_ABOUT })
+        .first();
+      expect(props.openAboutModal).not.toHaveBeenCalled();
+      openAboutItem.simulate("click");
+      expect(props.openAboutModal).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -28,6 +28,19 @@ import type { ExecuteRequest } from "@nteract/types/messaging";
 
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 
+export const OPEN_MODAL = "CORE/OPEN_MPODAL";
+export type OpenModal = {
+  type: "CORE/OPEN_MPODAL",
+  payload: {
+    modalType: string
+  }
+};
+
+export const CLOSE_MODAL = "CORE/CLOSE_MODAL";
+export type CloseModal = {
+  type: "CORE/CLOSE_MODAL"
+};
+
 export const FETCH_CONTENT = "CORE/FETCH_CONTENT";
 export type FetchContent = {
   type: "CORE/FETCH_CONTENT",

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -85,12 +85,23 @@ import type {
   DoneSavingConfigAction,
   // TODO: Needs an action creator
   SetNotebookCheckpointAction,
+  OpenModal,
+  CloseModal,
   FetchContent,
   FetchContentFulfilled,
   FetchContentFailed
 } from "../actionTypes";
 
 import { createExecuteRequest } from "@nteract/messaging";
+
+export const openModal = (payload: { modalType: string }) => ({
+  type: actionTypes.OPEN_MODAL,
+  payload
+});
+
+export const closeModal = () => ({
+  type: actionTypes.CLOSE_MODAL
+});
 
 export const fetchContent = (
   payload: { path: string, params: Object } = { path: "/", params: {} }

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -6,6 +6,8 @@ import syntax from "../themes/syntax-highlighting";
 
 export { default as NotebookMenu } from "./notebook-menu";
 
+export { default as ModalController } from "./modal-controller";
+
 export type PagersProps = {
   children: React.Node,
   hidden: boolean

--- a/packages/core/src/components/modal-controller/about-modal.js
+++ b/packages/core/src/components/modal-controller/about-modal.js
@@ -1,0 +1,93 @@
+// @flow
+
+// We need to allow to allow escape from the modal from an inner element.
+/* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
+
+// TODO: we can remove this if we knew an appropriate role for the modal shadow.
+// We want to allow the user to click on the modal-backdrop to escape.
+/* eslint jsx-a11y/no-static-element-interactions: 0 */
+
+import React from "react";
+import { modalCss } from "./styles";
+import { connect } from "react-redux";
+import * as actions from "../../actions";
+
+type Props = {
+  appVersion?: string,
+  hostType?: string,
+  closeModal: ?() => void
+};
+
+// We need to do this so that you can immediately `Escape` out of the dialog.
+// Otherwise, we'd need to (a) put an event listener on the document or (b)
+// require that the user clicks the content first before attempting to escape.
+const focusOnRender = el => el && el.focus();
+
+class PureAboutModal extends React.Component<Props> {
+  handleKeyDown = (event: KeyboardEvent) => {
+    const { closeModal } = this.props;
+    const { key, metaKey, altKey, ctrlKey, repeat, shiftKey } = event;
+    if (
+      key === "Escape" &&
+      !(metaKey || altKey || ctrlKey || repeat || shiftKey) &&
+      closeModal
+    ) {
+      closeModal();
+    }
+  };
+  handleOverlayClick = (event: Event) => {
+    const { closeModal } = this.props;
+    if (closeModal && event.target && event.target === event.currentTarget) {
+      closeModal();
+    }
+  };
+  render() {
+    const { appVersion, hostType } = this.props;
+    return (
+      <div>
+        <div
+          className="modal--overlay"
+          onClick={this.handleOverlayClick}
+          onKeyDown={this.handleKeyDown}
+          tabIndex={-1}
+        >
+          <dialog tabIndex={0} className="modal--content" ref={focusOnRender}>
+            <div className="modal--content--header">
+              <h2>About nteract on Jupyter</h2>
+              <p>You are using an nteract-rendered notebook on Jupyter.</p>
+            </div>
+            <div className="modal--content--body">
+              <p>
+                <span className="modal--content--body--field">Version:</span>
+                <span className="modal--content--body--value">
+                  {appVersion}
+                </span>
+              </p>
+              <p>
+                <span className="modal--content--body--field">Host Type:</span>
+                <span className="modal--content--body--value">{hostType}</span>
+              </p>
+            </div>
+          </dialog>
+        </div>
+        <style jsx>{modalCss}</style>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  appVersion: state.app.version,
+  hostType: state.app.host.type
+});
+
+const mapDispatchToProps = {
+  closeModal: actions.closeModal
+};
+
+const AboutModal = connect(mapStateToProps, mapDispatchToProps)(PureAboutModal);
+
+// We export this for testing purposes.
+export { PureAboutModal };
+
+export default AboutModal;

--- a/packages/core/src/components/modal-controller/constants.js
+++ b/packages/core/src/components/modal-controller/constants.js
@@ -1,0 +1,3 @@
+export const MODAL_TYPES = {
+  ABOUT: "core/about-modal"
+};

--- a/packages/core/src/components/modal-controller/index.js
+++ b/packages/core/src/components/modal-controller/index.js
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { MODAL_TYPES } from "./constants";
+import AboutModal from "./about-modal";
+import { connect } from "react-redux";
+
+class ModalController extends React.Component {
+  getModal = () => {
+    const { modalType } = this.props;
+    switch (modalType) {
+      case MODAL_TYPES.ABOUT:
+        return AboutModal;
+      default:
+        return null;
+    }
+  };
+  render() {
+    const Modal = this.getModal();
+    return Modal ? <Modal /> : null;
+  }
+}
+
+const mapStateToProps = state => ({
+  modalType: state.modals.modalType
+});
+
+export { MODAL_TYPES };
+
+export default connect(mapStateToProps)(ModalController);

--- a/packages/core/src/components/modal-controller/styles.js
+++ b/packages/core/src/components/modal-controller/styles.js
@@ -1,0 +1,75 @@
+// @flow
+import css from "styled-jsx/css";
+
+const TOP_OFFSET = "20px";
+export const modalCss = css`
+  /* completions styles */
+  dialog {
+    // We don't have a reset, so we need to reset some things on dialog.
+    width: initial;
+    height: initial;
+    margin: initial;
+    background: initial;
+  }
+  .modal--overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.25);
+    z-index: 10000;
+  }
+  .modal--content {
+    align-items: stretch;
+    background-color: var(--main-bg-color);
+    color: var(--main-fg-color);
+    border-radius: 4px;
+    border: var(--primary-border) 1px solid;
+    box-sizing: border-box;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: flex-start;
+    left: 400px;
+    max-height: calc(100vh - ${TOP_OFFSET} * 2);
+    outline: none;
+    overflow: auto;
+    padding: 20px;
+    position: absolute;
+    right: 400px;
+    top: ${TOP_OFFSET};
+    z-index: 10000;
+  }
+  @media only screen and (max-width: 1500px) {
+    .modal--content {
+      left: 200px;
+      right: 200px;
+    }
+  }
+  @media only screen and (max-width: 1000px) {
+    .modal--content {
+      left: 100px;
+      right: 100px;
+    }
+  }
+  @media only screen and (max-width: 600px) {
+    .modal--content {
+      left: 40px;
+      right: 40px;
+    }
+  }
+  .modal--content--header {
+    padding: 0 20px 20px 20px;
+    border-bottom: var(--primary-border) 1px solid;
+  }
+  .modal--content--body {
+    padding: 20px;
+  }
+  .modal--content--body--field {
+    font-weight: bold;
+    margin-right: 5px;
+  }
+  .modal--content--body--value {
+    font-family: monospace;
+  }
+`;

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -17,7 +17,8 @@ export const MENU_ITEM_ACTIONS = {
   PASTE_CELL: "paste-cell",
   MERGE_CELL_AFTER: "merge-cell-after",
   SET_THEME_DARK: "set-theme-dark",
-  SET_THEME_LIGHT: "set-theme-light"
+  SET_THEME_LIGHT: "set-theme-light",
+  OPEN_ABOUT: "open-about"
 };
 
 // These are top-level-menu or sub-menu keys in case we need interim look-ups
@@ -30,5 +31,6 @@ export const MENUS = {
   CELL: "cell",
   CELL_CREATE_CELL: "cell-create-cell",
   VIEW: "view",
-  VIEW_THEMES: "view-themes"
+  VIEW_THEMES: "view-themes",
+  HELP: "help"
 };

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -7,6 +7,7 @@ import * as Immutable from "immutable";
 import * as actions from "../../actions";
 import { MENU_ITEM_ACTIONS, MENUS } from "./constants";
 import * as extraHandlers from "./extra-handlers";
+import { MODAL_TYPES } from "../modal-controller";
 
 // To allow actions that can take dynamic arguments (like selecting a kernel
 // based on the host's kernelspecs), we have some simple utility functions to
@@ -32,7 +33,8 @@ type Props = {
   createMarkdownCell: ?(cellId: ?string) => void,
   setCellTypeCode: ?(cellId: ?string) => void,
   setCellTypeMarkdown: ?(cellId: ?string) => void,
-  setTheme: ?(theme: ?string) => void
+  setTheme: ?(theme: ?string) => void,
+  openAboutModal: ?() => void
 };
 
 class PureNotebookMenu extends React.Component<Props> {
@@ -51,7 +53,8 @@ class PureNotebookMenu extends React.Component<Props> {
     createMarkdownCell: null,
     setCellTypeCode: null,
     setCellTypeMarkdown: null,
-    setTheme: null
+    setTheme: null,
+    openAboutModal: null
   };
   handleClick = ({ key }: { key: string }) => {
     const {
@@ -67,6 +70,7 @@ class PureNotebookMenu extends React.Component<Props> {
       filename,
       mergeCellAfter,
       notebook,
+      openAboutModal,
       pasteCell,
       setCellTypeCode,
       setCellTypeMarkdown,
@@ -145,6 +149,11 @@ class PureNotebookMenu extends React.Component<Props> {
       case MENU_ITEM_ACTIONS.SET_THEME_LIGHT:
         if (setTheme) {
           setTheme("light");
+        }
+        break;
+      case MENU_ITEM_ACTIONS.OPEN_ABOUT:
+        if (openAboutModal) {
+          openAboutModal();
         }
         break;
       default:
@@ -235,6 +244,11 @@ class PureNotebookMenu extends React.Component<Props> {
               </MenuItem>
             </SubMenu>
           </SubMenu>
+          <SubMenu key={MENUS.HELP} title="Help">
+            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.OPEN_ABOUT)}>
+              About
+            </MenuItem>
+          </SubMenu>
         </Menu>
         <style global jsx>
           {localCss}
@@ -276,7 +290,9 @@ const mapDispatchToProps = dispatch => ({
   setCellTypeCode: cellId => dispatch(actions.changeCellType(cellId, "code")),
   setCellTypeMarkdown: cellId =>
     dispatch(actions.changeCellType(cellId, "markdown")),
-  setTheme: theme => dispatch(actions.setTheme(theme))
+  setTheme: theme => dispatch(actions.setTheme(theme)),
+  openAboutModal: () =>
+    dispatch(actions.openModal({ modalType: MODAL_TYPES.ABOUT }))
 });
 
 const NotebookMenu = connect(mapStateToProps, mapDispatchToProps)(

--- a/packages/core/src/reducers/index.js
+++ b/packages/core/src/reducers/index.js
@@ -3,6 +3,7 @@ import document from "./document";
 import comms from "./comms";
 import config from "./config";
 import app from "./app";
+import modals from "./modals";
 import {
   communicationKernelspecsByRef,
   entitiesKernelspecsByRef
@@ -13,6 +14,7 @@ export {
   comms,
   config,
   app,
+  modals,
   communicationKernelspecsByRef,
   entitiesKernelspecsByRef
 };

--- a/packages/core/src/reducers/modals.js
+++ b/packages/core/src/reducers/modals.js
@@ -1,0 +1,19 @@
+import * as actionTypes from "../actionTypes";
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
+const modalType = (state = "", action) => {
+  switch (action.type) {
+    case actionTypes.OPEN_MODAL:
+      return action.payload.modalType;
+    case actionTypes.CLOSE_MODAL:
+      return "";
+    default:
+      return state;
+  }
+};
+
+const makeModals = Immutable.Record({ modalType: "" });
+const modals = combineReducers({ modalType }, makeModals);
+
+export default modals;


### PR DESCRIPTION
First pass at the about menu. I didn't want to get too far into it so it's pretty minimal / uninformative... I could use some help understanding the rest of the information that needs to make its way into this menu.

<img width="880" alt="screen shot 2018-01-29 at 8 39 20 pm" src="https://user-images.githubusercontent.com/6611546/35548476-83475788-0534-11e8-87c3-46b9ddafc826.png">

