### PR TITLE
create readdirObservable, statObservable, more fully type

### DIFF
--- a/packages/fs-observable/src/index.js
+++ b/packages/fs-observable/src/index.js
@@ -36,3 +36,45 @@ export const readFileObservable = bindNodeCallback(fs.readFile);
 export const writeFileObservable = bindNodeCallback(fs.writeFile);
 
 export const mkdirpObservable = bindNodeCallback(mkdirp);
+
+type readdirCallback<T> = (err: ?ErrnoError, files: Array<T>) => void;
+
+function createReaddirCallback<T>(
+  observer: rxjs$Observer<Array<T>>
+): readdirCallback<T> {
+  return (err: ?ErrnoError, files: Array<T>) => {
+    if (err) {
+      observer.error(err);
+    } else {
+      observer.next(files);
+      observer.complete();
+    }
+  };
+}
+
+export const readdirObservable = (
+  path: string,
+  options?: string | { encoding: string }
+) =>
+  // TODO: readdir can resolve an Array<buffer>
+  // PR in progress: https://github.com/facebook/flow/pull/5820
+  // We'll default to string for now
+  Observable.create((observer: rxjs$Observer<Array<string>>) => {
+    if (!options) {
+      const callback: readdirCallback<string> = createReaddirCallback(observer);
+      fs.readdir(path, callback);
+    } else {
+      /*
+      // TODO: See above about readdir having the ability to resolve Array<buffer>
+      if (options === "buffer" || options.encoding === "buffer") {
+        const callback: readdirCallback<Buffer> = createReaddirCallback(
+          observer
+        );
+        fs.readdir(path, options, callback);
+        return;
+      }
+      */
+      const callback: readdirCallback<string> = createReaddirCallback(observer);
+      fs.readdir(path, options, callback);
+    }
+  });

--- a/packages/fs-observable/src/index.js
+++ b/packages/fs-observable/src/index.js
@@ -24,16 +24,32 @@ export const unlinkObservable = (path: string) =>
     }
   });
 
-export const createNewSymlinkObservable = bindNodeCallback(fs.symlink);
+export const createNewSymlinkObservable: (
+  srcpath: string,
+  dtspath: string,
+  type?: string
+) => rxjs$Observable<void> = bindNodeCallback(fs.symlink);
 
-export const createSymlinkObservable = (target: string, path: string) =>
+export const createSymlinkObservable = (
+  target: string,
+  path: string
+): rxjs$Observable<void> =>
   unlinkObservable(path).pipe(
     mergeMap(() => createNewSymlinkObservable(target, path))
   );
 
-export const readFileObservable = bindNodeCallback(fs.readFile);
+// NOTE: Flow types here match our current usage rather than inferring it,
+// due to bindNodeCallback not being typed
+export const readFileObservable: (
+  pth: string
+) => rxjs$Observable<Buffer> = bindNodeCallback(fs.readFile);
 
-export const writeFileObservable = bindNodeCallback(fs.writeFile);
+// NOTE: Flow types here match our current usage rather than inferring it,
+// due to bindNodeCallback not being typed
+export const writeFileObservable: (
+  filename: string,
+  data: Buffer | string
+) => rxjs$Observable<void> = bindNodeCallback(fs.writeFile);
 
 export const mkdirpObservable = bindNodeCallback(mkdirp);
 
@@ -78,3 +94,7 @@ export const readdirObservable = (
       fs.readdir(path, options, callback);
     }
   });
+
+export const statObservable: (
+  path: string
+) => rxjs$Observable<fs.Stats> = bindNodeCallback(fs.stat);


### PR DESCRIPTION
Two more functions for `fs-observable` and some additional type annotations since `bindNodeCallback` is not typed...

In support of #2532 (mostly to fully flesh out the "Contents API" for desktop).