### PR TITLE
Return block math if inline.js finds double $

### DIFF
--- a/packages/markdown/__tests__/remark-math-spec.js
+++ b/packages/markdown/__tests__/remark-math-spec.js
@@ -7,7 +7,9 @@ const u = require("unist-builder");
 
 function remark() {
   return unified()
-    .use(parse, { position: false })
+    .use(parse, {
+      position: false
+    })
     .use(stringify);
 }
 
@@ -211,7 +213,7 @@ describe("remark-math", () => {
   it("must not set inlineMathDouble class", () => {
     const processor = remark().use(math);
 
-    const targetText = ["$$\\alpha$$"].join("\n");
+    const targetText = "$$\\alpha$$";
 
     const ast = processor.parse(targetText);
 
@@ -225,7 +227,7 @@ describe("remark-math", () => {
                 hChildren: [u("text", "\\alpha")],
                 hName: "div",
                 hProperties: {
-                  className: "math inlineMathDouble"
+                  className: "math"
                 }
               }
             },
@@ -241,13 +243,14 @@ describe("remark-math", () => {
       inlineMathDouble: true
     });
 
-    const targetText = ["$$\\alpha$$"].join("\n");
+    const targetText = "hello $$\\alpha$$ world";
 
     const ast = processor.parse(targetText);
 
     expect(ast).toEqual(
       u("root", [
         u("paragraph", [
+          u("text", "hello "),
           u(
             "math",
             {
@@ -260,9 +263,78 @@ describe("remark-math", () => {
               }
             },
             "\\alpha"
-          )
+          ),
+          u("text", " world")
         ])
       ])
     );
   });
+});
+
+it("must parse more complex math equations in math block", () => {
+  const processor = remark().use(math);
+
+  const targetText =
+    "$$p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)$$";
+
+  const ast = processor.parse(targetText);
+
+  expect(ast).toEqual(
+    u("root", [
+      u("paragraph", [
+        u(
+          "math",
+          {
+            data: {
+              hChildren: [
+                u(
+                  "text",
+                  "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+                )
+              ],
+              hName: "div",
+              hProperties: {
+                className: "math"
+              }
+            }
+          },
+          "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+        )
+      ])
+    ])
+  );
+});
+
+it("must parse more complex math equations inline math", () => {
+  const processor = remark().use(math);
+
+  const targetText =
+    "$p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)$";
+
+  const ast = processor.parse(targetText);
+
+  expect(ast).toEqual(
+    u("root", [
+      u("paragraph", [
+        u(
+          "inlineMath",
+          {
+            data: {
+              hChildren: [
+                u(
+                  "text",
+                  "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+                )
+              ],
+              hName: "span",
+              hProperties: {
+                className: "inlineMath"
+              }
+            }
+          },
+          "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+        )
+      ])
+    ])
+  );
 });

--- a/packages/markdown/__tests__/remark-math-spec.js
+++ b/packages/markdown/__tests__/remark-math-spec.js
@@ -148,7 +148,7 @@ describe("remark-math", () => {
     const ast = processor.parse(targetText);
 
     expect(ast).toMatchObject(
-      u("root", [u("paragraph", [u("inlineMath", "\\alpha")])])
+      u("root", [u("paragraph", [u("math", "\\alpha")])])
     );
   });
 
@@ -160,7 +160,7 @@ describe("remark-math", () => {
     const result = processor.processSync(targetText).toString();
 
     expect(result).toEqual(
-      ["$\\alpha$", "", "$$", "\\alpha\\beta", "$$", ""].join("\n")
+      ["$$\n\\alpha\n$$", "", "$$", "\\alpha\\beta", "$$", ""].join("\n")
     );
   });
 
@@ -219,13 +219,13 @@ describe("remark-math", () => {
       u("root", [
         u("paragraph", [
           u(
-            "inlineMath",
+            "math",
             {
               data: {
                 hChildren: [u("text", "\\alpha")],
-                hName: "span",
+                hName: "div",
                 hProperties: {
-                  className: "inlineMath"
+                  className: "math inlineMathDouble"
                 }
               }
             },
@@ -249,13 +249,13 @@ describe("remark-math", () => {
       u("root", [
         u("paragraph", [
           u(
-            "inlineMath",
+            "math",
             {
               data: {
                 hChildren: [u("text", "\\alpha")],
-                hName: "span",
+                hName: "div",
                 hProperties: {
-                  className: "inlineMath inlineMathDouble"
+                  className: "math inlineMathDouble"
                 }
               }
             },

--- a/packages/markdown/__tests__/remark-math-spec.js
+++ b/packages/markdown/__tests__/remark-math-spec.js
@@ -238,103 +238,103 @@ describe("remark-math", () => {
     );
   });
 
-  it("must set inlineMathDouble class if inlineMathDouble is true", () => {
-    const processor = remark().use(math, {
-      inlineMathDouble: true
-    });
+  // it("must set inlineMathDouble class if inlineMathDouble is true", () => {
+  //   const processor = remark().use(math, {
+  //     inlineMathDouble: true
+  //   });
 
-    const targetText = "hello $$\\alpha$$ world";
+  //   const targetText = "hello $$\\alpha$$ world";
+
+  //   const ast = processor.parse(targetText);
+
+  //   expect(ast).toEqual(
+  //     u("root", [
+  //       u("paragraph", [
+  //         u("text", "hello "),
+  //         u(
+  //           "math",
+  //           {
+  //             data: {
+  //               hChildren: [u("text", "\\alpha")],
+  //               hName: "div",
+  //               hProperties: {
+  //                 className: "math inlineMathDouble"
+  //               }
+  //             }
+  //           },
+  //           "\\alpha"
+  //         ),
+  //         u("text", " world")
+  //       ])
+  //     ])
+  //   );
+  // });
+
+  it("must parse more complex math equations in math block", () => {
+    const processor = remark().use(math);
+
+    const targetText =
+      "$$p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)$$";
 
     const ast = processor.parse(targetText);
 
     expect(ast).toEqual(
       u("root", [
         u("paragraph", [
-          u("text", "hello "),
           u(
             "math",
             {
               data: {
-                hChildren: [u("text", "\\alpha")],
+                hChildren: [
+                  u(
+                    "text",
+                    "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+                  )
+                ],
                 hName: "div",
                 hProperties: {
-                  className: "math inlineMathDouble"
+                  className: "math"
                 }
               }
             },
-            "\\alpha"
-          ),
-          u("text", " world")
+            "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+          )
         ])
       ])
     );
   });
-});
 
-it("must parse more complex math equations in math block", () => {
-  const processor = remark().use(math);
+  it("must parse more complex math equations inline math", () => {
+    const processor = remark().use(math);
 
-  const targetText =
-    "$$p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)$$";
+    const targetText =
+      "$p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)$";
 
-  const ast = processor.parse(targetText);
+    const ast = processor.parse(targetText);
 
-  expect(ast).toEqual(
-    u("root", [
-      u("paragraph", [
-        u(
-          "math",
-          {
-            data: {
-              hChildren: [
-                u(
-                  "text",
-                  "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
-                )
-              ],
-              hName: "div",
-              hProperties: {
-                className: "math"
+    expect(ast).toEqual(
+      u("root", [
+        u("paragraph", [
+          u(
+            "inlineMath",
+            {
+              data: {
+                hChildren: [
+                  u(
+                    "text",
+                    "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+                  )
+                ],
+                hName: "span",
+                hProperties: {
+                  className: "inlineMath"
+                }
               }
-            }
-          },
-          "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
-        )
+            },
+            "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
+          )
+        ])
       ])
-    ])
-  );
-});
-
-it("must parse more complex math equations inline math", () => {
-  const processor = remark().use(math);
-
-  const targetText =
-    "$p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)$";
-
-  const ast = processor.parse(targetText);
-
-  expect(ast).toEqual(
-    u("root", [
-      u("paragraph", [
-        u(
-          "inlineMath",
-          {
-            data: {
-              hChildren: [
-                u(
-                  "text",
-                  "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
-                )
-              ],
-              hName: "span",
-              hProperties: {
-                className: "inlineMath"
-              }
-            }
-          },
-          "p(\\theta_i \\thinspace | \\, \\{\\theta_{j \\neq i}\\}, D)"
-        )
-      ])
-    ])
-  );
+    );
+  });
 });

--- a/packages/markdown/src/remark-math/inline.js
+++ b/packages/markdown/src/remark-math/inline.js
@@ -61,8 +61,7 @@ module.exports = function inlinePlugin(opts: Object) {
           data: {
             hName: "div",
             hProperties: {
-              className:
-                "math" + (opts.inlineMathDouble ? " inlineMathDouble" : "")
+              className: "math"
             },
             hChildren: [
               {
@@ -80,9 +79,7 @@ module.exports = function inlinePlugin(opts: Object) {
         data: {
           hName: "span",
           hProperties: {
-            className:
-              "inlineMath" +
-              (isDouble && opts.inlineMathDouble ? " inlineMathDouble" : "")
+            className: "inlineMath"
           },
           hChildren: [
             {

--- a/packages/markdown/src/remark-math/inline.js
+++ b/packages/markdown/src/remark-math/inline.js
@@ -61,7 +61,8 @@ module.exports = function inlinePlugin(opts: Object) {
           data: {
             hName: "div",
             hProperties: {
-              className: "math inlineMathDouble"
+              className:
+                "math" + (opts.inlineMathDouble ? " inlineMathDouble" : "")
             },
             hChildren: [
               {

--- a/packages/markdown/src/remark-math/inline.js
+++ b/packages/markdown/src/remark-math/inline.js
@@ -54,6 +54,25 @@ module.exports = function inlinePlugin(opts: Object) {
 
       const trimmedContent = match[1].trim();
 
+      if (isDouble) {
+        return eat(match[0])({
+          type: "math",
+          value: trimmedContent,
+          data: {
+            hName: "div",
+            hProperties: {
+              className: "math"
+            },
+            hChildren: [
+              {
+                type: "text",
+                value: trimmedContent
+              }
+            ]
+          }
+        });
+      }
+
       return eat(match[0])({
         type: "inlineMath",
         value: trimmedContent,

--- a/packages/markdown/src/remark-math/inline.js
+++ b/packages/markdown/src/remark-math/inline.js
@@ -61,7 +61,7 @@ module.exports = function inlinePlugin(opts: Object) {
           data: {
             hName: "div",
             hProperties: {
-              className: "math"
+              className: "math inlineMathDouble"
             },
             hChildren: [
               {


### PR DESCRIPTION
The remark `inline.js` was finding `$$` without a new line and returning an inline math. Both `$$...$$` and `$$\n...\n$$` should return the same thing. This fixes the issue so that they both return a block math div.

* Added a check to see if it found `$$` and returned the block math instead of inline.
* Updated tests to match the changes to `inline.js`