### PR TITLE
Add concept of sessions to plan doc.

### DIFF
--- a/packages/core/plan.md
+++ b/packages/core/plan.md
@@ -85,6 +85,14 @@ type core = {
         }
       }
     },
+    sessions: {
+      byRef: {
+        [ref: Ref]: {
+          loading: boolean,
+          error: ?Object
+        }
+      }
+    },
     kernels: {
       byRef: {
         [ref: Ref]: {
@@ -226,6 +234,19 @@ type core = {
         }
       }
     },
+
+    sessions: {
+      byRef: {
+        [ref: Ref]: {
+          id: Id,
+          name: string, // This is just a display name.
+          type: string, // TODO: this should be an enum.
+          kernelRef: Ref
+        }
+      },
+      refs: Array<Ref>
+    },
+    
     contents: {
       byRef: {
         [ref: Ref]: {
@@ -246,10 +267,10 @@ type core = {
           // here.
           model: ?Object, // null | DirectoryModel | NotebookModel | FileModel
 
-          // The kernelRef is nullable here because we don't necessarily need
-          // the kernel to be running to display the document. This allows us 
-          // to render a document and start up a kernel in parallel.
-          kernelRef: ?KernelRef 
+          // The sessionRef is nullable here because we don't necessarily need
+          // the session to be running to display the document. This allows us 
+          // to render a document and start up a session in parallel.
+          sessionRef: ?SessionRef 
         }
       }
     },


### PR DESCRIPTION
I'm not 100% sure on this state model. But I wanted to push it up to have a conversation.

We should try to design this state such that it will allow us to push the future features we want without too much stress. So, we should keep in mind that we may eventually want to show two (for lack of a better word, _contents_) at the same time, say, a notebook and a console... These _contents_ might have their own sessions.

I think in general, we should try to keep the state centered around one active _content_ hunk at a time. So our base assumption is that users are focused on one (and only one) thing in our app at a time.

^^ If we make that assumption then I think that core > content* > session > kernel > host is the natural order of referencing. That is, the top-level `core` state knows that one and only one `content`. The content knows about its session. A session knows about its kernel. And, finally, a kernel knows about its host.

*One potential caveat is a content that doesn't require a session (like an image file or something). That will likely need direct knowledge of its host. So maybe its more like core > content > (host, session > kernel > host).
