### PR TITLE
create unhide all redux setup

### DIFF
--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -270,8 +270,8 @@ describe("menu", () => {
       expect(store.dispatch).toHaveBeenCalledWith({
         type: "UNHIDE_ALL",
         payload: {
-          outputs: true,
-          input: true
+          outputHidden: false,
+          inputHidden: false
         }
       });
     });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -261,21 +261,19 @@ describe("menu", () => {
   });
 
   describe("dispatchUnhideAll", () => {
-    test("dispatches toggleCellInputVisibility for hidden code cells", () => {
+    test("", () => {
       const store = dummyStore({ hideAll: true });
       store.dispatch = jest.fn();
 
       menu.dispatchUnhideAll(store);
 
-      const first = store
-        .getState()
-        .document.getIn(["notebook", "cellOrder"])
-        .first();
-      const expectedAction = {
-        type: "TOGGLE_CELL_INPUT_VISIBILITY",
-        id: first
-      };
-      expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
+      expect(store.dispatch).toHaveBeenCalledWith({
+        type: "UNHIDE_ALL",
+        payload: {
+          outputs: true,
+          input: true
+        }
+      });
     });
   });
 

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -497,7 +497,7 @@ export function loadFullMenu(store: * = global.store) {
         click: createSender("menu:clear-all")
       },
       {
-        label: "Unhide All Outputs",
+        label: "Unhide Input and Output in all Cells",
         enabled: BrowserWindow.getAllWindows().length > 0,
         click: createSender("menu:unhide-all")
       }

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -160,10 +160,7 @@ export function dispatchClearAll(store: *) {
 }
 
 export function dispatchUnhideAll(store: *) {
-  const hiddenCellIds = selectors.currentHiddenCellIds(store.getState());
-  hiddenCellIds.forEach(id =>
-    store.dispatch(actions.toggleCellInputVisibility(id))
-  );
+  store.dispatch(actions.unhideAll());
 }
 
 export function dispatchKillKernel(store: *) {

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -21,6 +21,34 @@ describe("setLanguageInfo", () => {
   });
 });
 
+describe("unhideAll", () => {
+  test("allows being called with sets defaults for outputHidden and inputHidden", () => {
+    expect(actions.unhideAll({ outputHidden: true })).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: true,
+        inputHidden: false
+      }
+    });
+
+    expect(actions.unhideAll({ inputHidden: true })).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: false,
+        inputHidden: true
+      }
+    });
+
+    expect(actions.unhideAll()).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: false,
+        inputHidden: false
+      }
+    });
+  });
+});
+
 describe("commOpenAction", () => {
   test("creates a COMM_OPEN action", () => {
     const message = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -159,6 +159,15 @@ export type UpdateDisplayAction = {
   }
 };
 
+export const UNHIDE_ALL = "UNHIDE_ALL";
+export type UnhideAll = {
+  type: "UNHIDE_ALL",
+  payload: {
+    input: boolean,
+    outputs: boolean
+  }
+};
+
 export const TOGGLE_CELL_OUTPUT_VISIBILITY = "TOGGLE_CELL_OUTPUT_VISIBILITY";
 export type ToggleCellOutputVisibilityAction = {
   type: "TOGGLE_CELL_OUTPUT_VISIBILITY",

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -163,8 +163,8 @@ export const UNHIDE_ALL = "UNHIDE_ALL";
 export type UnhideAll = {
   type: "UNHIDE_ALL",
   payload: {
-    input: boolean,
-    outputs: boolean
+    inputHidden: boolean,
+    outputHidden: boolean
   }
 };
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -333,14 +333,14 @@ export function updateCellExecutionCount(
 }
 
 export function unhideAll(
-  payload: { outputs: boolean, input: boolean } = {
-    outputs: true,
-    input: true
+  payload?: { outputHidden: boolean, inputHidden: boolean } = {
+    outputHidden: false,
+    inputHidden: false
   }
 ): UnhideAll {
   return {
     type: "UNHIDE_ALL",
-    payload
+    payload: { outputHidden: false, inputHidden: false, ...payload }
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -30,6 +30,7 @@ import type {
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 
 import type {
+  UnhideAll,
   RestartKernel,
   RestartKernelFailed,
   RestartKernelSuccessful,
@@ -329,6 +330,18 @@ export function updateCellExecutionCount(
   count: number
 ): SetInCellAction<number> {
   return setInCell(id, ["execution_count"], count);
+}
+
+export function unhideAll(
+  payload: { outputs: boolean, input: boolean } = {
+    outputs: true,
+    input: true
+  }
+): UnhideAll {
+  return {
+    type: "UNHIDE_ALL",
+    payload
+  };
 }
 
 export function toggleCellOutputVisibility(

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -583,8 +583,8 @@ function unhideAll(state: DocumentRecord, action: UnhideAll) {
       if (cell.get("cell_type") === "code") {
         return cell.mergeIn(["metadata"], {
           // TODO: Verify that we convert to one namespace for hidden input/output
-          outputHidden: !action.payload.outputs,
-          inputHidden: !action.payload.input
+          outputHidden: action.payload.outputHidden,
+          inputHidden: action.payload.inputHidden
         });
       }
       return cell;


### PR DESCRIPTION
This sets up a menu item that unhides both input and outputs for all cells in the document.