### PR TITLE
Extract restart and clear output actions

### DIFF
--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -208,18 +208,14 @@ describe("menu", () => {
   });
 
   describe("dispatchClearAll", () => {
-    test("dispatches CLEAR_OUTPUTS actions", () => {
+    test("dispatches CLEAR_ALL_OUTPUTS actions", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
 
       menu.dispatchClearAll(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.CLEAR_OUTPUTS,
-        id: store
-          .getState()
-          .document.getIn(["notebook", "cellOrder"])
-          .first()
+        type: actionTypes.CLEAR_ALL_OUTPUTS
       });
     });
   });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -145,27 +145,33 @@ describe("menu", () => {
   });
 
   describe("dispatchRestartClearAll", () => {
-    test("dispatches KILL_KERNEL and CLEAR_OUTPUTS actions", () => {
+    test("dispatches RESTART_KERNEL with clearOutputs set to true", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
 
       menu.dispatchRestartClearAll(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.RESTART_KERNEL
+        type: actionTypes.RESTART_KERNEL,
+        payload: {
+          clearOutputs: true
+        }
       });
     });
   });
 
   describe("dispatchRestartKernel", () => {
-    test("dispatches KILL_KERNEL and LAUNCH_KERNEL_SUCCESSFUL actions", () => {
+    test("dispatches restart kernel with clearOutputs set to false", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
 
       menu.dispatchRestartKernel(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.RESTART_KERNEL
+        type: actionTypes.RESTART_KERNEL,
+        payload: {
+          clearOutputs: false
+        }
       });
     });
   });
@@ -193,7 +199,10 @@ describe("menu", () => {
       menu.dispatchKillKernel(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.KILL_KERNEL
+        type: actionTypes.KILL_KERNEL,
+        payload: {
+          restarting: false
+        }
       });
     });
   });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -152,7 +152,7 @@ describe("menu", () => {
       menu.dispatchRestartClearAll(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.KILL_KERNEL
+        type: actionTypes.RESTART_KERNEL
       });
     });
   });
