### PR TITLE
switch from language ➡️ runtime, decrease wordiness

### DIFF
--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -568,20 +568,20 @@ export function loadFullMenu(store = global.store) {
   };
 
   const languageMenu = {
-    label: "&Language",
+    label: "&Runtime",
     submenu: [
       {
-        label: "&Kill Running Kernel",
+        label: "&Kill",
         enabled: BrowserWindow.getAllWindows().length > 0,
         click: createSender("menu:kill-kernel")
       },
       {
-        label: "&Interrupt Running Kernel",
+        label: "&Interrupt",
         enabled: BrowserWindow.getAllWindows().length > 0,
         click: createSender("menu:interrupt-kernel")
       },
       {
-        label: "Restart Running Kernel",
+        label: "Restart",
         enabled: BrowserWindow.getAllWindows().length > 0,
         click: createSender("menu:restart-kernel")
       },


### PR DESCRIPTION
Just like in the jupyter extension, I want to use the word "runtime" instead of language to alleviate confusion vs. spoken language. I also removed traces of "kernel" in the same menu.