### PR TITLE
Allow kernel refs

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -1,6 +1,6 @@
 import { ActionsObservable } from "redux-observable";
 
-import { actionTypes } from "@nteract/core";
+import { actions, actionTypes } from "@nteract/core";
 
 import {
   acquireKernelInfo,
@@ -36,13 +36,15 @@ describe("launchKernelEpic", () => {
       err => done.fail(err)
     );
   });
+
   test("calls launchKernelObservable if given the correct action", async function() {
     const actionBuffer = [];
-    const action$ = ActionsObservable.of({
-      type: actionTypes.LAUNCH_KERNEL,
-      kernelSpec: { spec: "hokey", name: "woohoo" },
-      cwd: "~"
-    });
+    const action$ = ActionsObservable.of(
+      actions.launchKernel({
+        kernelSpec: { spec: "hokey", name: "woohoo" },
+        cwd: "~"
+      })
+    );
 
     const state = {
       app: {
@@ -61,12 +63,8 @@ describe("launchKernelEpic", () => {
       .toPromise();
 
     expect(responses).toEqual([
-      {
-        type: actionTypes.SET_KERNEL_INFO,
-        kernelInfo: { spec: "hokey", name: "woohoo" }
-      },
-      {
-        type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
+      actions.setNotebookKernelInfo({ spec: "hokey", name: "woohoo" }),
+      actions.launchKernelSuccessful({
         kernel: {
           ref: expect.any(String),
           lastActivity: null,
@@ -78,22 +76,22 @@ describe("launchKernelEpic", () => {
           kernelSpecName: "woohoo",
           status: "launched"
         }
-      },
-      {
-        type: "SET_EXECUTION_STATE",
+      }),
+      actions.setExecutionState({
         kernelStatus: "launched"
-      }
+      })
     ]);
   });
 });
 
 describe("launchKernelByNameEpic", () => {
   test("creates a LAUNCH_KERNEL action in response to a LAUNCH_KERNEL_BY_NAME action", done => {
-    const action$ = ActionsObservable.of({
-      type: actionTypes.LAUNCH_KERNEL_BY_NAME,
-      kernelSpecName: "python3",
-      cwd: "~"
-    });
+    const action$ = ActionsObservable.of(
+      actions.launchKernelByName({
+        kernelSpecName: "python3",
+        cwd: "~"
+      })
+    );
     const obs = launchKernelByNameEpic(action$);
     obs.pipe(toArray()).subscribe(
       actions => {

--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -63,6 +63,7 @@ describe("loadingEpic", () => {
           error: expect.anything(),
           path: "file"
         },
+        error: true,
         type: "CORE/FETCH_CONTENT_FAILED"
       }
     ]);
@@ -73,8 +74,10 @@ describe("newNotebookEpic", () => {
   test("calls new Kernel after creating a new notebook", async function() {
     const action$ = ActionsObservable.of({
       type: actionTypes.NEW_NOTEBOOK,
-      kernelSpec: {
-        name: "hylang"
+      payload: {
+        kernelSpec: {
+          name: "hylang"
+        }
       }
     });
     const responseActions = await newNotebookEpic(action$)
@@ -83,12 +86,14 @@ describe("newNotebookEpic", () => {
 
     expect(responseActions).toEqual([
       {
-        filename: null,
         type: actionTypes.SET_NOTEBOOK,
-        notebook: monocellNotebook.setIn(
-          ["metadata", "kernel_info", "name"],
-          "hylang"
-        )
+        payload: {
+          filename: null,
+          notebook: monocellNotebook.setIn(
+            ["metadata", "kernel_info", "name"],
+            "hylang"
+          )
+        }
       }
     ]);
   });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -185,7 +185,8 @@ describe("menu", () => {
 
       if (process.platform !== "win32") {
         expect(store.dispatch).toHaveBeenCalledWith({
-          type: actionTypes.INTERRUPT_KERNEL
+          type: actionTypes.INTERRUPT_KERNEL,
+          payload: {}
         });
       }
     });
@@ -304,8 +305,10 @@ describe("menu", () => {
 
       expect(store.dispatch).toHaveBeenCalledWith({
         type: actionTypes.LAUNCH_KERNEL,
-        kernelSpec: { spec: "hokey" },
-        cwd: process.cwd()
+        payload: {
+          kernelSpec: { spec: "hokey" },
+          cwd: process.cwd()
+        }
       });
     });
   });
@@ -360,8 +363,10 @@ describe("menu", () => {
       menu.dispatchNewNotebook(store, {}, { spec: "hokey" });
       expect(store.dispatch).toHaveBeenCalledWith({
         type: "NEW_NOTEBOOK",
-        kernelSpec: { spec: "hokey" },
-        cwd: process.cwd()
+        payload: {
+          kernelSpec: { spec: "hokey" },
+          cwd: process.cwd()
+        }
       });
     });
   });

--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -12,6 +12,7 @@ import { killKernelImmediately } from "./epics/zeromq-kernels";
 export function unload(store: Store<AppState, Action>) {
   const kernel = selectors.currentKernel(store.getState());
   if (kernel) {
+    // TODO: Do we need to provide a KernelRef here?
     killKernelImmediately(kernel);
   }
   return;

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -10,6 +10,8 @@ import { throttle } from "lodash";
 
 import { actions, selectors } from "@nteract/core";
 
+import type { KernelRef } from "@nteract/core/src/state/refs";
+
 export function cwdKernelFallback() {
   // HACK: If we see they're at /, we assume that was the OS launching the Application
   //       from a launcher (launchctl on macOS)
@@ -73,6 +75,7 @@ export function triggerWindowRefresh(store: *, filename: string) {
 }
 
 export function dispatchRestartKernel(store: *) {
+  // TODO: provide a KernelRef
   store.dispatch(actions.restartKernel());
 }
 
@@ -92,12 +95,17 @@ export function triggerKernelRefresh(store: *, filename: string): Promise<*> {
       },
       index => {
         if (index === 0) {
+          // TODO: get a KernelRef here and use it in selector.
           const kernel = selectors.currentKernel(store.getState());
           const cwd = filename
             ? path.dirname(path.resolve(filename))
             : cwdKernelFallback();
           store.dispatch(
-            actions.launchKernelByName(kernel.kernelSpecName, cwd)
+            // TODO: get a KernelRef here and use it in action.
+            actions.launchKernelByName({
+              kernelSpecName: kernel.kernelSpecName,
+              cwd
+            })
           );
         }
         resolve();
@@ -129,7 +137,8 @@ export function dispatchNewKernel(store: *, evt: Event, spec: Object) {
   const cwd = filename
     ? path.dirname(path.resolve(filename))
     : cwdKernelFallback();
-  store.dispatch(actions.launchKernel(spec, cwd));
+  // TODO: get a KernelRef here and use it in action.
+  store.dispatch(actions.launchKernel({ kernelSpec: spec, cwd }));
 }
 
 export function dispatchPublishAnonGist(store: *) {
@@ -172,7 +181,8 @@ export function dispatchUnhideAll(store: *) {
 }
 
 export function dispatchKillKernel(store: *) {
-  store.dispatch(actions.killKernel());
+  // TODO: get a KernelRef here and use it in action.
+  store.dispatch(actions.killKernel({ restarting: false }));
 }
 
 export function dispatchInterruptKernel(store: *) {
@@ -186,11 +196,13 @@ export function dispatchInterruptKernel(store: *) {
       level: "error"
     });
   } else {
-    store.dispatch(actions.interruptKernel());
+    // TODO: get a KernelRef here and use it in action.
+    store.dispatch(actions.interruptKernel({}));
   }
 }
 
 export function dispatchRestartClearAll(store: *) {
+  // TODO: provide a KernelRef
   store.dispatch(actions.restartKernel({ clearOutputs: true }));
 }
 
@@ -243,6 +255,7 @@ export function dispatchCreateTextCellAfter(store: *) {
 }
 
 export function dispatchLoad(store: *, event: Event, filename: string) {
+  // TODO: provide KernelRef here.
   store.dispatch(actions.fetchContent({ path: filename, params: {} }));
 }
 
@@ -251,7 +264,13 @@ export function dispatchNewNotebook(
   event: Event,
   kernelSpec: Object
 ) {
-  store.dispatch(actions.newNotebook(kernelSpec, cwdKernelFallback()));
+  // TODO: provide KernelRef here.
+  store.dispatch(
+    actions.newNotebook({
+      kernelSpec,
+      cwd: cwdKernelFallback()
+    })
+  );
 }
 
 /**

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -47,6 +47,7 @@ function createApp(jupyterConfigData: JupyterConfigData) {
       );
 
       // TODO: we should likely be passing in a hostRef to fetchContent too.
+      // TODO: provide a KernelRef
       store.dispatch(
         actions.fetchContent({
           path: jupyterConfigData.contentsPath,

--- a/package.json
+++ b/package.json
@@ -205,5 +205,6 @@
     "webpack-merge": "^4.1.2",
     "winston": "^2.3.0",
     "yargs": "^11.0.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -14,9 +14,9 @@ describe("setLanguageInfo", () => {
       version: "3.5.1"
     };
 
-    expect(actions.setLanguageInfo(langInfo)).toEqual({
+    expect(actions.setLanguageInfo({ langInfo })).toEqual({
       type: actionTypes.SET_LANGUAGE_INFO,
-      langInfo
+      payload: { langInfo }
     });
   });
 });
@@ -94,49 +94,71 @@ describe("commMessageAction", () => {
 
 describe("newNotebook", () => {
   test("creates a new notebook", () => {
-    expect(actions.newNotebook({ spec: "hokey" }, "/tmp")).toEqual({
+    expect(
+      actions.newNotebook({
+        kernelSpec: { spec: "hokey" },
+        cwd: "/tmp"
+      })
+    ).toEqual({
       type: actionTypes.NEW_NOTEBOOK,
-      kernelSpec: { spec: "hokey" },
-      cwd: "/tmp"
+      payload: {
+        kernelSpec: { spec: "hokey" },
+        cwd: "/tmp"
+      }
     });
   });
 });
 
 describe("setNotebook", () => {
   test("sets a notebook", () => {
-    expect(actions.setNotebook("test", { nbformat: 4, cells: [] })).toEqual({
+    expect(
+      actions.setNotebook({
+        filename: "test",
+        notebook: { nbformat: 4, cells: [] }
+      })
+    ).toEqual({
       type: actionTypes.SET_NOTEBOOK,
-      filename: "test",
-      notebook: { nbformat: 4, cells: [] }
+      payload: {
+        filename: "test",
+        notebook: { nbformat: 4, cells: [] }
+      }
     });
   });
 });
 
 describe("setExecutionState", () => {
   test("creates a SET_EXECUTION_STATE action", () => {
-    expect(actions.setExecutionState("idle")).toEqual({
+    expect(actions.setExecutionState({ kernelStatus: "idle" })).toEqual({
       type: actionTypes.SET_EXECUTION_STATE,
-      kernelStatus: "idle"
+      payload: { kernelStatus: "idle" }
     });
   });
 });
 
 describe("launchKernel", () => {
   test("creates a LAUNCH_KERNEL action", () => {
-    expect(actions.launchKernel({ spec: "hokey" }, ".")).toEqual({
+    expect(
+      actions.launchKernel({ kernelSpec: { spec: "hokey" }, cwd: "." })
+    ).toEqual({
       type: actionTypes.LAUNCH_KERNEL,
-      kernelSpec: { spec: "hokey" },
-      cwd: "."
+      payload: {
+        kernelSpec: { spec: "hokey" },
+        cwd: "."
+      }
     });
   });
 });
 
 describe("launchKernelByName", () => {
   test("creates a LAUNCH_KERNEL_BY_NAME action", () => {
-    expect(actions.launchKernelByName("python2", ".")).toEqual({
+    expect(
+      actions.launchKernelByName({ kernelSpecName: "python2", cwd: "." })
+    ).toEqual({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
-      kernelSpecName: "python2",
-      cwd: "."
+      payload: {
+        kernelSpecName: "python2",
+        cwd: "."
+      }
     });
   });
 });

--- a/packages/core/__tests__/app-spec.js
+++ b/packages/core/__tests__/app-spec.js
@@ -46,7 +46,7 @@ describe("setExecutionState", () => {
 
     const action = {
       type: actionTypes.SET_EXECUTION_STATE,
-      kernelStatus: "idle"
+      payload: { kernelStatus: "idle" }
     };
 
     const state = reducers.app(originalState, action);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -3,6 +3,7 @@
 import { List, Map, Set, is } from "immutable";
 
 import * as actionTypes from "../src/actionTypes";
+import * as actions from "../src/actions";
 import { document as reducers } from "../src/reducers";
 
 import {
@@ -163,10 +164,7 @@ describe("reduceOutputs", () => {
 describe("setNotebook", () => {
   test("converts a JSON notebook to our commutable notebook and puts in state", () => {
     const notebook = fromJS(dummyJSON);
-    const state = reducers(initialDocument, {
-      type: actionTypes.SET_NOTEBOOK,
-      notebook
-    });
+    const state = reducers(initialDocument, actions.setNotebook({ notebook }));
     expect(state.getIn(["notebook", "nbformat"])).toBe(4);
   });
 });
@@ -710,7 +708,7 @@ describe("setLanguageInfo", () => {
   test("sets the language object", () => {
     const originalState = monocellDocument;
 
-    const action = { type: actionTypes.SET_LANGUAGE_INFO, langInfo: "test" };
+    const action = actions.setLanguageInfo({ langInfo: "test" });
 
     const state = reducers(originalState, action);
     expect(state.getIn(["notebook", "metadata", "language_info"])).toBe("test");

--- a/packages/core/__tests__/epics/comm-spec.js
+++ b/packages/core/__tests__/epics/comm-spec.js
@@ -6,7 +6,7 @@ import {
   commActionObservable
 } from "../../src/epics/comm";
 
-import { commOpenAction, commMessageAction } from "../../src/actions";
+import * as actions from "../../src/actions";
 
 import { COMM_OPEN, COMM_MESSAGE, COMM_ERROR } from "../../src/actionTypes";
 
@@ -87,13 +87,13 @@ describe("commActionObservable", () => {
       buffers: new Uint8Array()
     };
 
-    const launchKernelAction = {
+    const action = actions.launchKernelSuccessful({
       kernel: {
         channels: of(commOpenMessage, commMessage)
       }
-    };
+    });
 
-    commActionObservable(launchKernelAction)
+    commActionObservable(action)
       .pipe(toArray())
       .subscribe(
         actions => {

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -272,8 +272,10 @@ describe("updateDisplayEpic", () => {
     const channels = from(messages);
     const action$ = ActionsObservable.of({
       type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-      kernel: {
-        channels
+      payload: {
+        kernel: {
+          channels
+        }
       }
     });
 

--- a/packages/core/__tests__/epics/kernel-lifecycle-spec.js
+++ b/packages/core/__tests__/epics/kernel-lifecycle-spec.js
@@ -36,7 +36,7 @@ describe("acquireKernelInfo", () => {
 
     obs.subscribe(langAction => {
       expect(langAction).toEqual({
-        langInfo: { language: "python" },
+        payload: { langInfo: { language: "python" } },
         type: "SET_LANGUAGE_INFO"
       });
       done();
@@ -48,11 +48,13 @@ describe("watchExecutionStateEpic", () => {
   test("returns an Observable with an initial state of idle", done => {
     const action$ = ActionsObservable.of({
       type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-      kernel: {
-        channels: of({
-          header: { msg_type: "status" },
-          content: { execution_state: "idle" }
-        })
+      payload: {
+        kernel: {
+          channels: of({
+            header: { msg_type: "status" },
+            content: { execution_state: "idle" }
+          })
+        }
       }
     });
     const obs = watchExecutionStateEpic(action$);

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -44,7 +44,9 @@ describe("launchWebSocketKernelEpic", () => {
       }
     };
 
-    const action$ = ActionsObservable.of(launchKernelByName("fancy", "/"));
+    const action$ = ActionsObservable.of(
+      launchKernelByName({ kernelSpecName: "fancy", cwd: "/" })
+    );
 
     const responseActions = await launchWebSocketKernelEpic(action$, store)
       .pipe(toArray())
@@ -53,12 +55,14 @@ describe("launchWebSocketKernelEpic", () => {
     expect(responseActions).toEqual([
       {
         type: "LAUNCH_KERNEL_SUCCESSFUL",
-        kernel: {
-          type: "websocket",
-          channels: expect.any(Subject),
-          kernelSpecName: "fancy",
-          cwd: "/",
-          id: "0"
+        payload: {
+          kernel: {
+            type: "websocket",
+            channels: expect.any(Subject),
+            kernelSpecName: "fancy",
+            cwd: "/",
+            id: "0"
+          }
         }
       }
     ]);
@@ -94,7 +98,7 @@ describe("interruptKernelEpic", () => {
       }
     };
 
-    const action$ = ActionsObservable.of(interruptKernel());
+    const action$ = ActionsObservable.of(interruptKernel({}));
 
     const responseActions = await interruptKernelEpic(action$, store)
       .pipe(toArray())
@@ -102,7 +106,8 @@ describe("interruptKernelEpic", () => {
 
     expect(responseActions).toEqual([
       {
-        type: "INTERRUPT_KERNEL_SUCCESSFUL"
+        type: "INTERRUPT_KERNEL_SUCCESSFUL",
+        payload: {}
       }
     ]);
   });

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { HostRef, KernelspecsRef } from "./state/refs";
+import type { HostRef, KernelRef, KernelspecsRef } from "./state/refs";
 import type { HostRecord } from "./state/entities/hosts";
 import type { KernelspecProps } from "./state/entities/kernelspecs";
 
@@ -52,7 +52,8 @@ export type FetchContent = {
   type: "CORE/FETCH_CONTENT",
   payload: {
     path: string,
-    params: Object
+    params: Object,
+    kernelRef?: KernelRef
   }
 };
 
@@ -61,7 +62,8 @@ export type FetchContentFulfilled = {
   type: "CORE/FETCH_CONTENT_FULFILLED",
   payload: {
     path: string,
-    model: any // literal response from API
+    model: any, // literal response from API
+    kernelRef?: KernelRef
   }
 };
 
@@ -70,8 +72,10 @@ export type FetchContentFailed = {
   type: "CORE/FETCH_CONTENT_FAILED",
   payload: {
     path: string,
-    error: Object
-  }
+    error: Error,
+    kernelRef?: KernelRef
+  },
+  error: true
 };
 
 export const FETCH_KERNELSPECS = "CORE/FETCH_KERNELSPECS";
@@ -205,7 +209,10 @@ export type AcceptPayloadMessageAction = {
 export const SET_LANGUAGE_INFO = "SET_LANGUAGE_INFO";
 export type SetLanguageInfoAction = {
   type: "SET_LANGUAGE_INFO",
-  langInfo: OldLanguageInfoMetadata
+  payload: {
+    langInfo: OldLanguageInfoMetadata,
+    ref?: KernelRef
+  }
 };
 
 export const SEND_EXECUTE_REQUEST = "SEND_EXECUTE_REQUEST";
@@ -369,7 +376,10 @@ export type ChangeCellTypeAction = {
 export const SET_EXECUTION_STATE = "SET_EXECUTION_STATE";
 export type SetExecutionStateAction = {
   type: "SET_EXECUTION_STATE",
-  kernelStatus: string
+  payload: {
+    kernelStatus: string,
+    ref?: KernelRef
+  }
 };
 
 export const SET_NOTIFICATION_SYSTEM = "SET_NOTIFICATION_SYSTEM";
@@ -384,41 +394,81 @@ export type SetNotificationSystemAction = {
 export const DONE_SAVING = "DONE_SAVING";
 export type DoneSavingAction = { type: "DONE_SAVING" };
 
+export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
+export type NewNotebook = {
+  type: "NEW_NOTEBOOK",
+  payload: {
+    kernelSpec: Object,
+    kernelRef?: KernelRef
+  }
+};
+
 // TODO: Make this action JSON serializable (don't use the Immutable.js version
 //       of the notebook in this action)
 export const SET_NOTEBOOK = "SET_NOTEBOOK";
 export type SetNotebookAction = {
   type: "SET_NOTEBOOK",
-  notebook: ImmutableNotebook,
-  filename: ?string
+  payload: {
+    notebook: ImmutableNotebook,
+    filename: ?string,
+    kernelRef?: KernelRef
+  }
 };
 
 export const START_SAVING = "START_SAVING";
 export type StartSavingAction = { type: "START_SAVING" };
 
 export const INTERRUPT_KERNEL = "INTERRUPT_KERNEL";
-export type InterruptKernel = { type: "INTERRUPT_KERNEL" };
+export type InterruptKernel = {
+  type: "INTERRUPT_KERNEL",
+  payload: {
+    ref?: KernelRef
+  }
+};
 
 export const INTERRUPT_KERNEL_SUCCESSFUL = "INTERRUPT_KERNEL_SUCCESSFUL";
-export type InterruptKernelSuccessful = { type: "INTERRUPT_KERNEL_SUCCESSFUL" };
+export type InterruptKernelSuccessful = {
+  type: "INTERRUPT_KERNEL_SUCCESSFUL",
+  payload: {
+    ref?: KernelRef
+  }
+};
 
 export const INTERRUPT_KERNEL_FAILED = "INTERRUPT_KERNEL_FAILED";
-export type InterruptKernelFailed = ErrorAction<"INTERRUPT_KERNEL_FAILED">;
+export type InterruptKernelFailed = {
+  type: "INTERRUPT_KERNEL_FAILED",
+  payload: {
+    error: Error,
+    ref?: KernelRef
+  },
+  error: true
+};
 
 export const KILL_KERNEL = "KILL_KERNEL";
 export type KillKernelAction = {
   type: "KILL_KERNEL",
   payload: {
-    restarting: boolean
+    restarting: boolean,
+    ref?: KernelRef
   }
 };
 
 export const KILL_KERNEL_FAILED = "KILL_KERNEL_FAILED";
-export type KillKernelFailed = ErrorAction<"KILL_KERNEL_FAILED">;
+export type KillKernelFailed = {
+  type: "KILL_KERNEL_FAILED",
+  payload: {
+    error: Error,
+    ref?: KernelRef
+  },
+  error: true
+};
 
 export const KILL_KERNEL_SUCCESSFUL = "KILL_KERNEL_SUCCESSFUL";
 export type KillKernelSuccessful = {
-  type: "KILL_KERNEL_SUCCESSFUL"
+  type: "KILL_KERNEL_SUCCESSFUL",
+  payload: {
+    ref?: KernelRef
+  }
 };
 
 export const SET_GITHUB_TOKEN = "SET_GITHUB_TOKEN";
@@ -431,60 +481,123 @@ export const RESTART_KERNEL = "RESTART_KERNEL";
 export type RestartKernel = {
   type: "RESTART_KERNEL",
   payload: {
-    clearOutputs: boolean
+    clearOutputs: boolean,
+    ref?: KernelRef
   }
 };
 
 export const RESTART_KERNEL_FAILED = "RESTART_KERNEL_FAILED";
-export type RestartKernelFailed = ErrorAction<"RESTART_KERNEL_FAILED">;
+export type RestartKernelFailed = {
+  type: "RESTART_KERNEL_FAILED",
+  payload: {
+    error: Error,
+    ref?: KernelRef
+  },
+  error: true
+};
 
 export const RESTART_KERNEL_SUCCESSFUL = "RESTART_KERNEL_SUCCESSFUL";
 export type RestartKernelSuccessful = {
-  type: "RESTART_KERNEL_SUCCESSFUL"
+  type: "RESTART_KERNEL_SUCCESSFUL",
+  payload: {
+    ref?: KernelRef
+  }
 };
 
 export const LAUNCH_KERNEL = "LAUNCH_KERNEL";
 export type LaunchKernelAction = {
   type: "LAUNCH_KERNEL",
-  kernelSpec: Object,
-  cwd: string
+  payload: {
+    ref?: KernelRef,
+    kernelSpec: Object,
+    cwd: string
+  }
 };
 
 export const LAUNCH_KERNEL_FAILED = "LAUNCH_KERNEL_FAILED";
-export type LaunchKernelFailed = ErrorAction<"LAUNCH_KERNEL_FAILED">;
+export type LaunchKernelFailed = {
+  type: "LAUNCH_KERNEL_FAILED",
+  payload: {
+    error: Error,
+    ref?: KernelRef
+  },
+  error: true
+};
 
 export const LAUNCH_KERNEL_SUCCESSFUL = "LAUNCH_KERNEL_SUCCESSFUL";
 export type NewKernelAction = {
   type: "LAUNCH_KERNEL_SUCCESSFUL",
-  kernel: OldLocalKernelProps | OldRemoteKernelProps
+  payload: {
+    kernel: OldLocalKernelProps | OldRemoteKernelProps,
+    ref?: KernelRef
+  }
 };
 
 export const LAUNCH_KERNEL_BY_NAME = "LAUNCH_KERNEL_BY_NAME";
 export type LaunchKernelByNameAction = {
   type: "LAUNCH_KERNEL_BY_NAME",
-  kernelSpecName: string,
-  cwd: string
+  payload: {
+    kernelSpecName: string,
+    cwd: string,
+    ref?: KernelRef
+  }
+};
+
+export const KERNEL_RAW_STDOUT = "KERNEL_RAW_STDOUT";
+export type KernelRawStdout = {
+  type: "KERNEL_RAW_STDOUT",
+  payload: {
+    ref?: KernelRef,
+    text: string
+  }
+};
+
+export const KERNEL_RAW_STDERR = "KERNEL_RAW_STDERR";
+export type KernelRawStderr = {
+  type: "KERNEL_RAW_STDERR",
+  payload: {
+    ref?: KernelRef,
+    text: string
+  }
 };
 
 export const DELETE_CONNECTION_FILE_FAILED = "DELETE_CONNECTION_FILE_FAILED";
-export type DeleteConnectionFileFailedAction = ErrorAction<
-  "DELETE_CONNECTION_FILE_FAILED"
->;
+export type DeleteConnectionFileFailedAction = {
+  type: "DELETE_CONNECTION_FILE_FAILED",
+  payload: {
+    error: Error,
+    ref?: KernelRef
+  },
+  error: true
+};
 
 export const DELETE_CONNECTION_FILE_SUCCESSFUL =
   "DELETE_CONNECTION_FILE_SUCCESSFUL";
 export type DeleteConnectionFileSuccessfulAction = {
-  type: "DELETE_CONNECTION_FILE_SUCCESSFUL"
+  type: "DELETE_CONNECTION_FILE_SUCCESSFUL",
+  payload: {
+    ref?: KernelRef
+  }
 };
 
 export const SHUTDOWN_REPLY_SUCCEEDED = "SHUTDOWN_REPLY_SUCCEEDED";
 export type ShutdownReplySucceeded = {
   type: "SHUTDOWN_REPLY_SUCCEEDED",
-  payload: Object
+  payload: {
+    text: string,
+    ref?: KernelRef
+  }
 };
 
 export const SHUTDOWN_REPLY_TIMED_OUT = "SHUTDOWN_REPLY_TIMED_OUT";
-export type ShutdownReplyTimedOut = ErrorAction<"SHUTDOWN_REPLY_TIMED_OUT">;
+export type ShutdownReplyTimedOut = {
+  type: "SHUTDOWN_REPLY_TIMED_OUT",
+  payload: {
+    error: Error,
+    ref?: KernelRef
+  },
+  error: true
+};
 
 // TODO: This action needs a proper flow type, its from desktop's github store
 export const PUBLISH_USER_GIST = "PUBLISH_USER_GIST";
@@ -497,18 +610,9 @@ export const SAVE_FAILED = "SAVE_FAILED";
 // TODO: Relocate this action type from desktop's app.js
 export const SAVE_AS = "SAVE_AS";
 
-// TODO: Properly type this action, which is only produced, never consumed
-export const KERNEL_RAW_STDOUT = "KERNEL_RAW_STDOUT";
-// TODO: Properly type this action, which is only produced, never consumed
-export const KERNEL_RAW_STDERR = "KERNEL_RAW_STDERR";
-
-// TODO: Properly type this action type, which is consumed only by epics
-export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
-
 // TODO: This needs a proper flow type, is only consumed by the epics
 export const ABORT_EXECUTION = "ABORT_EXECUTION";
 
 // TODO: Properly type these ERROR action types
 export const ERROR_UPDATE_DISPLAY = "ERROR_UPDATE_DISPLAY";
 export const ERROR_EXECUTING = "ERROR_EXECUTING";
-export const ERROR_KERNEL_LAUNCH_FAILED = "ERROR_KERNEL_LAUNCH_FAILED";

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -3,7 +3,7 @@ import * as actionTypes from "./actionTypes";
 
 import type { Notebook } from "@nteract/commutable";
 
-import type { HostRef, KernelspecsRef } from "./state/refs";
+import type { HostRef, KernelRef, KernelspecsRef } from "./state/refs";
 import type { KernelspecProps } from "./state/entities/kernelspecs";
 
 import type {
@@ -43,6 +43,7 @@ import type {
   DeleteMetadataFieldAction,
   OverwriteMetadataFieldAction,
   AcceptPayloadMessageAction,
+  NewNotebook,
   SetNotebookAction,
   NewCellAfterAction,
   NewCellBeforeAction,
@@ -75,6 +76,8 @@ import type {
   SetConfigAction,
   LaunchKernelAction,
   LaunchKernelByNameAction,
+  KernelRawStdout,
+  KernelRawStderr,
   InterruptKernel,
   InterruptKernelSuccessful,
   InterruptKernelFailed,
@@ -118,7 +121,10 @@ export const addHost = (payload: {
 });
 
 export const fetchContent = (
-  payload: { path: string, params: Object } = { path: "/", params: {} }
+  payload: { path: string, params: Object, kernelRef?: KernelRef } = {
+    path: "/",
+    params: {}
+  }
 ): FetchContent => ({
   type: actionTypes.FETCH_CONTENT,
   payload
@@ -126,7 +132,8 @@ export const fetchContent = (
 
 export const fetchContentFulfilled = (payload: {
   path: string,
-  model: any
+  model: any,
+  kernelRef?: KernelRef
 }): FetchContentFulfilled => ({
   type: actionTypes.FETCH_CONTENT_FULFILLED,
   payload
@@ -134,10 +141,12 @@ export const fetchContentFulfilled = (payload: {
 
 export const fetchContentFailed = (payload: {
   path: string,
-  error: Error
+  error: Error,
+  kernelRef?: KernelRef
 }): FetchContentFailed => ({
   type: actionTypes.FETCH_CONTENT_FAILED,
-  payload
+  payload,
+  error: true
 });
 
 export const fetchKernelspecs = (payload: {
@@ -174,34 +183,59 @@ export function launchKernelFailed(error: Error) {
   };
 }
 
-export function launchKernelSuccessful(
-  kernel: OldLocalKernelProps | OldRemoteKernelProps
-): NewKernelAction {
+export function launchKernelSuccessful(payload: {
+  kernel: OldLocalKernelProps | OldRemoteKernelProps,
+  ref?: KernelRef
+}): NewKernelAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
-    kernel
+    payload
   };
 }
 
-export function launchKernel(kernelSpec: any, cwd: string): LaunchKernelAction {
+export function launchKernel(payload: {
+  kernelSpec: any,
+  cwd: string,
+  ref?: KernelRef
+}): LaunchKernelAction {
   return {
     type: actionTypes.LAUNCH_KERNEL,
-    kernelSpec,
-    cwd
+    payload
   };
 }
 
-export function launchKernelByName(
+export function launchKernelByName(payload: {
   kernelSpecName: any,
-  cwd: string
-): LaunchKernelByNameAction {
+  cwd: string,
+  ref?: KernelRef
+}): LaunchKernelByNameAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_BY_NAME,
-    kernelSpecName,
-    cwd
+    payload
   };
 }
 
+export function kernelRawStdout(payload: {
+  text: string,
+  ref?: KernelRef
+}): KernelRawStdout {
+  return {
+    type: actionTypes.KERNEL_RAW_STDOUT,
+    payload
+  };
+}
+
+export function kernelRawStderr(payload: {
+  text: string,
+  ref?: KernelRef
+}): KernelRawStderr {
+  return {
+    type: actionTypes.KERNEL_RAW_STDERR,
+    payload
+  };
+}
+
+// TODO: Does this need to pass KernelRef information?
 export function setNotebookKernelInfo(kernelInfo: any): SetKernelInfoAction {
   return {
     type: actionTypes.SET_KERNEL_INFO,
@@ -209,12 +243,13 @@ export function setNotebookKernelInfo(kernelInfo: any): SetKernelInfoAction {
   };
 }
 
-export function setExecutionState(
-  kernelStatus: string
-): SetExecutionStateAction {
+export function setExecutionState(payload: {
+  kernelStatus: string,
+  ref?: KernelRef
+}): SetExecutionStateAction {
   return {
     type: actionTypes.SET_EXECUTION_STATE,
-    kernelStatus
+    payload
   };
 }
 
@@ -453,8 +488,9 @@ export function deleteMetadata(field: string): DeleteMetadataFieldAction {
   };
 }
 
+// TODO: we should probably remove the default here.
 export function killKernel(
-  payload: { restarting: boolean } = { restarting: false }
+  payload: { restarting: boolean, ref?: KernelRef } = { restarting: false }
 ): KillKernelAction {
   return {
     type: actionTypes.KILL_KERNEL,
@@ -462,7 +498,10 @@ export function killKernel(
   };
 }
 
-export function killKernelFailed(payload: Error): KillKernelFailed {
+export function killKernelFailed(payload: {
+  error: Error,
+  ref?: KernelRef
+}): KillKernelFailed {
   return {
     type: actionTypes.KILL_KERNEL_FAILED,
     payload,
@@ -470,28 +509,38 @@ export function killKernelFailed(payload: Error): KillKernelFailed {
   };
 }
 
-export function killKernelSuccessful(): KillKernelSuccessful {
+export function killKernelSuccessful(payload: {
+  ref?: KernelRef
+}): KillKernelSuccessful {
   return {
-    type: actionTypes.KILL_KERNEL_SUCCESSFUL
+    type: actionTypes.KILL_KERNEL_SUCCESSFUL,
+    payload
   };
 }
 
-export function interruptKernel(): InterruptKernel {
+export function interruptKernel(payload: { ref?: KernelRef }): InterruptKernel {
   return {
-    type: actionTypes.INTERRUPT_KERNEL
+    type: actionTypes.INTERRUPT_KERNEL,
+    payload
   };
 }
 
-export function interruptKernelSuccessful(): InterruptKernelSuccessful {
+export function interruptKernelSuccessful(payload: {
+  ref?: KernelRef
+}): InterruptKernelSuccessful {
   return {
-    type: actionTypes.INTERRUPT_KERNEL_SUCCESSFUL
+    type: actionTypes.INTERRUPT_KERNEL_SUCCESSFUL,
+    payload
   };
 }
 
-export function interruptKernelFailed(error: Error): interruptKernelFailed {
+export function interruptKernelFailed(payload: {
+  error: Error,
+  ref?: KernelRef
+}): interruptKernelFailed {
   return {
     type: actionTypes.INTERRUPT_KERNEL_FAILED,
-    payload: error,
+    payload,
     error: true
   };
 }
@@ -634,25 +683,32 @@ export function doneSaving() {
 }
 
 // TODO: Use a kernel spec type
-export function newNotebook(kernelSpec: Object, cwd: string) {
+export function newNotebook(payload: {
+  kernelSpec: Object,
+  cwd: string,
+  kernelRef?: KernelRef
+}): NewNotebook {
   return {
     type: actionTypes.NEW_NOTEBOOK,
-    kernelSpec,
-    cwd:
-      cwd ||
-      // TODO: Does it matter that this is our fallback when targeting the web app
-      process.cwd()
+    payload: {
+      kernelSpec: payload.kernelSpec,
+      cwd:
+        payload.cwd ||
+        // TODO: Does it matter that this is our fallback when targeting the web app
+        process.cwd(),
+      kernelRef: payload.kernelRef
+    }
   };
 }
 
 // Expects notebook to be JS Object or Immutable.js
-export const setNotebook = (
+export const setNotebook = (payload: {
   filename: ?string,
-  notebook: Notebook
-): SetNotebookAction => ({
+  notebook: Notebook,
+  kernelRef?: KernelRef
+}): SetNotebookAction => ({
   type: actionTypes.SET_NOTEBOOK,
-  filename,
-  notebook
+  payload
 });
 
 export const loadConfig = () => ({ type: actionTypes.LOAD_CONFIG });
@@ -736,50 +792,60 @@ export function updateDisplay(content: {
   };
 }
 
-export function setLanguageInfo(
-  langInfo: OldLanguageInfoMetadata
-): SetLanguageInfoAction {
+export function setLanguageInfo(payload: {
+  langInfo: OldLanguageInfoMetadata,
+  ref?: KernelRef
+}): SetLanguageInfoAction {
   return {
     type: actionTypes.SET_LANGUAGE_INFO,
-    langInfo
+    payload
   };
 }
 
-export function deleteConnectionFileFailed(
-  error: Error
-): DeleteConnectionFileFailedAction {
+export function deleteConnectionFileFailed(payload: {
+  error: Error,
+  ref?: KernelRef
+}): DeleteConnectionFileFailedAction {
   return {
     type: actionTypes.DELETE_CONNECTION_FILE_FAILED,
-    payload: error,
+    payload,
     error: true
   };
 }
 
-export function deleteConnectionFileSuccessful(): DeleteConnectionFileSuccessfulAction {
+export function deleteConnectionFileSuccessful(payload: {
+  ref?: KernelRef
+}): DeleteConnectionFileSuccessfulAction {
   return {
-    type: actionTypes.DELETE_CONNECTION_FILE_SUCCESSFUL
+    type: actionTypes.DELETE_CONNECTION_FILE_SUCCESSFUL,
+    payload
   };
 }
 
-export function shutdownReplySucceeded(
-  payload: Object
-): ShutdownReplySucceeded {
+export function shutdownReplySucceeded(payload: {
+  text: string,
+  ref?: KernelRef
+}): ShutdownReplySucceeded {
   return {
     type: actionTypes.SHUTDOWN_REPLY_SUCCEEDED,
     payload
   };
 }
 
-export function shutdownReplyTimedOut(error: Error): ShutdownReplyTimedOut {
+export function shutdownReplyTimedOut(payload: {
+  error: Error,
+  ref?: KernelRef
+}): ShutdownReplyTimedOut {
   return {
     type: actionTypes.SHUTDOWN_REPLY_TIMED_OUT,
-    payload: error,
+    payload,
     error: true
   };
 }
 
+// TODO: probably should remove default here.
 export function restartKernel(
-  payload: { clearOutputs: boolean } = { clearOutputs: false }
+  payload: { clearOutputs: boolean, ref?: KernelRef } = { clearOutputs: false }
 ): RestartKernel {
   return {
     type: actionTypes.RESTART_KERNEL,
@@ -787,16 +853,22 @@ export function restartKernel(
   };
 }
 
-export function restartKernelFailed(error: Error): RestartKernelFailed {
+export function restartKernelFailed(payload: {
+  error: Error,
+  ref?: KernelRef
+}): RestartKernelFailed {
   return {
     type: actionTypes.RESTART_KERNEL_FAILED,
-    payload: error,
+    payload,
     error: true
   };
 }
 
-export function restartKernelSuccessful(): RestartKernelSuccessful {
+export function restartKernelSuccessful(payload: {
+  ref?: KernelRef
+}): RestartKernelSuccessful {
   return {
-    type: actionTypes.RESTART_KERNEL_SUCCESSFUL
+    type: actionTypes.RESTART_KERNEL_SUCCESSFUL,
+    payload
   };
 }

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -38,10 +38,10 @@ type Props = {
   setCellTypeMarkdown: ?(cellId: ?string) => void,
   setTheme: ?(theme: ?string) => void,
   openAboutModal: ?() => void,
-  restartKernel: ?() => void,
-  restartKernelAndClearOutputs: ?() => void,
-  killKernel: ?() => void,
-  interruptKernel: ?() => void
+  restartKernel: ?(payload: *) => void,
+  restartKernelAndClearOutputs: ?(payload: *) => void,
+  killKernel: ?(payload: *) => void,
+  interruptKernel: ?(payload: *) => void
 };
 
 class PureNotebookMenu extends React.Component<Props> {
@@ -185,21 +185,25 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.INTERRUPT_KERNEL:
         if (interruptKernel) {
-          interruptKernel();
+          // TODO: provide KernelRef
+          interruptKernel({});
         }
         break;
       case MENU_ITEM_ACTIONS.RESTART_KERNEL:
         if (restartKernel) {
-          restartKernel();
+          // TODO: provide KernelRef
+          restartKernel({});
         }
         break;
       case MENU_ITEM_ACTIONS.KILL_KERNEL:
         if (killKernel) {
-          killKernel();
+          // TODO: provide KernelRef
+          killKernel({});
         }
       case MENU_ITEM_ACTIONS.RESTART_AND_CLEAR_OUTPUTS:
         if (restartKernelAndClearOutputs) {
-          restartKernelAndClearOutputs();
+          // TODO: provide KernelRef
+          restartKernelAndClearOutputs({});
         }
         break;
 
@@ -376,11 +380,11 @@ const mapDispatchToProps = dispatch => ({
   setTheme: theme => dispatch(actions.setTheme(theme)),
   openAboutModal: () =>
     dispatch(actions.openModal({ modalType: MODAL_TYPES.ABOUT })),
-  restartKernel: () => dispatch(actions.restartKernel()),
-  restartKernelAndClearOutputs: () =>
-    dispatch(actions.restartKernel({ clearOutputs: true })),
-  killKernel: () => dispatch(actions.killKernel()),
-  interruptKernel: () => dispatch(actions.interruptKernel())
+  restartKernel: payload => dispatch(actions.restartKernel(payload)),
+  restartKernelAndClearOutputs: payload =>
+    dispatch(actions.restartKernel({ ...payload, clearOutputs: true })),
+  killKernel: payload => dispatch(actions.killKernel(payload)),
+  interruptKernel: payload => dispatch(actions.interruptKernel(payload))
 });
 
 const NotebookMenu = connect(mapStateToProps, mapDispatchToProps)(

--- a/packages/core/src/epics/comm.js
+++ b/packages/core/src/epics/comm.js
@@ -74,7 +74,8 @@ export function createCommCloseMessage(
  * @param  {Object} launchKernelAction a LAUNCH_KERNEL_SUCCESSFUL action
  * @return {ActionsObservable}          all actions resulting from comm messages on this kernel
  */
-export function commActionObservable({ kernel }: NewKernelAction) {
+export function commActionObservable(action: NewKernelAction) {
+  const { payload: { kernel } } = action;
   const commOpenAction$ = kernel.channels.pipe(
     ofMessageType("comm_open"),
     map(commOpenAction)

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -249,7 +249,7 @@ export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
   action$.pipe(
     ofType(actionTypes.LAUNCH_KERNEL_SUCCESSFUL),
     switchMap((action: NewKernelAction) =>
-      action.kernel.channels.pipe(
+      action.payload.kernel.channels.pipe(
         ofMessageType("update_display_data"),
         map(msg => actions.updateDisplay(msg.content)),
         catchError(err =>

--- a/packages/core/src/reducers/app.js
+++ b/packages/core/src/reducers/app.js
@@ -35,7 +35,7 @@ export function launchKernelSuccessful(
   state: AppRecord,
   action: NewKernelAction
 ) {
-  if (!action.kernel || !action.kernel.type) {
+  if (!action.payload.kernel || !action.payload.kernel.type) {
     // unset on lack of kernel
     return state.set("kernel", null);
   }
@@ -43,12 +43,12 @@ export function launchKernelSuccessful(
   let kernel = null;
 
   // We create a record based on the kernel type
-  switch (action.kernel.type) {
+  switch (action.payload.kernel.type) {
     case "websocket":
-      kernel = makeOldRemoteKernelRecord(action.kernel);
+      kernel = makeOldRemoteKernelRecord(action.payload.kernel);
       break;
     case "zeromq":
-      kernel = makeOldLocalKernelRecord(action.kernel);
+      kernel = makeOldLocalKernelRecord(action.payload.kernel);
       break;
     default:
       kernel = null;
@@ -61,7 +61,7 @@ export function setExecutionState(
   state: AppRecord,
   action: SetExecutionStateAction
 ) {
-  return state.mergeIn(["kernel"], { status: action.kernelStatus });
+  return state.mergeIn(["kernel"], { status: action.payload.kernelStatus });
 }
 
 function setNotificationsSystem(

--- a/packages/core/src/reducers/document.js
+++ b/packages/core/src/reducers/document.js
@@ -150,7 +150,7 @@ export function cleanCellTransient(state: DocumentRecord, id: string) {
 }
 
 function setNotebook(state: DocumentRecord, action: SetNotebookAction) {
-  const { notebook, filename } = action;
+  const { payload: { notebook, filename } } = action;
 
   return state
     .set("notebook", notebook)
@@ -600,7 +600,7 @@ function updateCellStatus(
   return state.setIn(["transient", "cellMap", id, "status"], status);
 }
 function setLanguageInfo(state: DocumentRecord, action: SetLanguageInfoAction) {
-  const langInfo = Immutable.fromJS(action.langInfo);
+  const langInfo = Immutable.fromJS(action.payload.langInfo);
   return state.setIn(["notebook", "metadata", "language_info"], langInfo);
 }
 


### PR DESCRIPTION
Just trying to do this piece-by-piece. The goal of this PR is just to _allow_ `ref` and `kernelRef` to be passed around actions. I'll handle actually doing this in the next PR. Finally, we'll eventually change all the `ref?: KernelRef` and `kernelRef?: KernelRef` over to just `ref: KernelRef` and `kernelRef: KernelRef`.