### PR TITLE
Selectors everywhere

### DIFF
--- a/packages/core/__tests__/selectors-spec.js
+++ b/packages/core/__tests__/selectors-spec.js
@@ -1,0 +1,27 @@
+import Immutable from "immutable";
+import { dummyCommutable } from "../src/dummy";
+import * as selectors from "../src/selectors";
+
+describe("codeMirrorMode", () => {
+  test("determines the right mode from the notebook metadata", () => {
+    // TODO: better way to get dummy state?
+    const state1 = {
+      document: Immutable.Map({
+        notebook: dummyCommutable
+      })
+    };
+    const mode = selectors.codeMirrorMode(state1);
+    expect(mode).toEqual(Immutable.fromJS({ name: "ipython", version: 3 }));
+
+    const state2 = {
+      document: Immutable.Map({
+        notebook: dummyCommutable.setIn(
+          ["metadata", "language_info", "codemirror_mode", "name"],
+          "r"
+        )
+      })
+    };
+    const lang2 = selectors.codeMirrorMode(state2);
+    expect(lang2).toEqual(Immutable.fromJS({ name: "r", version: 3 }));
+  });
+});

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -447,6 +447,7 @@ export const PUBLISH_ANONYMOUS_GIST = "PUBLISH_ANONYMOUS_GIST";
 
 // TODO: Relocate this action type from desktop's app.js
 export const SAVE = "SAVE";
+export const SAVE_FAILED = "SAVE_FAILED";
 // TODO: Relocate this action type from desktop's app.js
 export const SAVE_AS = "SAVE_AS";
 // TODO: Relocate this action type from desktop's app.js

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -551,6 +551,14 @@ export function save() {
   };
 }
 
