### PR TITLE
configure nteract showcase with our webpack config

### DIFF
--- a/applications/showcase/next.config.js
+++ b/applications/showcase/next.config.js
@@ -1,13 +1,16 @@
+const configurator = require("@nteract/webpack-configurator");
+
 module.exports = {
   webpack: (config, { buildId, dev }) => {
     config.module.rules.push({
       test: /\.js$/,
-      exclude: /node_modules/,
+      exclude: configurator.exclude,
       loader: "babel-loader"
     });
 
     config.resolve = Object.assign({}, config.resolve, {
-      mainFields: ["nteractDesktop", "es2015", "jsnext:main", "module", "main"]
+      mainFields: ["nteractDesktop", "es2015", "jsnext:main", "module", "main"],
+      alias: configurator.mergeDefaultAliases(config.resolve.alias)
     });
     return config;
   }


### PR DESCRIPTION
Making it super easy to edit nteract components and work with them standalone in the showcase app. No more build step phooey, just run:

```
npm run app:showcase
```

Then load, for example, http://127.0.0.1:3000/dataresource and edit the `packages/transform-dataresource` component. :tada:

-----

Prepped this to make it so @emeeks can have a nice time hacking on the data resource transform.