### PR TITLE
track current working directory with the kernels

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -69,6 +69,7 @@ describe("launchKernelEpic", () => {
         type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
         kernel: {
           type: "zeromq",
+          cwd: "~",
           channels: expect.anything(),
           spawn: expect.anything(),
           connectionFile: "connectionFile.json",

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -110,6 +110,7 @@ export function launchKernelObservable(kernelSpec: KernelInfo, cwd: string) {
             channels,
             connectionFile,
             spawn,
+            cwd,
             kernelSpecName: kernelSpec.name,
             status: "launched" // TODO: Determine our taxonomy
           };

--- a/applications/desktop/src/notebook/reducers/app.js
+++ b/applications/desktop/src/notebook/reducers/app.js
@@ -5,17 +5,11 @@ import { app } from "@nteract/core/reducers";
 
 import {
   makeAppRecord,
-  makeLocalKernelRecord,
   makeDesktopHostRecord,
   AppRecord
 } from "@nteract/types/core/records";
 
-import type {
-  NewKernelAction,
-  SetGithubTokenAction,
-  KillKernelAction,
-  DoneSavingConfigAction
-} from "@nteract/core/actionTypes";
+import type { SetGithubTokenAction } from "@nteract/core/actionTypes";
 
 function setGithubToken(state: AppRecord, action: SetGithubTokenAction) {
   const { githubToken } = action;

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -56,6 +56,7 @@ describe("launchWebSocketKernelEpic", () => {
           type: "websocket",
           channels: expect.any(Subject),
           kernelSpecName: "fancy",
+          cwd: "/",
           id: "0"
         }
       }

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -32,7 +32,6 @@ import type { KernelInfo, LocalKernelProps } from "@nteract/types/core/records";
 import {
   setExecutionState,
   setNotebookKernelInfo,
-  launchKernelSuccessful,
   launchKernel,
   setLanguageInfo,
   launchKernelByName

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -53,6 +53,7 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
 
           const kernel = Object.assign({}, data.response, {
             type: "websocket",
+            cwd,
             channels: kernels.connect(config, data.response.id, session),
             kernelSpecName
           });

--- a/packages/types/core/plan.md
+++ b/packages/types/core/plan.md
@@ -149,12 +149,12 @@ type core = {
       },
       refs: Array<Ref>
     },
-    
+
     hostSpec: {
       // TODO: is this something that's going to be hard-coded into an app? Or,
       // is it something that we'll indeed need to request from some api? See
       // related hostSpec in the `communication` state hunk.
-      
+
       // Else, should this be sorta top-level alongside the `notebook` hunk
       // of state?
     },
@@ -200,7 +200,7 @@ type core = {
     kernels: {
       byRef: {
         [ref: Ref]: {
-          type: ("local" | "jupyter"), // same as server, unchanging
+          type: ("local" | "jupyter"), // same as server, literal, unchanging
           name: string,
           lastActivity: Date,
           channels: rxjs$Subject,
@@ -208,6 +208,7 @@ type core = {
           id: Id, // jupyter only
           spawn: ChildProcess, // local only
           connectionFile: string, // local only
+          cwd: string, // current working directory, absolute on local, relative to server on jupyter
         }
       }
     },

--- a/packages/types/src/core/hosts.js
+++ b/packages/types/src/core/hosts.js
@@ -70,6 +70,7 @@ export type BaseKernelProps = {
   kernelSpecName: ?string,
   lastActivity: ?Date,
   channels: ?rxjs$Subject<*, *>,
+  cwd: string,
   // Canonically: idle, busy, starting
   // Xref: http://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-status
   //
@@ -91,6 +92,7 @@ export type LocalKernelProps = BaseKernelProps & {
 
 export const makeLocalKernelRecord: RecordFactory<LocalKernelProps> = Record({
   type: "zeromq",
+  cwd: ".",
   ref: null,
   kernelSpecName: null,
   name: null,
@@ -103,6 +105,7 @@ export const makeLocalKernelRecord: RecordFactory<LocalKernelProps> = Record({
 
 export const makeRemoteKernelRecord: RecordFactory<RemoteKernelProps> = Record({
   type: "websocket",
+  cwd: ".",
   id: null,
   ref: null,
   kernelSpecName: null,


### PR DESCRIPTION
Much needed for #2512 

This includes the `cwd` that is used to launch a kernel with the kernel, to make it easy to restart the kernel (instead of recomputing it).