### PR TITLE
Small css improvements for Jupyter extension.

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.js
@@ -56,6 +56,7 @@ function createApp(jupyterConfigData: JupyterConfigData) {
                 color: var(--theme-app-fg);
                 /* All the old theme setups declared this, putting it back for consistency */
                 line-height: 1.3 !important;
+                margin: 0;
               }
 
               #app {

--- a/packages/core/src/components/notebook-menu/styles.js
+++ b/packages/core/src/components/notebook-menu/styles.js
@@ -9,8 +9,7 @@ export const localCss = css`
     padding-left: 0;
     list-style: none;
     border: 1px solid var(--theme-app-border);
-    box-shadow: var(--theme-menu-shadow);
-    border-radius: 3px;
+    box-shadow: none;
     color: var(--theme-menu-fg);
   }
   .rc-menu-hidden {
@@ -103,6 +102,7 @@ export const localCss = css`
     border: none;
     border-bottom: 1px solid var(--theme-app-border);
     box-shadow: none;
+    padding: 3px;
   }
   .rc-menu-horizontal > .rc-menu-item,
   .rc-menu-horizontal > .rc-menu-submenu > .rc-menu-submenu-title {


### PR DESCRIPTION
At some point I need to figure out how to get those little gaps next to the absolutely-positioned sub-menu items to disappear. Not going to mess with it right now. This just:

1. removes the `body` margin so that the menu extends across the whole page
2. removes box-shadow from the menu (I don't think it's super helpful)
3. removes radius from menu items (i think the blockier style looks better)

<img width="1515" alt="screen shot 2018-02-07 at 12 01 24 am" src="https://user-images.githubusercontent.com/6611546/35904976-122d0edc-0b9a-11e8-9173-aa093f6097a6.png">
