### PR TITLE
include ~/.npm in cache for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
 
       - save_cache:
           paths:
+            - ~/.npm
             - ./node_modules
             - ~/.jestcache
           key: v1-dependencies-{{ checksum "package.json" }}


### PR DESCRIPTION
This should help the lerna install out on circle CI to be a bit quicker.