### PR TITLE
That's so fetch!

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -10,7 +10,7 @@ import {
   setNotebook,
   extractNewKernel,
   convertRawNotebook,
-  loadEpic,
+  fetchContentEpic,
   newNotebookEpic
 } from "../../../src/notebook/epics/loading";
 
@@ -35,7 +35,7 @@ describe("loadingEpic", () => {
       type: "CORE/FETCH_CONTENT",
       payload: {}
     });
-    const responseActions = loadEpic(action$);
+    const responseActions = fetchContentEpic(action$);
     responseActions.subscribe(
       _ => _,
       err => {
@@ -53,7 +53,7 @@ describe("loadingEpic", () => {
       payload: { path: "file" }
     });
 
-    const responseActions = await loadEpic(action$)
+    const responseActions = await fetchContentEpic(action$)
       .pipe(toArray())
       .toPromise();
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -343,8 +343,10 @@ describe("menu", () => {
 
       menu.dispatchLoad(store, {}, "test-ipynb.ipynb");
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: "LOAD",
-        filename: "test-ipynb.ipynb"
+        type: "CORE/FETCH_CONTENT",
+        payload: {
+          path: "test-ipynb.ipynb"
+        }
       });
     });
   });

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -3,7 +3,7 @@ import { catchError } from "rxjs/operators";
 import { saveEpic, saveAsEpic } from "./saving";
 
 import {
-  loadEpic,
+  fetchContentEpic,
   newNotebookEpic,
   launchKernelWhenNotebookSetEpic
 } from "./loading";
@@ -54,7 +54,7 @@ const epics = [
   publishEpic,
   saveEpic,
   saveAsEpic,
-  loadEpic,
+  fetchContentEpic,
   newNotebookEpic,
   executeCellEpic,
   updateDisplayEpic,

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -2,7 +2,11 @@
 import { catchError } from "rxjs/operators";
 import { saveEpic, saveAsEpic } from "./saving";
 
-import { loadEpic, newNotebookEpic } from "./loading";
+import {
+  loadEpic,
+  newNotebookEpic,
+  launchKernelWhenNotebookSetEpic
+} from "./loading";
 
 import type { ActionsObservable, Epic } from "redux-observable";
 
@@ -21,7 +25,8 @@ import {
   executeCellEpic,
   updateDisplayEpic,
   commListenEpic,
-  executeAllCellsEpic
+  executeAllCellsEpic,
+  setNotebookEpic
 } from "@nteract/core/epics";
 
 import { publishEpic } from "./github-publish";
@@ -40,6 +45,8 @@ export const wrapEpic = (epic: Epic<*, *, *>) => (...args: any) =>
   epic(...args).pipe(catchError(retryAndEmitError));
 
 const epics = [
+  launchKernelWhenNotebookSetEpic,
+  setNotebookEpic,
   executeAllCellsEpic,
   restartKernelEpic,
   watchSpawn,

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -109,7 +109,7 @@ function createContentsResponse(
  *
  * @param  {ActionObservable}  A LOAD action with the notebook filename
  */
-export const loadEpic = (action$: ActionsObservable<*>) =>
+export const fetchContentEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
     ofType(actionTypes.FETCH_CONTENT),
     tap(action => {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -244,7 +244,7 @@ export function dispatchCreateTextCellAfter(store: *) {
 }
 
 export function dispatchLoad(store: *, event: Event, filename: string) {
-  store.dispatch(actions.load(filename));
+  store.dispatch(actions.fetchContent({ path: filename }));
 }
 
 export function dispatchNewNotebook(

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -92,15 +92,6 @@ describe("commMessageAction", () => {
   });
 });
 
-describe("load", () => {
-  test("loads a notebook", () => {
-    expect(actions.load("mytest.ipynb")).toEqual({
-      type: actionTypes.LOAD,
-      filename: "mytest.ipynb"
-    });
-  });
-});
-
 describe("newNotebook", () => {
   test("creates a new notebook", () => {
     expect(actions.newNotebook({ spec: "hokey" }, "/tmp")).toEqual({

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -493,8 +493,6 @@ export const SAVE = "SAVE";
 export const SAVE_FAILED = "SAVE_FAILED";
 // TODO: Relocate this action type from desktop's app.js
 export const SAVE_AS = "SAVE_AS";
-// TODO: Relocate this action type from desktop's app.js
-export const LOAD = "LOAD";
 
 // TODO: Properly type this action, which is only produced, never consumed
 export const KERNEL_RAW_STDOUT = "KERNEL_RAW_STDOUT";

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -133,9 +133,9 @@ export const fetchContentFulfilled = (payload: {
 
 export const fetchContentFailed = (payload: {
   path: string,
-  error: Object
-}): FetchContentFulfilled => ({
-  type: actionTypes.FETCH_CONTENT_FULFILLED,
+  error: Error
+}): FetchContentFailed => ({
+  type: actionTypes.FETCH_CONTENT_FAILED,
   payload
 });
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -628,13 +628,6 @@ export function doneSaving() {
   };
 }
 
-export function load(filename: string) {
-  return {
-    type: actionTypes.LOAD,
-    filename
-  };
-}
-
 // TODO: Use a kernel spec type
 export function newNotebook(kernelSpec: Object, cwd: string) {
   return {


### PR DESCRIPTION
Desktop is now just like the webapp, in that it creates Contents API responses! No more `load` action or `LOAD` actionType. 😄 

This also fixes up `fetchContentFailed` returning the right payload now.

All of this is in support of making #2516 easier to digest.