+export function saveFailed(error: Error) {
+  return {
+    type: actionTypes.SAVE_FAILED,
+    payload: error,
+    error: true
+  };
+}
+
 export function saveAs(filename: string) {
   return {
     type: actionTypes.SAVE_AS,

--- a/packages/core/src/components/modal-controller/index.js
+++ b/packages/core/src/components/modal-controller/index.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import { MODAL_TYPES } from "./constants";
 import AboutModal from "./about-modal";
 import { connect } from "react-redux";
+import * as selectors from "../../selectors";
 
 class ModalController extends React.Component<*, *> {
   getModal = () => {
@@ -23,7 +24,7 @@ class ModalController extends React.Component<*, *> {
 import type { MapStateToProps } from "react-redux";
 
 const mapStateToProps: MapStateToProps<*, *, *> = (state: *) => ({
-  modalType: state.modals.modalType
+  modalType: selectors.modalType(state)
 });
 
 export { MODAL_TYPES };

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -5,6 +5,7 @@ import { localCss } from "./styles";
 import { connect } from "react-redux";
 import * as Immutable from "immutable";
 import * as actions from "../../actions";
+import * as selectors from "../../selectors";
 import { MENU_ITEM_ACTIONS, MENUS } from "./constants";
 import * as extraHandlers from "./extra-handlers";
 import { MODAL_TYPES } from "../modal-controller";
@@ -286,11 +287,11 @@ class PureNotebookMenu extends React.Component<Props> {
 // information about the current document to decide which menu items are
 // available...
 const mapStateToProps = state => ({
-  cellFocused: state.document.cellFocused,
-  cellMap: state.document.getIn(["notebook", "cellMap"]),
-  cellOrder: state.document.getIn(["notebook", "cellOrder"]),
-  filename: state.document.get("filename"),
-  notebook: state.document.get("notebook")
+  cellFocused: selectors.currentFocusedCellId(state),
+  cellMap: selectors.currentCellMap(state),
+  cellOrder: selectors.currentCellOrder(state),
+  filename: selectors.currentFilename(state),
+  notebook: selectors.currentNotebook(state)
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -202,6 +202,14 @@ export function executeCellEpic(action$: ActionsObservable<*>, store: any) {
         // a new stream and unsubscribe from the old one.
         switchMap(({ id }) => {
           const cellMap = selectors.currentCellMap(store.getState());
+
+          // If for some reason this is run *outside* the context of viewing
+          // a notebook (stray async task or something), it's possible that the
+          // cellMap will be null;
+          if (!cellMap) {
+            return empty();
+          }
+
           const cell = cellMap.get(id, Immutable.Map());
 
           // We only execute code cells

--- a/packages/core/src/providers/cell-creator.js
+++ b/packages/core/src/providers/cell-creator.js
@@ -1,18 +1,15 @@
 // @flow
 import React, { Component } from "react";
 import { connect } from "react-redux";
-
-import {
-  createCellAfter,
-  createCellAppend,
-  createCellBefore,
-  mergeCellAfter
-} from "../actions";
+import * as actions from "../actions";
 import CellCreatorView from "../components/cell-creator";
 
 type Props = {
   above: boolean,
-  dispatch: Dispatch<*>,
+  createCellAppend: (type: string) => void,
+  createCellBefore: (type: string, id: string) => void,
+  createCellAfter: (type: string, id: string) => void,
+  mergeCellAfter: (id: string) => void,
   id?: string
 };
 
@@ -27,24 +24,28 @@ class CellCreator extends Component<Props> {
   }
 
   createCell(type: "code" | "markdown"): void {
-    const { dispatch, above, id } = this.props;
+    const {
+      above,
+      createCellAfter,
+      createCellAppend,
+      createCellBefore,
+      id
+    } = this.props;
 
     if (!id) {
-      dispatch(createCellAppend(type));
+      createCellAppend(type);
       return;
     }
 
-    above
-      ? dispatch(createCellBefore(type, id))
-      : dispatch(createCellAfter(type, id));
+    above ? createCellBefore(type, id) : createCellAfter(type, id);
   }
 
   mergeCell(): void {
-    const { dispatch, id } = this.props;
+    const { mergeCellAfter, id } = this.props;
 
     // We can't merge cells if we don't have a cell ID
     if (id) {
-      dispatch(mergeCellAfter(id));
+      mergeCellAfter(id);
     }
   }
 
@@ -59,4 +60,11 @@ class CellCreator extends Component<Props> {
   }
 }
 
-export default connect()(CellCreator);
+const mapDispatchToProps = dispatch => ({
+  createCellAppend: type => dispatch(actions.createCellAppend(type)),
+  createCellBefore: (type, id) => dispatch(actions.createCellBefore(type, id)),
+  createCellAfter: (type, id) => dispatch(actions.createCellAfter(type, id)),
+  mergeCellAfter: id => dispatch(actions.mergeCellAfter(id))
+});
+
+export default connect(null, mapDispatchToProps)(CellCreator);

--- a/packages/core/src/providers/editor.js
+++ b/packages/core/src/providers/editor.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 import { connect } from "react-redux";
+import * as selectors from "../selectors";
 
 import { focusCell, focusCellEditor, updateCellSource } from "../actions";
 
@@ -21,14 +22,14 @@ function mapStateToProps(
   state: Object,
   ownProps: CodeMirrorEditorProps
 ): Object {
+  const kernel = selectors.currentKernel(state);
+  const { cursorBlinkRate } = selectors.userPreferences(state);
   return {
     options: ownProps.options
-      ? Object.assign(ownProps.options, {
-          cursorBlinkRate: state.config.get("cursorBlinkRate")
-        })
-      : { cursorBlinkRate: state.config.get("cursorBlinkRate") },
-    channels: state.app.kernel ? state.app.kernel.channels : null,
-    kernelStatus: state.app.getIn(["kernel", "status"], "not connected")
+      ? Object.assign(ownProps.options, { cursorBlinkRate })
+      : { cursorBlinkRate },
+    channels: kernel ? kernel.channels : null,
+    kernelStatus: selectors.currentKernelStatus(state)
   };
 }
 

--- a/packages/core/src/providers/toolbar.js
+++ b/packages/core/src/providers/toolbar.js
@@ -1,105 +1,50 @@
 // @flow
 import * as React from "react";
-import { connect } from "react-redux";
+import * as actions from "../actions";
 import ToolbarView from "../components/toolbar";
-
-import {
-  executeCell,
-  removeCell,
-  toggleStickyCell,
-  clearOutputs,
-  toggleCellOutputVisibility,
-  toggleCellInputVisibility,
-  changeCellType,
-  toggleOutputExpansion
-} from "../actions";
+import { connect } from "react-redux";
 
 type Props = {
   id: string,
   type: "markdown" | "code" | "raw",
-  dispatch: Dispatch<Action>
+  executeCell: () => void,
+  removeCell: () => void,
+  toggleStickyCell: () => void,
+  clearOutputs: () => void,
+  toggleCellOutputVisibility: () => void,
+  toggleCellInputVisibility: () => void,
+  changeCellType: () => void,
+  toggleOutputExpansion: () => void
 };
 
-class Toolbar extends React.PureComponent<Props> {
-  removeCell: () => void;
-  executeCell: () => void;
-  clearOutputs: () => void;
-  toggleStickyCell: () => void;
-  toggleCellInputVisibility: () => void;
-  toggleCellOutputVisibility: () => void;
-  changeCellType: () => void;
-  toggleOutputExpansion: () => void;
+const Toolbar = (props: Props) => (
+  <ToolbarView
+    type={props.type}
+    executeCell={props.executeCell}
+    removeCell={props.removeCell}
+    toggleStickyCell={props.toggleStickyCell}
+    clearOutputs={props.clearOutputs}
+    toggleCellInputVisibility={props.toggleCellInputVisibility}
+    toggleCellOutputVisibility={props.toggleCellOutputVisibility}
+    toggleOutputExpansion={props.toggleOutputExpansion}
+    changeCellType={props.changeCellType}
+  />
+);
 
-  constructor(props: Props): void {
-    super(props);
-    this.removeCell = this.removeCell.bind(this);
-    this.executeCell = this.executeCell.bind(this);
-    this.clearOutputs = this.clearOutputs.bind(this);
-    this.toggleStickyCell = this.toggleStickyCell.bind(this);
-    this.toggleCellInputVisibility = this.toggleCellInputVisibility.bind(this);
-    this.toggleCellOutputVisibility = this.toggleCellOutputVisibility.bind(
-      this
-    );
-    this.changeCellType = this.changeCellType.bind(this);
-    this.toggleOutputExpansion = this.toggleOutputExpansion.bind(this);
-  }
+const mapDispatchToProps = (dispatch, { id, type }) => ({
+  toggleStickyCell: () => dispatch(actions.toggleStickyCell(id)),
+  removeCell: () => dispatch(actions.removeCell(id)),
+  executeCell: () => dispatch(actions.executeCell(id)),
+  clearOutputs: () => dispatch(actions.clearOutputs(id)),
+  toggleCellInputVisibility: () =>
+    dispatch(actions.toggleCellInputVisibility(id)),
+  toggleCellOutputVisibility: () =>
+    dispatch(actions.toggleCellOutputVisibility(id)),
+  changeCellType: () =>
+    dispatch(
+      actions.changeCellType(id, type === "markdown" ? "code" : "markdown")
+    ),
+  toggleOutputExpansion: () => dispatch(actions.toggleOutputExpansion(id))
+});
 
-  toggleStickyCell(): void {
-    const { dispatch } = this.props;
-    dispatch(toggleStickyCell(this.props.id));
-  }
-
-  removeCell(): void {
-    const { dispatch } = this.props;
-    dispatch(removeCell(this.props.id));
-  }
-
-  executeCell(): void {
-    const { dispatch } = this.props;
-    dispatch(executeCell(this.props.id));
-  }
-
-  clearOutputs(): void {
-    const { dispatch } = this.props;
-    dispatch(clearOutputs(this.props.id));
-  }
-
-  toggleCellInputVisibility(): void {
-    const { dispatch } = this.props;
-    dispatch(toggleCellInputVisibility(this.props.id));
-  }
-
-  toggleCellOutputVisibility(): void {
-    const { dispatch } = this.props;
-    dispatch(toggleCellOutputVisibility(this.props.id));
-  }
-
-  changeCellType(): void {
-    const { dispatch } = this.props;
-    const to = this.props.type === "markdown" ? "code" : "markdown";
-    dispatch(changeCellType(this.props.id, to));
-  }
-
-  toggleOutputExpansion(): void {
-    const { dispatch } = this.props;
-    dispatch(toggleOutputExpansion(this.props.id));
-  }
-
-  render(): ?React$Element<any> {
-    return (
-      <ToolbarView
-        type={this.props.type}
-        executeCell={this.executeCell}
-        removeCell={this.removeCell}
-        toggleStickyCell={this.toggleStickyCell}
-        clearOutputs={this.clearOutputs}
-        toggleCellInputVisibility={this.toggleCellInputVisibility}
-        toggleCellOutputVisibility={this.toggleCellOutputVisibility}
-        toggleOutputExpansion={this.toggleOutputExpansion}
-        changeCellType={this.changeCellType}
-      />
-    );
-  }
-}
-
-export default connect()(Toolbar);
+export default connect(null, mapDispatchToProps)(Toolbar);


### PR DESCRIPTION
In response to some comments @rgbkrk left in #2500 I used selectors in `mapStateToProps`. I also couldn't help myself and added a commit in here that updates some usage of `mapDispatchToProps`. I _think_ the latter change is an overall improvement. However, I don't know how cleverly/simply the `mapDispatchToProps` arg is handled in `connect`. It could potentially be a perf issue to re-create all the functions in `mapDispatchToProps`... just wanted to draw that out.

Also, I _think_ I found a test that was yielding false positives. You'll see it skipped in the diff. Here's an issue I opened about it:

https://github.com/nteract/nteract/issues/2506

Just to reiterate, the goal of these refactors are to ensure that our code doesn't depend on the structure of our state 🌲. We want to reorganize the state and add useful things like app `ref`s to our state (see the `plan.md` file for details on that).