### PR TITLE
move interrupt zeromq kernels logic to epic

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -8,7 +8,7 @@ import {
   launchKernelObservable,
   launchKernelEpic,
   launchKernelByNameEpic
-} from "../../../src/notebook/epics/kernel-launch";
+} from "../../../src/notebook/epics/zeromq-kernels";
 
 import { of } from "rxjs/observable/of";
 import { toArray, share } from "rxjs/operators";

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -6,7 +6,11 @@ import { loadEpic, newNotebookEpic } from "./loading";
 
 import type { ActionsObservable, Epic } from "redux-observable";
 
-import { launchKernelEpic, launchKernelByNameEpic } from "./kernel-launch";
+import {
+  launchKernelEpic,
+  launchKernelByNameEpic,
+  interruptKernelEpic
+} from "./zeromq-kernels";
 
 import {
   acquireKernelInfoEpic,
@@ -45,6 +49,7 @@ const epics = [
   updateDisplayEpic,
   launchKernelEpic,
   launchKernelByNameEpic,
+  interruptKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
   loadConfigEpic,

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -2,6 +2,7 @@
 
 import { Observable } from "rxjs/Observable";
 import { of } from "rxjs/observable/of";
+import { fromEvent } from "rxjs/observable/fromEvent";
 import { merge } from "rxjs/observable/merge";
 
 import {
@@ -12,7 +13,8 @@ import {
   catchError,
   first,
   pluck,
-  switchMap
+  switchMap,
+  concatMap
 } from "rxjs/operators";
 
 import { launchSpec } from "spawnteract";
@@ -36,11 +38,14 @@ import {
   setExecutionState,
   setNotebookKernelInfo,
   launchKernelSuccessful,
+  interruptKernelSuccessful,
+  interruptKernelFailed,
   launchKernel,
   setLanguageInfo
 } from "@nteract/core/actions";
 
 import {
+  INTERRUPT_KERNEL,
   LAUNCH_KERNEL_SUCCESSFUL,
   LAUNCH_KERNEL,
   LAUNCH_KERNEL_BY_NAME,
@@ -163,4 +168,53 @@ export const launchKernelEpic = (action$: ActionsObservable<*>) =>
         source
       )
     )
+  );
+
+export const interruptKernelEpic = (action$: *, store: *) =>
+  action$.pipe(
+    ofType(INTERRUPT_KERNEL),
+    filter(() => {
+      const state = store.getState();
+      const host = state.app.host;
+      const kernel = state.app.kernel;
+
+      // This epic can only interrupt direct zeromq connected kernels
+      return (
+        host &&
+        kernel &&
+        host.type === "local" &&
+        kernel.type === "zeromq" &&
+        kernel.spawn
+      );
+    }),
+    // If the user fires off _more_ interrupts, we shouldn't interrupt the in-flight
+    // interrupt, instead doing it after the last one happens
+    concatMap(() => {
+      const state = store.getState();
+      const kernel = state.app.kernel;
+
+      const spawn = kernel.spawn;
+
+      //
+      // From the node.js docs
+      //
+      // > The ChildProcess object may emit an 'error' event if the signal cannot be delivered.
+      //
+      // We have other error handling (above) in the kernel launch epic for the spawn
+      // We probably want to route errors to actions from that handling, in which case we
+      // will unconditionally say that it was successful (we have no other indication)
+      //
+      spawn.kill("SIGINT");
+
+      return merge(
+        of(interruptKernelSuccessful())
+        // Since the error handling for spawn is registered upon launch, we'll
+        // not register some event handling
+        /*fromEvent(spawn, "error").pipe(
+          map(error => interruptKernelFailed(error))
+        )*/
+        // TODO: Consider requesting kernel status and expecting a response
+        //       within some amount of time
+      );
+    })
   );

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -15,12 +15,8 @@ import {
 import type {
   NewKernelAction,
   SetGithubTokenAction,
-  SetExecutionStateAction,
   ExitAction,
-  StartSavingAction,
-  InterruptKernelAction,
   KillKernelAction,
-  DoneSavingAction,
   DoneSavingConfigAction
 } from "@nteract/core/actionTypes";
 
@@ -41,16 +37,6 @@ function exit(state: AppRecord) {
   return cleanupKernel(state);
 }
 
-function interruptKernel(state: AppRecord) {
-  // TODO: This should be an epic instead
-  if (state.kernel.type === "zeromq") {
-    state.kernel.spawn.kill("SIGINT");
-  } else {
-    console.log("cant interrupt non-zeromq kernels currently");
-  }
-  return state;
-}
-
 function setGithubToken(state: AppRecord, action: SetGithubTokenAction) {
   const { githubToken } = action;
   return state.set("githubToken", githubToken);
@@ -59,12 +45,8 @@ function setGithubToken(state: AppRecord, action: SetGithubTokenAction) {
 type AppAction =
   | NewKernelAction
   | SetGithubTokenAction
-  | SetExecutionStateAction
   | ExitAction
-  | StartSavingAction
-  | InterruptKernelAction
-  | KillKernelAction
-  | DoneSavingAction;
+  | KillKernelAction;
 
 export default function handleApp(
   state: AppRecord = makeAppRecord({
@@ -83,8 +65,6 @@ export default function handleApp(
       return exit(state);
     case "KILL_KERNEL":
       return cleanupKernel(state);
-    case "INTERRUPT_KERNEL":
-      return interruptKernel(state);
     case "SET_GITHUB_TOKEN":
       return setGithubToken(state, action);
     default:

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -5,7 +5,6 @@ import { ofType } from "redux-observable";
 import {
   catchError,
   map,
-  mapTo,
   mergeMap,
   switchMap,
   concatMap,
@@ -23,7 +22,7 @@ import {
 
 import type { AppState, RemoteKernelProps } from "@nteract/types/core/records";
 
-import { kernels, shutdown, kernelspecs } from "rx-jupyter";
+import { kernels, shutdown } from "rx-jupyter";
 import { v4 as uuid } from "uuid";
 
 import { getServerConfig } from "../selectors";

--- a/packages/enchannel-zmq-backend/__tests__/index_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/index_spec.js
@@ -1,6 +1,5 @@
 import uuidv4 from "uuid/v4";
 import { Subject } from "rxjs/Subject";
-import { fromEvent } from "rxjs/observable/fromEvent";
 
 const EventEmitter = require("events");
 


### PR DESCRIPTION
Handles part of #2461.

This does some cleanup of desktop's app reducer to bring the epic structure inline with the web app based version. After this I'll handle the launch kernel cleanup + shutdown logic.