### PR TITLE
switch order to match more closely with jupyter

### DIFF
--- a/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
+++ b/packages/core/__tests__/components/__snapshots__/notebook-menu-spec.js.snap
@@ -77,34 +77,6 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
       <div
         aria-expanded={false}
         aria-haspopup="true"
-        aria-owns="cell$Menu"
-        className="rc-menu-submenu-title"
-        onBlur={undefined}
-        onClick={[Function]}
-        onContextMenu={undefined}
-        onFocus={undefined}
-        onMouseDown={undefined}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onTouchStart={undefined}
-        style={Object {}}
-        title="Cell"
-      >
-        Cell
-        <i
-          className="rc-menu-submenu-arrow"
-        />
-      </div>
-    </li>
-    <li
-      className="rc-menu-submenu rc-menu-submenu-horizontal"
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      style={undefined}
-    >
-      <div
-        aria-expanded={false}
-        aria-haspopup="true"
         aria-owns="view$Menu"
         className="rc-menu-submenu-title"
         onBlur={undefined}
@@ -133,7 +105,7 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
       <div
         aria-expanded={false}
         aria-haspopup="true"
-        aria-owns="help$Menu"
+        aria-owns="cell$Menu"
         className="rc-menu-submenu-title"
         onBlur={undefined}
         onClick={[Function]}
@@ -144,9 +116,9 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
         onMouseLeave={[Function]}
         onTouchStart={undefined}
         style={Object {}}
-        title="Help"
+        title="Cell"
       >
-        Help
+        Cell
         <i
           className="rc-menu-submenu-arrow"
         />
@@ -175,6 +147,34 @@ exports[`PureNotebookMenu  snapshots renders the default 1`] = `
         title="Runtime"
       >
         Runtime
+        <i
+          className="rc-menu-submenu-arrow"
+        />
+      </div>
+    </li>
+    <li
+      className="rc-menu-submenu rc-menu-submenu-horizontal"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      style={undefined}
+    >
+      <div
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-owns="help$Menu"
+        className="rc-menu-submenu-title"
+        onBlur={undefined}
+        onClick={[Function]}
+        onContextMenu={undefined}
+        onFocus={undefined}
+        onMouseDown={undefined}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={undefined}
+        style={Object {}}
+        title="Help"
+      >
+        Help
         <i
           className="rc-menu-submenu-arrow"
         />

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -216,6 +216,18 @@ class PureNotebookMenu extends React.Component<Props> {
               </MenuItem>
             </SubMenu>
           </SubMenu>
+          <SubMenu key={MENUS.VIEW} title="View">
+            <SubMenu key={MENUS.VIEW_THEMES} title="themes">
+              <MenuItem
+                key={createActionKey(MENU_ITEM_ACTIONS.SET_THEME_LIGHT)}
+              >
+                light
+              </MenuItem>
+              <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.SET_THEME_DARK)}>
+                dark
+              </MenuItem>
+            </SubMenu>
+          </SubMenu>
           <SubMenu key={MENUS.CELL} title="Cell">
             <MenuItem
               key={createActionKey(MENU_ITEM_ACTIONS.EXECUTE_ALL_CELLS)}
@@ -241,27 +253,16 @@ class PureNotebookMenu extends React.Component<Props> {
               </MenuItem>
             </SubMenu>
           </SubMenu>
-          <SubMenu key={MENUS.VIEW} title="View">
-            <SubMenu key={MENUS.VIEW_THEMES} title="themes">
-              <MenuItem
-                key={createActionKey(MENU_ITEM_ACTIONS.SET_THEME_LIGHT)}
-              >
-                light
-              </MenuItem>
-              <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.SET_THEME_DARK)}>
-                dark
-              </MenuItem>
-            </SubMenu>
-          </SubMenu>
-          <SubMenu key={MENUS.HELP} title="Help">
-            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.OPEN_ABOUT)}>
-              About
-            </MenuItem>
-          </SubMenu>
 
           <SubMenu key={MENUS.RUNTIME} title="Runtime">
             <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.INTERRUPT_KERNEL)}>
               Interrupt
+            </MenuItem>
+          </SubMenu>
+
+          <SubMenu key={MENUS.HELP} title="Help">
+            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.OPEN_ABOUT)}>
+              About
             </MenuItem>
           </SubMenu>
         </Menu>


### PR DESCRIPTION
Switch around the menu order to match what was outlined in  https://github.com/nteract/nteract/issues/2430

```
File  |  Edit  |  View  |  Cell  |  Runtime  |  Help
```

🍽
