### PR TITLE
Halt Kernel in Menu

### DIFF
--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -27,6 +27,12 @@ import type { ExecuteRequest } from "@nteract/messaging";
 
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 
+export type ErrorAction<T: string> = {
+  type: T,
+  payload: Error,
+  error: true
+};
+
 export const OPEN_MODAL = "CORE/OPEN_MPODAL";
 export type OpenModal = {
   type: "CORE/OPEN_MPODAL",
@@ -394,11 +400,7 @@ export const INTERRUPT_KERNEL_SUCCESSFUL = "INTERRUPT_KERNEL_SUCCESSFUL";
 export type InterruptKernelSuccessful = { type: "INTERRUPT_KERNEL_SUCCESSFUL" };
 
 export const INTERRUPT_KERNEL_FAILED = "INTERRUPT_KERNEL_FAILED";
-export type InterruptKernelFailed = {
-  type: "INTERRUPT_KERNEL_FAILED",
-  payload: Error,
-  error: true
-};
+export type InterruptKernelFailed = ErrorAction<"INTERRUPT_KERNEL_FAILED">;
 
 export const KILL_KERNEL = "KILL_KERNEL";
 export type KillKernelAction = {
@@ -406,6 +408,14 @@ export type KillKernelAction = {
   payload: {
     restarting: boolean
   }
+};
+
+export const KILL_KERNEL_FAILED = "KILL_KERNEL_FAILED";
+export type KillKernelFailed = ErrorAction<"KILL_KERNEL_FAILED">;
+
+export const KILL_KERNEL_SUCCESSFUL = "KILL_KERNEL_SUCCESSFUL";
+export type KillKernelSuccessful = {
+  type: "KILL_KERNEL_SUCCESSFUL"
 };
 
 export const SET_GITHUB_TOKEN = "SET_GITHUB_TOKEN";
@@ -423,11 +433,7 @@ export type RestartKernel = {
 };
 
 export const RESTART_KERNEL_FAILED = "RESTART_KERNEL_FAILED";
-export type RestartKernelFailed = {
-  type: "RESTART_KERNEL_FAILED",
-  payload: Error,
-  error: true
-};
+export type RestartKernelFailed = ErrorAction<"RESTART_KERNEL_FAILED">;
 
 export const RESTART_KERNEL_SUCCESSFUL = "RESTART_KERNEL_SUCCESSFUL";
 export type RestartKernelSuccessful = {
@@ -442,11 +448,7 @@ export type LaunchKernelAction = {
 };
 
 export const LAUNCH_KERNEL_FAILED = "LAUNCH_KERNEL_FAILED";
-export type LaunchKernelFailed = {
-  type: "LAUNCH_KERNEL_FAILED",
-  payload: Error,
-  error: true
-};
+export type LaunchKernelFailed = ErrorAction<"LAUNCH_KERNEL_FAILED">;
 
 export const LAUNCH_KERNEL_SUCCESSFUL = "LAUNCH_KERNEL_SUCCESSFUL";
 export type NewKernelAction = {
@@ -462,11 +464,9 @@ export type LaunchKernelByNameAction = {
 };
 
 export const DELETE_CONNECTION_FILE_FAILED = "DELETE_CONNECTION_FILE_FAILED";
-export type DeleteConnectionFileFailedAction = {
-  type: "DELETE_CONNECTION_FILE_FAILED",
-  payload: Error,
-  error: true
-};
+export type DeleteConnectionFileFailedAction = ErrorAction<
+  "DELETE_CONNECTION_FILE_FAILED"
+>;
 
 export const DELETE_CONNECTION_FILE_SUCCESSFUL =
   "DELETE_CONNECTION_FILE_SUCCESSFUL";
@@ -481,11 +481,7 @@ export type ShutdownReplySucceeded = {
 };
 
 export const SHUTDOWN_REPLY_TIMED_OUT = "SHUTDOWN_REPLY_TIMED_OUT";
-export type ShutdownReplyTimedOut = {
-  type: "SHUTDOWN_REPLY_TIMED_OUT",
-  payload: Error,
-  error: true
-};
+export type ShutdownReplyTimedOut = ErrorAction<"SHUTDOWN_REPLY_TIMED_OUT">;
 
 // TODO: This action needs a proper flow type, its from desktop's github store
 export const PUBLISH_USER_GIST = "PUBLISH_USER_GIST";

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -88,6 +88,8 @@ import type {
   InterruptKernelSuccessful,
   InterruptKernelFailed,
   KillKernelAction,
+  KillKernelFailed,
+  KillKernelSuccessful,
   // TODO: Needs an action creator
   StartSavingAction,
   // TODO: Needs an action creator
@@ -452,6 +454,20 @@ export function killKernel(
   return {
     type: actionTypes.KILL_KERNEL,
     payload
+  };
+}
+
+export function killKernelFailed(payload: Error): KillKernelFailed {
+  return {
+    type: actionTypes.KILL_KERNEL_FAILED,
+    payload,
+    error: true
+  };
+}
+
+export function killKernelSuccessful(): KillKernelSuccessful {
+  return {
+    type: actionTypes.KILL_KERNEL_SUCCESSFUL
   };
 }
 

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -23,6 +23,7 @@ export const MENU_ITEM_ACTIONS = {
   SET_THEME_DARK: "set-theme-dark",
   SET_THEME_LIGHT: "set-theme-light",
   OPEN_ABOUT: "open-about",
+  KILL_KERNEL: "kill-kernel",
   INTERRUPT_KERNEL: "interrupt-kernel"
 };
 

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -40,6 +40,7 @@ type Props = {
   openAboutModal: ?() => void,
   restartKernel: ?() => void,
   restartKernelAndClearOutputs: ?() => void,
+  killKernel: ?() => void,
   interruptKernel: ?() => void
 };
 
@@ -64,6 +65,7 @@ class PureNotebookMenu extends React.Component<Props> {
     setTheme: null,
     openAboutModal: null,
     restartKernel: null,
+    killKernel: null,
     interruptKernel: null
   };
   handleClick = ({ key }: { key: string }) => {
@@ -89,6 +91,7 @@ class PureNotebookMenu extends React.Component<Props> {
       setTheme,
       restartKernel,
       restartKernelAndClearOutputs,
+      killKernel,
       interruptKernel
     } = this.props;
     const [action, ...args] = parseActionKey(key);
@@ -190,6 +193,10 @@ class PureNotebookMenu extends React.Component<Props> {
           restartKernel();
         }
         break;
+      case MENU_ITEM_ACTIONS.KILL_KERNEL:
+        if (killKernel) {
+          killKernel();
+        }
       case MENU_ITEM_ACTIONS.RESTART_AND_CLEAR_OUTPUTS:
         if (restartKernelAndClearOutputs) {
           restartKernelAndClearOutputs();
@@ -300,6 +307,10 @@ class PureNotebookMenu extends React.Component<Props> {
             <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.INTERRUPT_KERNEL)}>
               Interrupt
             </MenuItem>
+            <Divider />
+            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.KILL_KERNEL)}>
+              Halt
+            </MenuItem>
             <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.RESTART_KERNEL)}>
               Restart
             </MenuItem>
@@ -368,6 +379,7 @@ const mapDispatchToProps = dispatch => ({
   restartKernel: () => dispatch(actions.restartKernel()),
   restartKernelAndClearOutputs: () =>
     dispatch(actions.restartKernel({ clearOutputs: true })),
+  killKernel: () => dispatch(actions.killKernel()),
   interruptKernel: () => dispatch(actions.interruptKernel())
 });
 

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -10,7 +10,8 @@ import { commListenEpic } from "./comm";
 
 import {
   launchWebSocketKernelEpic,
-  interruptKernelEpic
+  interruptKernelEpic,
+  killKernelEpic
 } from "./websocket-kernel";
 
 import {
@@ -34,6 +35,7 @@ const allEpics = [
   commListenEpic,
   launchWebSocketKernelEpic,
   interruptKernelEpic,
+  killKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
   launchKernelWhenNotebookSetEpic,
@@ -52,6 +54,7 @@ export {
   commListenEpic,
   launchWebSocketKernelEpic,
   interruptKernelEpic,
+  killKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
   launchKernelWhenNotebookSetEpic,

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -14,31 +14,20 @@ import { of } from "rxjs/observable/of";
 import { from } from "rxjs/observable/from";
 import { merge } from "rxjs/observable/merge";
 
-import {
-  launchKernelSuccessful,
-  interruptKernelSuccessful,
-  interruptKernelFailed
-} from "../actions";
-
 import type { AppState, RemoteKernelProps } from "@nteract/types/core/records";
 
 import { kernels, shutdown } from "rx-jupyter";
 import { v4 as uuid } from "uuid";
 
+import * as actions from "../actions";
 import * as selectors from "../selectors";
-
-import {
-  LAUNCH_KERNEL,
-  LAUNCH_KERNEL_BY_NAME,
-  LAUNCH_KERNEL_SUCCESSFUL,
-  INTERRUPT_KERNEL
-} from "../actionTypes";
+import * as actionTypes from "../actionTypes";
 
 import { executeRequest, kernelInfoRequest } from "@nteract/messaging";
 
 export const launchWebSocketKernelEpic = (action$: *, store: *) =>
   action$.pipe(
-    ofType(LAUNCH_KERNEL_BY_NAME),
+    ofType(actionTypes.LAUNCH_KERNEL_BY_NAME),
     // Only accept jupyter servers for the host with this epic
     filter(() => selectors.isCurrentHostJupyter(store.getState())),
     // TODO: When a switchMap happens, we need to close down the originating
@@ -60,7 +49,7 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
 
           kernel.channels.next(kernelInfoRequest());
 
-          return of(launchKernelSuccessful(kernel));
+          return of(actions.launchKernelSuccessful(kernel));
         })
       );
     })
@@ -68,9 +57,9 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
 
 export const interruptKernelEpic = (action$: *, store: *) =>
   action$.pipe(
-    ofType(INTERRUPT_KERNEL),
+    ofType(actionTypes.INTERRUPT_KERNEL),
     // This epic can only interrupt kernels on jupyter websockets
-    filter(() => selectors.isCurrentKernelJupyterWebsocket(store.getState())),
+    filter(() => selectors.isCurrentHostJupyter(store.getState())),
     // If the user fires off _more_ interrupts, we shouldn't interrupt the in-flight
     // interrupt, instead doing it after the last one happens
     concatMap(() => {
@@ -82,8 +71,30 @@ export const interruptKernelEpic = (action$: *, store: *) =>
       return kernels
         .interrupt(serverConfig, id)
         .pipe(
-          map(() => interruptKernelSuccessful()),
-          catchError(err => interruptKernelFailed(err))
+          map(() => actions.interruptKernelSuccessful()),
+          catchError(err => actions.interruptKernelFailed(err))
+        );
+    })
+  );
+
+export const killKernelEpic = (action$: *, store: *) =>
+  action$.pipe(
+    ofType(actionTypes.KILL_KERNEL),
+    // This epic can only interrupt kernels on jupyter websockets
+    filter(() => selectors.isCurrentHostJupyter(store.getState())),
+    // If the user fires off _more_ kills, we shouldn't interrupt the in-flight
+    // kill, instead doing it after the last one happens
+    concatMap(() => {
+      const state = store.getState();
+      const serverConfig = selectors.serverConfig(state);
+      const kernel = selectors.currentKernel(state);
+      const id = kernel.id;
+
+      return kernels
+        .kill(serverConfig, id)
+        .pipe(
+          map(() => actions.killKernelSuccessful()),
+          catchError(err => actions.killKernelFailed(err))
         );
     })
   );

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -72,7 +72,7 @@ export const interruptKernelEpic = (action$: *, store: *) =>
         .interrupt(serverConfig, id)
         .pipe(
           map(() => actions.interruptKernelSuccessful()),
-          catchError(err => actions.interruptKernelFailed(err))
+          catchError(err => of(actions.interruptKernelFailed(err)))
         );
     })
   );
@@ -94,7 +94,7 @@ export const killKernelEpic = (action$: *, store: *) =>
         .kill(serverConfig, id)
         .pipe(
           map(() => actions.killKernelSuccessful()),
-          catchError(err => actions.killKernelFailed(err))
+          catchError(err => of(actions.killKernelFailed(err)))
         );
     })
   );


### PR DESCRIPTION
As part of this, I created parametrized error actions for the boilerplatey `*failed` actions. It works well with flow too:

```js
let x: ?KillKernelFailed;

// Flow will bomb out here, as it expects the literal "KILL_KERNEL_FAILED"
x = {
  type: KILL_KERNEL,
  payload: new Error("test"),
  error: true
};

// ok with flow, like we want 👌🏻
x = {
  type: KILL_KERNEL_FAILED,
  payload: new Error("test"),
  error: true
};
```

* [x] create killKernel(success,fail)
* [x] create web based epic for killing kernel
* [x] put halt in the menu