### PR TITLE
Interrupt Epic + Menu Entry

### DIFF
--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -237,7 +237,7 @@ export function dispatchInterruptKernel(store) {
       level: "error"
     });
   } else {
-    store.dispatch(interruptKernel);
+    store.dispatch(interruptKernel());
   }
 }
 

--- a/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/epics/index.js
@@ -1,5 +1,6 @@
 // @flow
 import {
+  interruptKernelEpic,
   fetchKernelspecsEpic,
   fetchContentEpic,
   setNotebookEpic,
@@ -15,6 +16,7 @@ import {
 
 // TODO: Bring desktop's wrapEpic over to @nteract/core so we can use it here
 const epics = [
+  interruptKernelEpic,
   fetchKernelspecsEpic,
   executeCellEpic,
   updateDisplayEpic,

--- a/packages/core/__mocks__/rx-jupyter.js
+++ b/packages/core/__mocks__/rx-jupyter.js
@@ -48,8 +48,9 @@ module.exports = {
   kernels: {
     start: (config, kernelSpecName, cwd) => of({ response: { id: "0" } }),
     connect: (config, id, session) => new Subject(),
-    // TODO: See what the response really is
-    interrupt: (config, id) => of({ response: { id: "0" } })
+    interrupt: (config, id) =>
+      // successful interrupt
+      of({ response: null, responseType: "json", status: 204 })
   },
   kernelspecs: {
     list: config => of({ response: mockListReponse })

--- a/packages/core/__mocks__/rx-jupyter.js
+++ b/packages/core/__mocks__/rx-jupyter.js
@@ -47,7 +47,9 @@ const mockListReponse = {
 module.exports = {
   kernels: {
     start: (config, kernelSpecName, cwd) => of({ response: { id: "0" } }),
-    connect: (config, id, session) => new Subject()
+    connect: (config, id, session) => new Subject(),
+    // TODO: See what the response really is
+    interrupt: (config, id) => of({ response: { id: "0" } })
   },
   kernelspecs: {
     list: config => of({ response: mockListReponse })

--- a/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
+++ b/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
@@ -152,6 +152,34 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
         />
       </div>
     </li>
+    <li
+      className="rc-menu-submenu rc-menu-submenu-horizontal"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={undefined}
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-owns="runtime$Menu"
+        className="rc-menu-submenu-title"
+        onBlur={undefined}
+        onClick={[Function]}
+        onContextMenu={undefined}
+        onFocus={undefined}
+        onMouseDown={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={undefined}
+        style={Object {}}
+        title="Runtime"
+      >
+        Runtime
+        <i
+          className="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
   </ul>
 </div>
 `;

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -46,6 +46,7 @@ describe("PureNotebookMenu ", () => {
         setTheme: jest.fn(),
         saveNotebook: jest.fn(),
         openAboutModal: jest.fn(),
+        interruptKernel: jest.fn(),
 
         // document state (we mock out the implementation, so these are just
         // dummy variables.
@@ -191,6 +192,13 @@ describe("PureNotebookMenu ", () => {
       expect(props.openAboutModal).not.toHaveBeenCalled();
       openAboutItem.simulate("click");
       expect(props.openAboutModal).toHaveBeenCalledTimes(1);
+
+      const interruptKernelItem = wrapper
+        .find({ eventKey: MENU_ITEM_ACTIONS.INTERRUPT_KERNEL })
+        .first();
+      expect(props.interruptKernel).not.toHaveBeenCalled();
+      interruptKernelItem.simulate("click");
+      expect(props.interruptKernel).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -96,7 +96,7 @@ describe("interruptKernelEpic", () => {
       }
     };
 
-    const action$ = ActionsObservable.of(interruptKernel);
+    const action$ = ActionsObservable.of(interruptKernel());
 
     const responseActions = await interruptKernelEpic(action$, store)
       .pipe(toArray())
@@ -104,7 +104,7 @@ describe("interruptKernelEpic", () => {
 
     expect(responseActions).toEqual([
       {
-        type: "INTERRUPTED"
+        type: "INTERRUPT_KERNEL_SUCCESSFUL"
       }
     ]);
   });

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -1,7 +1,10 @@
 // @flow
 import { ActionsObservable } from "redux-observable";
-import { launchKernelByName } from "../../src/actions";
-import { launchWebSocketKernelEpic } from "../../src/epics";
+import { launchKernelByName, interruptKernel } from "../../src/actions";
+import {
+  launchWebSocketKernelEpic,
+  interruptKernelEpic
+} from "../../src/epics";
 
 import { toArray } from "rxjs/operators";
 
@@ -58,6 +61,50 @@ describe("launchWebSocketKernelEpic", () => {
           kernelSpecName: "fancy",
           id: "0"
         }
+      }
+    ]);
+  });
+});
+
+describe("interruptKernelEpic", () => {
+  test("", async function() {
+    const store = {
+      getState() {
+        return this.state;
+      },
+      state: {
+        app: {
+          host: {
+            type: "jupyter",
+            token: "eh",
+            serverUrl: "http://localhost:8888/"
+          },
+          kernel: {
+            type: "websocket",
+            channels: jest.fn(),
+            kernelSpecName: "fancy",
+            id: "0"
+          },
+          notificationSystem: { addNotification: jest.fn() }
+        },
+        document: Immutable.fromJS({
+          notebook: {
+            cellMap: {},
+            cellOrder: []
+          }
+        })
+      }
+    };
+
+    const action$ = ActionsObservable.of(interruptKernel);
+
+    const responseActions = await interruptKernelEpic(action$, store)
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responseActions).toEqual([
+      {
+        type: "INTERRUPTED"
       }
     ]);
   });

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -1,6 +1,15 @@
 // @flow
 import { ActionsObservable } from "redux-observable";
 import { launchKernelByName, interruptKernel } from "../../src/actions";
+
+import {
+  makeAppRecord,
+  makeJupyterHostRecord,
+  makeRemoteKernelRecord,
+  makeDocumentRecord
+} from "@nteract/types/core/records";
+
+import { emptyNotebook } from "@nteract/commutable";
 import {
   launchWebSocketKernelEpic,
   interruptKernelEpic
@@ -19,29 +28,17 @@ describe("launchWebSocketKernelEpic", () => {
         return this.state;
       },
       state: {
-        app: {
-          host: {
+        app: makeAppRecord({
+          host: makeJupyterHostRecord({
             type: "jupyter",
             token: "eh",
             serverUrl: "http://localhost:8888/"
-          },
+          }),
           kernel: null,
           notificationSystem: { addNotification: jest.fn() }
-        },
+        }),
         document: Immutable.fromJS({
-          notebook: {
-            cellMap: {
-              first: {
-                source: "woo",
-                cell_type: "code"
-              },
-              second: {
-                source: "eh",
-                cell_type: "code"
-              }
-            },
-            cellOrder: ["first", "second"]
-          }
+          notebook: emptyNotebook
         })
       }
     };
@@ -73,25 +70,22 @@ describe("interruptKernelEpic", () => {
         return this.state;
       },
       state: {
-        app: {
-          host: {
+        app: makeAppRecord({
+          host: makeJupyterHostRecord({
             type: "jupyter",
             token: "eh",
             serverUrl: "http://localhost:8888/"
-          },
-          kernel: {
+          }),
+          kernel: makeRemoteKernelRecord({
             type: "websocket",
             channels: jest.fn(),
             kernelSpecName: "fancy",
             id: "0"
-          },
+          }),
           notificationSystem: { addNotification: jest.fn() }
-        },
-        document: Immutable.fromJS({
-          notebook: {
-            cellMap: {},
-            cellOrder: []
-          }
+        }),
+        document: makeDocumentRecord({
+          notebook: emptyNotebook
         })
       }
     };

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -377,7 +377,17 @@ export const START_SAVING = "START_SAVING";
 export type StartSavingAction = { type: "START_SAVING" };
 
 export const INTERRUPT_KERNEL = "INTERRUPT_KERNEL";
-export type InterruptKernelAction = { type: "INTERRUPT_KERNEL" };
+export type InterruptKernel = { type: "INTERRUPT_KERNEL" };
+
+export const INTERRUPT_KERNEL_SUCCESSFUL = "INTERRUPT_KERNEL_SUCCESSFUL";
+export type InterruptKernelSuccessful = { type: "INTERRUPT_KERNEL_SUCCESSFUL" };
+
+export const INTERRUPT_KERNEL_FAILED = "INTERRUPT_KERNEL_FAILED";
+export type InterruptKernelFailed = {
+  type: "INTERRUPT_KERNEL_FAILED",
+  payload: Error,
+  error: true
+};
 
 export const KILL_KERNEL = "KILL_KERNEL";
 export type KillKernelAction = { type: "KILL_KERNEL" };

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -75,7 +75,9 @@ import type {
   SetConfigAction,
   LaunchKernelAction,
   LaunchKernelByNameAction,
-  InterruptKernelAction,
+  InterruptKernel,
+  InterruptKernelSuccessful,
+  InterruptKernelFailed,
   KillKernelAction,
   // TODO: Needs an action creator
   StartSavingAction,
@@ -413,9 +415,25 @@ export const killKernel: KillKernelAction = {
   type: actionTypes.KILL_KERNEL
 };
 
-export const interruptKernel: InterruptKernelAction = {
-  type: actionTypes.INTERRUPT_KERNEL
-};
+export function interruptKernel(): InterruptKernel {
+  return {
+    type: actionTypes.INTERRUPT_KERNEL
+  };
+}
+
+export function interruptKernelSuccessful(): InterruptKernelSuccessful {
+  return {
+    type: actionTypes.INTERRUPT_KERNEL_SUCCESSFUL
+  };
+}
+
+export function interruptKernelFailed(error: Error): interruptKernelFailed {
+  return {
+    type: actionTypes.INTERRUPT_KERNEL_FAILED,
+    payload: error,
+    error: true
+  };
+}
 
 export function setNotificationSystem(
   notificationSystem: any

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -18,7 +18,8 @@ export const MENU_ITEM_ACTIONS = {
   MERGE_CELL_AFTER: "merge-cell-after",
   SET_THEME_DARK: "set-theme-dark",
   SET_THEME_LIGHT: "set-theme-light",
-  OPEN_ABOUT: "open-about"
+  OPEN_ABOUT: "open-about",
+  INTERRUPT_KERNEL: "interrupt-kernel"
 };
 
 // These are top-level-menu or sub-menu keys in case we need interim look-ups
@@ -32,5 +33,6 @@ export const MENUS = {
   CELL_CREATE_CELL: "cell-create-cell",
   VIEW: "view",
   VIEW_THEMES: "view-themes",
+  RUNTIME: "runtime",
   HELP: "help"
 };

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -34,7 +34,8 @@ type Props = {
   setCellTypeCode: ?(cellId: ?string) => void,
   setCellTypeMarkdown: ?(cellId: ?string) => void,
   setTheme: ?(theme: ?string) => void,
-  openAboutModal: ?() => void
+  openAboutModal: ?() => void,
+  interruptKernel: ?() => void
 };
 
 class PureNotebookMenu extends React.Component<Props> {
@@ -54,7 +55,8 @@ class PureNotebookMenu extends React.Component<Props> {
     setCellTypeCode: null,
     setCellTypeMarkdown: null,
     setTheme: null,
-    openAboutModal: null
+    openAboutModal: null,
+    interruptKernel: null
   };
   handleClick = ({ key }: { key: string }) => {
     const {
@@ -74,7 +76,8 @@ class PureNotebookMenu extends React.Component<Props> {
       pasteCell,
       setCellTypeCode,
       setCellTypeMarkdown,
-      setTheme
+      setTheme,
+      interruptKernel
     } = this.props;
     const [action, ...args] = parseActionKey(key);
     switch (action) {
@@ -156,6 +159,12 @@ class PureNotebookMenu extends React.Component<Props> {
           openAboutModal();
         }
         break;
+      case MENU_ITEM_ACTIONS.INTERRUPT_KERNEL:
+        if (interruptKernel) {
+          interruptKernel();
+        }
+        break;
+
       default:
         console.log(`unhandled action: ${action}`);
     }
@@ -249,6 +258,12 @@ class PureNotebookMenu extends React.Component<Props> {
               About
             </MenuItem>
           </SubMenu>
+
+          <SubMenu key={MENUS.RUNTIME} title="Runtime">
+            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.INTERRUPT_KERNEL)}>
+              Interrupt
+            </MenuItem>
+          </SubMenu>
         </Menu>
         <style global jsx>
           {localCss}
@@ -292,7 +307,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(actions.changeCellType(cellId, "markdown")),
   setTheme: theme => dispatch(actions.setTheme(theme)),
   openAboutModal: () =>
-    dispatch(actions.openModal({ modalType: MODAL_TYPES.ABOUT }))
+    dispatch(actions.openModal({ modalType: MODAL_TYPES.ABOUT })),
+  interruptKernel: () => dispatch(actions.interruptKernel)
 });
 
 const NotebookMenu = connect(mapStateToProps, mapDispatchToProps)(

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -308,7 +308,7 @@ const mapDispatchToProps = dispatch => ({
   setTheme: theme => dispatch(actions.setTheme(theme)),
   openAboutModal: () =>
     dispatch(actions.openModal({ modalType: MODAL_TYPES.ABOUT })),
-  interruptKernel: () => dispatch(actions.interruptKernel)
+  interruptKernel: () => dispatch(actions.interruptKernel())
 });
 
 const NotebookMenu = connect(mapStateToProps, mapDispatchToProps)(

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -1,7 +1,10 @@
 // @flow
 export { executeCellEpic, updateDisplayEpic } from "./execute";
 export { commListenEpic } from "./comm";
-export { launchWebSocketKernelEpic } from "./websocket-kernel";
+export {
+  launchWebSocketKernelEpic,
+  interruptKernelEpic
+} from "./websocket-kernel";
 
 export {
   acquireKernelInfoEpic,

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -5,6 +5,7 @@ import { ofType } from "redux-observable";
 import {
   catchError,
   map,
+  mapTo,
   mergeMap,
   switchMap,
   concatMap,
@@ -89,6 +90,8 @@ export const interruptKernelEpic = (action$: *, store: *) =>
       const serverConfig = getServerConfig(state);
       const id = state.app.kernel.id;
 
-      return kernels.interrupt(serverConfig, id).mapTo({ type: "INTERRUPTED" });
+      return kernels
+        .interrupt(serverConfig, id)
+        .pipe(mapTo({ type: "INTERRUPTED" }));
     })
   );


### PR DESCRIPTION
This introduces an interrupt epic for the jupyter extension as well as a menu entry for it. :tada: Runtime :tada: section of the menu!

![interrupt](https://user-images.githubusercontent.com/836375/35544087-72d0bd84-051d-11e8-87f5-59c82ec99c3c.gif)

In the style of Sir Winston Churchill, I opted for no interrupting while already interrupting by using `concatMap`.

* [x] epic for interrupting
* [x] menu for `Runtime`
  * [x] menu item for `Interrupt`
* [x] Tests for menu entry
* [x] Tests for interrupt epic