### PR TITLE
Clean up some remaining selector usage

### DIFF
--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -214,6 +214,8 @@ export const named = {
 };
 
 export function loadFullMenu(store: * = global.store) {
+  // NOTE for those looking for selectors -- this state is not the same as the
+  //      "core" state -- it's a main process side model in the electron app
   const state = store.getState();
   const kernelSpecs = state.get("kernelSpecs") ? state.get("kernelSpecs") : {};
 

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -163,7 +163,7 @@ export function handleGistAction(store: any, action: any) {
   const githubUsername = selectors.currentNotebookGithubUsername(state);
   const gistId = selectors.currentNotebookGistId(state);
   const filename = selectors.currentFilename(state);
-  const notificationSystem = state.app.get("notificationSystem");
+  const notificationSystem = selectors.notificationSystem(state);
   let publishAsUser = false;
   if (action.type === PUBLISH_USER_GIST) {
     const githubToken = state.app.get("githubToken");

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -41,7 +41,7 @@ export function saveEpic(
         map(() => {
           if (process.platform !== "darwin") {
             const state = store.getState();
-            const notificationSystem = state.app.get("notificationSystem");
+            const notificationSystem = selectors.notificationSystem(state);
             notificationSystem.addNotification({
               title: "Save successful!",
               autoDismiss: 2,

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -127,7 +127,7 @@ export const restartKernelEpic = (action$: ActionsObservable<*>, store: *) =>
     concatMap(action => {
       const state = store.getState();
       const kernel = selectors.currentKernel(state);
-      const notificationSystem = state.app.notificationSystem;
+      const notificationSystem = selectors.notificationSystem(state);
 
       if (!kernel) {
         notificationSystem.addNotification({

--- a/packages/core/src/middlewares.js
+++ b/packages/core/src/middlewares.js
@@ -2,6 +2,8 @@
 // NOTE: These are just default middlewares here for now until I figure out how
 // to divide up the desktop app and this core package
 
+import * as selectors from "../selectors";
+
 type Action = {
   type: string
 };
@@ -24,7 +26,7 @@ export const errorMiddleware = (
     errorText = JSON.stringify(action, null, 2);
   }
   const state = store.getState();
-  const notificationSystem = state.app.get("notificationSystem");
+  const notificationSystem = selectors.notificationSystem(state);
   if (notificationSystem) {
     notificationSystem.addNotification({
       title: action.type,


### PR DESCRIPTION
This switches out the remaining usages of `store.getState()` to use proper `selectors`.

I also didn't change tests that use `store.getState()`, opting instead to let it pick the path directly.

Note: I didn't touch the one use of the `githubToken`.