### PR TITLE
Finish off cleaning the top level namespace of core

### DIFF
--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -18,16 +18,7 @@ import {
   watchSpawn
 } from "./zeromq-kernels";
 
-import {
-  restartKernelEpic,
-  acquireKernelInfoEpic,
-  watchExecutionStateEpic,
-  executeCellEpic,
-  updateDisplayEpic,
-  commListenEpic,
-  executeAllCellsEpic,
-  setNotebookEpic
-} from "@nteract/core/epics";
+import { epics as coreEpics } from "@nteract/core";
 
 import { publishEpic } from "./github-publish";
 
@@ -46,25 +37,26 @@ export const wrapEpic = (epic: Epic<*, *, *>) => (...args: any) =>
   epic(...args).pipe(catchError(retryAndEmitError));
 
 const epics = [
+  coreEpics.restartKernelEpic,
+  coreEpics.acquireKernelInfoEpic,
+  coreEpics.watchExecutionStateEpic,
+  coreEpics.executeCellEpic,
+  coreEpics.updateDisplayEpic,
+  coreEpics.commListenEpic,
+  coreEpics.executeAllCellsEpic,
+  coreEpics.setNotebookEpic,
+
   launchKernelWhenNotebookSetEpic,
-  setNotebookEpic,
-  executeAllCellsEpic,
-  restartKernelEpic,
   watchSpawn,
-  commListenEpic,
   publishEpic,
   saveEpic,
   saveAsEpic,
   fetchContentEpic,
   newNotebookEpic,
-  executeCellEpic,
-  updateDisplayEpic,
   launchKernelEpic,
   launchKernelByNameEpic,
   interruptKernelEpic,
   killKernelEpic,
-  acquireKernelInfoEpic,
-  watchExecutionStateEpic,
   loadConfigEpic,
   saveConfigEpic,
   saveConfigOnChangeEpic

--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -5,7 +5,7 @@ import type { AppState } from "@nteract/core/src/state";
 
 import { dialog } from "electron";
 import { is } from "immutable";
-import * as selectors from "@nteract/core/selectors";
+import { selectors } from "@nteract/core";
 
 import { killKernelImmediately } from "./epics/zeromq-kernels";
 

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -22,6 +22,7 @@ import { initGlobalHandlers } from "./global-events";
 
 import { state } from "@nteract/core";
 
+// $FlowFixMe: this state tree is missing core and modals
 const store = configureStore({
   // $FlowFixMe
   app: state.makeAppRecord({

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -22,7 +22,6 @@ import { initGlobalHandlers } from "./global-events";
 
 import { state } from "@nteract/core";
 
-// $FlowFixMe: this state tree is missing core and modals
 const store = configureStore({
   // $FlowFixMe
   app: state.makeAppRecord({
@@ -33,7 +32,10 @@ const store = configureStore({
   comms: state.makeCommsRecord(),
   config: ImmutableMap({
     theme: "light"
-  })
+  }),
+  // TODO: FIXME FIXME
+  core: ImmutableMap(),
+  modals: ImmutableMap()
 });
 
 // Register for debugging

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -8,9 +8,7 @@ import * as fs from "fs";
 
 import { throttle } from "lodash";
 
-import { actions } from "@nteract/core";
-
-import * as selectors from "@nteract/core/selectors";
+import { actions, selectors } from "@nteract/core";
 
 export function cwdKernelFallback() {
   // HACK: If we see they're at /, we assume that was the OS launching the Application

--- a/applications/desktop/src/notebook/middlewares.js
+++ b/applications/desktop/src/notebook/middlewares.js
@@ -1,5 +1,5 @@
 // @flow
-import { errorMiddleware } from "@nteract/core/middlewares";
+import { middlewares as coreMiddlewares } from "@nteract/core";
 
 import { createEpicMiddleware, combineEpics } from "redux-observable";
 
@@ -11,7 +11,10 @@ type Action = {
   type: string
 };
 
-const middlewares = [createEpicMiddleware(rootEpic), errorMiddleware];
+const middlewares = [
+  createEpicMiddleware(rootEpic),
+  coreMiddlewares.errorMiddleware
+];
 
 if (process.env.DEBUG === "true") {
   const logger = require("./logger"); // eslint-disable-line global-require

--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.js
@@ -6,9 +6,7 @@ import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-import { reducers, state } from "@nteract/core";
-
-import { allEpics as epics } from "@nteract/core/epics";
+import { reducers, state, epics as coreEpics } from "@nteract/core";
 
 export type JupyterConfigData = {
   token: string,
@@ -49,7 +47,7 @@ export default function configureStore({
     })
   };
 
-  const rootEpic = combineEpics(...epics);
+  const rootEpic = combineEpics(...coreEpics.allEpics);
   const middlewares = [createEpicMiddleware(rootEpic)];
 
   return createStore(

--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.js
@@ -44,7 +44,10 @@ export default function configureStore({
     comms: state.makeCommsRecord(),
     config: ImmutableMap({
       theme: "light"
-    })
+    }),
+    // FIXME FIXME FIXME FIXME
+    core: ImmutableMap(),
+    modals: ImmutableMap()
   };
 
   const rootEpic = combineEpics(...coreEpics.allEpics);

--- a/applications/notebook-on-next/store.js
+++ b/applications/notebook-on-next/store.js
@@ -22,7 +22,10 @@ const defaultState = {
   comms: state.makeCommsRecord(),
   config: ImmutableMap({
     theme: "light"
-  })
+  }),
+  // TODO FIXME FIXME FIXME
+  core: ImmutableMap(),
+  modals: ImmutableMap()
 };
 
 const composeEnhancers =

--- a/applications/notebook-on-next/store.js
+++ b/applications/notebook-on-next/store.js
@@ -4,26 +4,10 @@ import { createEpicMiddleware, combineEpics } from "redux-observable";
 
 import { Map as ImmutableMap } from "immutable";
 
-import { reducers, state } from "@nteract/core";
-
-import {
-  executeCellEpic,
-  updateDisplayEpic,
-  commListenEpic,
-  launchWebSocketKernelEpic,
-  acquireKernelInfoEpic,
-  watchExecutionStateEpic
-} from "@nteract/core/epics";
+import { reducers, state, epics as coreEpics } from "@nteract/core";
 
 // TODO: Bring desktop's wrapEpic over to @nteract/core so we can use it here
-const epics = [
-  executeCellEpic,
-  updateDisplayEpic,
-  commListenEpic,
-  launchWebSocketKernelEpic,
-  acquireKernelInfoEpic,
-  watchExecutionStateEpic
-];
+const epics = coreEpics.allEpics;
 
 const rootReducer = combineReducers({
   app: reducers.app,

--- a/applications/play/redux/createStore.js
+++ b/applications/play/redux/createStore.js
@@ -2,7 +2,8 @@
 import { applyMiddleware, createStore } from "redux";
 import { combineReducers, compose } from "redux";
 import { createEpicMiddleware } from "redux-observable";
-import { errorMiddleware } from "@nteract/core/middlewares";
+import { middlewares as coreMiddlewares } from "@nteract/core";
+
 import epics from "./epics";
 import reducer from "./reducer";
 import getInitialState from "./getInitialState";
@@ -37,6 +38,8 @@ export default function(givenInitialState: Object = {}) {
   return createStore(
     reducer,
     initialState,
-    composeEnhancers(applyMiddleware(epicMiddleware, errorMiddleware))
+    composeEnhancers(
+      applyMiddleware(epicMiddleware, coreMiddlewares.errorMiddleware)
+    )
   );
 }

--- a/packages/core/actionTypes.js
+++ b/packages/core/actionTypes.js
@@ -1,1 +1,0 @@
-module.exports = require("./").constants;

--- a/packages/core/epics.js
+++ b/packages/core/epics.js
@@ -1,2 +1,0 @@
-// @flow
-module.exports = require("./").epics;

--- a/packages/core/middlewares.js
+++ b/packages/core/middlewares.js
@@ -1,1 +1,0 @@
-module.exports = require("./").middlewares;

--- a/packages/core/selectors.js
+++ b/packages/core/selectors.js
@@ -1,1 +1,0 @@
-module.exports = require("./").selectors;

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -25,8 +25,8 @@ import { fetchKernelspecsEpic } from "./kernelspecs";
 
 import { fetchContentEpic, setNotebookEpic, saveContentEpic } from "./contents";
 
-// Because `@nteract/core/epics` ends up being a commonjs import, we can't currently
-// rely on a default export or a `import * as epics from ""@nteract/core/epics"`
+// Because `@nteract/core` ends up being a commonjs import, we can't currently
+// rely on `import { epics } from ""@nteract/core"`
 // as it would collide the array with the named exports
 const allEpics = [
   executeCellEpic,

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -135,7 +135,7 @@ export const restartKernelEpic = (action$: ActionsObservable<*>, store: *) =>
           level: "error"
         });
 
-        // TODO: Wow do we need to send notifcations through our store for
+        // TODO: Wow do we need to send notifications through our store for
         // consistency
         return empty();
       }

--- a/packages/core/src/middlewares.js
+++ b/packages/core/src/middlewares.js
@@ -2,7 +2,7 @@
 // NOTE: These are just default middlewares here for now until I figure out how
 // to divide up the desktop app and this core package
 
-import * as selectors from "../selectors";
+import * as selectors from "./selectors";
 
 type Action = {
   type: string

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -3,8 +3,8 @@
 // FIXME FIXME FIXME SUPER WRONG FIXME FIXME FIXME
 type AppState = {
   // The new way
-  core: Object,
-  modals: Object,
+  core: any,
+  modals: any,
 
   // The old way
   app: Object,

--- a/packages/core/src/state/old/index.js
+++ b/packages/core/src/state/old/index.js
@@ -212,5 +212,7 @@ export type AppState = {
   app: RecordOf<AppRecordProps>,
   document: RecordOf<DocumentRecordProps>,
   comms: RecordOf<CommsRecordProps>,
-  config: Map<string, any>
+  config: Map<string, any>,
+  core: *,
+  modals: *
 };

--- a/packages/core/src/state/old/index.js
+++ b/packages/core/src/state/old/index.js
@@ -213,6 +213,7 @@ export type AppState = {
   document: RecordOf<DocumentRecordProps>,
   comms: RecordOf<CommsRecordProps>,
   config: Map<string, any>,
-  core: *,
-  modals: *
+  // TODO FIXME FIXME
+  core: Map<any, any>,
+  modals: Map<any, any>
 };


### PR DESCRIPTION
This cleans up the top level namespace of core (no more `@nteract/core/actions`)