### PR TITLE
pin to an exact electron version

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -128,7 +128,7 @@
     "commonmark-react-renderer": "^4.3.3",
     "cross-env": "^5.1.3",
     "date-fns": "^1.29.0",
-    "electron": "^1.7.10",
+    "electron": "1.7.10",
     "electron-builder": "^20.0.0",
     "electron-context-menu": "^0.9.1",
     "electron-log": "^2.2.13",


### PR DESCRIPTION
The `1.8.x` releases just came out for electron and they're currently not working with our `install-app-deps` step, so something has to be fixed up _somewhere_. For the sake of `master` allowing launch, I'm just pinning this for now.

/cc @lgeiger 