### PR TITLE
create contents API responses on Desktop

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -62,7 +62,7 @@ describe("loadingEpic", () => {
         const types = actions.map(({ type }) => type);
         expect(types).toEqual(["ERROR"]);
       },
-      () => done.fail(),
+      err => done.fail(err),
       () => done()
     );
   });

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -1,13 +1,15 @@
 /* @flow */
 
 import * as path from "path";
+import * as fs from "fs";
 
 import { of } from "rxjs/observable/of";
+import { forkJoin } from "rxjs/observable/forkJoin";
 import { map, tap, mergeMap, switchMap, catchError } from "rxjs/operators";
 
 import { ActionsObservable, ofType } from "redux-observable";
 
-import { readFileObservable } from "fs-observable";
+import { readFileObservable, statObservable } from "fs-observable";
 
 import { monocellNotebook, fromJS, parseNotebook } from "@nteract/commutable";
 import type { Notebook, ImmutableNotebook } from "@nteract/commutable";
@@ -52,13 +54,69 @@ export const convertRawNotebook = (filename: string, data: string) => ({
   notebook: fromJS(parseNotebook(data))
 });
 
+function createContentsResponse(
+  filePath: string,
+  stat: fs.Stats,
+  content: *
+): JupyterApi$Content {
+  const parsedFilePath = path.parse(filePath);
+
+  const name = parsedFilePath.base;
+  const writable = Boolean(fs.constants.W_OK & stat.mode);
+  const created = stat.birthtime;
+  const last_modified = stat.mtime;
+
+  if (stat.isDirectory()) {
+    return {
+      type: "directory",
+      mimetype: null,
+      format: "json",
+      content,
+      writable: true,
+      name: name === "." ? "" : name,
+      path: filePath === "." ? "" : filePath,
+      created,
+      last_modified
+    };
+  } else if (stat.isFile()) {
+    if (parsedFilePath.ext === ".ipynb") {
+      return {
+        type: "notebook",
+        mimetype: null,
+        format: "json",
+        content,
+        writable: true,
+        name,
+        path: filePath,
+        created,
+        last_modified
+      };
+    }
+
+    // TODO: Mimetype detection
+    return {
+      type: "file",
+      mimetype: null,
+      format: "text",
+      content,
+      writable: true,
+      name,
+      path: filePath,
+      created,
+      last_modified
+    };
+  }
+
+  throw new Error(`Unsupported filetype at ${filePath}`);
+}
+
 /**
  * Loads a notebook and launches its kernel.
  *
  * @param  {ActionObservable}  A LOAD action with the notebook filename
  */
-export const loadEpic = (actions: ActionsObservable<*>) =>
-  actions.pipe(
+export const loadEpic = (action$: ActionsObservable<*>) =>
+  action$.pipe(
     ofType(actionTypes.LOAD),
     tap(action => {
       // If there isn't a filename, save-as it instead
@@ -67,9 +125,18 @@ export const loadEpic = (actions: ActionsObservable<*>) =>
       }
     }),
     // Switch map since we want the last load request to be the lead
-    switchMap(action =>
-      readFileObservable(action.filename).pipe(
-        map(data => convertRawNotebook(action.filename, data)),
+    switchMap(action => {
+      const filepath = action.filename;
+
+      return forkJoin(
+        readFileObservable(filepath),
+        statObservable(filepath),
+        // Project onto the Contents API response
+        (content, stat) => createContentsResponse(filepath, stat, content)
+      ).pipe(
+        // TODO: Switch this all to a response to fetchContents instead
+        //       and handle accordingly
+        map(({ content, path }) => convertRawNotebook(path, content)),
         mergeMap(({ filename, notebook }) => {
           const { cwd, kernelSpecName } = extractNewKernel(filename, notebook);
           return of(
@@ -81,8 +148,8 @@ export const loadEpic = (actions: ActionsObservable<*>) =>
           );
         }),
         catchError(err => of({ type: "ERROR", payload: err, error: true }))
-      )
-    )
+      );
+    })
   );
 
 /**


### PR DESCRIPTION
In order to get `@nteract/core` and Desktop inline, I've made the `LOAD` action create a contents API response. It gets dropped at the moment (you can `tap` it to see the payload).

Also a precursor to #2532.