### PR TITLE
flowtype core

### DIFF
--- a/packages/core/src/components/modal-controller/constants.js
+++ b/packages/core/src/components/modal-controller/constants.js
@@ -1,3 +1,4 @@
+// @flow
 export const MODAL_TYPES = {
   ABOUT: "core/about-modal"
 };

--- a/packages/core/src/components/modal-controller/index.js
+++ b/packages/core/src/components/modal-controller/index.js
@@ -1,9 +1,10 @@
+// @flow
 import * as React from "react";
 import { MODAL_TYPES } from "./constants";
 import AboutModal from "./about-modal";
 import { connect } from "react-redux";
 
-class ModalController extends React.Component {
+class ModalController extends React.Component<*, *> {
   getModal = () => {
     const { modalType } = this.props;
     switch (modalType) {
@@ -19,7 +20,9 @@ class ModalController extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
+import type { MapStateToProps } from "react-redux";
+
+const mapStateToProps: MapStateToProps<*, *, *> = (state: *) => ({
   modalType: state.modals.modalType
 });
 

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -1,3 +1,4 @@
+// @flow
 // Note, we can reuse keys, but all paths need to be unique in the menu.
 
 // These actions map to a case in a switch handler. They are meant to cause a

--- a/packages/core/src/dummy/dummy-nb.js
+++ b/packages/core/src/dummy/dummy-nb.js
@@ -1,3 +1,4 @@
+// @flow
 /* eslint-disable no-multi-str */
 import { fromJS } from "@nteract/commutable";
 

--- a/packages/core/src/dummy/index.js
+++ b/packages/core/src/dummy/index.js
@@ -1,5 +1,5 @@
-/* eslint-disable no-plusplus */
 // @flow
+/* eslint-disable no-plusplus */
 
 import * as Immutable from "immutable";
 

--- a/packages/core/src/reducers/kernelspecs.js
+++ b/packages/core/src/reducers/kernelspecs.js
@@ -1,3 +1,4 @@
+// @flow
 import {
   makeCommunicationKernelspecs,
   makeKernelspec

--- a/packages/core/src/reducers/modals.js
+++ b/packages/core/src/reducers/modals.js
@@ -1,3 +1,4 @@
+// @flow
 import * as actionTypes from "../actionTypes";
 import { combineReducers } from "redux-immutable";
 import * as Immutable from "immutable";

--- a/packages/core/src/themes/dark.js
+++ b/packages/core/src/themes/dark.js
@@ -1,3 +1,4 @@
+// @flow
 module.exports = `
   --main-bg-color: #2b2b2b;
   --main-fg-color: #ccc;

--- a/packages/core/src/themes/index.js
+++ b/packages/core/src/themes/index.js
@@ -1,3 +1,4 @@
+// @flow
 // ES5, skipping compile step
 const dark = require("./dark");
 const light = require("./light");

--- a/packages/core/src/themes/light.js
+++ b/packages/core/src/themes/light.js
@@ -1,3 +1,4 @@
+// @flow
 module.exports = `
   --main-bg-color: white;
   --main-fg-color: rgb(51, 51, 51);

--- a/packages/core/src/themes/syntax-highlighting.js
+++ b/packages/core/src/themes/syntax-highlighting.js
@@ -1,3 +1,4 @@
+// @flow
 module.exports = {
   hljs: {
     display: "block",


### PR DESCRIPTION
Solidifying the base. Don't be too fooled though, our actual flow coverage is pretty low still here due to `*` and a lack of proper `state` types (see #2408).