### PR TITLE
build all apps with build:apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "npm run build:packages",
-    "build:apps": "lerna run build --scope nteract --scope @nteract/play --scope @nteract/commuter --scope @nteract/notebook-on-next --parallel --stream",
+    "build:apps": "lerna run build --scope nteract --scope @nteract/play --scope @nteract/commuter --scope @nteract/commuter-frontend --scope @nteract/notebook-on-next --scope nteract-on-jupyter --parallel --stream",
     "build:desktop": "lerna run build --scope nteract --stream",
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "lerna run build --parallel --ignore @nteract/play --ignore @nteract/showcase --ignore nteract --ignore @nteract/commuter-frontend --ignore @nteract/notebook-on-next --ignore nteract-on-jupyter",


### PR DESCRIPTION
This adds on the jupyter extension and the commuter frontend to our `build:apps` command.