### PR TITLE
return observable of execution state

### DIFF
--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -287,7 +287,7 @@ function killKernel(kernel): Observable<Action> {
         // Pass on our intermediate action
         of(action),
         // Inform about the state
-        setExecutionState("shutting down"),
+        of(setExecutionState("shutting down")),
         // and our connection file deletion
         del$
       );


### PR DESCRIPTION
Fixes #2486.

Definitely shows how a last minute refactor can be problematic and how kernel killing shouldn't affect the "next" kernel in line.