@@ -165,7 +165,7 @@ describe("menu", () => {
       menu.dispatchRestartKernel(store);
 
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.KILL_KERNEL
+        type: actionTypes.RESTART_KERNEL
       });
     });
   });

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -15,11 +15,9 @@ import {
 } from "./zeromq-kernels";
 
 import {
+  restartKernelEpic,
   acquireKernelInfoEpic,
-  watchExecutionStateEpic
-} from "@nteract/core/epics";
-
-import {
+  watchExecutionStateEpic,
   executeCellEpic,
   updateDisplayEpic,
   commListenEpic
@@ -41,6 +39,7 @@ export const wrapEpic = (epic: Epic<*, *, *>) => (...args: any) =>
   epic(...args).pipe(catchError(retryAndEmitError));
 
 const epics = [
+  restartKernelEpic,
   watchSpawn,
   commListenEpic,
   publishEpic,

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -66,7 +66,7 @@ export function dispatchRestartKernel(store: *) {
     ? path.dirname(path.resolve(filename))
     : cwdKernelFallback();
 
-  store.dispatch(actions.killKernel);
+  store.dispatch(actions.killKernel());
   // TODO: Use the kernelspec directly, requires us having the kernelspecs available
   //       in the store.
   // TODO: `kernel &&` may be redundant if Record default is `null` for this.
@@ -201,7 +201,7 @@ export function dispatchUnhideAll(store: *) {
 }
 
 export function dispatchKillKernel(store: *) {
-  store.dispatch(actions.killKernel);
+  store.dispatch(actions.killKernel());
 }
 
 export function dispatchInterruptKernel(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -54,45 +54,6 @@ export function triggerWindowRefresh(store: *, filename: string) {
 
 export function dispatchRestartKernel(store: *) {
   store.dispatch(actions.restartKernel());
-
-  // TODO: Make this an action to dispatch that an epic consumes, which will stop the
-  //       current kernel and launch a new kernel of the same type
-  const state = store.getState();
-  const notificationSystem = state.app.notificationSystem;
-  const filename = selectors.currentFilename(state);
-  const kernel = selectors.currentKernel(state);
-
-  const cwd = filename
-    ? path.dirname(path.resolve(filename))
-    : cwdKernelFallback();
-
-  store.dispatch(actions.killKernel());
-  // TODO: Use the kernelspec directly, requires us having the kernelspecs available
-  //       in the store.
-  // TODO: `kernel &&` may be redundant if Record default is `null` for this.
-  const kernelName =
-    kernel && kernel.kernelSpecName ? kernel.kernelSpecName : null;
-
-  if (!kernelName) {
-    notificationSystem.addNotification({
-      title: "Failure to Restart",
-      message: `Unable to restart kernel, please select a new kernel.`,
-      dismissible: true,
-      position: "tr",
-      level: "error"
-    });
-
-    return;
-  }
-  store.dispatch(actions.launchKernelByName(kernelName, cwd));
-
-  notificationSystem.addNotification({
-    title: "Kernel Restarted",
-    message: `Kernel ${kernelName} has been restarted.`,
-    dismissible: true,
-    position: "tr",
-    level: "success"
-  });
 }
 
 export function triggerKernelRefresh(store: *): Promise<*> {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -72,7 +72,7 @@ export function triggerKernelRefresh(store: *, filename: string): Promise<*> {
       },
       index => {
         if (index === 0) {
-          const kernel = selectors.currentKernel();
+          const kernel = selectors.currentKernel(store.getState());
           const cwd = filename
             ? path.dirname(path.resolve(filename))
             : cwdKernelFallback();
@@ -156,8 +156,7 @@ export function dispatchRunAll(store: *) {
 }
 
 export function dispatchClearAll(store: *) {
-  const cellOrder = selectors.currentCellOrder(store.getState());
-  cellOrder.forEach(id => store.dispatch(actions.clearOutputs(id)));
+  store.dispatch(actions.clearAllOutputs());
 }
 
 export function dispatchUnhideAll(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -8,34 +8,13 @@ import * as fs from "fs";
 
 import { throttle } from "lodash";
 
-import {
-  toggleCellInputVisibility,
-  clearOutputs,
-  copyCell,
-  createCellAfter,
-  cutCell,
-  executeCell,
-  interruptKernel,
-  killKernel,
-  launchKernel,
-  launchKernelByName,
-  load,
-  loadConfig,
-  newNotebook,
-  pasteCell,
-  save,
-  saveAs,
-  setCursorBlink,
-  setGithubToken,
-  setTheme,
-  toggleOutputExpansion
-} from "@nteract/core/actions";
+import * as actions from "@nteract/core/actions";
 
 import * as selectors from "@nteract/core/selectors";
 import { defaultPathFallback, cwdKernelFallback } from "./path";
 
 export function dispatchSaveAs(store: *, evt: Event, filename: string) {
-  store.dispatch(saveAs(filename));
+  store.dispatch(actions.saveAs(filename));
 }
 
 const dialog = remote.dialog;
@@ -70,7 +49,7 @@ export function triggerWindowRefresh(store: *, filename: string) {
   if (!filename) {
     return;
   }
-  store.dispatch(saveAs(filename));
+  store.dispatch(actions.saveAs(filename));
 }
 
 export function dispatchRestartKernel(store: *) {
@@ -85,7 +64,7 @@ export function dispatchRestartKernel(store: *) {
     ? path.dirname(path.resolve(filename))
     : cwdKernelFallback();
 
-  store.dispatch(killKernel);
+  store.dispatch(actions.killKernel);
   // TODO: Use the kernelspec directly, requires us having the kernelspecs available
   //       in the store.
   // TODO: `kernel &&` may be redundant if Record default is `null` for this.
@@ -103,7 +82,7 @@ export function dispatchRestartKernel(store: *) {
 
     return;
   }
-  store.dispatch(launchKernelByName(kernelName, cwd));
+  store.dispatch(actions.launchKernelByName(kernelName, cwd));
 
   notificationSystem.addNotification({
     title: "Kernel Restarted",
@@ -152,7 +131,7 @@ export function dispatchSave(store: *) {
   if (!filename) {
     triggerSaveAs(store);
   } else {
-    store.dispatch(save());
+    store.dispatch(actions.save());
   }
 }
 
@@ -161,7 +140,7 @@ export function dispatchNewKernel(store: *, evt: Event, spec: Object) {
   const cwd = filename
     ? path.dirname(path.resolve(filename))
     : cwdKernelFallback();
-  store.dispatch(launchKernel(spec, cwd));
+  store.dispatch(actions.launchKernel(spec, cwd));
 }
 
 export function dispatchPublishAnonGist(store: *) {
@@ -174,7 +153,7 @@ export function dispatchPublishUserGist(
   githubToken: string
 ) {
   if (githubToken) {
-    store.dispatch(setGithubToken(githubToken));
+    store.dispatch(actions.setGithubToken(githubToken));
   }
   store.dispatch({ type: "PUBLISH_USER_GIST" });
 }
@@ -193,7 +172,7 @@ export function dispatchRunAllBelow(store: *) {
   const codeCellIdsBelow = selectors.currentCodeCellIdsBelow(state);
 
   codeCellIdsBelow.forEach(id =>
-    store.dispatch(executeCell(id, cellMap.getIn([id, "source"])))
+    store.dispatch(actions.executeCell(id, cellMap.getIn([id, "source"])))
   );
 }
 
@@ -203,22 +182,24 @@ export function dispatchRunAll(store: *) {
   const cellMap = selectors.currentCellMap(state);
   const codeCellIds = selectors.currentCodeCellIds(state);
   codeCellIds.forEach(id =>
-    store.dispatch(executeCell(id, cellMap.getIn([id, "source"])))
+    store.dispatch(actions.executeCell(id, cellMap.getIn([id, "source"])))
   );
 }
 
 export function dispatchClearAll(store: *) {
   const cellOrder = selectors.currentCellOrder(store.getState());
-  cellOrder.forEach(id => store.dispatch(clearOutputs(id)));
+  cellOrder.forEach(id => store.dispatch(actions.clearOutputs(id)));
 }
 
 export function dispatchUnhideAll(store: *) {
   const hiddenCellIds = selectors.currentHiddenCellIds(store.getState());
-  hiddenCellIds.forEach(id => store.dispatch(toggleCellInputVisibility(id)));
+  hiddenCellIds.forEach(id =>
+    store.dispatch(actions.toggleCellInputVisibility(id))
+  );
 }
 
 export function dispatchKillKernel(store: *) {
-  store.dispatch(killKernel);
+  store.dispatch(actions.killKernel);
 }
 
 export function dispatchInterruptKernel(store: *) {
@@ -231,7 +212,7 @@ export function dispatchInterruptKernel(store: *) {
       level: "error"
     });
   } else {
-    store.dispatch(interruptKernel());
+    store.dispatch(actions.interruptKernel());
   }
 }
 
@@ -253,43 +234,43 @@ export function dispatchZoomReset() {
 }
 
 export function dispatchSetTheme(store: *, evt: Event, theme: string) {
-  store.dispatch(setTheme(theme));
+  store.dispatch(actions.setTheme(theme));
 }
 
 export function dispatchSetCursorBlink(store: *, evt: Event, value: *) {
-  store.dispatch(setCursorBlink(value));
+  store.dispatch(actions.setCursorBlink(value));
 }
 
 export function dispatchCopyCell(store: *) {
   const state = store.getState();
   const focused = state.document.get("cellFocused");
-  store.dispatch(copyCell(focused));
+  store.dispatch(actions.copyCell(focused));
 }
 
 export function dispatchCutCell(store: *) {
   const state = store.getState();
   const focused = state.document.get("cellFocused");
-  store.dispatch(cutCell(focused));
+  store.dispatch(actions.cutCell(focused));
 }
 
 export function dispatchPasteCell(store: *) {
-  store.dispatch(pasteCell());
+  store.dispatch(actions.pasteCell());
 }
 
 export function dispatchCreateCellAfter(store: *) {
   const state = store.getState();
   const focused = state.document.get("cellFocused");
-  store.dispatch(createCellAfter("code", focused));
+  store.dispatch(actions.createCellAfter("code", focused));
 }
 
 export function dispatchCreateTextCellAfter(store: *) {
   const state = store.getState();
   const focused = state.document.get("cellFocused");
-  store.dispatch(createCellAfter("markdown", focused));
+  store.dispatch(actions.createCellAfter("markdown", focused));
 }
 
 export function dispatchLoad(store: *, event: Event, filename: string) {
-  store.dispatch(load(filename));
+  store.dispatch(actions.load(filename));
 }
 
 export function dispatchNewNotebook(
@@ -297,7 +278,7 @@ export function dispatchNewNotebook(
   event: Event,
   kernelSpec: Object
 ) {
-  store.dispatch(newNotebook(kernelSpec, cwdKernelFallback()));
+  store.dispatch(actions.newNotebook(kernelSpec, cwdKernelFallback()));
 }
 
 /**
@@ -322,7 +303,9 @@ export function exportPDF(
   );
 
   // Expand unexpanded cells
-  unexpandedCells.map(cellID => store.dispatch(toggleOutputExpansion(cellID)));
+  unexpandedCells.map(cellID =>
+    store.dispatch(actions.toggleOutputExpansion(cellID))
+  );
 
   remote.getCurrentWindow().webContents.printToPDF(
     {
@@ -333,7 +316,7 @@ export function exportPDF(
 
       // Restore the modified cells to their unexpanded state.
       unexpandedCells.map(cellID =>
-        store.dispatch(toggleOutputExpansion(cellID))
+        store.dispatch(actions.toggleOutputExpansion(cellID))
       );
 
       fs.writeFile(`${filename}.pdf`, data, error_fs => {
@@ -401,7 +384,7 @@ export function storeToPDF(store: *) {
 }
 
 export function dispatchLoadConfig(store: *) {
-  store.dispatch(loadConfig());
+  store.dispatch(actions.loadConfig());
 }
 
 export function initMenuHandlers(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -53,6 +53,8 @@ export function triggerWindowRefresh(store: *, filename: string) {
 }
 
 export function dispatchRestartKernel(store: *) {
+  store.dispatch(actions.restartKernel());
+
   // TODO: Make this an action to dispatch that an epic consumes, which will stop the
   //       current kernel and launch a new kernel of the same type
   const state = store.getState();

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -387,6 +387,23 @@ export type SetGithubTokenAction = {
   githubToken: string
 };
 
+export const RESTART_KERNEL = "RESTART_KERNEL";
+export type RestartKernel = {
+  type: "RESTART_KERNEL"
+};
+
+export const RESTART_KERNEL_FAILED = "RESTART_KERNEL_FAILED";
+export type RestartKernelFailed = {
+  type: "RESTART_KERNEL_FAILED",
+  payload: Error,
+  error: true
+};
+
+export const RESTART_KERNEL_SUCCESSFUL = "RESTART_KERNEL_SUCCESSFUL";
+export type RestartKernelSuccessful = {
+  type: "RESTART_KERNEL_SUCCESSFUL"
+};
+
 export const LAUNCH_KERNEL = "LAUNCH_KERNEL";
 export type LaunchKernelAction = {
   type: "LAUNCH_KERNEL",

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -389,7 +389,10 @@ export type SetGithubTokenAction = {
 
 export const RESTART_KERNEL = "RESTART_KERNEL";
 export type RestartKernel = {
-  type: "RESTART_KERNEL"
+  type: "RESTART_KERNEL",
+  payload: {
+    clearOutputs: boolean
+  }
 };
 
 export const RESTART_KERNEL_FAILED = "RESTART_KERNEL_FAILED";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -379,7 +379,12 @@ export type InterruptKernelFailed = {
 };
 
 export const KILL_KERNEL = "KILL_KERNEL";
-export type KillKernelAction = { type: "KILL_KERNEL" };
+export type KillKernelAction = {
+  type: "KILL_KERNEL",
+  payload: {
+    restarting: boolean
+  }
+};
 
 export const SET_GITHUB_TOKEN = "SET_GITHUB_TOKEN";
 export type SetGithubTokenAction = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -174,6 +174,9 @@ export type ToggleCellInputVisibilityAction = {
 export const CLEAR_OUTPUTS = "CLEAR_OUTPUTS";
 export type ClearOutputsAction = { type: "CLEAR_OUTPUTS", id: CellID };
 
+export const CLEAR_ALL_OUTPUTS = "CLEAR_ALL_OUTPUTS";
+export type ClearAllOutputs = { type: "CLEAR_ALL_OUTPUTS" };
+
 export const ACCEPT_PAYLOAD_MESSAGE_ACTION = "ACCEPT_PAYLOAD_MESSAGE_ACTION";
 export type AcceptPayloadMessageAction = {
   type: "ACCEPT_PAYLOAD_MESSAGE_ACTION",

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -727,9 +727,12 @@ export function shutdownReplyTimedOut(error: Error): ShutdownReplyTimedOut {
   };
 }
 
-export function restartKernel(): RestartKernel {
+export function restartKernel(
+  payload: { clearOutputs: boolean } = { clearOutputs: false }
+): RestartKernel {
   return {
-    type: actionTypes.RESTART_KERNEL
+    type: actionTypes.RESTART_KERNEL,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -426,9 +426,14 @@ export function deleteMetadata(field: string): DeleteMetadataFieldAction {
   };
 }
 
-export const killKernel: KillKernelAction = {
-  type: actionTypes.KILL_KERNEL
-};
+export function killKernel(
+  payload: { restarting: boolean } = { restarting: false }
+): KillKernelAction {
+  return {
+    type: actionTypes.KILL_KERNEL,
+    payload
+  };
+}
 
 export function interruptKernel(): InterruptKernel {
   return {

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -54,6 +54,7 @@ import type {
   SetNotebookAction,
   NewCellAfterAction,
   NewCellBeforeAction,
+  ClearAllOutputs,
   ClearOutputsAction,
   AppendOutputAction,
   UpdateDisplayAction,
@@ -215,6 +216,12 @@ export function clearOutputs(id: string): ClearOutputsAction {
   return {
     type: actionTypes.CLEAR_OUTPUTS,
     id
+  };
+}
+
+export function clearAllOutputs(): ClearAllOutputs {
+  return {
+    type: actionTypes.CLEAR_ALL_OUTPUTS
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -30,6 +30,9 @@ import type {
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 
 import type {
+  RestartKernel,
+  RestartKernelFailed,
+  RestartKernelSuccessful,
   ShutdownReplyTimedOut,
   ShutdownReplySucceeded,
   DeleteConnectionFileFailedAction,
@@ -721,5 +724,25 @@ export function shutdownReplyTimedOut(error: Error): ShutdownReplyTimedOut {
     type: actionTypes.SHUTDOWN_REPLY_TIMED_OUT,
     payload: error,
     error: true
+  };
+}
+
+export function restartKernel(): RestartKernel {
+  return {
+    type: actionTypes.RESTART_KERNEL
+  };
+}
+
+export function restartKernelFailed(error: Error): RestartKernel {
+  return {
+    type: actionTypes.RESTART_KERNEL_FAILED,
+    payload: error,
+    error: true
+  };
+}
+
+export function restartKernelSuccessful(): RestartKernelSuccessful {
+  return {
+    type: actionTypes.RESTART_KERNEL_SUCCESSFUL
   };
 }

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -9,7 +9,8 @@ export {
 export {
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
-  launchKernelWhenNotebookSetEpic
+  launchKernelWhenNotebookSetEpic,
+  restartKernelEpic
 } from "./kernel-lifecycle";
 
 export { fetchKernelspecsEpic } from "./kernelspecs";

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -126,7 +126,7 @@ export const restartKernel = (action$: ActionsObservable<*>, store: *) =>
       // TODO: Incorporate notification system bits
 
       return merge(
-        actions.killKernel,
+        actions.killKernel({ restarting: true }),
         actions.launchKernelByName(kernel.kernelSpecName, kernel.cwd)
       );
     })

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -17,6 +17,7 @@ import {
   map,
   tap,
   mergeMap,
+  concatMap,
   catchError,
   first,
   pluck,
@@ -122,7 +123,7 @@ export const launchKernelWhenNotebookSetEpic = (
 export const restartKernelEpic = (action$: ActionsObservable<*>, store: *) =>
   action$.pipe(
     ofType(actionTypes.RESTART_KERNEL),
-    mergeMap(action => {
+    concatMap(action => {
       const state = store.getState();
       const kernel = selectors.currentKernel(state);
       const notificationSystem = state.app.notificationSystem;
@@ -152,9 +153,9 @@ export const restartKernelEpic = (action$: ActionsObservable<*>, store: *) =>
         level: "success"
       });
 
-      return from([
+      return of(
         actions.killKernel({ restarting: true }),
         actions.launchKernelByName(kernel.kernelSpecName, kernel.cwd)
-      ]);
+      );
     })
   );

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -10,6 +10,8 @@ import * as actionTypes from "../actionTypes";
 // TODO: With the new document plan, I think it starts to make sense to decouple
 //       the document view actions and the underlying document format
 import type {
+  RestartKernel,
+  ClearAllOutputs,
   PasteCellAction,
   ChangeFilenameAction,
   ToggleCellExpansionAction,
@@ -193,6 +195,42 @@ function clearOutputs(state: DocumentRecord, action: ClearOutputsAction) {
     );
   }
   return state;
+}
+
+function clearAllOutputs(
+  state: DocumentRecord,
+  action: ClearAllOutputs | RestartKernel
+) {
+  // If we get a restart kernel action that said to clear outputs, we'll
+  // handle it
+  if (
+    action.type === actionTypes.RESTART_KERNEL &&
+    !action.payload.clearOutputs
+  ) {
+    return state;
+  }
+
+  return (
+    state
+      // For every cell, clear the outputs and execution counts
+      .updateIn(["notebook", "cellMap"], cellMap => {
+        // NOTE: My kingdom for a mergeMap
+        return cellMap.map(cell => {
+          cell.merge({
+            outputs: new Immutable.List(),
+            execution_count: null
+          });
+        });
+      })
+      // Clear all the transient data too
+      .set(
+        ["notebook", "transient"],
+        Immutable.Map({
+          keyPathsForDisplays: Immutable.Map(),
+          cellMap: Immutable.Map() // clear out the statuses
+        })
+      )
+  );
 }
 
 function appendOutput(state: DocumentRecord, action: AppendOutputAction) {
@@ -704,6 +742,8 @@ type DocumentAction =
   | AcceptPayloadMessageAction
   | SendExecuteMessageAction
   | DoneSavingAction
+  | RestartKernel
+  | ClearAllOutputs
   | SetInCellAction<*>;
 
 const defaultDocument: DocumentRecord = makeDocumentRecord();
@@ -723,6 +763,9 @@ function handleDocument(
       return focusCell(state, action);
     case actionTypes.CLEAR_OUTPUTS:
       return clearOutputs(state, action);
+    case actionTypes.CLEAR_ALL_OUTPUTS:
+    case actionTypes.RESTART_KERNEL:
+      return clearAllOutputs(state, action);
     case actionTypes.APPEND_OUTPUT:
       return appendOutput(state, action);
     case actionTypes.UPDATE_DISPLAY:


### PR DESCRIPTION
This turns what was _way too much_ work from desktop's menu into appropriate epics and reducers for our core state. It does leave some of the old cruft, including use of the notification system when slightly inaccurate. Once the kernel refs are in, we can clean the restarts up even further.

Clear outputs is incredibly sane now that we don't have to do it for each and every cell as a separate action. It's looking more and more like `transient` should be a record, though I'll just wait for the core architecture plan to get implemented before I shuffle that around.