### PR TITLE
[WIP] create a scales segment of our styles

### DIFF
--- a/packages/styles/src/config.json
+++ b/packages/styles/src/config.json
@@ -97,6 +97,42 @@
           "lightest": "hsl(33, 75%, 97%)"
         }
       },
+      "scale": {
+        "category10": [
+          "#1f77b4",
+          "#ff7f0e",
+          "#2ca02c",
+          "#d62728",
+          "#9467bd",
+          "#8c564b",
+          "#e377c2",
+          "#7f7f7f",
+          "#bcbd22",
+          "#17becf"
+        ],
+        "category20": [
+          "#1f77b4",
+          "#aec7e8",
+          "#ff7f0e",
+          "#ffbb78",
+          "#2ca02c",
+          "#98df8a",
+          "#d62728",
+          "#ff9896",
+          "#9467bd",
+          "#c5b0d5",
+          "#8c564b",
+          "#c49c94",
+          "#e377c2",
+          "#f7b6d2",
+          "#7f7f7f",
+          "#c7c7c7",
+          "#bcbd22",
+          "#dbdb8d",
+          "#17becf",
+          "#9edae5"
+        ]
+      },
       "borderRadius": {
         "none": 0,
         "s": "1px",


### PR DESCRIPTION
This incorporate's two of [vega's color scales](https://github.com/vega/vega/wiki/Scales), category10 and category20.

I don't know _how_ we'd want to do categorical palettes with our styles setup, so I'm just starting this to kick it off and get input from @theengineear.

I'm imagining the way we'd use this is with:

```css
.completion-type-keyword:before {
  content: "k";
}
.completion-type-keyword {
  background-color: var(--theme-scale-idx-1);
}

.completion-type-class:before {
  content: "C";
}
.completion-type-class {
  background-color: var(--theme-scale-idx-2);
}
```

Whereas the theme would set / use a particular scale. For the light theme, they could use:

```css
--theme-scale-idx-1: var(--nt-scale-vega-category10-1)
```

Thoughts?
