### PR TITLE
More selectors

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/github-publish-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/github-publish-spec.js
@@ -1,6 +1,6 @@
 import { ActionsObservable } from "redux-observable";
 
-import { dummyStore, dummyCommutable } from "@nteract/core/dummy";
+import { dummy, dummyStore, dummyCommutable } from "@nteract/core/dummy";
 
 import { toArray } from "rxjs/operators";
 
@@ -54,7 +54,9 @@ describe("publishNotebookObservable", () => {
     const notificationSystem = createNotificationSystem();
     const publishNotebookObs = publishNotebookObservable(
       GitHub(),
-      dummyCommutable,
+      dummy,
+      "fake-github-username",
+      "fake-gist-id",
       "./test.ipynb",
       notificationSystem,
       false,
@@ -68,7 +70,9 @@ describe("publishNotebookObservable", () => {
     const notificationSystem = createNotificationSystem();
     const publishNotebookObs = publishNotebookObservable(
       GitHub(),
-      dummyCommutable,
+      dummy,
+      "fake-github-username",
+      "fake-gist-id",
       "./test.ipynb",
       notificationSystem,
       false,
@@ -88,7 +92,9 @@ describe("publishNotebookObservable", () => {
     const notificationSystem = createNotificationSystem();
     const publishNotebookObs = publishNotebookObservable(
       github,
-      dummyCommutable,
+      dummy,
+      "fake-github-username",
+      "fake-gist-id",
       "./test.ipynb",
       notificationSystem,
       false,
@@ -103,11 +109,12 @@ describe("publishNotebookObservable", () => {
   test("edits gist that is already made", done => {
     const github = GitHub();
     const store = dummyStore();
-    const notebook = dummyCommutable.setIn(["metadata", "gist_id"], "ID123");
     const notificationSystem = createNotificationSystem();
     const publishNotebookObs = publishNotebookObservable(
       github,
-      notebook,
+      dummy,
+      "fake-github-username",
+      "fake-gist-id",
       "./test.ipynb",
       notificationSystem,
       true,
@@ -140,7 +147,9 @@ describe("createGistCallback", () => {
     const notificationSystem = createNotificationSystem();
     const publishNotebookObs = publishNotebookObservable(
       github,
-      dummyCommutable,
+      dummy,
+      "fake-github-username",
+      "fake-gist-id",
       "./test.ipynb",
       notificationSystem,
       false,

--- a/applications/desktop/src/notebook/epics/config.js
+++ b/applications/desktop/src/notebook/epics/config.js
@@ -9,6 +9,7 @@ import {
 
 import { doneSavingConfig, configLoaded } from "@nteract/core/actions";
 
+import * as selectors from "@nteract/core/selectors";
 import { readFileObservable, writeFileObservable } from "fs-observable";
 import { mapTo, mergeMap, map, switchMap } from "rxjs/operators";
 import { ofType } from "redux-observable";
@@ -59,7 +60,7 @@ export const saveConfigEpic = (actions: ActionsObservable<*>, store: any) =>
     mergeMap(() =>
       writeFileObservable(
         CONFIG_FILE_PATH,
-        JSON.stringify(store.getState().config.toJS())
+        JSON.stringify(selectors.userPreferences(store.getState()))
       ).pipe(map(doneSavingConfig))
     )
   );

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -6,6 +6,7 @@ import {
 } from "redux-observable"; /* eslint-disable no-unused-vars */
 import { writeFileObservable } from "fs-observable";
 import { SAVE, SAVE_AS } from "@nteract/core/actionTypes";
+import * as selectors from "@nteract/core/selectors";
 
 import { changeFilename, save, doneSaving } from "@nteract/core/actions";
 
@@ -27,19 +28,15 @@ export function saveEpic(
     ofType(SAVE),
     mergeMap(action => {
       const state = store.getState();
+      const currentNotebook = selectors.currentNotebook(state);
+      const filename = selectors.currentFilename(state);
+      // TODO: this default version should probably not be here.
+      const appVersion = selectors.appVersion(state) || "0.0.0-beta";
       const notebook = stringifyNotebook(
         toJS(
-          state.document
-            .get("notebook")
-            .setIn(
-              ["metadata", "nteract", "version"],
-              state.app.get("version", "0.0.0-beta")
-            )
+          currentNotebook.setIn(["metadata", "nteract", "version"], appVersion)
         )
       );
-
-      const filename = state.document.get("filename");
-
       return writeFileObservable(filename, notebook).pipe(
         map(() => {
           if (process.platform !== "darwin") {
@@ -70,16 +67,10 @@ export function saveEpic(
  *
  * @param  {ActionObservable}  action$ The SAVE_AS action with the filename and notebook
  */
-export function saveAsEpic(
-  action$: ActionsObservable<*>,
-  store: Store<any, any>
-) {
+export function saveAsEpic(action$: ActionsObservable<*>) {
   return action$.pipe(
     ofType(SAVE_AS),
     mergeMap(action => {
-      const state = store.getState();
-      const notebook = state.document.get("notebook");
-
       return [
         // order matters here, since we need the filename set in the state
         // before we save the document

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -181,7 +181,7 @@ export const launchKernelEpic = (
     // We must kill the previous kernel now
     // Then launch the next one
     switchMap(action => {
-      const kernel = selectors.getCurrentKernel(store.getState());
+      const kernel = selectors.currentKernel(store.getState());
 
       return merge(
         launchKernelObservable(action.kernelSpec, action.cwd),
@@ -202,7 +202,7 @@ export const interruptKernelEpic = (action$: *, store: *): Observable<Action> =>
     // If the user fires off _more_ interrupts, we shouldn't interrupt the in-flight
     // interrupt, instead doing it after the last one happens
     concatMap(() => {
-      const kernel = selectors.getCurrentKernel(store.getState());
+      const kernel = selectors.currentKernel(store.getState());
 
       const spawn = kernel.spawn;
 
@@ -305,7 +305,7 @@ export const killKernelEpic = (action$: *, store: *): Observable<Action> =>
     // This epic can only interrupt direct zeromq connected kernels
     filter(() => selectors.isCurrentKernelZeroMQ(store.getState())),
     concatMap(action => {
-      const kernel = selectors.getCurrentKernel(store.getState());
+      const kernel = selectors.currentKernel(store.getState());
       return killKernel(kernel);
     })
   );

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -43,11 +43,7 @@ import type { NewKernelAction } from "@nteract/core/actionTypes";
 
 import type { KernelInfo, LocalKernelProps } from "@nteract/types/core/records";
 
-import {
-  getCurrentKernel,
-  getCurrentHost,
-  isCurrentKernelZeroMQ
-} from "@nteract/core/selectors";
+import * as selectors from "@nteract/core/selectors";
 
 import {
   createMessage,
@@ -185,7 +181,7 @@ export const launchKernelEpic = (
     // We must kill the previous kernel now
     // Then launch the next one
     switchMap(action => {
-      const kernel = getCurrentKernel(store.getState());
+      const kernel = selectors.getCurrentKernel(store.getState());
 
       return merge(
         launchKernelObservable(action.kernelSpec, action.cwd),
@@ -202,11 +198,11 @@ export const interruptKernelEpic = (action$: *, store: *): Observable<Action> =>
   action$.pipe(
     ofType(INTERRUPT_KERNEL),
     // This epic can only interrupt direct zeromq connected kernels
-    filter(() => isCurrentKernelZeroMQ(store.getState())),
+    filter(() => selectors.isCurrentKernelZeroMQ(store.getState())),
     // If the user fires off _more_ interrupts, we shouldn't interrupt the in-flight
     // interrupt, instead doing it after the last one happens
     concatMap(() => {
-      const kernel = getCurrentKernel(store.getState());
+      const kernel = selectors.getCurrentKernel(store.getState());
 
       const spawn = kernel.spawn;
 
@@ -307,9 +303,9 @@ export const killKernelEpic = (action$: *, store: *): Observable<Action> =>
   action$.pipe(
     ofType(KILL_KERNEL),
     // This epic can only interrupt direct zeromq connected kernels
-    filter(() => isCurrentKernelZeroMQ(store.getState())),
+    filter(() => selectors.isCurrentKernelZeroMQ(store.getState())),
     concatMap(action => {
-      const kernel = getCurrentKernel(store.getState());
+      const kernel = selectors.getCurrentKernel(store.getState());
       return killKernel(kernel);
     })
   );

--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -5,15 +5,14 @@ import type { AppState } from "@nteract/types/core/records";
 
 import { dialog } from "electron";
 import { is } from "immutable";
+import * as selectors from "@nteract/core/selectors";
 
 import { killKernelImmediately } from "./epics/zeromq-kernels";
 
 import type { Action } from "@nteract/types/redux";
 
 export function unload(store: Store<AppState, Action>) {
-  const state = store.getState();
-
-  const kernel = state.app.kernel;
+  const kernel = selectors.currentKernel(store.getState());
   if (kernel) {
     killKernelImmediately(kernel);
   }
@@ -23,8 +22,8 @@ export function unload(store: Store<AppState, Action>) {
 export function beforeUnload(store: Store<AppState, Action>, e: any) {
   const state = store.getState();
   const saved = is(
-    state.document.get("notebook"),
-    state.document.get("savedNotebook")
+    selectors.currentNotebook(state),
+    selectors.currentSavedNotebook(state)
   );
   if (!saved) {
     // Will prevent closing "will-prevent-unload"

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -8,10 +8,6 @@ import * as fs from "fs";
 
 import { throttle } from "lodash";
 
-import { load, newNotebook } from "@nteract/core/actions";
-
-import { loadConfig } from "@nteract/core/actions";
-
 import {
   toggleCellInputVisibility,
   clearOutputs,
@@ -23,6 +19,9 @@ import {
   killKernel,
   launchKernel,
   launchKernelByName,
+  load,
+  loadConfig,
+  newNotebook,
   pasteCell,
   save,
   saveAs,

--- a/packages/core/src/components/modal-controller/about-modal.js
+++ b/packages/core/src/components/modal-controller/about-modal.js
@@ -11,6 +11,7 @@ import React from "react";
 import { modalCss } from "./styles";
 import { connect } from "react-redux";
 import * as actions from "../../actions";
+import * as selectors from "../../selectors";
 
 type Props = {
   appVersion?: string,
@@ -77,8 +78,8 @@ class PureAboutModal extends React.Component<Props> {
 }
 
 const mapStateToProps = state => ({
-  appVersion: state.app.version,
-  hostType: state.app.host.type
+  appVersion: selectors.appVersion(state),
+  hostType: selectors.currentHostType(state)
 });
 
 const mapDispatchToProps = {

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -44,7 +44,7 @@ export function fetchContentEpic(
       }
     }),
     switchMap((action: FetchContent) => {
-      const serverConfig = selectors.getServerConfig(store.getState());
+      const serverConfig = selectors.serverConfig(store.getState());
 
       return contents
         .get(serverConfig, action.payload.path, action.payload.params)
@@ -89,7 +89,7 @@ export function saveContentEpic(
           .setIn(["metadata", "nteract", "version"], version)
       );
 
-      const serverConfig = selectors.getServerConfig(state);
+      const serverConfig = selectors.serverConfig(state);
 
       const model = {
         content: notebook,

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -21,7 +21,7 @@ import {
 
 import { FETCH_CONTENT_FULFILLED } from "../actionTypes";
 
-import { getServerConfig } from "../selectors";
+import * as selectors from "../selectors";
 
 import type { ActionsObservable } from "redux-observable";
 
@@ -44,7 +44,7 @@ export function fetchContentEpic(
       }
     }),
     switchMap((action: FetchContent) => {
-      const serverConfig = getServerConfig(store.getState());
+      const serverConfig = selectors.getServerConfig(store.getState());
 
       return contents
         .get(serverConfig, action.payload.path, action.payload.params)
@@ -89,7 +89,7 @@ export function saveContentEpic(
           .setIn(["metadata", "nteract", "version"], version)
       );
 
-      const serverConfig = getServerConfig(state);
+      const serverConfig = selectors.getServerConfig(state);
 
       const model = {
         content: notebook,

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -78,15 +78,15 @@ export function saveContentEpic(
     ofType(SAVE),
     mergeMap(action => {
       const state = store.getState();
+      const currentNotebook = selectors.currentNotebook(state);
 
-      const filename = state.document.get("filename");
-      const version = state.app.get("version", "0.0.0-beta");
+      const filename = selectors.currentFilename(state);
+      // TODO: this default version should probably not be here.
+      const appVersion = selectors.appVersion(state) || "0.0.0-beta";
 
       // contents API takes notebook as raw JSON
       const notebook = toJS(
-        state.document
-          .get("notebook")
-          .setIn(["metadata", "nteract", "version"], version)
+        currentNotebook.setIn(["metadata", "nteract", "version"], appVersion)
       );
 
       const serverConfig = selectors.serverConfig(state);

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -11,7 +11,7 @@ import {
   executionCounts
 } from "@nteract/messaging";
 
-import { getCurrentKernel } from "../selectors";
+import * as selectors from "../selectors";
 
 import { Observable } from "rxjs/Observable";
 import { of } from "rxjs/observable/of";
@@ -137,7 +137,7 @@ export function createExecuteCellStream(
   message: ExecuteRequest,
   id: string
 ) {
-  const kernel = getCurrentKernel(store.getState());
+  const kernel = selectors.getCurrentKernel(store.getState());
 
   const channels = kernel ? kernel.channels : null;
 

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -184,8 +184,7 @@ export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
     ofType(EXECUTE_CELL, EXECUTE_FOCUSED_CELL),
     mergeMap(action => {
       if (action.type === EXECUTE_FOCUSED_CELL) {
-        const state = store.getState();
-        const id = state.document.get("cellFocused");
+        const id = selectors.currentFocusedCellId(store.getState());
         if (!id) {
           throw new Error("attempted to execute without an id");
         }
@@ -206,12 +205,8 @@ export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
         // When a new EXECUTE_CELL comes in with the current ID, we create a
         // a new stream and unsubscribe from the old one.
         switchMap(({ id }) => {
-          const state = store.getState();
-
-          const cell = state.document.getIn(
-            ["notebook", "cellMap", id],
-            Immutable.Map()
-          );
+          const cellMap = selectors.currentCellMap(store.getState());
+          const cell = cellMap.get(id, Immutable.Map());
 
           // We only execute code cells
           if (cell.get("cell_type") !== "code") {

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -137,7 +137,7 @@ export function createExecuteCellStream(
   message: ExecuteRequest,
   id: string
 ) {
-  const kernel = selectors.getCurrentKernel(store.getState());
+  const kernel = selectors.currentKernel(store.getState());
 
   const channels = kernel ? kernel.channels : null;
 

--- a/packages/core/src/epics/kernelspecs.js
+++ b/packages/core/src/epics/kernelspecs.js
@@ -8,7 +8,7 @@ import { ofType } from "redux-observable";
 import type { ActionsObservable } from "redux-observable";
 import type { KernelspecProps, Kernelspecs } from "@nteract/types/core/records";
 
-import { getServerConfig } from "../selectors";
+import * as selectors from "../selectors";
 
 export const fetchKernelspecsEpic = (
   action$: ActionsObservable<*>,
@@ -17,7 +17,7 @@ export const fetchKernelspecsEpic = (
   action$.pipe(
     ofType(actionTypes.FETCH_KERNELSPECS),
     mergeMap(({ payload: { kernelspecsRef } }) => {
-      const serverConfig = getServerConfig(store.getState());
+      const serverConfig = selectors.getServerConfig(store.getState());
       // $FlowFixMe: this should be ok, once rebased this should work out
       return kernelspecs.list(serverConfig).pipe(
         map(data => {

--- a/packages/core/src/epics/kernelspecs.js
+++ b/packages/core/src/epics/kernelspecs.js
@@ -17,7 +17,7 @@ export const fetchKernelspecsEpic = (
   action$.pipe(
     ofType(actionTypes.FETCH_KERNELSPECS),
     mergeMap(({ payload: { kernelspecsRef } }) => {
-      const serverConfig = selectors.getServerConfig(store.getState());
+      const serverConfig = selectors.serverConfig(store.getState());
       // $FlowFixMe: this should be ok, once rebased this should work out
       return kernelspecs.list(serverConfig).pipe(
         map(data => {

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -25,11 +25,7 @@ import type { AppState, RemoteKernelProps } from "@nteract/types/core/records";
 import { kernels, shutdown } from "rx-jupyter";
 import { v4 as uuid } from "uuid";
 
-import {
-  getServerConfig,
-  isCurrentHostJupyter,
-  isCurrentKernelJupyterWebsocket
-} from "../selectors";
+import * as selectors from "../selectors";
 
 import {
   LAUNCH_KERNEL,
@@ -44,12 +40,12 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
   action$.pipe(
     ofType(LAUNCH_KERNEL_BY_NAME),
     // Only accept jupyter servers for the host with this epic
-    filter(() => isCurrentHostJupyter(store.getState())),
+    filter(() => selectors.isCurrentHostJupyter(store.getState())),
     // TODO: When a switchMap happens, we need to close down the originating
     // kernel, likely by sending a different action. Right now this gets
     // coordinated in a different way.
     switchMap(({ kernelSpecName, cwd }) => {
-      const config = getServerConfig(store.getState());
+      const config = selectors.getServerConfig(store.getState());
 
       return kernels.start(config, kernelSpecName, cwd).pipe(
         mergeMap(data => {
@@ -73,12 +69,12 @@ export const interruptKernelEpic = (action$: *, store: *) =>
   action$.pipe(
     ofType(INTERRUPT_KERNEL),
     // This epic can only interrupt kernels on jupyter websockets
-    filter(() => isCurrentKernelJupyterWebsocket(store.getState())),
+    filter(() => selectors.isCurrentKernelJupyterWebsocket(store.getState())),
     // If the user fires off _more_ interrupts, we shouldn't interrupt the in-flight
     // interrupt, instead doing it after the last one happens
     concatMap(() => {
       const state = store.getState();
-      const serverConfig = getServerConfig(state);
+      const serverConfig = selectors.getServerConfig(state);
       const id = state.app.kernel.id;
 
       return kernels

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -45,7 +45,7 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
     // kernel, likely by sending a different action. Right now this gets
     // coordinated in a different way.
     switchMap(({ kernelSpecName, cwd }) => {
-      const config = selectors.getServerConfig(store.getState());
+      const config = selectors.serverConfig(store.getState());
 
       return kernels.start(config, kernelSpecName, cwd).pipe(
         mergeMap(data => {
@@ -74,7 +74,7 @@ export const interruptKernelEpic = (action$: *, store: *) =>
     // interrupt, instead doing it after the last one happens
     concatMap(() => {
       const state = store.getState();
-      const serverConfig = selectors.getServerConfig(state);
+      const serverConfig = selectors.serverConfig(state);
       const id = state.app.kernel.id;
 
       return kernels

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -75,7 +75,8 @@ export const interruptKernelEpic = (action$: *, store: *) =>
     concatMap(() => {
       const state = store.getState();
       const serverConfig = selectors.serverConfig(state);
-      const id = state.app.kernel.id;
+      const kernel = selectors.currentKernel(state);
+      const id = kernel.id;
 
       return kernels
         .interrupt(serverConfig, id)

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -7,7 +7,7 @@ const serverUrl = (state: AppState) => state.app.host.serverUrl;
 const crossDomain = (state: AppState) => state.app.host.crossDomain;
 const token = (state: AppState) => state.app.host.token;
 
-export const getServerConfig = createSelector(
+export const serverConfig = createSelector(
   [serverUrl, crossDomain, token],
   (serverUrl, crossDomain, token) => ({
     endpoint: serverUrl,
@@ -20,27 +20,24 @@ export const getServerConfig = createSelector(
 //
 // Intended to be useful for a core app and be future proof for when we have
 // both refs and selected/current hosts and kernels
-export const getCurrentHost = createSelector(
+export const currentHost = createSelector(
   (state: AppState) => state.app.host,
   host => host
 );
 
-export const getCurrentKernel = createSelector(
+export const currentKernel = createSelector(
   (state: AppState) => state.app.kernel,
   kernel => kernel
 );
 
-export const getCurrentKernelType = createSelector(
-  [getCurrentKernel],
-  kernel => {
-    if (kernel && kernel.type) {
-      return kernel.type;
-    }
-    return null;
+export const currentKernelType = createSelector([currentKernel], kernel => {
+  if (kernel && kernel.type) {
+    return kernel.type;
   }
-);
+  return null;
+});
 
-export const getCurrentHostType = createSelector([getCurrentHost], host => {
+export const currentHostType = createSelector([currentHost], host => {
   if (host && host.type) {
     return host.type;
   }
@@ -48,19 +45,19 @@ export const getCurrentHostType = createSelector([getCurrentHost], host => {
 });
 
 export const isCurrentKernelZeroMQ = createSelector(
-  [getCurrentHostType, getCurrentKernelType],
+  [currentHostType, currentKernelType],
   (hostType, kernelType) => {
     return hostType === "local" && kernelType === "zeromq";
   }
 );
 
 export const isCurrentHostJupyter = createSelector(
-  [getCurrentHostType],
+  [currentHostType],
   hostType => hostType === "jupyter"
 );
 
 export const isCurrentKernelJupyterWebsocket = createSelector(
-  [getCurrentHostType, getCurrentKernelType],
+  [currentHostType, currentKernelType],
   (hostType, kernelType) => {
     return hostType === "jupyter" && kernelType === "websocket";
   }

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -1,8 +1,10 @@
 // @flow
 import type { AppState } from "@nteract/types/core/records";
+import { toJS, stringifyNotebook } from "@nteract/commutable";
 
 import { createSelector } from "reselect";
 
+const identity = thing => thing;
 const serverUrl = (state: AppState) => state.app.host.serverUrl;
 const crossDomain = (state: AppState) => state.app.host.crossDomain;
 const token = (state: AppState) => state.app.host.token;
@@ -16,18 +18,28 @@ export const serverConfig = createSelector(
   })
 );
 
+export const userPreferences = createSelector(
+  (state: AppState) => state.config,
+  config => config.toJS()
+);
+
+export const appVersion = createSelector(
+  (state: AppState) => state.app.version,
+  identity
+);
+
 // Quick memoized host and kernel selection.
 //
 // Intended to be useful for a core app and be future proof for when we have
 // both refs and selected/current hosts and kernels
 export const currentHost = createSelector(
   (state: AppState) => state.app.host,
-  host => host
+  identity
 );
 
 export const currentKernel = createSelector(
   (state: AppState) => state.app.kernel,
-  kernel => kernel
+  identity
 );
 
 export const currentKernelType = createSelector([currentKernel], kernel => {
@@ -61,4 +73,76 @@ export const isCurrentKernelJupyterWebsocket = createSelector(
   (hostType, kernelType) => {
     return hostType === "jupyter" && kernelType === "websocket";
   }
+);
+
+// TODO: if we're not looking at a notebook in the UI, there may not _be_ a
+// notebook object to get. Do we return null? Throw an error?
+export const currentNotebook = createSelector(
+  (state: AppState) => state.document.get("notebook"),
+  identity
+);
+
+export const currentSavedNotebook = createSelector(
+  (state: AppState) => state.document.get("savedNotebook"),
+  identity
+);
+
+export const currentNotebookGithubUsername = createSelector(
+  [currentNotebook],
+  notebook => notebook.getIn(["metadata", "github_username"])
+);
+
+export const currentNotebookGistId = createSelector(
+  [currentNotebook],
+  notebook => notebook.getIn(["metadata", "gist_id"])
+);
+
+export const currentNotebookJS = createSelector([currentNotebook], notebook =>
+  toJS(notebook)
+);
+
+export const currentNotebookString = createSelector(
+  [currentNotebookJS],
+  notebookJS => stringifyNotebook(notebookJS)
+);
+
+export const currentFocusedCellId = createSelector(
+  (state: AppState) => state.document.get("cellFocused"),
+  identity
+);
+
+export const currentCellMap = createSelector([currentNotebook], notebook =>
+  notebook.get("cellMap")
+);
+
+export const currentCellOrder = createSelector([currentNotebook], notebook =>
+  notebook.get("cellOrder")
+);
+
+export const currentCodeCellIds = createSelector(
+  [currentCellMap, currentCellOrder],
+  (cellMap, cellOrder) => {
+    return cellOrder.filter(id => cellMap.getIn([id, "cell_type"]) === "code");
+  }
+);
+
+export const currentCodeCellIdsBelow = createSelector(
+  [currentFocusedCellId, currentCellMap, currentCellOrder],
+  (focusedCellId, cellMap, cellOrder) => {
+    const index = cellOrder.indexOf(focusedCellId);
+    return cellOrder
+      .skip(index)
+      .filter(id => cellMap.getIn([id, "cell_type"]) === "code");
+  }
+);
+
+export const currentHiddenCellIds = createSelector(
+  [currentCellMap, currentCellOrder],
+  (cellMap, cellOrder) =>
+    cellOrder.filter(id => cellMap.getIn([id, "metadata", "inputHidden"]))
+);
+
+export const currentFilename = createSelector(
+  (state: AppState) => state.document.get("filename"),
+  identity
 );


### PR DESCRIPTION
Jumping on the selectors train! I want to start moving state around, but I won't be confident about doing that until we centralize access with these selectors.

Couple questions:

1. naming: holy `getCurrent*`, batman! It's a little wordy! Maybe `current` should be the default thing we assume to be getting when we're using selectors.
2. `notificationStystem` stuff: not touching it, it's like an object with methods on it? I'm just going to assume we're not moving that :0
3. putting selectors to work: since we're memoizing, we might as well make selectors that do all the work for us! One example here is the `getCurrentCodeCellIdsBelow` (i know, a mouthful...). you're on board for more of the same, right?
4. In general, we should try and keep selectors as specific as possible. The more general they are, the less we can change state! I.e., selectors should be a black box. We should never return hunks of state that we think we'd want to refactor the internals of. Ya?
