### PR TITLE
switch config epic to use action$

### DIFF
--- a/applications/desktop/src/notebook/epics/config.js
+++ b/applications/desktop/src/notebook/epics/config.js
@@ -3,7 +3,7 @@ import { remote } from "electron";
 
 import { selectors, actions, actionTypes } from "@nteract/core";
 import { readFileObservable, writeFileObservable } from "fs-observable";
-import { mapTo, mergeMap, map, switchMap } from "rxjs/operators";
+import { mapTo, mergeMap, map, switchMap, filter } from "rxjs/operators";
 import { ofType } from "redux-observable";
 
 import type { ActionsObservable } from "redux-observable";
@@ -16,41 +16,31 @@ export const CONFIG_FILE_PATH = path.join(HOME, ".jupyter", "nteract.json");
 
 /**
  * An epic that loads the configuration.
- *
- * @param  {ActionObservable}  actions ActionObservable for LOAD_CONFIG action
- * @return {ActionObservable}  ActionObservable for MERGE_CONFIG action
  */
-export const loadConfigEpic = (actions: ActionsObservable<*>) =>
-  actions.pipe(
+export const loadConfigEpic = (action$: ActionsObservable<*>) =>
+  action$.pipe(
     ofType(actionTypes.LOAD_CONFIG),
     switchMap(() =>
       readFileObservable(CONFIG_FILE_PATH).pipe(
-        map(JSON.parse),
-        map(actions.configLoaded)
+        map(data => actions.configLoaded(JSON.parse(data)))
       )
     )
   );
 
 /**
  * An epic that saves the configuration if it has been changed.
- *
- * @param  {ActionObservable}  actions ActionObservable for SET_CONFIG_AT_KEY action
- * @return {ActionObservable}  ActionObservable with SAVE_CONFIG type
  */
-export const saveConfigOnChangeEpic = (actions: ActionsObservable<*>) =>
-  actions.pipe(
+export const saveConfigOnChangeEpic = (action$: ActionsObservable<*>) =>
+  action$.pipe(
     ofType(actionTypes.SET_CONFIG_AT_KEY),
     mapTo({ type: actionTypes.SAVE_CONFIG })
   );
 
 /**
  * An epic that saves the configuration.
- *
- * @param  {ActionObservable}  actions ActionObservable containing SAVE_CONFIG action
- * @return {ActionObservable}  ActionObservable for DONE_SAVING action
  */
-export const saveConfigEpic = (actions: ActionsObservable<*>, store: any) =>
-  actions.pipe(
+export const saveConfigEpic = (action$: ActionsObservable<*>, store: any) =>
+  action$.pipe(
     ofType(actionTypes.SAVE_CONFIG),
     mergeMap(() =>
       writeFileObservable(


### PR DESCRIPTION
There was a name collision with `actions`. This switches the config epic to use `action$` for the stream.