### PR TITLE
enforce install:app-deps prior to spawn

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -23,8 +23,9 @@
   "scripts": {
     "clean": "rimraf lib dist",
     "install:app-deps": "electron-builder install-app-deps",
-    "prestart": "npm run install:app-deps && npm run build",
+    "prestart": "npm run build",
     "start": "npm run spawn",
+    "prespawn": "npm run install:app-deps",
     "spawn": "cross-env NODE_ENV=development electron .",
     "spawn:debug": "cross-env DEBUG=true NODE_ENV=development electron .",
     "prebuild": "rimraf lib",


### PR DESCRIPTION
I've gotten myself tripped up with this a few times while running `npm run build:desktop:watch` in one tab and `npm run spawn` in another. It's not too big a deal to rebuild each time since we're basically just swapping the binary dependency (takes less than a second).