### PR TITLE
Allow content ref in actions

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -88,7 +88,7 @@ describe("launchKernelEpic", () => {
       .toPromise();
 
     expect(responses).toEqual([
-      actions.setNotebookKernelInfo({ spec: "hokey", name: "woohoo" }),
+      actions.setKernelInfo({ kernelInfo: { spec: "hokey", name: "woohoo" } }),
       actions.launchKernelSuccessful({
         kernel: {
           kernelRef: expect.any(String),

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -39,7 +39,7 @@ describe("saveAsEpic", () => {
       .toPromise();
 
     expect(responses).toEqual([
-      actions.changeFilename("great-filename"),
+      actions.changeFilename({ filename: "great-filename" }),
       actions.save()
     ]);
   });

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -23,7 +23,7 @@ describe("saveEpic", () => {
     // TODO: This should be testing that the mocks for fs were called with the
     // filename and notebook from the state tree
 
-    expect(responses).toEqual([actions.saveFulfilled()]);
+    expect(responses).toEqual([actions.saveFulfilled({})]);
   });
 });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -41,16 +41,13 @@ describe("menu", () => {
   });
 
   describe("dispatchCutCell", () => {
-    test("dispatches a CUT_CELL action", () => {
+    test("dispatches a cutCell action", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
-
       menu.dispatchCutCell(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.CUT_CELL,
-        id: null
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        actions.cutCell({ id: null })
+      );
     });
   });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -220,9 +220,7 @@ describe("menu", () => {
 
       menu.dispatchClearAll(store);
 
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.CLEAR_ALL_OUTPUTS
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(actions.clearAllOutputs({}));
     });
   });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -55,16 +55,13 @@ describe("menu", () => {
   });
 
   describe("dispatchCopyCell", () => {
-    test("dispatches a COPY_CELL action", () => {
+    test("dispatches a copyCell action", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
-
       menu.dispatchCopyCell(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.COPY_CELL,
-        id: null
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        actions.copyCell({ id: null })
+      );
     });
   });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -6,34 +6,24 @@ import { actions, actionTypes } from "@nteract/core";
 
 describe("menu", () => {
   describe("dispatchCreateCellAfter", () => {
-    test("dispatches a CREATE_CELL_AFTER action", () => {
+    test("dispatches a CREATE_CELL_AFTER with code action", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
-
       menu.dispatchCreateCellAfter(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.NEW_CELL_AFTER,
-        cellType: "code",
-        source: "",
-        id: null
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        actions.createCellAfter({ cellType: "code", id: null, source: "" })
+      );
     });
   });
 
   describe("dispatchCreateTextCellAfter", () => {
-    test("dispatches a CREATE_TEXT_CELL_AFTER action", () => {
+    test("dispatches a CREATE_CELL_AFTER with markdown action", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
-
       menu.dispatchCreateTextCellAfter(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.NEW_CELL_AFTER,
-        cellType: "markdown",
-        source: "",
-        id: null
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        actions.createCellAfter({ cellType: "markdown", id: null, source: "" })
+      );
     });
   });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -28,15 +28,11 @@ describe("menu", () => {
   });
 
   describe("dispatchPasteCell", () => {
-    test("dispatches a PASTE_CELL action", () => {
+    test("dispatches a pasteCell action", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
-
       menu.dispatchPasteCell(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.PASTE_CELL
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(actions.pasteCell({}));
     });
   });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -238,16 +238,10 @@ describe("menu", () => {
     test("", () => {
       const store = dummyStore({ hideAll: true });
       store.dispatch = jest.fn();
-
       menu.dispatchUnhideAll(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: "UNHIDE_ALL",
-        payload: {
-          outputHidden: false,
-          inputHidden: false
-        }
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        actions.unhideAll({ outputHidden: false, inputHidden: false })
+      );
     });
   });
 

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -113,7 +113,8 @@ export function publishNotebookObservable(
               value: res.data.login
             })
           );
-          observer.next(actions.deleteMetadata("gist_id"));
+          // TODO: #2618
+          observer.next(actions.deleteMetadataField({ field: "gist_id" }));
         }
       });
     }

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -65,7 +65,10 @@ export function createGistCallback(
       return;
     }
     const gistID = response.data.id;
-    observer.next(actions.overwriteMetadata("gist_id", gistID));
+    // TODO: #2618
+    observer.next(
+      actions.overwriteMetadataField({ field: "gist_id", value: gistID })
+    );
     notifyUser(filename, gistID, notificationSystem);
     observer.complete();
   };
@@ -105,7 +108,10 @@ export function publishNotebookObservable(
         });
         if (githubUsername !== (res.data.login || undefined)) {
           observer.next(
-            actions.overwriteMetadata("github_username", res.data.login)
+            actions.overwriteMetadataField({
+              field: "github_username",
+              value: res.data.login
+            })
           );
           observer.next(actions.deleteMetadata("gist_id"));
         }

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -27,7 +27,7 @@ import { actionTypes, actions } from "@nteract/core";
 import type {
   FetchContent,
   NewNotebook,
-  SetNotebookAction
+  SetNotebook
 } from "@nteract/core/src/actionTypes";
 
 /**
@@ -158,7 +158,7 @@ export const launchKernelWhenNotebookSetEpic = (
 ) =>
   action$.pipe(
     ofType(actionTypes.SET_NOTEBOOK),
-    map((action: SetNotebookAction) => {
+    map((action: SetNotebook) => {
       const { cwd, kernelSpecName } = extractNewKernel(
         action.payload.filename,
         action.payload.notebook
@@ -194,6 +194,7 @@ export const newNotebookEpic = (action$: ActionsObservable<*>) =>
         notebook = notebook.setIn(["metadata", "kernelspec"], spec);
       }
 
+      // TODO: #2618
       return actions.setNotebook({ filename: null, notebook, kernelRef });
     })
   );

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -47,7 +47,8 @@ export function saveEpic(
               level: "success"
             });
           }
-          return actions.saveFulfilled();
+          // TODO: #2618
+          return actions.saveFulfilled({});
         }),
         catchError((error: Error) => of(actions.saveFailed(error)))
       );

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -68,7 +68,8 @@ export function saveAsEpic(action$: ActionsObservable<*>) {
       return [
         // order matters here, since we need the filename set in the state
         // before we save the document
-        actions.changeFilename(action.filename),
+        // TODO: #2618
+        actions.changeFilename({ filename: action.filename }),
         actions.save()
       ];
     })

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -89,7 +89,8 @@ export function launchKernelObservable(
       // do dependency injection of jmp to make it match our ABI version of node
       createMainChannel(config, undefined, undefined, jmp)
         .then((channels: Channels) => {
-          observer.next(actions.setNotebookKernelInfo(kernelSpec));
+          // TODO: #2618
+          observer.next(actions.setKernelInfo({ kernelInfo: kernelSpec }));
 
           const kernel: LocalKernelProps = {
             kernelRef,

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -338,7 +338,8 @@ export function exportPDF(
   //       run through before we print...
   // Expand unexpanded cells
   unexpandedCells.map(cellID =>
-    store.dispatch(actions.toggleOutputExpansion(cellID))
+    // TODO: #2618
+    store.dispatch(actions.toggleOutputExpansion({ id: cellID }))
   );
 
   remote.getCurrentWindow().webContents.printToPDF(
@@ -350,7 +351,7 @@ export function exportPDF(
 
       // Restore the modified cells to their unexpanded state.
       unexpandedCells.map(cellID =>
-        store.dispatch(actions.toggleOutputExpansion(cellID))
+        store.dispatch(actions.toggleOutputExpansion({ id: cellID }))
       );
 
       fs.writeFile(`${filename}.pdf`, data, error_fs => {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -258,7 +258,8 @@ export function dispatchSetCursorBlink(store: *, evt: Event, value: *) {
 export function dispatchCopyCell(store: *) {
   const state = store.getState();
   const focused = selectors.currentFocusedCellId(state);
-  store.dispatch(actions.copyCell(focused));
+  // TODO: #2618
+  store.dispatch(actions.copyCell({ id: focused }));
 }
 
 export function dispatchCutCell(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -270,7 +270,8 @@ export function dispatchCutCell(store: *) {
 }
 
 export function dispatchPasteCell(store: *) {
-  store.dispatch(actions.pasteCell());
+  // TODO: #2618
+  store.dispatch(actions.pasteCell({}));
 }
 
 export function dispatchCreateCellAfter(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -265,7 +265,8 @@ export function dispatchCopyCell(store: *) {
 export function dispatchCutCell(store: *) {
   const state = store.getState();
   const focused = selectors.currentFocusedCellId(state);
-  store.dispatch(actions.cutCell(focused));
+  // TODO: #2618
+  store.dispatch(actions.cutCell({ id: focused }));
 }
 
 export function dispatchPasteCell(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -192,7 +192,8 @@ export function dispatchRunAll(store: *) {
 }
 
 export function dispatchClearAll(store: *) {
-  store.dispatch(actions.clearAllOutputs());
+  // TODO: #2618
+  store.dispatch(actions.clearAllOutputs({}));
 }
 
 export function dispatchUnhideAll(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -274,13 +274,19 @@ export function dispatchPasteCell(store: *) {
 export function dispatchCreateCellAfter(store: *) {
   const state = store.getState();
   const focused = selectors.currentFocusedCellId(state);
-  store.dispatch(actions.createCellAfter("code", focused));
+  // TODO: #2618
+  store.dispatch(
+    actions.createCellAfter({ cellType: "code", id: focused, source: "" })
+  );
 }
 
 export function dispatchCreateTextCellAfter(store: *) {
   const state = store.getState();
   const focused = selectors.currentFocusedCellId(state);
-  store.dispatch(actions.createCellAfter("markdown", focused));
+  // TODO: #2618
+  store.dispatch(
+    actions.createCellAfter({ cellType: "markdown", id: focused, source: "" })
+  );
 }
 
 export function dispatchLoad(store: *, event: Event, filename: string) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -197,6 +197,7 @@ export function dispatchClearAll(store: *) {
 }
 
 export function dispatchUnhideAll(store: *) {
+  // TODO: #2618
   store.dispatch(
     actions.unhideAll({
       outputHidden: false,

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -278,9 +278,9 @@ describe("focusNextCell", () => {
 
 describe("focusPreviousCell", () => {
   test("creates a FOCUS_PREVIOUS_CELL action", () => {
-    expect(actions.focusPreviousCell("1234")).toEqual({
+    expect(actions.focusPreviousCell({ id: "1234" })).toEqual({
       type: actionTypes.FOCUS_PREVIOUS_CELL,
-      id: "1234"
+      payload: { id: "1234" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -333,11 +333,15 @@ describe("createCellAfter", () => {
 });
 
 describe("createCellBefore", () => {
-  test("creates a NEW_CELL_BEFORE action", () => {
-    expect(actions.createCellBefore("markdown", "1234")).toEqual({
-      type: actionTypes.NEW_CELL_BEFORE,
-      cellType: "markdown",
-      id: "1234"
+  test("creates a CREATE_CELL_BEFORE action", () => {
+    expect(
+      actions.createCellBefore({ cellType: "markdown", id: "1234" })
+    ).toEqual({
+      type: actionTypes.CREATE_CELL_BEFORE,
+      payload: {
+        cellType: "markdown",
+        id: "1234"
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -253,17 +253,25 @@ describe("focusCell", () => {
 
 describe("focusNextCell", () => {
   test("creates a FOCUS_NEXT_CELL action", () => {
-    expect(actions.focusNextCell("1234", false)).toEqual({
+    expect(
+      actions.focusNextCell({ id: "1234", createCellIfUndefined: false })
+    ).toEqual({
       type: actionTypes.FOCUS_NEXT_CELL,
-      id: "1234",
-      createCellIfUndefined: false
+      payload: {
+        id: "1234",
+        createCellIfUndefined: false
+      }
     });
   });
   test("creates a FOCUS_NEXT_CELL action with cell creation flag", () => {
-    expect(actions.focusNextCell("1234", true)).toEqual({
+    expect(
+      actions.focusNextCell({ id: "1234", createCellIfUndefined: true })
+    ).toEqual({
       type: actionTypes.FOCUS_NEXT_CELL,
-      id: "1234",
-      createCellIfUndefined: true
+      payload: {
+        id: "1234",
+        createCellIfUndefined: true
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -244,9 +244,9 @@ describe("removeCell", () => {
 
 describe("focusCell", () => {
   test("creates a FOCUS_CELL action", () => {
-    expect(actions.focusCell("1234")).toEqual({
+    expect(actions.focusCell({ id: "1234" })).toEqual({
       type: actionTypes.FOCUS_CELL,
-      id: "1234"
+      payload: { id: "1234" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -343,9 +343,11 @@ describe("createCellBefore", () => {
 
 describe("toggleStickyCell", () => {
   test("creates a TOGGLE_STICKY_CELL action", () => {
-    expect(actions.toggleStickyCell("1234")).toEqual({
+    expect(actions.toggleStickyCell({ id: "1234" })).toEqual({
       type: actionTypes.TOGGLE_STICKY_CELL,
-      id: "1234"
+      payload: {
+        id: "1234"
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -409,9 +409,9 @@ describe("overwriteMetadataField", () => {
 
 describe("copyCell", () => {
   test("creates a COPY_CELL action", () => {
-    expect(actions.copyCell("235")).toEqual({
+    expect(actions.copyCell({ id: "235" })).toEqual({
       type: actionTypes.COPY_CELL,
-      id: "235"
+      payload: { id: "235" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -454,10 +454,12 @@ describe("pasteCell", () => {
 
 describe("changeCellType", () => {
   test("creates a CHANGE_CELL_TYPE action", () => {
-    expect(actions.changeCellType("235", "markdown")).toEqual({
+    expect(actions.changeCellType({ id: "235", to: "markdown" })).toEqual({
       type: actionTypes.CHANGE_CELL_TYPE,
-      id: "235",
-      to: "markdown"
+      payload: {
+        id: "235",
+        to: "markdown"
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -368,9 +368,9 @@ describe("createCellAppend", () => {
 
 describe("mergeCellAfter", () => {
   test("creates a MERGE_CELL_AFTER action", () => {
-    expect(actions.mergeCellAfter("0121")).toEqual({
+    expect(actions.mergeCellAfter({ id: "0121" })).toEqual({
       type: actionTypes.MERGE_CELL_AFTER,
-      id: "0121"
+      payload: { id: "0121" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -183,11 +183,13 @@ describe("setNotebookKernelInfo", () => {
 
 describe("updateCellSource", () => {
   test("creates a UPDATE_CELL_SOURCE action", () => {
-    expect(actions.updateCellSource("1234", "# test")).toEqual({
+    expect(actions.updateCellSource({ id: "1234", value: "# test" })).toEqual({
       type: "SET_IN_CELL",
-      id: "1234",
-      path: ["source"],
-      value: "# test"
+      payload: {
+        id: "1234",
+        path: ["source"],
+        value: "# test"
+      }
     });
   });
 });
@@ -203,11 +205,13 @@ describe("clearOutputs", () => {
 
 describe("updateCellExecutionCount", () => {
   test("creates a SET_IN_CELL action with the right path", () => {
-    expect(actions.updateCellExecutionCount("1234", 3)).toEqual({
+    expect(actions.updateCellExecutionCount({ id: "1234", value: 3 })).toEqual({
       type: "SET_IN_CELL",
-      id: "1234",
-      path: ["execution_count"],
-      value: 3
+      payload: {
+        id: "1234",
+        path: ["execution_count"],
+        value: 3
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -427,9 +427,9 @@ describe("toggleCellOutputVisibility", () => {
 
 describe("toggleCellInputVisibility", () => {
   test("creates a TOGGLE_CELL_INPUT_VISIBILITY action", () => {
-    expect(actions.toggleCellInputVisibility("235")).toEqual({
+    expect(actions.toggleCellInputVisibility({ id: "235" })).toEqual({
       type: actionTypes.TOGGLE_CELL_INPUT_VISIBILITY,
-      id: "235"
+      payload: { id: "235" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -418,9 +418,9 @@ describe("copyCell", () => {
 
 describe("cutCell", () => {
   test("creates a CUT_CELL action", () => {
-    expect(actions.cutCell("235")).toEqual({
+    expect(actions.cutCell({ id: "235" })).toEqual({
       type: actionTypes.CUT_CELL,
-      id: "235"
+      payload: { id: "235" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -477,8 +477,9 @@ describe("save", () => {
   });
 
   test("creates a SAVE_FULFILLED action", () => {
-    expect(actions.saveFulfilled()).toEqual({
-      type: actionTypes.SAVE_FULFILLED
+    expect(actions.saveFulfilled({})).toEqual({
+      type: actionTypes.SAVE_FULFILLED,
+      payload: {}
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -418,9 +418,9 @@ describe("cutCell", () => {
 
 describe("toggleCellOutputVisibility", () => {
   test("creates a TOGGLE_CELL_OUTPUT_VISIBILITY action", () => {
-    expect(actions.toggleCellOutputVisibility("235")).toEqual({
+    expect(actions.toggleCellOutputVisibility({ id: "235" })).toEqual({
       type: actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY,
-      id: "235"
+      payload: { id: "235" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -296,9 +296,9 @@ describe("focusCellEditor", () => {
 
 describe("focusPreviousCellEditor", () => {
   test("creates a FOCUS_PREVIOUS_CELL_EDITOR action", () => {
-    expect(actions.focusPreviousCellEditor("1234")).toEqual({
+    expect(actions.focusPreviousCellEditor({ id: "1234" })).toEqual({
       type: actionTypes.FOCUS_PREVIOUS_CELL_EDITOR,
-      id: "1234"
+      payload: { id: "1234" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -445,7 +445,10 @@ describe("toggleCellInputVisibility", () => {
 
 describe("pasteCell", () => {
   test("creates a PASTE_CELL action", () => {
-    expect(actions.pasteCell()).toEqual({ type: actionTypes.PASTE_CELL });
+    expect(actions.pasteCell({})).toEqual({
+      type: actionTypes.PASTE_CELL,
+      payload: {}
+    });
   });
 });
 

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -305,9 +305,9 @@ describe("focusPreviousCellEditor", () => {
 
 describe("focusNextCellEditor", () => {
   test("creates a FOCUS_NEXT_CELL_EDITOR action", () => {
-    expect(actions.focusNextCellEditor("1234")).toEqual({
+    expect(actions.focusNextCellEditor({ id: "1234" })).toEqual({
       type: actionTypes.FOCUS_NEXT_CELL_EDITOR,
-      id: "1234"
+      payload: { id: "1234" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -194,9 +194,9 @@ describe("updateCellSource", () => {
 
 describe("clearOutputs", () => {
   test("creates a CLEAR_OUTPUTS action", () => {
-    expect(actions.clearOutputs("woo")).toEqual({
+    expect(actions.clearOutputs({ id: "woo" })).toEqual({
       type: "CLEAR_OUTPUTS",
-      id: "woo"
+      payload: { id: "woo" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -243,9 +243,9 @@ describe("moveCell", () => {
 
 describe("removeCell", () => {
   test("creates a REMOVE_CELL action", () => {
-    expect(actions.removeCell("1234")).toEqual({
+    expect(actions.removeCell({ id: "1234" })).toEqual({
       type: actionTypes.REMOVE_CELL,
-      id: "1234"
+      payload: { id: "1234" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -218,10 +218,12 @@ describe("updateCellExecutionCount", () => {
 
 describe("updateCellStatus", () => {
   test("creates an UPDATE_CELL_STATUS action", () => {
-    expect(actions.updateCellStatus("1234", "test")).toEqual({
+    expect(actions.updateCellStatus({ id: "1234", status: "test" })).toEqual({
       type: actionTypes.UPDATE_CELL_STATUS,
-      id: "1234",
-      status: "test"
+      payload: {
+        id: "1234",
+        status: "test"
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -321,20 +321,13 @@ describe("focusNextCellEditor", () => {
 });
 
 describe("createCellAfter", () => {
-  test("creates a NEW_CELL_AFTER action with default empty source string", () => {
-    expect(actions.createCellAfter("markdown", "1234")).toEqual({
-      type: actionTypes.NEW_CELL_AFTER,
-      source: "",
-      cellType: "markdown",
-      id: "1234"
-    });
-  });
-  test("creates a NEW_CELL_AFTER action with provided source string", () => {
-    expect(actions.createCellAfter("code", "1234", 'print("woo")')).toEqual({
-      type: actionTypes.NEW_CELL_AFTER,
-      source: 'print("woo")',
-      cellType: "code",
-      id: "1234"
+  test("creates a CREATE_CELL_AFTER action with provided source string", () => {
+    const cellType = "code";
+    const id = "1234";
+    const source = 'print("woo")';
+    expect(actions.createCellAfter({ cellType, id, source })).toEqual({
+      type: actionTypes.CREATE_CELL_AFTER,
+      payload: { source, cellType, id }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -228,11 +228,15 @@ describe("updateCellStatus", () => {
 
 describe("moveCell", () => {
   test("creates a MOVE_CELL action", () => {
-    expect(actions.moveCell("1234", "5678", true)).toEqual({
+    expect(
+      actions.moveCell({ id: "1234", destinationId: "5678", above: true })
+    ).toEqual({
       type: actionTypes.MOVE_CELL,
-      id: "1234",
-      destinationId: "5678",
-      above: true
+      payload: {
+        id: "1234",
+        destinationId: "5678",
+        above: true
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -388,16 +388,21 @@ describe("setNotificationSystem", () => {
   });
 });
 
-describe("overwriteMetadata", () => {
+describe("overwriteMetadataField", () => {
   test("creates an OVERWRITE_METADATA_FIELD", () => {
     expect(
-      actions.overwriteMetadata("foo", {
-        bar: 3
+      actions.overwriteMetadataField({
+        field: "foo",
+        value: {
+          bar: 3
+        }
       })
     ).toEqual({
       type: actionTypes.OVERWRITE_METADATA_FIELD,
-      field: "foo",
-      value: { bar: 3 }
+      payload: {
+        field: "foo",
+        value: { bar: 3 }
+      }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -475,9 +475,9 @@ describe("setGithubToken", () => {
 
 describe("toggleOutputExpansion", () => {
   test("creates a TOGGLE_OUTPUT_EXPANSION action", () => {
-    expect(actions.toggleOutputExpansion("235")).toEqual({
+    expect(actions.toggleOutputExpansion({ id: "235" })).toEqual({
       type: actionTypes.TOGGLE_OUTPUT_EXPANSION,
-      id: "235"
+      payload: { id: "235" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -169,13 +169,15 @@ describe("launchKernelByName", () => {
   });
 });
 
-describe("setNotebookKernelInfo", () => {
+describe("setKernelInfo", () => {
   test("creates a SET_KERNEL_INFO action", () => {
     const kernelInfo = { name: "japanese" };
-    expect(actions.setNotebookKernelInfo(kernelInfo)).toEqual({
+    expect(actions.setKernelInfo({ kernelInfo })).toEqual({
       type: actionTypes.SET_KERNEL_INFO,
-      kernelInfo: {
-        name: "japanese"
+      payload: {
+        kernelInfo: {
+          name: "japanese"
+        }
       }
     });
   });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -299,9 +299,9 @@ describe("focusPreviousCell", () => {
 
 describe("focusCellEditor", () => {
   test("creates a FOCUS_CELL_EDITOR action", () => {
-    expect(actions.focusCellEditor("1234")).toEqual({
+    expect(actions.focusCellEditor({ id: "1234" })).toEqual({
       type: actionTypes.FOCUS_CELL_EDITOR,
-      id: "1234"
+      payload: { id: "1234" }
     });
   });
 });

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -358,10 +358,10 @@ describe("toggleStickyCell", () => {
 });
 
 describe("createCellAppend", () => {
-  test("creates a NEW_CELL_APPEND action", () => {
-    expect(actions.createCellAppend("markdown")).toEqual({
-      type: actionTypes.NEW_CELL_APPEND,
-      cellType: "markdown"
+  test("creates a CREATE_CELL_APPEND action", () => {
+    expect(actions.createCellAppend({ cellType: "markdown" })).toEqual({
+      type: actionTypes.CREATE_CELL_APPEND,
+      payload: { cellType: "markdown" }
     });
   });
 });

--- a/packages/core/__tests__/app-spec.js
+++ b/packages/core/__tests__/app-spec.js
@@ -37,7 +37,7 @@ describe("saveFulfilled", () => {
       isSaving: true
     });
 
-    const state = reducers.app(originalState, actions.saveFulfilled());
+    const state = reducers.app(originalState, actions.saveFulfilled({}));
     expect(state.isSaving).toBe(false);
   });
 });

--- a/packages/core/__tests__/components/cell-creator-spec.js
+++ b/packages/core/__tests__/components/cell-creator-spec.js
@@ -137,7 +137,7 @@ describe("CellCreatorProvider", () => {
 
     return new Promise(resolve => {
       const dispatch = action => {
-        expect(action.id).toBe("test");
+        expect(action.payload.id).toBe("test");
         expect(action.type).toBe(MERGE_CELL_AFTER);
         resolve();
       };

--- a/packages/core/__tests__/components/cell-creator-spec.js
+++ b/packages/core/__tests__/components/cell-creator-spec.js
@@ -8,7 +8,7 @@ import { dummyStore } from "../../src/dummy";
 import {
   CREATE_CELL_AFTER,
   CREATE_CELL_BEFORE,
-  NEW_CELL_APPEND,
+  CREATE_CELL_APPEND,
   MERGE_CELL_AFTER
 } from "../../src/actionTypes";
 
@@ -113,8 +113,8 @@ describe("CellCreatorProvider", () => {
 
     return new Promise(resolve => {
       const dispatch = action => {
-        expect(action.cellType).toBe("code");
-        expect(action.type).toBe(NEW_CELL_APPEND);
+        expect(action.payload.cellType).toBe("code");
+        expect(action.type).toBe(CREATE_CELL_APPEND);
         resolve();
       };
       store.dispatch = dispatch;

--- a/packages/core/__tests__/components/cell-creator-spec.js
+++ b/packages/core/__tests__/components/cell-creator-spec.js
@@ -7,7 +7,7 @@ import CellCreator from "../../src/components/cell-creator";
 import { dummyStore } from "../../src/dummy";
 import {
   CREATE_CELL_AFTER,
-  NEW_CELL_BEFORE,
+  CREATE_CELL_BEFORE,
   NEW_CELL_APPEND,
   MERGE_CELL_AFTER
 } from "../../src/actionTypes";
@@ -88,9 +88,9 @@ describe("CellCreatorProvider", () => {
 
     return new Promise(resolve => {
       const dispatch = action => {
-        expect(action.id).toBe("test");
-        expect(action.cellType).toBe("code");
-        expect(action.type).toBe(NEW_CELL_BEFORE);
+        expect(action.payload.id).toBe("test");
+        expect(action.payload.cellType).toBe("code");
+        expect(action.type).toBe(CREATE_CELL_BEFORE);
         resolve();
       };
       store.dispatch = dispatch;

--- a/packages/core/__tests__/components/cell-creator-spec.js
+++ b/packages/core/__tests__/components/cell-creator-spec.js
@@ -6,7 +6,7 @@ import { Provider } from "react-redux";
 import CellCreator from "../../src/components/cell-creator";
 import { dummyStore } from "../../src/dummy";
 import {
-  NEW_CELL_AFTER,
+  CREATE_CELL_AFTER,
   NEW_CELL_BEFORE,
   NEW_CELL_APPEND,
   MERGE_CELL_AFTER
@@ -38,9 +38,9 @@ describe("CellCreatorProvider", () => {
 
     return new Promise(resolve => {
       const dispatch = action => {
-        expect(action.id).toBe("test");
-        expect(action.cellType).toBe("markdown");
-        expect(action.type).toBe(NEW_CELL_AFTER);
+        expect(action.payload.id).toBe("test");
+        expect(action.payload.cellType).toBe("markdown");
+        expect(action.type).toBe(CREATE_CELL_AFTER);
         resolve();
       };
       store.dispatch = dispatch;
@@ -63,9 +63,9 @@ describe("CellCreatorProvider", () => {
 
     return new Promise(resolve => {
       const dispatch = action => {
-        expect(action.id).toBe("test");
-        expect(action.cellType).toBe("code");
-        expect(action.type).toBe(NEW_CELL_AFTER);
+        expect(action.payload.id).toBe("test");
+        expect(action.payload.cellType).toBe("code");
+        expect(action.type).toBe(CREATE_CELL_AFTER);
         resolve();
       };
       store.dispatch = dispatch;

--- a/packages/core/__tests__/components/editor-spec.js
+++ b/packages/core/__tests__/components/editor-spec.js
@@ -23,8 +23,8 @@ describe("EditorProvider", () => {
   test("onChange updates cell source", () =>
     new Promise(resolve => {
       const dispatch = action => {
-        expect(action.id).toBe("test");
-        expect(action.value).toBe("i love nteract");
+        expect(action.payload.id).toBe("test");
+        expect(action.payload.value).toBe("i love nteract");
         expect(action.type).toBe(actionTypes.SET_IN_CELL);
         resolve();
       };

--- a/packages/core/__tests__/components/editor-spec.js
+++ b/packages/core/__tests__/components/editor-spec.js
@@ -39,7 +39,7 @@ describe("EditorProvider", () => {
   test("onFocusChange can update editor focus", () =>
     new Promise(resolve => {
       const dispatch = action => {
-        expect(action.id).toBe("test");
+        expect(action.payload.id).toBe("test");
         expect(action.type).toBe(actionTypes.FOCUS_CELL_EDITOR);
         resolve();
       };

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -96,7 +96,7 @@ describe("PureNotebookMenu ", () => {
       expect(props.cutCell).not.toHaveBeenCalled();
       cutCellItem.simulate("click");
       expect(props.cutCell).toHaveBeenCalledTimes(1);
-      expect(props.cutCell).toHaveBeenCalledWith(props.cellFocused);
+      expect(props.cutCell).toHaveBeenCalledWith({ id: props.cellFocused });
 
       const copyCellItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.COPY_CELL })

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -104,7 +104,7 @@ describe("PureNotebookMenu ", () => {
       expect(props.copyCell).not.toHaveBeenCalled();
       copyCellItem.simulate("click");
       expect(props.copyCell).toHaveBeenCalledTimes(1);
-      expect(props.copyCell).toHaveBeenCalledWith(props.cellFocused);
+      expect(props.copyCell).toHaveBeenCalledWith({ id: props.cellFocused });
 
       const pasteCellItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.PASTE_CELL })

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -120,7 +120,9 @@ describe("PureNotebookMenu ", () => {
       expect(props.mergeCellAfter).not.toHaveBeenCalled();
       mergeCellAfterItem.simulate("click");
       expect(props.mergeCellAfter).toHaveBeenCalledTimes(1);
-      expect(props.mergeCellAfter).toHaveBeenCalledWith(props.cellFocused);
+      expect(props.mergeCellAfter).toHaveBeenCalledWith({
+        id: props.cellFocused
+      });
 
       const createMarkdownCellItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.CREATE_MARKDOWN_CELL })

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -112,7 +112,7 @@ describe("PureNotebookMenu ", () => {
       expect(props.pasteCell).not.toHaveBeenCalled();
       pasteCellItem.simulate("click");
       expect(props.pasteCell).toHaveBeenCalledTimes(1);
-      expect(props.pasteCell).toHaveBeenCalledWith();
+      expect(props.pasteCell).toHaveBeenCalledWith({});
 
       const mergeCellAfterItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.MERGE_CELL_AFTER })

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -288,12 +288,8 @@ describe("focusPreviousCell", () => {
 describe("focusCellEditor", () => {
   test("should set editorFocused to the appropriate cell ID", () => {
     const originalState = monocellDocument;
-
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = { type: actionTypes.FOCUS_CELL_EDITOR, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.focusCellEditor({ id }));
     expect(state.get("editorFocused")).toBe(id);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -898,27 +898,24 @@ describe("cleanCellTransient", () => {
 });
 
 describe("changeFilename", () => {
-  test("returns the same originalState if filename is undefined", () => {
+  test("returns the same originalState if filename is null", () => {
     const originalState = makeDocumentRecord({
       filename: "original.ipynb"
     });
-
-    const action = { type: actionTypes.CHANGE_FILENAME };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.changeFilename({ filename: null })
+    );
     expect(state.filename).toBe("original.ipynb");
   });
   test("sets the filename if given a valid one", () => {
     const originalState = makeDocumentRecord({
       filename: "original.ipynb"
     });
-
-    const action = {
-      type: actionTypes.CHANGE_FILENAME,
-      filename: "test.ipynb"
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.changeFilename({ filename: "test.ipynb" })
+    );
     expect(state.filename).toBe("test.ipynb");
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -684,10 +684,7 @@ describe("pasteCell", () => {
         id
       })
     );
-
-    const action = { type: actionTypes.PASTE_CELL };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.pasteCell({}));
     const copiedId = state.getIn(["notebook", "cellOrder", 1]);
 
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -303,10 +303,7 @@ describe("focusNextCellEditor", () => {
     const originalState = monocellDocument;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.FOCUS_NEXT_CELL_EDITOR, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.focusNextCellEditor({ id }));
     expect(state.get("editorFocused")).not.toBeNull();
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -735,12 +735,11 @@ describe("toggleOutputExpansion", () => {
       cells =>
         cells.map(value => value.setIn(["metadata", "outputExpanded"], false))
     );
-
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.TOGGLE_OUTPUT_EXPANSION, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.toggleOutputExpansion({ id })
+    );
     expect(
       state.getIn(["notebook", "cellMap", id, "metadata", "outputExpanded"])
     ).toBe(true);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -653,10 +653,7 @@ describe("copyCell", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
     const cell = originalState.getIn(["notebook", "cellMap", id]);
-
-    const action = { type: actionTypes.COPY_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.copyCell({ id }));
     expect(state.getIn(["copied", "cell"])).toBe(cell);
     expect(state.getIn(["copied", "id"])).toBe(id);
   });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -174,10 +174,7 @@ describe("setNotebook", () => {
 
 describe("setNotebookCheckpoint", () => {
   test("stores saved notebook", () => {
-    const state = reducers(
-      initialDocument,
-      actions.saveFulfilled(dummyCommutable)
-    );
+    const state = reducers(initialDocument, actions.saveFulfilled({}));
     expect(state.get("notebook")).toEqual(state.get("savedNotebook"));
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -350,15 +350,10 @@ describe("updateExecutionCount", () => {
     const originalState = monocellDocument;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = {
-      type: "SET_IN_CELL",
-      id,
-      path: ["execution_count"],
-      value: 42
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.setInCell({ id, path: ["execution_count"], value: 42 })
+    );
     expect(state.getIn(["notebook", "cellMap", id, "execution_count"])).toBe(
       42
     );
@@ -564,15 +559,10 @@ describe("updateSource", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = {
-      type: "SET_IN_CELL",
-      id,
-      path: ["source"],
-      value: "This is a test"
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.setInCell({ id, path: ["source"], value: "This is a test" })
+    );
     expect(state.getIn(["notebook", "cellMap", id, "source"])).toBe(
       "This is a test"
     );

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -521,10 +521,10 @@ describe("mergeCellAfter", () => {
 describe("newCellAppend", () => {
   test("appends a new code cell at the end", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);
-
-    const action = { type: actionTypes.NEW_CELL_APPEND, cellType: "code" };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.createCellAppend({ cellType: "code" })
+    );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -489,19 +489,14 @@ describe("createCellAfter", () => {
   });
 });
 
-describe("newCellBefore", () => {
-  test("creates a new cell after the given id", () => {
+describe("createCellBefore", () => {
+  test("creates a new cell before the given id", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);
-
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = {
-      type: actionTypes.NEW_CELL_BEFORE,
-      id,
-      cellType: "markdown"
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.createCellBefore({ cellType: "markdown", id })
+    );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
     expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(id);
   });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -898,14 +898,13 @@ describe("updateDisplay", () => {
           transient: { display_id: "1234" }
         }
       }),
-      {
-        type: actionTypes.UPDATE_DISPLAY,
+      actions.updateDisplay({
         content: {
           output_type: "update_display_data",
           data: { "text/html": "<marquee>WOO</marquee>" },
           transient: { display_id: "1234" }
         }
-      }
+      })
     ];
 
     const state = actionArray.reduce(

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -823,14 +823,13 @@ describe("appendOutput", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder", 2]);
 
-    const action = {
-      type: actionTypes.APPEND_OUTPUT,
+    const action = actions.appendOutput({
       id,
       output: {
         output_type: "display_data",
         data: { "text/html": "<marquee>wee</marquee>" }
       }
-    };
+    });
 
     const state = reducers(originalState, action);
     expect(
@@ -854,15 +853,14 @@ describe("appendOutput", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder", 2]);
 
-    const action = {
-      type: actionTypes.APPEND_OUTPUT,
+    const action = actions.appendOutput({
       id,
       output: {
         output_type: "display_data",
         data: { "text/html": "<marquee>wee</marquee>" },
         transient: { display_id: "1234" }
       }
-    };
+    });
 
     const state = reducers(originalState, action);
     expect(
@@ -891,16 +889,15 @@ describe("updateDisplay", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder", 2]);
 
-    const actions = [
-      {
-        type: actionTypes.APPEND_OUTPUT,
+    const actionArray = [
+      actions.appendOutput({
         id,
         output: {
           output_type: "display_data",
           data: { "text/html": "<marquee>wee</marquee>" },
           transient: { display_id: "1234" }
         }
-      },
+      }),
       {
         type: actionTypes.UPDATE_DISPLAY,
         content: {
@@ -911,7 +908,7 @@ describe("updateDisplay", () => {
       }
     ];
 
-    const state = actions.reduce(
+    const state = actionArray.reduce(
       (s, action) => reducers(s, action),
       originalState
     );

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -209,20 +209,20 @@ describe("focusNextCell", () => {
     const originalState = monocellDocument;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.FOCUS_NEXT_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.focusNextCell({ id, createCellIfUndefined: false })
+    );
     expect(state.get("cellFocused")).not.toBeNull();
   });
   test("should return same state if last cell and createCellIfUndefined is false", () => {
     const originalState = monocellDocument;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = { type: actionTypes.FOCUS_NEXT_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.focusNextCell({ id, createCellIfUndefined: false })
+    );
     expect(state.get("cellFocused")).not.toBeNull();
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
   });
@@ -233,14 +233,10 @@ describe("focusNextCell", () => {
     );
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = {
-      type: actionTypes.FOCUS_NEXT_CELL,
-      id,
-      createCellIfUndefined: true
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.focusNextCell({ id, createCellIfUndefined: true })
+    );
     const newCellId = state.getIn(["notebook", "cellOrder"]).last();
     const newCellType = state.getIn([
       "notebook",
@@ -260,14 +256,10 @@ describe("focusNextCell", () => {
     );
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = {
-      type: actionTypes.FOCUS_NEXT_CELL,
-      id,
-      createCellIfUndefined: true
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.focusNextCell({ id, createCellIfUndefined: true })
+    );
     const newCellId = state.getIn(["notebook", "cellOrder"]).last();
     const newCellType = state.getIn([
       "notebook",

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -367,10 +367,10 @@ describe("moveCell", () => {
     const cellOrder = originalState.getIn(["notebook", "cellOrder"]);
     const id = cellOrder.last();
     const destinationId = cellOrder.first();
-
-    const action = { type: actionTypes.MOVE_CELL, id, destinationId };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.moveCell({ id, destinationId, above: false })
+    );
     expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(id);
     expect(state.getIn(["notebook", "cellOrder"]).first()).toBe(destinationId);
   });
@@ -380,15 +380,10 @@ describe("moveCell", () => {
     const cellOrder = originalState.getIn(["notebook", "cellOrder"]);
     const id = cellOrder.last();
     const destinationId = cellOrder.first();
-
-    const action = {
-      type: actionTypes.MOVE_CELL,
-      id,
-      destinationId,
-      above: true
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.moveCell({ id, destinationId, above: true })
+    );
     expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(destinationId);
     expect(state.getIn(["notebook", "cellOrder"]).first()).toBe(id);
   });
@@ -405,28 +400,28 @@ describe("moveCell", () => {
 
     const cellOrder = originalState.getIn(["notebook", "cellOrder"]);
 
-    const action = {
-      type: actionTypes.MOVE_CELL,
-      id: cellOrder.get(0),
-      destinationId: cellOrder.get(1)
-    };
-    // implicitly above: false
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.moveCell({
+        id: cellOrder.get(0),
+        destinationId: cellOrder.get(1),
+        above: false
+      })
+    );
     expect(state.getIn(["notebook", "cellOrder"]).toJS()).toEqual([
       cellOrder.get(1),
       cellOrder.get(0),
       cellOrder.get(2)
     ]);
 
-    const action2 = {
-      type: actionTypes.MOVE_CELL,
-      id: cellOrder.get(0),
-      destinationId: cellOrder.get(1),
-      above: true
-    };
-
-    const state2 = reducers(originalState, action2);
+    const state2 = reducers(
+      originalState,
+      actions.moveCell({
+        id: cellOrder.get(0),
+        destinationId: cellOrder.get(1),
+        above: true
+      })
+    );
     expect(state2.getIn(["notebook", "cellOrder"]).toJS()).toEqual([
       cellOrder.get(0),
       cellOrder.get(1),

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -505,21 +505,15 @@ describe("createCellBefore", () => {
 describe("mergeCellAfter", () => {
   test("merges cells appropriately", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);
-
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-    const action = { type: actionTypes.MERGE_CELL_AFTER, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.mergeCellAfter({ id }));
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(1);
     expect(state.getIn(["notebook", "cellOrder"]).first()).toBe(id);
   });
   test("should do nothing if merging the last cell", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);
-
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-    const action = { type: actionTypes.MERGE_CELL_AFTER, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.mergeCellAfter({ id }));
     expect(state).toEqual(originalState);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -625,14 +625,10 @@ describe("updateCellStatus", () => {
     const originalState = monocellDocument;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = {
-      type: actionTypes.UPDATE_CELL_STATUS,
-      id,
-      status: "test status"
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.updateCellStatus({ id, status: "test status" })
+    );
     expect(state.getIn(["transient", "cellMap", id, "status"])).toBe(
       "test status"
     );

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -698,37 +698,32 @@ describe("pasteCell", () => {
 describe("changeCellType", () => {
   test("converts code cell to markdown cell", () => {
     const originalState = monocellDocument;
-
     const id = monocellDocument.getIn(["notebook", "cellOrder"]).last();
-
-    const action = { type: actionTypes.CHANGE_CELL_TYPE, id, to: "markdown" };
-
-    const state = reducers(originalState, action);
-
+    const state = reducers(
+      originalState,
+      actions.changeCellType({ id, to: "markdown" })
+    );
     expect(state.getIn(["notebook", "cellMap", id, "cell_type"])).toBe(
       "markdown"
     );
   });
   test("converts markdown cell to code cell", () => {
     const originalState = monocellDocument;
-
     const id = monocellDocument.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.CHANGE_CELL_TYPE, id, to: "code" };
-
-    const state = reducers(originalState, action);
-
+    const state = reducers(
+      originalState,
+      actions.changeCellType({ id, to: "code" })
+    );
     expect(state.getIn(["notebook", "cellMap", id, "cell_type"])).toBe("code");
     expect(state.getIn(["notebook", "cellMap", id, "outputs"])).toBeDefined();
   });
   test("does nothing if cell type is same", () => {
     const originalState = monocellDocument;
-
     const id = monocellDocument.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.CHANGE_CELL_TYPE, id, to: "markdown" };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.changeCellType({ id, to: "markdown" })
+    );
     expect(state).toBe(originalState);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -390,12 +390,11 @@ describe("moveCell", () => {
   test("should move a cell above another when asked", () => {
     const originalState = reducers(
       initialDocument.set("notebook", dummyCommutable),
-      {
-        type: "NEW_CELL_AFTER",
+      actions.createCellAfter({
         id: dummyCommutable.get("cellOrder").first(),
         cellType: "markdown",
         source: "# Woo\n*Yay*"
-      }
+      })
     );
 
     const cellOrder = originalState.getIn(["notebook", "cellOrder"]);
@@ -475,18 +474,14 @@ describe("clearOutputs", () => {
   });
 });
 
-describe("newCellAfter", () => {
+describe("createCellAfter", () => {
   test("creates a brand new cell after the given id", () => {
     const originalState = monocellDocument;
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = {
-      type: actionTypes.NEW_CELL_AFTER,
-      id,
-      cellType: "markdown"
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.createCellAfter({ cellType: "markdown", id })
+    );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
     const cellID = state.getIn(["notebook", "cellOrder"]).last();
     const cell = state.getIn(["notebook", "cellMap", cellID]);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -558,14 +558,16 @@ describe("overwriteMetadataField", () => {
   });
 });
 
-describe("deleteMetadata", () => {
+describe("deleteMetadataField", () => {
   test("deletes notebook metadata appropriately", () => {
     const originalState = monocellDocument.setIn(
       ["notebook", "metadata", "name"],
       "johnwashere"
     );
-    const action = { type: actionTypes.DELETE_METADATA_FIELD, field: "name" };
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.deleteMetadataField({ field: "name" })
+    );
     expect(state.getIn(["notebook", "metadata", "name"])).toBe(undefined);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -330,10 +330,7 @@ describe("toggleStickyCell", () => {
     const originalState = doc;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.TOGGLE_STICKY_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.toggleStickyCell({ id }));
     expect(state.hasIn(["stickyCells", id])).toBe(true);
   });
   test("should unstick a stuck cell given its ID", () => {
@@ -343,10 +340,7 @@ describe("toggleStickyCell", () => {
       .set("stickyCells", new Set([id]));
 
     const originalState = doc;
-
-    const action = { type: actionTypes.TOGGLE_STICKY_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.toggleStickyCell({ id }));
     expect(state.hasIn(["stickyCells", id])).toBe(false);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -1034,11 +1034,10 @@ describe("sendExecuteRequest", () => {
       })
     });
 
-    const state = reducers(initialState, {
-      type: actionTypes.SEND_EXECUTE_REQUEST,
-      id,
-      message: {}
-    });
+    const state = reducers(
+      initialState,
+      actions.sendExecuteRequest({ id, message: {} })
+    );
 
     expect(state.getIn(["transient", "cellMap", id, "status"])).toEqual(
       "queued"

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -665,10 +665,7 @@ describe("cutCell", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
     const cell = originalState.getIn(["notebook", "cellMap", id]);
-
-    const action = { type: actionTypes.CUT_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.cutCell({ id }));
     expect(state.getIn(["copied", "cell"])).toBe(cell);
     expect(state.getIn(["copied", "id"])).toBe(id);
     expect(state.getIn(["notebook", "cellMap", id])).toBeUndefined();

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -185,10 +185,10 @@ describe("setLanguageInfo", () => {
       name: "french",
       spec: { language: "french", display_name: "français" }
     };
-    const state = reducers(initialDocument, {
-      type: actionTypes.SET_KERNEL_INFO,
-      kernelInfo
-    });
+    const state = reducers(
+      initialDocument,
+      actions.setKernelInfo({ kernelInfo })
+    );
     const metadata = state.getIn(["notebook", "metadata"]);
     expect(metadata.getIn(["kernel_info", "name"])).toBe("french");
     expect(metadata.getIn(["kernelspec", "name"])).toBe("french");

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -580,10 +580,10 @@ describe("toggleCellOutputVisibility", () => {
     );
 
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.toggleCellOutputVisibility({ id })
+    );
     expect(
       state.getIn(["notebook", "cellMap", id, "metadata", "outputHidden"])
     ).toBe(true);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -314,10 +314,10 @@ describe("focusPreviousCellEditor", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
     const previousId = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.FOCUS_PREVIOUS_CELL_EDITOR, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.focusPreviousCellEditor({ id })
+    );
     expect(state.get("editorFocused")).toBe(previousId);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -433,12 +433,8 @@ describe("moveCell", () => {
 describe("removeCell", () => {
   test("should remove a cell given an ID", () => {
     const originalState = monocellDocument;
-
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.REMOVE_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.removeCell({ id }));
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(2);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -977,28 +977,32 @@ describe("sendExecuteRequest", () => {
 
 describe("acceptPayloadMessage", () => {
   test("processes jupyter payload message types", () => {
-    const state = reducers(initialDocument, {
-      type: actionTypes.ACCEPT_PAYLOAD_MESSAGE_ACTION,
-      id: firstCellId,
-      payload: {
-        source: "page",
-        data: { well: "alright" }
-      }
-    });
+    const state = reducers(
+      initialDocument,
+      actions.acceptPayloadMessage({
+        id: firstCellId,
+        payload: {
+          source: "page",
+          data: { well: "alright" }
+        }
+      })
+    );
 
     expect(state.getIn(["cellPagers", firstCellId])).toEqual(
       Immutable.List([{ well: "alright" }])
     );
 
-    const nextState = reducers(state, {
-      type: actionTypes.ACCEPT_PAYLOAD_MESSAGE_ACTION,
-      id: firstCellId,
-      payload: {
-        source: "set_next_input",
-        replace: true,
-        text: "this is now the text"
-      }
-    });
+    const nextState = reducers(
+      state,
+      actions.acceptPayloadMessage({
+        id: firstCellId,
+        payload: {
+          source: "set_next_input",
+          replace: true,
+          text: "this is now the text"
+        }
+      })
+    );
 
     expect(
       nextState.getIn(["notebook", "cellMap", firstCellId, "source"])

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -597,12 +597,13 @@ describe("toggleCellInputVisibility", () => {
       cells =>
         cells.map(value => value.setIn(["metadata", "inputHidden"], false))
     );
-
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.TOGGLE_CELL_INPUT_VISIBILITY, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.toggleCellInputVisibility({
+        id
+      })
+    );
     expect(
       state.getIn(["notebook", "cellMap", id, "metadata", "inputHidden"])
     ).toBe(true);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -544,17 +544,16 @@ describe("updateSource", () => {
   });
 });
 
-describe("overwriteMetadata", () => {
+describe("overwriteMetadataField", () => {
   test("overwrites notebook metadata appropriately", () => {
     const originalState = monocellDocument;
-
-    const action = {
-      type: actionTypes.OVERWRITE_METADATA_FIELD,
-      field: "name",
-      value: "javascript"
-    };
-
-    const state = reducers(originalState, action);
+    const state = reducers(
+      originalState,
+      actions.overwriteMetadataField({
+        field: "name",
+        value: "javascript"
+      })
+    );
     expect(state.getIn(["notebook", "metadata", "name"])).toBe("javascript");
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -490,9 +490,7 @@ describe("clearOutputs", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
 
-    const action = { type: actionTypes.CLEAR_OUTPUTS, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.clearOutputs({ id }));
     const outputs = state.getIn(["notebook", "cellMap", id, "outputs"]);
     expect(outputs).toBe(List.of());
   });
@@ -505,10 +503,7 @@ describe("clearOutputs", () => {
     });
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = { type: actionTypes.CLEAR_OUTPUTS, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.clearOutputs({ id }));
     const outputs = state.getIn(["notebook", "cellMap", id, "outputs"]);
     expect(outputs).toBeUndefined();
   });
@@ -674,10 +669,7 @@ describe("clearOutputs", () => {
     const originalState = monocellDocument;
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
-
-    const action = { type: actionTypes.CLEAR_OUTPUTS, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.clearOutputs({ id }));
     expect(state.getIn(["notebook", "cellMap", id, "outputs"]).count()).toBe(0);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -199,10 +199,7 @@ describe("setLanguageInfo", () => {
 describe("focusCell", () => {
   test("should set cellFocused to the appropriate cell ID", () => {
     const id = monocellDocument.getIn(["notebook", "cellOrder"]).last();
-
-    const action = { type: actionTypes.FOCUS_CELL, id };
-
-    const state = reducers(monocellDocument, action);
+    const state = reducers(monocellDocument, actions.focusCell({ id }));
     expect(state.get("cellFocused")).toBe(id);
   });
 });

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -280,10 +280,7 @@ describe("focusPreviousCell", () => {
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
     const previousId = originalState.getIn(["notebook", "cellOrder"]).first();
-
-    const action = { type: actionTypes.FOCUS_PREVIOUS_CELL, id };
-
-    const state = reducers(originalState, action);
+    const state = reducers(originalState, actions.focusPreviousCell({ id }));
     expect(state.get("cellFocused")).toBe(previousId);
   });
 });

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -82,9 +82,7 @@ describe("createExecuteCellStream", () => {
         })
       }
     };
-    const action$ = ActionsObservable.of({
-      type: actionTypes.SEND_EXECUTE_REQUEST
-    });
+    const action$ = ActionsObservable.of(actions.sendExecuteRequest({}));
     const observable = createExecuteCellStream(action$, store, "source", "id");
     observable.pipe(toArray()).subscribe(
       actions => {
@@ -147,11 +145,7 @@ describe("createExecuteCellStream", () => {
     const actionBuffer = [];
     observable.subscribe(x => actionBuffer.push(x), err => done.fail(err));
     expect(actionBuffer).toEqual([
-      {
-        type: actionTypes.SEND_EXECUTE_REQUEST,
-        id: "id",
-        message
-      }
+      actions.sendExecuteRequest({ id: "id", message })
     ]);
     done();
   });

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -310,20 +310,18 @@ describe("updateDisplayEpic", () => {
       },
       () => {
         expect(responseActions).toEqual([
-          {
-            type: actionTypes.UPDATE_DISPLAY,
+          actions.updateDisplay({
             content: {
               data: { "text/html": "<marquee>wee</marquee>" },
               transient: { display_id: "1234" }
             }
-          },
-          {
-            type: actionTypes.UPDATE_DISPLAY,
+          }),
+          actions.updateDisplay({
             content: {
               data: { "text/plain": "i am text" },
               transient: { display_id: "here" }
             }
-          }
+          })
         ]);
         done();
       }

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -272,8 +272,15 @@ export type ExecuteFailed = {
   payload: Error
 };
 
+// TODO: #2618
 export const FOCUS_CELL = "FOCUS_CELL";
-export type FocusCellAction = { type: "FOCUS_CELL", id: ?CellID };
+export type FocusCell = {
+  type: "FOCUS_CELL",
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
+};
 
 export const FOCUS_NEXT_CELL = "FOCUS_NEXT_CELL";
 export type FocusNextCellAction = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -274,11 +274,15 @@ export type ClearAllOutputs = {
   payload: { contentRef?: ContentRef }
 };
 
-export const ACCEPT_PAYLOAD_MESSAGE_ACTION = "ACCEPT_PAYLOAD_MESSAGE_ACTION";
-export type AcceptPayloadMessageAction = {
-  type: "ACCEPT_PAYLOAD_MESSAGE_ACTION",
-  id: CellID,
-  payload: *
+// TODO: #2618
+export const ACCEPT_PAYLOAD_MESSAGE = "ACCEPT_PAYLOAD_MESSAGE";
+export type AcceptPayloadMessage = {
+  type: "ACCEPT_PAYLOAD_MESSAGE",
+  payload: {
+    id: CellID,
+    payload: *,
+    contentRef?: ContentRef
+  }
 };
 
 export const SET_LANGUAGE_INFO = "SET_LANGUAGE_INFO";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -377,10 +377,14 @@ export type FocusPreviousCell = {
   }
 };
 
+// TODO: #2618
 export const FOCUS_CELL_EDITOR = "FOCUS_CELL_EDITOR";
-export type FocusCellEditorAction = {
+export type FocusCellEditor = {
   type: "FOCUS_CELL_EDITOR",
-  id: ?CellID
+  payload: {
+    id: ?CellID,
+    contentRef?: ContentRef
+  }
 };
 
 // TODO: #2618

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -172,13 +172,17 @@ export type AppendOutput = {
   }
 };
 
+// TODO: #2618
 export const UPDATE_DISPLAY = "UPDATE_DISPLAY";
-export type UpdateDisplayAction = {
+export type UpdateDisplay = {
   type: "UPDATE_DISPLAY",
-  content: {
-    data: MimeBundle,
-    metadata: JSONObject,
-    transient: { display_id: string }
+  payload: {
+    content: {
+      data: MimeBundle,
+      metadata: JSONObject,
+      transient: { display_id: string }
+    },
+    contentRef?: ContentRef
   }
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -143,8 +143,15 @@ export type MoveCell = {
   }
 };
 
+// TODO: #2618
 export const REMOVE_CELL = "REMOVE_CELL";
-export type RemoveCellAction = { type: "REMOVE_CELL", id: CellID };
+export type RemoveCell = {
+  type: "REMOVE_CELL",
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
+};
 
 export const NEW_CELL_AFTER = "NEW_CELL_AFTER";
 export type NewCellAfterAction = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -119,12 +119,16 @@ export type ChangeFilenameAction = {
   filename: string
 };
 
+// TODO: #2618
 export const SET_IN_CELL = "SET_IN_CELL";
-export type SetInCellAction<T> = {
+export type SetInCell<T> = {
   type: "SET_IN_CELL",
-  id: CellID,
-  path: Array<string>,
-  value: T
+  payload: {
+    id: CellID,
+    path: Array<string>,
+    value: T,
+    contentRef?: ContentRef
+  }
 };
 
 export const MOVE_CELL = "MOVE_CELL";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -153,12 +153,16 @@ export type RemoveCell = {
   }
 };
 
-export const NEW_CELL_AFTER = "NEW_CELL_AFTER";
-export type NewCellAfterAction = {
-  type: "NEW_CELL_AFTER",
-  id: CellID,
-  cellType: CellType,
-  source: string
+// TODO: #2618
+export const CREATE_CELL_AFTER = "CREATE_CELL_AFTER";
+export type CreateCellAfter = {
+  type: "CREATE_CELL_AFTER",
+  payload: {
+    id: CellID,
+    cellType: CellType,
+    source: string,
+    contentRef?: ContentRef
+  }
 };
 
 export const NEW_CELL_BEFORE = "NEW_CELL_BEFORE";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -338,10 +338,14 @@ export type FocusNextCellEditor = {
   }
 };
 
+// TODO: #2618
 export const FOCUS_PREVIOUS_CELL_EDITOR = "FOCUS_PREVIOUS_CELL_EDITOR";
-export type FocusPreviousCellEditorAction = {
+export type FocusPreviousCellEditor = {
   type: "FOCUS_PREVIOUS_CELL_EDITOR",
-  id: ?CellID
+  payload: {
+    id: ?CellID,
+    contentRef?: ContentRef
+  }
 };
 
 export const TOGGLE_STICKY_CELL = "TOGGLE_STICKY_CELL";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -503,8 +503,12 @@ export type ToggleCellExpansionAction = {
 export const CUT_CELL = "CUT_CELL";
 export type CutCellAction = { type: "CUT_CELL", id: CellID };
 
+// TODO: #2618
 export const COPY_CELL = "COPY_CELL";
-export type CopyCellAction = { type: "COPY_CELL", id: CellID };
+export type CopyCell = {
+  type: "COPY_CELL",
+  payload: { id: CellID, contentRef?: ContentRef }
+};
 
 export const PASTE_CELL = "PASTE_CELL";
 export type PasteCellAction = { type: "PASTE_CELL" };

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -113,10 +113,14 @@ export type FetchKernelspecsFailed = {
   }
 };
 
+// TODO: #2618
 export const CHANGE_FILENAME = "CHANGE_FILENAME";
 export type ChangeFilenameAction = {
   type: "CHANGE_FILENAME",
-  filename: string
+  payload: {
+    filename: ?string,
+    contentRef?: ContentRef
+  }
 };
 
 // TODO: #2618

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -131,11 +131,16 @@ export type SetInCell<T> = {
   }
 };
 
+// TODO: #2618
 export const MOVE_CELL = "MOVE_CELL";
-export type MoveCellAction = {
+export type MoveCell = {
   type: "MOVE_CELL",
-  id: CellID,
-  destinationId: CellID
+  payload: {
+    id: CellID,
+    destinationId: CellID,
+    above: boolean,
+    contentRef?: ContentRef
+  }
 };
 
 export const REMOVE_CELL = "REMOVE_CELL";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -237,10 +237,14 @@ export type UnhideAll = {
   }
 };
 
+// TODO: #2618
 export const TOGGLE_CELL_OUTPUT_VISIBILITY = "TOGGLE_CELL_OUTPUT_VISIBILITY";
-export type ToggleCellOutputVisibilityAction = {
+export type ToggleCellOutputVisibility = {
   type: "TOGGLE_CELL_OUTPUT_VISIBILITY",
-  id: CellID
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
 };
 
 export const TOGGLE_CELL_INPUT_VISIBILITY = "TOGGLE_CELL_INPUT_VISIBILITY";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -428,10 +428,14 @@ export type OverwriteMetadataField = {
   }
 };
 
+// TODO: #2618
 export const DELETE_METADATA_FIELD = "DELETE_METADATA_FIELD";
-export type DeleteMetadataFieldAction = {
+export type DeleteMetadataField = {
   type: "DELETE_METADATA_FIELD",
-  field: string
+  payload: {
+    field: string,
+    contentRef?: ContentRef
+  }
 };
 
 // TODO: #2618

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -521,11 +521,15 @@ export type PasteCell = {
   payload: { contentRef?: ContentRef }
 };
 
+// TODO: #2618
 export const CHANGE_CELL_TYPE = "CHANGE_CELL_TYPE";
-export type ChangeCellTypeAction = {
+export type ChangeCellType = {
   type: "CHANGE_CELL_TYPE",
-  id: CellID,
-  to: string
+  payload: {
+    id: CellID,
+    to: CellType,
+    contentRef?: ContentRef
+  }
 };
 
 export const SET_EXECUTION_STATE = "SET_EXECUTION_STATE";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -440,13 +440,15 @@ export type NewNotebook = {
 
 // TODO: Make this action JSON serializable (don't use the Immutable.js version
 //       of the notebook in this action)
+// TODO: #2618
 export const SET_NOTEBOOK = "SET_NOTEBOOK";
-export type SetNotebookAction = {
+export type SetNotebook = {
   type: "SET_NOTEBOOK",
   payload: {
     notebook: ImmutableNotebook,
     filename: ?string,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -285,12 +285,14 @@ export type AcceptPayloadMessage = {
   }
 };
 
+// TODO: #2618
 export const SET_LANGUAGE_INFO = "SET_LANGUAGE_INFO";
-export type SetLanguageInfoAction = {
+export type SetLanguageInfo = {
   type: "SET_LANGUAGE_INFO",
   payload: {
     langInfo: LanguageInfoMetadata,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -228,12 +228,14 @@ export type UpdateDisplayFailed = {
   error: true
 };
 
+// TODO: #2618
 export const UNHIDE_ALL = "UNHIDE_ALL";
 export type UnhideAll = {
   type: "UNHIDE_ALL",
   payload: {
     inputHidden: boolean,
-    outputHidden: boolean
+    outputHidden: boolean,
+    contentRef?: ContentRef
   }
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -216,8 +216,12 @@ export type ClearOutputs = {
   }
 };
 
+// TODO: #2618
 export const CLEAR_ALL_OUTPUTS = "CLEAR_ALL_OUTPUTS";
-export type ClearAllOutputs = { type: "CLEAR_ALL_OUTPUTS" };
+export type ClearAllOutputs = {
+  type: "CLEAR_ALL_OUTPUTS",
+  payload: { contentRef?: ContentRef }
+};
 
 export const ACCEPT_PAYLOAD_MESSAGE_ACTION = "ACCEPT_PAYLOAD_MESSAGE_ACTION";
 export type AcceptPayloadMessageAction = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -328,10 +328,14 @@ export type FocusCellEditorAction = {
   id: ?CellID
 };
 
+// TODO: #2618
 export const FOCUS_NEXT_CELL_EDITOR = "FOCUS_NEXT_CELL_EDITOR";
-export type FocusNextCellEditorAction = {
+export type FocusNextCellEditor = {
   type: "FOCUS_NEXT_CELL_EDITOR",
-  id: ?CellID
+  payload: {
+    id: ?CellID,
+    contentRef?: ContentRef
+  }
 };
 
 export const FOCUS_PREVIOUS_CELL_EDITOR = "FOCUS_PREVIOUS_CELL_EDITOR";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -1,5 +1,10 @@
 /* @flow */
-import type { HostRef, KernelRef, KernelspecsRef } from "./state/refs";
+import type {
+  ContentRef,
+  HostRef,
+  KernelRef,
+  KernelspecsRef
+} from "./state/refs";
 import type { HostRecord } from "./state/entities/hosts";
 import type { KernelspecProps } from "./state/entities/kernelspecs";
 
@@ -223,11 +228,15 @@ export type SetLanguageInfoAction = {
   }
 };
 
+// TODO: #2618
 export const SEND_EXECUTE_REQUEST = "SEND_EXECUTE_REQUEST";
-export type SendExecuteMessageAction = {
+export type SendExecuteRequest = {
   type: "SEND_EXECUTE_REQUEST",
-  id: CellID,
-  message: ExecuteRequest
+  payload: {
+    id: CellID,
+    message: ExecuteRequest,
+    contentRef?: ContentRef
+  }
 };
 
 export const EXECUTE_CELL = "EXECUTE_CELL";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -161,11 +161,15 @@ export type NewCellAppendAction = {
 export const MERGE_CELL_AFTER = "MERGE_CELL_AFTER";
 export type MergeCellAfterAction = { type: "MERGE_CELL_AFTER", id: CellID };
 
+// TODO: #2618
 export const APPEND_OUTPUT = "APPEND_OUTPUT";
-export type AppendOutputAction = {
+export type AppendOutput = {
   type: "APPEND_OUTPUT",
-  id: CellID,
-  output: Output
+  payload: {
+    id: CellID,
+    output: Output,
+    contentRef?: ContentRef
+  }
 };
 
 export const UPDATE_DISPLAY = "UPDATE_DISPLAY";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -348,8 +348,15 @@ export type FocusPreviousCellEditor = {
   }
 };
 
+// TODO: #2618
 export const TOGGLE_STICKY_CELL = "TOGGLE_STICKY_CELL";
-export type ToggleStickyCellAction = { type: "TOGGLE_STICKY_CELL", id: CellID };
+export type ToggleStickyCell = {
+  type: "TOGGLE_STICKY_CELL",
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
+};
 
 export const SET_KERNEL_INFO = "SET_KERNEL_INFO";
 export type SetKernelInfoAction = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -165,11 +165,15 @@ export type CreateCellAfter = {
   }
 };
 
-export const NEW_CELL_BEFORE = "NEW_CELL_BEFORE";
-export type NewCellBeforeAction = {
-  type: "NEW_CELL_BEFORE",
-  cellType: CellType,
-  id: CellID
+// TODO: #2618
+export const CREATE_CELL_BEFORE = "CREATE_CELL_BEFORE";
+export type CreateCellBefore = {
+  type: "CREATE_CELL_BEFORE",
+  payload: {
+    cellType: CellType,
+    id: CellID,
+    contentRef?: ContentRef
+  }
 };
 
 export const NEW_CELL_APPEND = "NEW_CELL_APPEND";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -247,10 +247,14 @@ export type ToggleCellOutputVisibility = {
   }
 };
 
+// TODO: #2618
 export const TOGGLE_CELL_INPUT_VISIBILITY = "TOGGLE_CELL_INPUT_VISIBILITY";
-export type ToggleCellInputVisibilityAction = {
+export type ToggleCellInputVisibility = {
   type: "TOGGLE_CELL_INPUT_VISIBILITY",
-  id: CellID
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
 };
 
 // TODO: #2618

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -206,8 +206,15 @@ export type ToggleCellInputVisibilityAction = {
   id: CellID
 };
 
+// TODO: #2618
 export const CLEAR_OUTPUTS = "CLEAR_OUTPUTS";
-export type ClearOutputsAction = { type: "CLEAR_OUTPUTS", id: CellID };
+export type ClearOutputs = {
+  type: "CLEAR_OUTPUTS",
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
+};
 
 export const CLEAR_ALL_OUTPUTS = "CLEAR_ALL_OUTPUTS";
 export type ClearAllOutputs = { type: "CLEAR_ALL_OUTPUTS" };

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -301,11 +301,15 @@ export type FocusCell = {
   }
 };
 
+// TODO: #2618
 export const FOCUS_NEXT_CELL = "FOCUS_NEXT_CELL";
-export type FocusNextCellAction = {
+export type FocusNextCell = {
   type: "FOCUS_NEXT_CELL",
-  id: ?CellID,
-  createCellIfUndefined: boolean
+  payload: {
+    id: ?CellID,
+    createCellIfUndefined: boolean,
+    contentRef?: ContentRef
+  }
 };
 
 export const FOCUS_PREVIOUS_CELL = "FOCUS_PREVIOUS_CELL";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -407,10 +407,14 @@ export type ToggleStickyCell = {
   }
 };
 
+// TODO: #2618
 export const SET_KERNEL_INFO = "SET_KERNEL_INFO";
-export type SetKernelInfoAction = {
+export type SetKernelInfo = {
   type: "SET_KERNEL_INFO",
-  kernelInfo: KernelInfo
+  payload: {
+    kernelInfo: KernelInfo,
+    contentRef?: ContentRef
+  }
 };
 
 export const OVERWRITE_METADATA_FIELD = "OVERWRITE_METADATA_FIELD";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -312,10 +312,14 @@ export type FocusNextCell = {
   }
 };
 
+// TODO: #2618
 export const FOCUS_PREVIOUS_CELL = "FOCUS_PREVIOUS_CELL";
-export type FocusPreviousCellAction = {
+export type FocusPreviousCell = {
   type: "FOCUS_PREVIOUS_CELL",
-  id: ?CellID
+  payload: {
+    id: ?CellID,
+    contentRef?: ContentRef
+  }
 };
 
 export const FOCUS_CELL_EDITOR = "FOCUS_CELL_EDITOR";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -417,11 +417,15 @@ export type SetKernelInfo = {
   }
 };
 
+// TODO: #2618
 export const OVERWRITE_METADATA_FIELD = "OVERWRITE_METADATA_FIELD";
-export type OverwriteMetadataFieldAction = {
+export type OverwriteMetadataField = {
   type: "OVERWRITE_METADATA_FIELD",
-  field: string,
-  value: any
+  payload: {
+    field: string,
+    value: any,
+    contentRef?: ContentRef
+  }
 };
 
 export const DELETE_METADATA_FIELD = "DELETE_METADATA_FIELD";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -500,8 +500,12 @@ export type ToggleCellExpansionAction = {
   id: CellID
 };
 
+// TODO: #2618
 export const CUT_CELL = "CUT_CELL";
-export type CutCellAction = { type: "CUT_CELL", id: CellID };
+export type CutCell = {
+  type: "CUT_CELL",
+  payload: { id: CellID, contentRef?: ContentRef }
+};
 
 // TODO: #2618
 export const COPY_CELL = "COPY_CELL";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -514,8 +514,12 @@ export type CopyCell = {
   payload: { id: CellID, contentRef?: ContentRef }
 };
 
+// TODO: #2618
 export const PASTE_CELL = "PASTE_CELL";
-export type PasteCellAction = { type: "PASTE_CELL" };
+export type PasteCell = {
+  type: "PASTE_CELL",
+  payload: { contentRef?: ContentRef }
+};
 
 export const CHANGE_CELL_TYPE = "CHANGE_CELL_TYPE";
 export type ChangeCellTypeAction = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -426,8 +426,12 @@ export type SaveAs = { type: "SAVE_AS", filename: string };
 export const SAVE_FAILED = "SAVE_FAILED";
 export type SaveFailed = { type: "SAVE_FAILED" };
 
+// TODO: #2618
 export const SAVE_FULFILLED = "SAVE_FULFILLED";
-export type SaveFulfilled = { type: "SAVE_FULFILLED" };
+export type SaveFulfilled = {
+  type: "SAVE_FULFILLED",
+  payload: { contentRef?: ContentRef }
+};
 
 export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
 export type NewNotebook = {

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -182,8 +182,15 @@ export type NewCellAppendAction = {
   cellType: CellType
 };
 
+// TODO: #2618
 export const MERGE_CELL_AFTER = "MERGE_CELL_AFTER";
-export type MergeCellAfterAction = { type: "MERGE_CELL_AFTER", id: CellID };
+export type MergeCellAfter = {
+  type: "MERGE_CELL_AFTER",
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
+};
 
 // TODO: #2618
 export const APPEND_OUTPUT = "APPEND_OUTPUT";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -424,11 +424,15 @@ export type DeleteMetadataFieldAction = {
   field: string
 };
 
+// TODO: #2618
 export const UPDATE_CELL_STATUS = "UPDATE_CELL_STATUS";
-export type UpdateCellStatusAction = {
+export type UpdateCellStatus = {
   type: "UPDATE_CELL_STATUS",
-  id: CellID,
-  status: string
+  payload: {
+    id: CellID,
+    status: string,
+    contentRef?: ContentRef
+  }
 };
 
 export const REGISTER_COMM_TARGET = "REGISTER_COMM_TARGET";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -494,10 +494,14 @@ export type SaveConfigAction = { type: "SAVE_CONFIG" };
 export const DONE_SAVING_CONFIG = "DONE_SAVING_CONFIG";
 export type DoneSavingConfigAction = { type: "DONE_SAVING_CONFIG" };
 
+// TODO: #2618
 export const TOGGLE_OUTPUT_EXPANSION = "TOGGLE_OUTPUT_EXPANSION";
-export type ToggleCellExpansionAction = {
+export type ToggleCellExpansion = {
   type: "TOGGLE_OUTPUT_EXPANSION",
-  id: CellID
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
 };
 
 // TODO: #2618

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -225,10 +225,14 @@ export type UpdateDisplay = {
   }
 };
 
+// TODO: #2618
 export const UPDATE_DISPLAY_FAILED = "UPDATE_DISPLAY_FAILED";
 export type UpdateDisplayFailed = {
   type: "UPDATE_DISPLAY_FAILED",
-  payload: Error,
+  payload: {
+    error: Error,
+    contentRef?: ContentRef
+  },
   error: true
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -176,10 +176,14 @@ export type CreateCellBefore = {
   }
 };
 
-export const NEW_CELL_APPEND = "NEW_CELL_APPEND";
-export type NewCellAppendAction = {
-  type: "NEW_CELL_APPEND",
-  cellType: CellType
+// TODO: #2618
+export const CREATE_CELL_APPEND = "CREATE_CELL_APPEND";
+export type CreateCellAppend = {
+  type: "CREATE_CELL_APPEND",
+  payload: {
+    cellType: CellType,
+    contentRef?: ContentRef
+  }
 };
 
 // TODO: #2618

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -922,10 +922,14 @@ export function updateDisplay(payload: {
   };
 }
 
-export function updateDisplayFailed(error: Error): UpdateDisplayFailed {
+// TODO: #2618
+export function updateDisplayFailed(payload: {
+  error: Error,
+  contentRef?: ContentRef
+}): UpdateDisplayFailed {
   return {
     type: actionTypes.UPDATE_DISPLAY_FAILED,
-    payload: error,
+    payload,
     error: true
   };
 }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -69,7 +69,7 @@ import type {
   FocusCell,
   NewCellAppendAction,
   MergeCellAfterAction,
-  MoveCellAction,
+  MoveCell,
   ToggleStickyCell,
   FocusPreviousCell,
   SetKernelInfoAction,
@@ -292,16 +292,16 @@ export function clearAllOutputs(payload: {
   };
 }
 
-export function moveCell(
+// TODO: #2618
+export function moveCell(payload: {
   id: string,
   destinationId: string,
-  above: boolean
-): MoveCellAction {
+  above: boolean,
+  contentRef?: ContentRef
+}): MoveCell {
   return {
     type: actionTypes.MOVE_CELL,
-    id,
-    destinationId,
-    above
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -61,7 +61,7 @@ import type {
   AppendOutput,
   UpdateDisplay,
   UpdateDisplayFailed,
-  FocusNextCellAction,
+  FocusNextCell,
   FocusCellEditorAction,
   FocusNextCellEditorAction,
   FocusPreviousCellEditorAction,
@@ -450,14 +450,15 @@ export function focusCell(payload: {
   };
 }
 
-export function focusNextCell(
+// TODO: #2618
+export function focusNextCell(payload: {
   id: ?string,
-  createCellIfUndefined: boolean
-): FocusNextCellAction {
+  createCellIfUndefined: boolean,
+  contentRef?: ContentRef
+}): FocusNextCell {
   return {
     type: actionTypes.FOCUS_NEXT_CELL,
-    id,
-    createCellIfUndefined
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -54,7 +54,7 @@ import type {
   AcceptPayloadMessageAction,
   NewNotebook,
   SetNotebook,
-  NewCellAfterAction,
+  CreateCellAfter,
   NewCellBeforeAction,
   ClearAllOutputs,
   ClearOutputs,
@@ -316,16 +316,16 @@ export function removeCell(payload: {
   };
 }
 
-export function createCellAfter(
+// TODO: #2618
+export function createCellAfter(payload: {
+  id: CellID,
   cellType: CellType,
-  id: string,
-  source: string = ""
-): NewCellAfterAction {
+  source: string,
+  contentRef?: ContentRef
+}): CreateCellAfter {
   return {
-    type: actionTypes.NEW_CELL_AFTER,
-    source,
-    cellType,
-    id
+    type: actionTypes.CREATE_CELL_AFTER,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -71,7 +71,7 @@ import type {
   MergeCellAfterAction,
   MoveCellAction,
   ToggleStickyCellAction,
-  FocusPreviousCellAction,
+  FocusPreviousCell,
   SetKernelInfoAction,
   SetLanguageInfoAction,
   UpdateCellStatusAction,
@@ -469,10 +469,14 @@ export function focusNextCellEditor(id: ?string): FocusNextCellEditorAction {
   };
 }
 
-export function focusPreviousCell(id: ?string): FocusPreviousCellAction {
+// TODO: #2618
+export function focusPreviousCell(payload: {
+  id: ?string,
+  contentRef?: ContentRef
+}): FocusPreviousCell {
   return {
     type: actionTypes.FOCUS_PREVIOUS_CELL,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -51,7 +51,7 @@ import type {
   CopyCellAction,
   DeleteMetadataFieldAction,
   OverwriteMetadataFieldAction,
-  AcceptPayloadMessageAction,
+  AcceptPayloadMessage,
   NewNotebook,
   SetNotebook,
   CreateCellAfter,
@@ -857,13 +857,14 @@ export function appendOutput(payload: {
   };
 }
 
-export function acceptPayloadMessage(
+// TODO: #2618
+export function acceptPayloadMessage(payload: {
   id: CellID,
-  payload: *
-): AcceptPayloadMessageAction {
+  payload: *,
+  contentRef?: ContentRef
+}): AcceptPayloadMessage {
   return {
-    type: actionTypes.ACCEPT_PAYLOAD_MESSAGE_ACTION,
-    id,
+    type: actionTypes.ACCEPT_PAYLOAD_MESSAGE,
     payload
   };
 }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -709,9 +709,13 @@ export function saveFailed(error: Error): SaveFailed {
   };
 }
 
-export function saveFulfilled(): SaveFulfilled {
+// TODO: #2618
+export function saveFulfilled(payload: {
+  contentRef?: ContentRef
+}): SaveFulfilled {
   return {
-    type: actionTypes.SAVE_FULFILLED
+    type: actionTypes.SAVE_FULFILLED,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -48,7 +48,7 @@ import type {
   ToggleCellExpansionAction,
   ChangeCellTypeAction,
   CutCellAction,
-  CopyCellAction,
+  CopyCell,
   DeleteMetadataField,
   OverwriteMetadataField,
   AcceptPayloadMessage,
@@ -626,10 +626,14 @@ export function setNotificationSystem(
   };
 }
 
-export function copyCell(id: CellID): CopyCellAction {
+// TODO: #2618
+export function copyCell(payload: {
+  id: CellID,
+  contentRef?: ContentRef
+}): CopyCell {
   return {
     type: actionTypes.COPY_CELL,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -75,7 +75,7 @@ import type {
   SetKernelInfoAction,
   SetLanguageInfoAction,
   UpdateCellStatusAction,
-  ToggleCellInputVisibilityAction,
+  ToggleCellInputVisibility,
   ToggleCellOutputVisibility,
   SetInCell,
   SendExecuteRequest,
@@ -432,12 +432,14 @@ export function toggleCellOutputVisibility(payload: {
   };
 }
 
-export function toggleCellInputVisibility(
-  id: string
-): ToggleCellInputVisibilityAction {
+// TODO: #2618
+export function toggleCellInputVisibility(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ToggleCellInputVisibility {
   return {
     type: actionTypes.TOGGLE_CELL_INPUT_VISIBILITY,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -70,7 +70,7 @@ import type {
   NewCellAppendAction,
   MergeCellAfterAction,
   MoveCellAction,
-  ToggleStickyCellAction,
+  ToggleStickyCell,
   FocusPreviousCell,
   SetKernelInfoAction,
   SetLanguageInfoAction,
@@ -502,10 +502,14 @@ export function focusPreviousCellEditor(payload: {
   };
 }
 
-export function toggleStickyCell(id: string): ToggleStickyCellAction {
+// TODO: #2618
+export function toggleStickyCell(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ToggleStickyCell {
   return {
     type: actionTypes.TOGGLE_STICKY_CELL,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -282,9 +282,13 @@ export function clearOutputs(payload: {
   };
 }
 
-export function clearAllOutputs(): ClearAllOutputs {
+// TODO: #2618
+export function clearAllOutputs(payload: {
+  contentRef?: ContentRef
+}): ClearAllOutputs {
   return {
-    type: actionTypes.CLEAR_ALL_OUTPUTS
+    type: actionTypes.CLEAR_ALL_OUTPUTS,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -67,7 +67,7 @@ import type {
   FocusPreviousCellEditor,
   RemoveCell,
   FocusCell,
-  NewCellAppendAction,
+  CreateCellAppend,
   MergeCellAfter,
   MoveCell,
   ToggleStickyCell,
@@ -341,10 +341,14 @@ export function createCellBefore(payload: {
   };
 }
 
-export function createCellAppend(cellType: CellType): NewCellAppendAction {
+// TODO: #2618
+export function createCellAppend(payload: {
+  cellType: CellType,
+  contentRef?: ContentRef
+}): CreateCellAppend {
   return {
-    type: actionTypes.NEW_CELL_APPEND,
-    cellType
+    type: actionTypes.CREATE_CELL_APPEND,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -47,7 +47,7 @@ import type {
   ChangeFilenameAction,
   ToggleCellExpansionAction,
   ChangeCellTypeAction,
-  CutCellAction,
+  CutCell,
   CopyCell,
   DeleteMetadataField,
   OverwriteMetadataField,
@@ -637,10 +637,14 @@ export function copyCell(payload: {
   };
 }
 
-export function cutCell(id: CellID): CutCellAction {
+// TODO: #2618
+export function cutCell(payload: {
+  id: CellID,
+  contentRef?: ContentRef
+}): CutCell {
   return {
     type: actionTypes.CUT_CELL,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -59,7 +59,7 @@ import type {
   ClearAllOutputs,
   ClearOutputs,
   AppendOutput,
-  UpdateDisplayAction,
+  UpdateDisplay,
   UpdateDisplayFailed,
   FocusNextCellAction,
   FocusCellEditorAction,
@@ -836,14 +836,18 @@ export function acceptPayloadMessage(
   };
 }
 
-export function updateDisplay(content: {
-  data: MimeBundle,
-  metadata: JSONObject,
-  transient: { display_id: string }
-}): UpdateDisplayAction {
+// TODO: #2618
+export function updateDisplay(payload: {
+  content: {
+    data: MimeBundle,
+    metadata: JSONObject,
+    transient: { display_id: string }
+  },
+  contentRef?: ContentRef
+}): UpdateDisplay {
   return {
     type: actionTypes.UPDATE_DISPLAY,
-    content
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -45,7 +45,7 @@ import type {
   FetchKernelspecsFailed,
   PasteCell,
   ChangeFilenameAction,
-  ToggleCellExpansionAction,
+  ToggleCellExpansion,
   ChangeCellType,
   CutCell,
   CopyCell,
@@ -691,10 +691,14 @@ export function setCursorBlink(value: string): SetConfigAction<string> {
   return setConfigAtKey("cursorBlinkRate", value);
 }
 
-export function toggleOutputExpansion(id: string): ToggleCellExpansionAction {
+// TODO: #2618
+export function toggleOutputExpansion(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ToggleCellExpansion {
   return {
     type: actionTypes.TOGGLE_OUTPUT_EXPANSION,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -68,7 +68,7 @@ import type {
   RemoveCell,
   FocusCell,
   NewCellAppendAction,
-  MergeCellAfterAction,
+  MergeCellAfter,
   MoveCell,
   ToggleStickyCell,
   FocusPreviousCell,
@@ -348,10 +348,14 @@ export function createCellAppend(cellType: CellType): NewCellAppendAction {
   };
 }
 
-export function mergeCellAfter(id: string): MergeCellAfterAction {
+// TODO: #2618
+export function mergeCellAfter(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): MergeCellAfter {
   return {
     type: actionTypes.MERGE_CELL_AFTER,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -43,7 +43,7 @@ import type {
   FetchKernelspecs,
   FetchKernelspecsFulfilled,
   FetchKernelspecsFailed,
-  PasteCellAction,
+  PasteCell,
   ChangeFilenameAction,
   ToggleCellExpansionAction,
   ChangeCellTypeAction,
@@ -648,9 +648,11 @@ export function cutCell(payload: {
   };
 }
 
-export function pasteCell(): PasteCellAction {
+// TODO: #2618
+export function pasteCell(payload: { contentRef?: ContentRef }): PasteCell {
   return {
-    type: actionTypes.PASTE_CELL
+    type: actionTypes.PASTE_CELL,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -64,7 +64,7 @@ import type {
   FocusNextCell,
   FocusCellEditorAction,
   FocusNextCellEditor,
-  FocusPreviousCellEditorAction,
+  FocusPreviousCellEditor,
   RemoveCellAction,
   FocusCell,
   NewCellAppendAction,
@@ -491,12 +491,14 @@ export function focusCellEditor(id: ?string): FocusCellEditorAction {
   };
 }
 
-export function focusPreviousCellEditor(
-  id: ?string
-): FocusPreviousCellEditorAction {
+// TODO: #2618
+export function focusPreviousCellEditor(payload: {
+  id: ?string,
+  contentRef?: ContentRef
+}): FocusPreviousCellEditor {
   return {
     type: actionTypes.FOCUS_PREVIOUS_CELL_EDITOR,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -755,10 +755,14 @@ export function executeFailed(error: Error): ExecuteFailed {
   };
 }
 
-export function changeFilename(filename: string): ChangeFilenameAction {
+// TODO: #2618
+export function changeFilename(payload: {
+  filename: ?string,
+  contentRef?: ContentRef
+}): ChangeFilenameAction {
   return {
     type: actionTypes.CHANGE_FILENAME,
-    filename
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -55,7 +55,7 @@ import type {
   NewNotebook,
   SetNotebook,
   CreateCellAfter,
-  NewCellBeforeAction,
+  CreateCellBefore,
   ClearAllOutputs,
   ClearOutputs,
   AppendOutput,
@@ -329,14 +329,15 @@ export function createCellAfter(payload: {
   };
 }
 
-export function createCellBefore(
+// TODO: #2618
+export function createCellBefore(payload: {
   cellType: CellType,
-  id: string
-): NewCellBeforeAction {
+  id: string,
+  contentRef?: ContentRef
+}): CreateCellBefore {
   return {
-    type: actionTypes.NEW_CELL_BEFORE,
-    cellType,
-    id
+    type: actionTypes.CREATE_CELL_BEFORE,
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -3,7 +3,12 @@ import * as actionTypes from "./actionTypes";
 
 import type { Notebook, ImmutableNotebook } from "@nteract/commutable";
 
-import type { HostRef, KernelRef, KernelspecsRef } from "./state/refs";
+import type {
+  ContentRef,
+  HostRef,
+  KernelRef,
+  KernelspecsRef
+} from "./state/refs";
 import type { KernelspecProps } from "./state/entities/kernelspecs";
 
 import type {
@@ -73,7 +78,7 @@ import type {
   ToggleCellInputVisibilityAction,
   ToggleCellOutputVisibilityAction,
   SetInCellAction,
-  SendExecuteMessageAction,
+  SendExecuteRequest,
   NewKernelAction,
   SetGithubTokenAction,
   SetNotificationSystemAction,
@@ -650,14 +655,15 @@ export function executeFocusedCell(): ExecuteFocusedCellAction {
   };
 }
 
-export function sendExecuteMessage(
+// TODO: #2618
+export function sendExecuteRequest(payload: {
   id: string,
-  message: *
-): SendExecuteMessageAction {
+  message: *,
+  contentRef?: ContentRef
+}): SendExecuteRequest {
   return {
     type: actionTypes.SEND_EXECUTE_REQUEST,
-    id,
-    message
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -73,7 +73,7 @@ import type {
   ToggleStickyCell,
   FocusPreviousCell,
   SetKernelInfoAction,
-  SetLanguageInfoAction,
+  SetLanguageInfo,
   UpdateCellStatus,
   ToggleCellInputVisibility,
   ToggleCellOutputVisibility,
@@ -893,10 +893,12 @@ export function updateDisplayFailed(error: Error): UpdateDisplayFailed {
   };
 }
 
+// TODO: #2618
 export function setLanguageInfo(payload: {
   langInfo: LanguageInfoMetadata,
-  kernelRef: KernelRef
-}): SetLanguageInfoAction {
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
+}): SetLanguageInfo {
   return {
     type: actionTypes.SET_LANGUAGE_INFO,
     payload

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -415,9 +415,11 @@ export function updateCellExecutionCount(payload: {
   return setInCell({ ...payload, path: ["execution_count"] });
 }
 
+// TODO: #2618
 export function unhideAll(payload: {
   outputHidden: boolean,
-  inputHidden: boolean
+  inputHidden: boolean,
+  contentRef?: ContentRef
 }): UnhideAll {
   return {
     type: "UNHIDE_ALL",

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -77,7 +77,7 @@ import type {
   UpdateCellStatusAction,
   ToggleCellInputVisibilityAction,
   ToggleCellOutputVisibilityAction,
-  SetInCellAction,
+  SetInCell,
   SendExecuteRequest,
   NewKernelAction,
   SetGithubTokenAction,
@@ -350,12 +350,13 @@ export function mergeCellAfter(id: string): MergeCellAfterAction {
   };
 }
 
+// TODO: #2618
 /**
  * setInCell can generically be used to set any attribute on a cell, including
  * and especially for changing metadata per cell.
- * @param {CellID} id    cell ID
- * @param {Array<string>} path  path within a cell to set
- * @param {any} value what to set it to
+ * @param {CellID} payload.id    cell ID
+ * @param {Array<string>} payload.path  path within a cell to set
+ * @param {any} payload.value what to set it to
  *
  * Example:
  *
@@ -371,31 +372,30 @@ export function mergeCellAfter(id: string): MergeCellAfterAction {
  * }
  *
  */
-export function setInCell<T>(
+export function setInCell<T>(payload: {
   id: CellID,
   path: Array<string>,
-  value: T
-): SetInCellAction<T> {
+  value: T,
+  contentRef?: ContentRef
+}): SetInCell<T> {
   return {
     type: actionTypes.SET_IN_CELL,
-    id,
-    path,
-    value
+    payload
   };
 }
 
-export function updateCellSource(
+export function updateCellSource(payload: {
   id: string,
-  source: string
-): SetInCellAction<string> {
-  return setInCell(id, ["source"], source);
+  value: string
+}): SetInCell<string> {
+  return setInCell({ ...payload, path: ["source"] });
 }
 
-export function updateCellExecutionCount(
+export function updateCellExecutionCount(payload: {
   id: string,
-  count: number
-): SetInCellAction<number> {
-  return setInCell(id, ["execution_count"], count);
+  value: number
+}): SetInCell<number> {
+  return setInCell({ ...payload, path: ["execution_count"] });
 }
 
 export function unhideAll(payload: {

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -62,7 +62,7 @@ import type {
   UpdateDisplay,
   UpdateDisplayFailed,
   FocusNextCell,
-  FocusCellEditorAction,
+  FocusCellEditor,
   FocusNextCellEditor,
   FocusPreviousCellEditor,
   RemoveCell,
@@ -508,10 +508,14 @@ export function focusPreviousCell(payload: {
   };
 }
 
-export function focusCellEditor(id: ?string): FocusCellEditorAction {
+// TODO: #2618
+export function focusCellEditor(payload: {
+  id: ?string,
+  contentRef?: ContentRef
+}): FocusCellEditor {
   return {
     type: actionTypes.FOCUS_CELL_EDITOR,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -58,7 +58,7 @@ import type {
   NewCellBeforeAction,
   ClearAllOutputs,
   ClearOutputs,
-  AppendOutputAction,
+  AppendOutput,
   UpdateDisplayAction,
   UpdateDisplayFailed,
   FocusNextCellAction,
@@ -813,11 +813,15 @@ export function commMessageAction(message: any) {
   };
 }
 
-export function appendOutput(id: CellID, output: Output): AppendOutputAction {
+// TODO: #2618
+export function appendOutput(payload: {
+  id: CellID,
+  output: Output,
+  contentRef?: ContentRef
+}): AppendOutput {
   return {
     type: actionTypes.APPEND_OUTPUT,
-    id,
-    output
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -72,7 +72,7 @@ import type {
   MoveCell,
   ToggleStickyCell,
   FocusPreviousCell,
-  SetKernelInfoAction,
+  SetKernelInfo,
   SetLanguageInfo,
   UpdateCellStatus,
   ToggleCellInputVisibility,
@@ -254,10 +254,14 @@ export function kernelRawStderr(payload: {
 }
 
 // TODO: Does this need to pass KernelRef information?
-export function setNotebookKernelInfo(kernelInfo: any): SetKernelInfoAction {
+// TODO: #2618
+export function setKernelInfo(payload: {
+  kernelInfo: any,
+  contentRef?: ContentRef
+}): SetKernelInfo {
   return {
     type: actionTypes.SET_KERNEL_INFO,
-    kernelInfo
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -74,7 +74,7 @@ import type {
   FocusPreviousCell,
   SetKernelInfoAction,
   SetLanguageInfoAction,
-  UpdateCellStatusAction,
+  UpdateCellStatus,
   ToggleCellInputVisibility,
   ToggleCellOutputVisibility,
   SetInCell,
@@ -443,14 +443,15 @@ export function toggleCellInputVisibility(payload: {
   };
 }
 
-export function updateCellStatus(
+// TODO: #2618
+export function updateCellStatus(payload: {
   id: string,
-  status: string
-): UpdateCellStatusAction {
+  status: string,
+  contentRef?: ContentRef
+}): UpdateCellStatus {
   return {
     type: actionTypes.UPDATE_CELL_STATUS,
-    id,
-    status
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -66,7 +66,7 @@ import type {
   FocusNextCellEditorAction,
   FocusPreviousCellEditorAction,
   RemoveCellAction,
-  FocusCellAction,
+  FocusCell,
   NewCellAppendAction,
   MergeCellAfterAction,
   MoveCellAction,
@@ -431,10 +431,14 @@ export function updateCellStatus(
 
 /* Unlike focus next & previous, to set focus, we require an ID,
    because the others are based on there already being a focused cell */
-export function focusCell(id: string): FocusCellAction {
+// TODO: #2618
+export function focusCell(payload: {
+  id: CellID,
+  contentRef?: ContentRef
+}): FocusCell {
   return {
     type: actionTypes.FOCUS_CELL,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -57,7 +57,7 @@ import type {
   NewCellAfterAction,
   NewCellBeforeAction,
   ClearAllOutputs,
-  ClearOutputsAction,
+  ClearOutputs,
   AppendOutputAction,
   UpdateDisplayAction,
   UpdateDisplayFailed,
@@ -271,10 +271,14 @@ export function setExecutionState(payload: {
   };
 }
 
-export function clearOutputs(id: string): ClearOutputsAction {
+// TODO: #2618
+export function clearOutputs(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ClearOutputs {
   return {
     type: actionTypes.CLEAR_OUTPUTS,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -50,7 +50,7 @@ import type {
   CutCellAction,
   CopyCellAction,
   DeleteMetadataFieldAction,
-  OverwriteMetadataFieldAction,
+  OverwriteMetadataField,
   AcceptPayloadMessage,
   NewNotebook,
   SetNotebook,
@@ -535,14 +535,15 @@ export function toggleStickyCell(payload: {
   };
 }
 
-export function overwriteMetadata(
+// TODO: #2618
+export function overwriteMetadataField(payload: {
   field: string,
-  value: any
-): OverwriteMetadataFieldAction {
+  value: any,
+  contentRef?: ContentRef
+}): OverwriteMetadataField {
   return {
     type: actionTypes.OVERWRITE_METADATA_FIELD,
-    field,
-    value
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -53,7 +53,7 @@ import type {
   OverwriteMetadataFieldAction,
   AcceptPayloadMessageAction,
   NewNotebook,
-  SetNotebookAction,
+  SetNotebook,
   NewCellAfterAction,
   NewCellBeforeAction,
   ClearAllOutputs,
@@ -735,11 +735,13 @@ export function newNotebook(payload: {
 }
 
 // Expects notebook to be JS Object or Immutable.js
+// TODO: #2618
 export const setNotebook = (payload: {
   filename: ?string,
   notebook: ImmutableNotebook,
-  kernelRef: KernelRef
-}): SetNotebookAction => ({
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
+}): SetNotebook => ({
   type: actionTypes.SET_NOTEBOOK,
   payload
 });

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -63,7 +63,7 @@ import type {
   UpdateDisplayFailed,
   FocusNextCell,
   FocusCellEditorAction,
-  FocusNextCellEditorAction,
+  FocusNextCellEditor,
   FocusPreviousCellEditorAction,
   RemoveCellAction,
   FocusCell,
@@ -462,10 +462,14 @@ export function focusNextCell(payload: {
   };
 }
 
-export function focusNextCellEditor(id: ?string): FocusNextCellEditorAction {
+// TODO: #2618
+export function focusNextCellEditor(payload: {
+  id: ?string,
+  contentRef?: ContentRef
+}): FocusNextCellEditor {
   return {
     type: actionTypes.FOCUS_NEXT_CELL_EDITOR,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -49,7 +49,7 @@ import type {
   ChangeCellTypeAction,
   CutCellAction,
   CopyCellAction,
-  DeleteMetadataFieldAction,
+  DeleteMetadataField,
   OverwriteMetadataField,
   AcceptPayloadMessage,
   NewNotebook,
@@ -547,10 +547,14 @@ export function overwriteMetadataField(payload: {
   };
 }
 
-export function deleteMetadata(field: string): DeleteMetadataFieldAction {
+// TODO: #2618
+export function deleteMetadataField(payload: {
+  field: string,
+  contentRef?: ContentRef
+}): DeleteMetadataField {
   return {
     type: actionTypes.DELETE_METADATA_FIELD,
-    field
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -46,7 +46,7 @@ import type {
   PasteCell,
   ChangeFilenameAction,
   ToggleCellExpansionAction,
-  ChangeCellTypeAction,
+  ChangeCellType,
   CutCell,
   CopyCell,
   DeleteMetadataField,
@@ -656,11 +656,15 @@ export function pasteCell(payload: { contentRef?: ContentRef }): PasteCell {
   };
 }
 
-export function changeCellType(id: CellID, to: CellType): ChangeCellTypeAction {
+// TODO: #2618
+export function changeCellType(payload: {
+  id: CellID,
+  to: CellType,
+  contentRef?: ContentRef
+}): ChangeCellType {
   return {
     type: actionTypes.CHANGE_CELL_TYPE,
-    id,
-    to
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -76,7 +76,7 @@ import type {
   SetLanguageInfoAction,
   UpdateCellStatusAction,
   ToggleCellInputVisibilityAction,
-  ToggleCellOutputVisibilityAction,
+  ToggleCellOutputVisibility,
   SetInCell,
   SendExecuteRequest,
   NewKernelAction,
@@ -421,12 +421,14 @@ export function unhideAll(payload: {
   };
 }
 
-export function toggleCellOutputVisibility(
-  id: string
-): ToggleCellOutputVisibilityAction {
+// TODO: #2618
+export function toggleCellOutputVisibility(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ToggleCellOutputVisibility {
   return {
     type: actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -65,7 +65,7 @@ import type {
   FocusCellEditorAction,
   FocusNextCellEditor,
   FocusPreviousCellEditor,
-  RemoveCellAction,
+  RemoveCell,
   FocusCell,
   NewCellAppendAction,
   MergeCellAfterAction,
@@ -305,10 +305,14 @@ export function moveCell(payload: {
   };
 }
 
-export function removeCell(id: string): RemoveCellAction {
+// TODO: #2618
+export function removeCell(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): RemoveCell {
   return {
     type: actionTypes.REMOVE_CELL,
-    id
+    payload
   };
 }
 

--- a/packages/core/src/components/cell-creator.js
+++ b/packages/core/src/components/cell-creator.js
@@ -11,7 +11,7 @@ type Props = {
 
 type ConnectedProps = {
   above: boolean,
-  createCellAppend: (type: string) => void,
+  createCellAppend: (payload: *) => void,
   createCellBefore: (payload: *) => void,
   createCellAfter: (payload: *) => void,
   mergeCellAfter: (payload: *) => void,
@@ -140,7 +140,8 @@ class CellCreator extends React.Component<ConnectedProps> {
     } = this.props;
 
     if (!id) {
-      createCellAppend(type);
+      // TODO: #2618
+      createCellAppend({ cellType: type });
       return;
     }
 
@@ -172,7 +173,7 @@ class CellCreator extends React.Component<ConnectedProps> {
 }
 
 const mapDispatchToProps = dispatch => ({
-  createCellAppend: type => dispatch(actions.createCellAppend(type)),
+  createCellAppend: (payload: *) => dispatch(actions.createCellAppend(payload)),
   createCellBefore: (payload: *) => dispatch(actions.createCellBefore(payload)),
   createCellAfter: (payload: *) => dispatch(actions.createCellAfter(payload)),
   mergeCellAfter: (payload: *) => dispatch(actions.mergeCellAfter(payload))

--- a/packages/core/src/components/cell-creator.js
+++ b/packages/core/src/components/cell-creator.js
@@ -13,7 +13,7 @@ type ConnectedProps = {
   above: boolean,
   createCellAppend: (type: string) => void,
   createCellBefore: (type: string, id: string) => void,
-  createCellAfter: (type: string, id: string) => void,
+  createCellAfter: (payload: *) => void,
   mergeCellAfter: (id: string) => void,
   id?: string
 };
@@ -144,7 +144,10 @@ class CellCreator extends React.Component<ConnectedProps> {
       return;
     }
 
-    above ? createCellBefore(type, id) : createCellAfter(type, id);
+    // TODO: #2618
+    above
+      ? createCellBefore(type, id)
+      : createCellAfter({ cellType: type, id, source: "" });
   }
 
   mergeCell(): void {
@@ -170,7 +173,7 @@ class CellCreator extends React.Component<ConnectedProps> {
 const mapDispatchToProps = dispatch => ({
   createCellAppend: type => dispatch(actions.createCellAppend(type)),
   createCellBefore: (type, id) => dispatch(actions.createCellBefore(type, id)),
-  createCellAfter: (type, id) => dispatch(actions.createCellAfter(type, id)),
+  createCellAfter: (payload: *) => dispatch(actions.createCellAfter(payload)),
   mergeCellAfter: id => dispatch(actions.mergeCellAfter(id))
 });
 

--- a/packages/core/src/components/cell-creator.js
+++ b/packages/core/src/components/cell-creator.js
@@ -14,7 +14,7 @@ type ConnectedProps = {
   createCellAppend: (type: string) => void,
   createCellBefore: (payload: *) => void,
   createCellAfter: (payload: *) => void,
-  mergeCellAfter: (id: string) => void,
+  mergeCellAfter: (payload: *) => void,
   id?: string
 };
 
@@ -155,7 +155,8 @@ class CellCreator extends React.Component<ConnectedProps> {
 
     // We can't merge cells if we don't have a cell ID
     if (id) {
-      mergeCellAfter(id);
+      // TODO: #2618
+      mergeCellAfter({ id });
     }
   }
 
@@ -174,7 +175,7 @@ const mapDispatchToProps = dispatch => ({
   createCellAppend: type => dispatch(actions.createCellAppend(type)),
   createCellBefore: (payload: *) => dispatch(actions.createCellBefore(payload)),
   createCellAfter: (payload: *) => dispatch(actions.createCellAfter(payload)),
-  mergeCellAfter: id => dispatch(actions.mergeCellAfter(id))
+  mergeCellAfter: (payload: *) => dispatch(actions.mergeCellAfter(payload))
 });
 
 export default connect(null, mapDispatchToProps)(CellCreator);

--- a/packages/core/src/components/cell-creator.js
+++ b/packages/core/src/components/cell-creator.js
@@ -12,7 +12,7 @@ type Props = {
 type ConnectedProps = {
   above: boolean,
   createCellAppend: (type: string) => void,
-  createCellBefore: (type: string, id: string) => void,
+  createCellBefore: (payload: *) => void,
   createCellAfter: (payload: *) => void,
   mergeCellAfter: (id: string) => void,
   id?: string
@@ -146,7 +146,7 @@ class CellCreator extends React.Component<ConnectedProps> {
 
     // TODO: #2618
     above
-      ? createCellBefore(type, id)
+      ? createCellBefore({ cellType: type, id })
       : createCellAfter({ cellType: type, id, source: "" });
   }
 
@@ -172,7 +172,7 @@ class CellCreator extends React.Component<ConnectedProps> {
 
 const mapDispatchToProps = dispatch => ({
   createCellAppend: type => dispatch(actions.createCellAppend(type)),
-  createCellBefore: (type, id) => dispatch(actions.createCellBefore(type, id)),
+  createCellBefore: (payload: *) => dispatch(actions.createCellBefore(payload)),
   createCellAfter: (payload: *) => dispatch(actions.createCellAfter(payload)),
   mergeCellAfter: id => dispatch(actions.mergeCellAfter(id))
 });

--- a/packages/core/src/components/draggable-cell.js
+++ b/packages/core/src/components/draggable-cell.js
@@ -39,7 +39,7 @@ type Props = {|
   connectDragPreview: (img: Image) => void,
   connectDragSource: (el: ?React$Element<any>) => void,
   connectDropTarget: (el: ?React$Element<any>) => void,
-  selectCell: () => void,
+  focusCell: (payload: *) => *,
   id: string,
   isDragging: boolean,
   isOver: boolean,
@@ -119,6 +119,11 @@ class DraggableCellView extends React.Component<Props, State> {
     };
   }
 
+  selectCell = () => {
+    // TODO: #2618
+    this.props.focusCell({ id: this.props.id });
+  };
+
   render(): ?React$Element<any> {
     return this.props.connectDropTarget(
       <div
@@ -141,7 +146,7 @@ class DraggableCellView extends React.Component<Props, State> {
         {this.props.connectDragSource(
           <div
             className="cell-drag-handle"
-            onClick={this.props.selectCell}
+            onClick={this.selectCell}
             role="presentation"
           />
         )}

--- a/packages/core/src/components/draggable-cell.js
+++ b/packages/core/src/components/draggable-cell.js
@@ -43,7 +43,7 @@ type Props = {|
   id: string,
   isDragging: boolean,
   isOver: boolean,
-  moveCell: (source: string, dest: string, above: boolean) => Object,
+  moveCell: (payload: *) => Object,
   children: React.Element<any>
 |};
 
@@ -74,7 +74,12 @@ const cellTarget = {
     if (monitor) {
       const hoverUpperHalf = isDragUpper(props, monitor, component.el);
       // DropTargetSpec monitor definition could be undefined. we'll need a check for monitor in order to pass validation.
-      props.moveCell(monitor.getItem().id, props.id, hoverUpperHalf);
+      // TODO: #2618
+      props.moveCell({
+        id: monitor.getItem().id,
+        destinationId: props.id,
+        above: hoverUpperHalf
+      });
     }
   },
 

--- a/packages/core/src/components/editor.js
+++ b/packages/core/src/components/editor.js
@@ -54,7 +54,8 @@ class Editor extends React.Component<Props> {
     const { cellFocused, dispatch, id } = this.props;
 
     if (focused) {
-      dispatch(focusCellEditor(id));
+      // TODO: #2618
+      dispatch(focusCellEditor({ id }));
       if (!cellFocused) {
         // TODO: #2618
         dispatch(focusCell({ id }));

--- a/packages/core/src/components/editor.js
+++ b/packages/core/src/components/editor.js
@@ -56,7 +56,8 @@ class Editor extends React.Component<Props> {
     if (focused) {
       dispatch(focusCellEditor(id));
       if (!cellFocused) {
-        dispatch(focusCell(id));
+        // TODO: #2618
+        dispatch(focusCell({ id }));
       }
     }
   }

--- a/packages/core/src/components/editor.js
+++ b/packages/core/src/components/editor.js
@@ -46,8 +46,8 @@ class Editor extends React.Component<Props> {
 
   onChange(text: string): void {
     const { dispatch, id } = this.props;
-
-    dispatch(updateCellSource(id, text));
+    // TODO: #2618
+    dispatch(updateCellSource({ id, value: text }));
   }
 
   onFocusChange(focused: boolean): void {

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -118,7 +118,8 @@ const mapDispatchToCellProps = (dispatch, { id }) => ({
   focusBelowCell: () => {
     // TODO: #2618
     dispatch(actions.focusNextCell({ id, createCellIfUndefined: true }));
-    dispatch(actions.focusNextCellEditor(id));
+    // TODO: #2618
+    dispatch(actions.focusNextCellEditor({ id }));
   }
 });
 
@@ -305,7 +306,7 @@ type NotebookDispatchProps = {
   focusCell: (payload: *) => *,
   executeFocusedCell: () => *,
   focusNextCell: (*) => *,
-  focusNextCellEditor: () => *
+  focusNextCellEditor: (*) => *
 };
 
 const mapStateToProps = (
@@ -331,7 +332,8 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): NotebookDispatchProps => ({
   focusCell: (payload: *) => dispatch(actions.focusCell(payload)),
   executeFocusedCell: () => dispatch(actions.executeFocusedCell()),
   focusNextCell: (payload: *) => dispatch(actions.focusNextCell(payload)),
-  focusNextCellEditor: () => dispatch(actions.focusNextCellEditor())
+  focusNextCellEditor: (payload: *) =>
+    dispatch(actions.focusNextCellEditor(payload))
 });
 
 export class NotebookApp extends React.PureComponent<NotebookProps> {
@@ -394,7 +396,8 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
       // Couldn't focusNextCell just do focusing of both?
       // TODO: #2618
       focusNextCell({ id: null, createCellIfUndefined: true });
-      focusNextCellEditor();
+      // TODO: #2618
+      focusNextCellEditor({ id: null });
     }
   }
 

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -106,7 +106,8 @@ const mapStateToCellProps = (state, { id }) => {
 };
 
 const mapDispatchToCellProps = (dispatch, { id }) => ({
-  selectCell: () => dispatch(actions.focusCell(id)),
+  // TODO: #2618
+  selectCell: () => dispatch(actions.focusCell({ id })),
   focusEditor: () => dispatch(actions.focusCellEditor(id)),
   unfocusEditor: () => dispatch(actions.focusCellEditor(null)),
   focusAboveCell: () => {
@@ -299,7 +300,7 @@ type NotebookStateProps = {
 
 type NotebookDispatchProps = {
   moveCell: (sourceId: string, destinationId: string, above: boolean) => *,
-  selectCell: (id: string) => *,
+  focusCell: (payload: *) => *,
   executeFocusedCell: () => *,
   focusNextCell: (*, *) => *,
   focusNextCellEditor: () => *
@@ -325,7 +326,7 @@ const mapStateToProps = (
 const mapDispatchToProps = (dispatch: Dispatch<*>): NotebookDispatchProps => ({
   moveCell: (sourceId: string, destinationId: string, above: boolean) =>
     dispatch(actions.moveCell(sourceId, destinationId, above)),
-  selectCell: (id: string) => dispatch(actions.focusCell(id)),
+  focusCell: (payload: *) => dispatch(actions.focusCell(payload)),
   executeFocusedCell: () => dispatch(actions.executeFocusedCell()),
   focusNextCell: (...args) => dispatch(actions.focusNextCell(...args)),
   focusNextCellEditor: () => dispatch(actions.focusNextCellEditor())
@@ -418,13 +419,11 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
   }
 
   renderCell(id: string): ?React$Element<any> {
-    const { selectCell } = this.props;
     return (
       <ConnectedCell
         id={id}
         transforms={this.props.transforms}
         displayOrder={this.props.displayOrder}
-        selectCell={selectCell}
         codeMirrorMode={this.props.codeMirrorMode}
       />
     );
@@ -432,13 +431,13 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
 
   createCellElement(id: string): React$Element<*> {
     const isStickied = this.props.stickyCells.get(id);
-    const { moveCell, selectCell } = this.props;
+    const { moveCell, focusCell } = this.props;
     return (
       <div className="cell-container" key={`cell-container-${id}`}>
         {isStickied ? (
           <PinnedPlaceHolderCell />
         ) : (
-          <DraggableCell moveCell={moveCell} id={id} selectCell={selectCell}>
+          <DraggableCell moveCell={moveCell} id={id} focusCell={focusCell}>
             {this.renderCell(id)}
           </DraggableCell>
         )}

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -113,7 +113,8 @@ const mapDispatchToCellProps = (dispatch, { id }) => ({
   focusAboveCell: () => {
     // TODO: #2618
     dispatch(actions.focusPreviousCell({ id }));
-    dispatch(actions.focusPreviousCellEditor(id));
+    // TODO: #2618
+    dispatch(actions.focusPreviousCellEditor({ id }));
   },
   focusBelowCell: () => {
     // TODO: #2618

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -111,7 +111,8 @@ const mapDispatchToCellProps = (dispatch, { id }) => ({
   focusEditor: () => dispatch(actions.focusCellEditor(id)),
   unfocusEditor: () => dispatch(actions.focusCellEditor(null)),
   focusAboveCell: () => {
-    dispatch(actions.focusPreviousCell(id));
+    // TODO: #2618
+    dispatch(actions.focusPreviousCell({ id }));
     dispatch(actions.focusPreviousCellEditor(id));
   },
   focusBelowCell: () => {

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -115,7 +115,8 @@ const mapDispatchToCellProps = (dispatch, { id }) => ({
     dispatch(actions.focusPreviousCellEditor(id));
   },
   focusBelowCell: () => {
-    dispatch(actions.focusNextCell(id, true));
+    // TODO: #2618
+    dispatch(actions.focusNextCell({ id, createCellIfUndefined: true }));
     dispatch(actions.focusNextCellEditor(id));
   }
 });
@@ -302,7 +303,7 @@ type NotebookDispatchProps = {
   moveCell: (sourceId: string, destinationId: string, above: boolean) => *,
   focusCell: (payload: *) => *,
   executeFocusedCell: () => *,
-  focusNextCell: (*, *) => *,
+  focusNextCell: (*) => *,
   focusNextCellEditor: () => *
 };
 
@@ -328,7 +329,7 @@ const mapDispatchToProps = (dispatch: Dispatch<*>): NotebookDispatchProps => ({
     dispatch(actions.moveCell(sourceId, destinationId, above)),
   focusCell: (payload: *) => dispatch(actions.focusCell(payload)),
   executeFocusedCell: () => dispatch(actions.executeFocusedCell()),
-  focusNextCell: (...args) => dispatch(actions.focusNextCell(...args)),
+  focusNextCell: (payload: *) => dispatch(actions.focusNextCell(payload)),
   focusNextCellEditor: () => dispatch(actions.focusNextCellEditor())
 });
 
@@ -390,7 +391,8 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
 
     if (e.shiftKey) {
       // Couldn't focusNextCell just do focusing of both?
-      focusNextCell(null, true);
+      // TODO: #2618
+      focusNextCell({ id: null, createCellIfUndefined: true });
       focusNextCellEditor();
     }
   }

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -108,8 +108,10 @@ const mapStateToCellProps = (state, { id }) => {
 const mapDispatchToCellProps = (dispatch, { id }) => ({
   // TODO: #2618
   selectCell: () => dispatch(actions.focusCell({ id })),
-  focusEditor: () => dispatch(actions.focusCellEditor(id)),
-  unfocusEditor: () => dispatch(actions.focusCellEditor(null)),
+  // TODO: #2618
+  focusEditor: () => dispatch(actions.focusCellEditor({ id })),
+  // TODO: #2618
+  unfocusEditor: () => dispatch(actions.focusCellEditor({ id: null })),
   focusAboveCell: () => {
     // TODO: #2618
     dispatch(actions.focusPreviousCell({ id }));

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -303,7 +303,7 @@ type NotebookStateProps = {
 };
 
 type NotebookDispatchProps = {
-  moveCell: (sourceId: string, destinationId: string, above: boolean) => *,
+  moveCell: (payload: *) => *,
   focusCell: (payload: *) => *,
   executeFocusedCell: () => *,
   focusNextCell: (*) => *,
@@ -328,8 +328,7 @@ const mapStateToProps = (
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<*>): NotebookDispatchProps => ({
-  moveCell: (sourceId: string, destinationId: string, above: boolean) =>
-    dispatch(actions.moveCell(sourceId, destinationId, above)),
+  moveCell: (payload: *) => dispatch(actions.moveCell(payload)),
   focusCell: (payload: *) => dispatch(actions.focusCell(payload)),
   executeFocusedCell: () => dispatch(actions.executeFocusedCell()),
   focusNextCell: (payload: *) => dispatch(actions.focusNextCell(payload)),

--- a/packages/core/src/components/notebook-menu/constants.js
+++ b/packages/core/src/components/notebook-menu/constants.js
@@ -11,7 +11,7 @@ export const MENU_ITEM_ACTIONS = {
   RESTART_KERNEL: "restart-kernel",
   RESTART_AND_CLEAR_OUTPUTS: "restart-kernel-and-clear-outputs",
   CLEAR_ALL_OUTPUTS: "clear-all-outputs",
-  UNHIDE_ALL_CELLS: "unhide-all-cells",
+  UNHIDE_ALL: "unhide-all",
   CREATE_CODE_CELL: "create-code-cell",
   CREATE_MARKDOWN_CELL: "create-markdown-cell",
   SET_CELL_TYPE_CODE: "set-cell-type-code",

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -26,7 +26,7 @@ type Props = {
   executeCell: ?(cellId: ?string) => void,
   executeAllCells: ?() => void,
   executeAllCellsBelow: ?() => void,
-  clearAllOutputs: ?() => void,
+  clearAllOutputs: ?(payload: *) => void,
   unhideAllCells: ?(*) => void,
   cutCell: ?(cellId: ?string) => void,
   copyCell: ?(cellId: ?string) => void,
@@ -169,7 +169,8 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.CLEAR_ALL_OUTPUTS:
         if (clearAllOutputs) {
-          clearAllOutputs();
+          // TODO: #2618
+          clearAllOutputs({});
         }
         break;
       case MENU_ITEM_ACTIONS.SET_THEME_DARK:
@@ -367,7 +368,7 @@ const mapDispatchToProps = dispatch => ({
   executeCell: cellId => dispatch(actions.executeCell(cellId)),
   executeAllCells: () => dispatch(actions.executeAllCells()),
   executeAllCellsBelow: () => dispatch(actions.executeAllCellsBelow()),
-  clearAllOutputs: () => dispatch(actions.clearAllOutputs()),
+  clearAllOutputs: (payload: *) => dispatch(actions.clearAllOutputs(payload)),
   unhideAllCells: payload => dispatch(actions.unhideAll(payload)),
   cutCell: cellId => dispatch(actions.cutCell(cellId)),
   copyCell: cellId => dispatch(actions.copyCell(cellId)),

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -374,9 +374,15 @@ const mapDispatchToProps = dispatch => ({
   copyCell: cellId => dispatch(actions.copyCell(cellId)),
   pasteCell: () => dispatch(actions.pasteCell()),
   mergeCellAfter: cellId => dispatch(actions.mergeCellAfter(cellId)),
-  createCodeCell: cellId => dispatch(actions.createCellAfter("code", cellId)),
+  // TODO: #2618
+  createCodeCell: cellId =>
+    dispatch(
+      actions.createCellAfter({ cellType: "code", id: cellId, source: "" })
+    ),
   createMarkdownCell: cellId =>
-    dispatch(actions.createCellAfter("markdown", cellId)),
+    dispatch(
+      actions.createCellAfter({ cellType: "markdown", id: cellId, source: "" })
+    ),
   setCellTypeCode: cellId => dispatch(actions.changeCellType(cellId, "code")),
   setCellTypeMarkdown: cellId =>
     dispatch(actions.changeCellType(cellId, "markdown")),

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -387,9 +387,11 @@ const mapDispatchToProps = dispatch => ({
     dispatch(
       actions.createCellAfter({ cellType: "markdown", id: cellId, source: "" })
     ),
-  setCellTypeCode: cellId => dispatch(actions.changeCellType(cellId, "code")),
+  // TODO: #2618
+  setCellTypeCode: cellId =>
+    dispatch(actions.changeCellType({ id: cellId, to: "code" })),
   setCellTypeMarkdown: cellId =>
-    dispatch(actions.changeCellType(cellId, "markdown")),
+    dispatch(actions.changeCellType({ id: cellId, to: "markdown" })),
   setTheme: theme => dispatch(actions.setTheme(theme)),
   openAboutModal: () =>
     dispatch(actions.openModal({ modalType: MODAL_TYPES.ABOUT })),

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -27,7 +27,7 @@ type Props = {
   executeAllCells: ?() => void,
   executeAllCellsBelow: ?() => void,
   clearAllOutputs: ?(payload: *) => void,
-  unhideAllCells: ?(*) => void,
+  unhideAll: ?(*) => void,
   cutCell: ?(payload: *) => void,
   copyCell: ?(payload: *) => void,
   mergeCellAfter: ?(payload: *) => void,
@@ -55,7 +55,7 @@ class PureNotebookMenu extends React.Component<Props> {
     executeAllCells: null,
     executeAllCellsBelow: null,
     clearAllOutputs: null,
-    unhideAllCells: null,
+    unhideAll: null,
     cutCell: null,
     copyCell: null,
     mergeCellAfter: null,
@@ -84,7 +84,7 @@ class PureNotebookMenu extends React.Component<Props> {
       executeAllCells,
       executeAllCellsBelow,
       clearAllOutputs,
-      unhideAllCells,
+      unhideAll,
       filename,
       mergeCellAfter,
       notebook,
@@ -166,9 +166,10 @@ class PureNotebookMenu extends React.Component<Props> {
           executeAllCellsBelow();
         }
         break;
-      case MENU_ITEM_ACTIONS.UNHIDE_ALL_CELLS:
-        if (unhideAllCells) {
-          unhideAllCells({ outputHidden: false, inputHidden: false });
+      case MENU_ITEM_ACTIONS.UNHIDE_ALL:
+        if (unhideAll) {
+          // TODO: #2618
+          unhideAll({ outputHidden: false, inputHidden: false });
         }
         break;
       case MENU_ITEM_ACTIONS.CLEAR_ALL_OUTPUTS:
@@ -308,7 +309,7 @@ class PureNotebookMenu extends React.Component<Props> {
               Clear All Outputs
             </MenuItem>
 
-            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.UNHIDE_ALL_CELLS)}>
+            <MenuItem key={createActionKey(MENU_ITEM_ACTIONS.UNHIDE_ALL)}>
               Unhide All Input and Output
             </MenuItem>
           </SubMenu>
@@ -373,7 +374,7 @@ const mapDispatchToProps = dispatch => ({
   executeAllCells: () => dispatch(actions.executeAllCells()),
   executeAllCellsBelow: () => dispatch(actions.executeAllCellsBelow()),
   clearAllOutputs: (payload: *) => dispatch(actions.clearAllOutputs(payload)),
-  unhideAllCells: payload => dispatch(actions.unhideAll(payload)),
+  unhideAll: payload => dispatch(actions.unhideAll(payload)),
   cutCell: (payload: *) => dispatch(actions.cutCell(payload)),
   copyCell: (payload: *) => dispatch(actions.copyCell(payload)),
   pasteCell: (payload: *) => dispatch(actions.pasteCell(payload)),

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -28,7 +28,7 @@ type Props = {
   executeAllCellsBelow: ?() => void,
   clearAllOutputs: ?(payload: *) => void,
   unhideAllCells: ?(*) => void,
-  cutCell: ?(cellId: ?string) => void,
+  cutCell: ?(payload: *) => void,
   copyCell: ?(payload: *) => void,
   mergeCellAfter: ?(payload: *) => void,
   filename: ?string,
@@ -120,7 +120,8 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.CUT_CELL:
         if (cutCell) {
-          cutCell(cellFocused);
+          // TODO: #2618
+          cutCell({ id: cellFocused });
         }
         break;
       case MENU_ITEM_ACTIONS.PASTE_CELL:
@@ -372,7 +373,7 @@ const mapDispatchToProps = dispatch => ({
   executeAllCellsBelow: () => dispatch(actions.executeAllCellsBelow()),
   clearAllOutputs: (payload: *) => dispatch(actions.clearAllOutputs(payload)),
   unhideAllCells: payload => dispatch(actions.unhideAll(payload)),
-  cutCell: cellId => dispatch(actions.cutCell(cellId)),
+  cutCell: (payload: *) => dispatch(actions.cutCell(payload)),
   copyCell: (payload: *) => dispatch(actions.copyCell(payload)),
   pasteCell: () => dispatch(actions.pasteCell()),
   mergeCellAfter: (payload: *) => dispatch(actions.mergeCellAfter(payload)),

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -33,7 +33,7 @@ type Props = {
   mergeCellAfter: ?(payload: *) => void,
   filename: ?string,
   notebook: Immutable.Map<string, *>,
-  pasteCell: ?() => void,
+  pasteCell: ?(payload: *) => void,
   createCodeCell: ?(cellId: ?string) => void,
   createMarkdownCell: ?(cellId: ?string) => void,
   setCellTypeCode: ?(cellId: ?string) => void,
@@ -126,7 +126,8 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.PASTE_CELL:
         if (pasteCell) {
-          pasteCell();
+          // TODO: #2618
+          pasteCell({});
         }
         break;
       case MENU_ITEM_ACTIONS.MERGE_CELL_AFTER:
@@ -375,7 +376,7 @@ const mapDispatchToProps = dispatch => ({
   unhideAllCells: payload => dispatch(actions.unhideAll(payload)),
   cutCell: (payload: *) => dispatch(actions.cutCell(payload)),
   copyCell: (payload: *) => dispatch(actions.copyCell(payload)),
-  pasteCell: () => dispatch(actions.pasteCell()),
+  pasteCell: (payload: *) => dispatch(actions.pasteCell(payload)),
   mergeCellAfter: (payload: *) => dispatch(actions.mergeCellAfter(payload)),
   // TODO: #2618
   createCodeCell: cellId =>

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -29,7 +29,7 @@ type Props = {
   clearAllOutputs: ?(payload: *) => void,
   unhideAllCells: ?(*) => void,
   cutCell: ?(cellId: ?string) => void,
-  copyCell: ?(cellId: ?string) => void,
+  copyCell: ?(payload: *) => void,
   mergeCellAfter: ?(payload: *) => void,
   filename: ?string,
   notebook: Immutable.Map<string, *>,
@@ -114,7 +114,8 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.COPY_CELL:
         if (copyCell) {
-          copyCell(cellFocused);
+          // TODO: #2618
+          copyCell({ id: cellFocused });
         }
         break;
       case MENU_ITEM_ACTIONS.CUT_CELL:
@@ -372,7 +373,7 @@ const mapDispatchToProps = dispatch => ({
   clearAllOutputs: (payload: *) => dispatch(actions.clearAllOutputs(payload)),
   unhideAllCells: payload => dispatch(actions.unhideAll(payload)),
   cutCell: cellId => dispatch(actions.cutCell(cellId)),
-  copyCell: cellId => dispatch(actions.copyCell(cellId)),
+  copyCell: (payload: *) => dispatch(actions.copyCell(payload)),
   pasteCell: () => dispatch(actions.pasteCell()),
   mergeCellAfter: (payload: *) => dispatch(actions.mergeCellAfter(payload)),
   // TODO: #2618

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -30,7 +30,7 @@ type Props = {
   unhideAllCells: ?(*) => void,
   cutCell: ?(cellId: ?string) => void,
   copyCell: ?(cellId: ?string) => void,
-  mergeCellAfter: ?(cellId: ?string) => void,
+  mergeCellAfter: ?(payload: *) => void,
   filename: ?string,
   notebook: Immutable.Map<string, *>,
   pasteCell: ?() => void,
@@ -129,7 +129,8 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.MERGE_CELL_AFTER:
         if (mergeCellAfter) {
-          mergeCellAfter(cellFocused);
+          // TODO: #2618
+          mergeCellAfter({ id: cellFocused });
         }
         break;
       case MENU_ITEM_ACTIONS.CREATE_CODE_CELL:
@@ -373,7 +374,7 @@ const mapDispatchToProps = dispatch => ({
   cutCell: cellId => dispatch(actions.cutCell(cellId)),
   copyCell: cellId => dispatch(actions.copyCell(cellId)),
   pasteCell: () => dispatch(actions.pasteCell()),
-  mergeCellAfter: cellId => dispatch(actions.mergeCellAfter(cellId)),
+  mergeCellAfter: (payload: *) => dispatch(actions.mergeCellAfter(payload)),
   // TODO: #2618
   createCodeCell: cellId =>
     dispatch(

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -264,7 +264,8 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
   toggleStickyCell: () => dispatch(actions.toggleStickyCell(id)),
   removeCell: () => dispatch(actions.removeCell(id)),
   executeCell: () => dispatch(actions.executeCell(id)),
-  clearOutputs: () => dispatch(actions.clearOutputs(id)),
+  // TODO: #2618
+  clearOutputs: () => dispatch(actions.clearOutputs({ id })),
   toggleCellInputVisibility: () =>
     dispatch(actions.toggleCellInputVisibility(id)),
   toggleCellOutputVisibility: () =>

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -281,7 +281,8 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
         to: type === "markdown" ? "code" : "markdown"
       })
     ),
-  toggleOutputExpansion: () => dispatch(actions.toggleOutputExpansion(id))
+  // TODO: #2618
+  toggleOutputExpansion: () => dispatch(actions.toggleOutputExpansion({ id }))
 });
 
 export default connect(null, mapDispatchToProps)(PureToolbar);

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -263,7 +263,8 @@ type ConnectedProps = {
 const mapDispatchToProps = (dispatch, { id, type }) => ({
   // TODO: #2618
   toggleStickyCell: () => dispatch(actions.toggleStickyCell({ id })),
-  removeCell: () => dispatch(actions.removeCell(id)),
+  // TODO: #2618
+  removeCell: () => dispatch(actions.removeCell({ id })),
   executeCell: () => dispatch(actions.executeCell(id)),
   // TODO: #2618
   clearOutputs: () => dispatch(actions.clearOutputs({ id })),

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -270,8 +270,9 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
   clearOutputs: () => dispatch(actions.clearOutputs({ id })),
   toggleCellInputVisibility: () =>
     dispatch(actions.toggleCellInputVisibility(id)),
+  // TODO: #2618
   toggleCellOutputVisibility: () =>
-    dispatch(actions.toggleCellOutputVisibility(id)),
+    dispatch(actions.toggleCellOutputVisibility({ id })),
   changeCellType: () =>
     dispatch(
       actions.changeCellType(id, type === "markdown" ? "code" : "markdown")

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -273,9 +273,13 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
   // TODO: #2618
   toggleCellInputVisibility: () =>
     dispatch(actions.toggleCellInputVisibility({ id })),
+  // TODO: #2618
   changeCellType: () =>
     dispatch(
-      actions.changeCellType(id, type === "markdown" ? "code" : "markdown")
+      actions.changeCellType({
+        id,
+        to: type === "markdown" ? "code" : "markdown"
+      })
     ),
   toggleOutputExpansion: () => dispatch(actions.toggleOutputExpansion(id))
 });

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -271,8 +271,8 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
   toggleCellInputVisibility: () =>
     dispatch(actions.toggleCellInputVisibility(id)),
   // TODO: #2618
-  toggleCellOutputVisibility: () =>
-    dispatch(actions.toggleCellOutputVisibility({ id })),
+  toggleCellInputVisibility: () =>
+    dispatch(actions.toggleCellInputVisibility({ id })),
   changeCellType: () =>
     dispatch(
       actions.changeCellType(id, type === "markdown" ? "code" : "markdown")

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -261,7 +261,8 @@ type ConnectedProps = {
 };
 
 const mapDispatchToProps = (dispatch, { id, type }) => ({
-  toggleStickyCell: () => dispatch(actions.toggleStickyCell(id)),
+  // TODO: #2618
+  toggleStickyCell: () => dispatch(actions.toggleStickyCell({ id })),
   removeCell: () => dispatch(actions.removeCell(id)),
   executeCell: () => dispatch(actions.executeCell(id)),
   // TODO: #2618

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -99,12 +99,11 @@ export function saveContentEpic(
         type: "notebook"
       };
 
-      return contents
-        .save(serverConfig, filename, model)
-        .pipe(
-          mapTo(actions.saveFulfilled()),
-          catchError((error: Error) => of(actions.saveFailed(error)))
-        );
+      return contents.save(serverConfig, filename, model).pipe(
+        // TODO: #2618
+        mapTo(actions.saveFulfilled({})),
+        catchError((error: Error) => of(actions.saveFailed(error)))
+      );
     })
   );
 }

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -130,6 +130,7 @@ export function setNotebookEpic(
         action.payload.model.type === "notebook"
     ),
     map((action: FetchContentFulfilled) =>
+      // TODO: #2618
       actions.setNotebook({
         filename: action.payload.path,
         notebook: fromJS(action.payload.model.content),

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -93,7 +93,8 @@ export function executeCellStream(
     // All actions for new outputs
     cellMessages.pipe(
       outputs(),
-      map(output => actions.appendOutput(id, output))
+      // TODO: #2618
+      map(output => actions.appendOutput({ id, output }))
     ),
 
     // clear_output display message

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -99,7 +99,8 @@ export function executeCellStream(
     // clear_output display message
     cellMessages.pipe(
       ofMessageType("clear_output"),
-      mapTo(actions.clearOutputs(id))
+      // TODO: #2618
+      mapTo(actions.clearOutputs({ id }))
     )
   );
 

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -82,7 +82,8 @@ export function executeCellStream(
     // All actions for updating cell status
     cellMessages.pipe(
       kernelStatuses(),
-      map(status => actions.updateCellStatus(id, status))
+      // TODO: #2618
+      map(status => actions.updateCellStatus({ id, status }))
     ),
 
     // Update the input numbering: `[ ]`

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -255,7 +255,8 @@ export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
         ofMessageType("update_display_data"),
         // TODO: #2618
         map(msg => actions.updateDisplay({ content: msg.content })),
-        catchError(err => of(actions.updateDisplayFailed(err)))
+        // TODO: #2618
+        catchError(error => of(actions.updateDisplayFailed({ error })))
       )
     )
   );

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -150,8 +150,9 @@ export function createExecuteCellStream(
 
   return merge(
     // We make sure to propagate back to "ourselves" the actual message
-    // that we sent to the kernel with the sendExecuteMessage action
-    of(actions.sendExecuteMessage(id, message)),
+    // that we sent to the kernel with the sendExecuteRequest action
+    // TODO: #2618
+    of(actions.sendExecuteRequest({ id, message })),
     // Merging it in with the actual stream
     cellStream
   );

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -87,7 +87,8 @@ export function executeCellStream(
     // Update the input numbering: `[ ]`
     cellMessages.pipe(
       executionCounts(),
-      map(ct => actions.updateCellExecutionCount(id, ct))
+      // TODO: #2618
+      map(ct => actions.updateCellExecutionCount({ id, value: ct }))
     ),
 
     // All actions for new outputs

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -137,8 +137,13 @@ export function createExecuteCellStream(
     takeUntil(
       merge(
         action$.pipe(
-          filter(laterAction => laterAction.id === id),
-          ofType(actionTypes.EXECUTE_CANCELED, actionTypes.REMOVE_CELL)
+          ofType(actionTypes.EXECUTE_CANCELED, actionTypes.REMOVE_CELL),
+          // TODO: Type this when payloads are equivalent and simplify...
+          filter(
+            laterAction =>
+              (laterAction.payload && laterAction.payload.id === id) ||
+              laterAction.id === id
+          )
         ),
         action$.pipe(
           ofType(

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -245,7 +245,8 @@ export const updateDisplayEpic = (action$: ActionsObservable<*>) =>
     switchMap((action: NewKernelAction) =>
       action.payload.kernel.channels.pipe(
         ofMessageType("update_display_data"),
-        map(msg => actions.updateDisplay(msg.content)),
+        // TODO: #2618
+        map(msg => actions.updateDisplay({ content: msg.content })),
         catchError(err => of(actions.updateDisplayFailed(err)))
       )
     )

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -75,7 +75,8 @@ export function executeCellStream(
 
   const cellAction$ = merge(
     payloadStream.pipe(
-      map(payload => actions.acceptPayloadMessage(id, payload))
+      // TODO: #2618
+      map(payload => actions.acceptPayloadMessage({ id, payload }))
     ),
 
     // All actions for updating cell status

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -75,6 +75,7 @@ export function acquireKernelInfo(channels: Channels, kernelRef: KernelRef) {
     ofMessageType("kernel_info_reply"),
     first(),
     pluck("content", "language_info"),
+    // TODO: #2618
     map(langInfo => actions.setLanguageInfo({ langInfo, kernelRef }))
   );
 

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -33,7 +33,7 @@ import * as uuid from "uuid";
 import type {
   NewKernelAction,
   RestartKernel,
-  SetNotebookAction
+  SetNotebook
 } from "../actionTypes";
 
 import * as selectors from "../selectors";
@@ -122,7 +122,7 @@ export const launchKernelWhenNotebookSetEpic = (
 ) =>
   action$.pipe(
     ofType(actionTypes.SET_NOTEBOOK),
-    map((action: SetNotebookAction) => {
+    map((action: SetNotebook) => {
       const { cwd, kernelSpecName } = extractNewKernel(
         action.payload.filename,
         action.payload.notebook

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -103,22 +103,20 @@ export const killKernelEpic = (action$: *, store: *) =>
       const kernel = selectors.currentKernel(state);
       const id = kernel.id;
 
-      return kernels
-        .kill(serverConfig, id)
-        .pipe(
-          map(() =>
-            actions.killKernelSuccessful({
+      return kernels.kill(serverConfig, id).pipe(
+        map(() =>
+          actions.killKernelSuccessful({
+            kernelRef: action.payload.kernelRef
+          })
+        ),
+        catchError(err =>
+          of(
+            actions.killKernelFailed({
+              error: err,
               kernelRef: action.payload.kernelRef
             })
-          ),
-          catchError(err =>
-            of(
-              actions.killKernelFailed({
-                error: err,
-                kernelRef: action.payload.kernelRef
-              })
-            )
           )
-        );
+        )
+      );
     })
   );

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -24,7 +24,7 @@ import type {
   AcceptPayloadMessageAction,
   SetNotebook,
   CreateCellAfter,
-  NewCellBeforeAction,
+  CreateCellBefore,
   ClearOutputs,
   AppendOutput,
   SaveFulfilled,
@@ -457,8 +457,8 @@ function createCellAfter(state: DocumentRecord, action: CreateCellAfter) {
   });
 }
 
-function newCellBefore(state: DocumentRecord, action: NewCellBeforeAction) {
-  const { cellType, id } = action;
+function createCellBefore(state: DocumentRecord, action: CreateCellBefore) {
+  const { cellType, id } = action.payload;
   const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
   const cellID = uuid.v4();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
@@ -752,7 +752,7 @@ type DocumentAction =
   | MoveCell
   | RemoveCell
   | CreateCellAfter
-  | NewCellBeforeAction
+  | CreateCellBefore
   | NewCellAppendAction
   | MergeCellAfterAction
   | ToggleCellOutputVisibilityAction
@@ -820,8 +820,8 @@ function document(
       return removeCellFromState(state, action);
     case actionTypes.CREATE_CELL_AFTER:
       return createCellAfter(state, action);
-    case actionTypes.NEW_CELL_BEFORE:
-      return newCellBefore(state, action);
+    case actionTypes.CREATE_CELL_BEFORE:
+      return createCellBefore(state, action);
     case actionTypes.MERGE_CELL_AFTER:
       return mergeCellAfter(state, action);
     case actionTypes.NEW_CELL_APPEND:

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -39,7 +39,7 @@ import type {
   MergeCellAfterAction,
   MoveCellAction,
   ToggleStickyCellAction,
-  FocusPreviousCellAction,
+  FocusPreviousCell,
   SetKernelInfoAction,
   SetLanguageInfoAction,
   UpdateCellStatusAction,
@@ -355,10 +355,12 @@ function focusNextCell(state: DocumentRecord, action: FocusNextCell) {
 
 function focusPreviousCell(
   state: DocumentRecord,
-  action: FocusPreviousCellAction
+  action: FocusPreviousCell
 ): DocumentRecord {
   const cellOrder = state.getIn(["notebook", "cellOrder"], Immutable.List());
-  const curIndex = cellOrder.findIndex((id: CellID) => id === action.id);
+  const curIndex = cellOrder.findIndex(
+    (id: CellID) => id === action.payload.id
+  );
   const nextIndex = Math.max(0, curIndex - 1);
 
   return state.set("cellFocused", cellOrder.get(nextIndex));
@@ -732,7 +734,7 @@ function changeFilename(state: DocumentRecord, action: ChangeFilenameAction) {
 type DocumentAction =
   | ToggleStickyCellAction
   | FocusPreviousCellEditorAction
-  | FocusPreviousCellAction
+  | FocusPreviousCell
   | FocusNextCellEditorAction
   | FocusNextCell
   | FocusCellEditorAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -46,7 +46,7 @@ import type {
   ToggleCellInputVisibilityAction,
   ToggleCellOutputVisibilityAction,
   SetInCellAction,
-  SendExecuteMessageAction
+  SendExecuteRequest
 } from "../../../actionTypes";
 
 import type { DocumentRecord } from "../../../state/entities/contents";
@@ -546,11 +546,8 @@ function acceptPayloadMessage(
   return state;
 }
 
-function sendExecuteRequest(
-  state: DocumentRecord,
-  action: SendExecuteMessageAction
-) {
-  const { id } = action;
+function sendExecuteRequest(state: DocumentRecord, action: SendExecuteRequest) {
+  const { id } = action.payload;
   // TODO: Record the last execute request for this cell
 
   // * Clear outputs
@@ -762,7 +759,7 @@ type DocumentAction =
   | ChangeCellTypeAction
   | ToggleCellExpansionAction
   | AcceptPayloadMessageAction
-  | SendExecuteMessageAction
+  | SendExecuteRequest
   | SaveFulfilled
   | RestartKernel
   | ClearAllOutputs

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -30,7 +30,7 @@ import type {
   SaveFulfilled,
   UpdateDisplay,
   FocusNextCell,
-  FocusCellEditorAction,
+  FocusCellEditor,
   FocusNextCellEditor,
   FocusPreviousCellEditor,
   RemoveCell,
@@ -366,8 +366,8 @@ function focusPreviousCell(
   return state.set("cellFocused", cellOrder.get(nextIndex));
 }
 
-function focusCellEditor(state: DocumentRecord, action: FocusCellEditorAction) {
-  return state.set("editorFocused", action.id);
+function focusCellEditor(state: DocumentRecord, action: FocusCellEditor) {
+  return state.set("editorFocused", action.payload.id);
 }
 
 function focusNextCellEditor(
@@ -742,7 +742,7 @@ type DocumentAction =
   | FocusPreviousCell
   | FocusNextCellEditor
   | FocusNextCell
-  | FocusCellEditorAction
+  | FocusCellEditor
   | FocusCell
   | SetNotebook
   | ClearOutputs

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -19,7 +19,7 @@ import type {
   ChangeCellTypeAction,
   CutCellAction,
   CopyCellAction,
-  DeleteMetadataFieldAction,
+  DeleteMetadataField,
   OverwriteMetadataField,
   AcceptPayloadMessage,
   SetNotebook,
@@ -645,11 +645,11 @@ function overwriteMetadataField(
   const { field, value } = action.payload;
   return state.setIn(["notebook", "metadata", field], Immutable.fromJS(value));
 }
-function deleteMetadata(
+function deleteMetadataField(
   state: DocumentRecord,
-  action: DeleteMetadataFieldAction
+  action: DeleteMetadataField
 ) {
-  const { field } = action;
+  const { field } = action.payload;
   return state.deleteIn(["notebook", "metadata", field]);
 }
 
@@ -759,7 +759,7 @@ type DocumentAction =
   | SetLanguageInfo
   | SetKernelInfo
   | OverwriteMetadataField
-  | DeleteMetadataFieldAction
+  | DeleteMetadataField
   | CopyCellAction
   | CutCellAction
   | PasteCellAction
@@ -839,7 +839,7 @@ function document(
     case actionTypes.OVERWRITE_METADATA_FIELD:
       return overwriteMetadataField(state, action);
     case actionTypes.DELETE_METADATA_FIELD:
-      return deleteMetadata(state, action);
+      return deleteMetadataField(state, action);
     case actionTypes.COPY_CELL:
       return copyCell(state, action);
     case actionTypes.CUT_CELL:

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -22,7 +22,7 @@ import type {
   DeleteMetadataFieldAction,
   OverwriteMetadataFieldAction,
   AcceptPayloadMessageAction,
-  SetNotebookAction,
+  SetNotebook,
   NewCellAfterAction,
   NewCellBeforeAction,
   ClearOutputsAction,
@@ -152,7 +152,7 @@ export function cleanCellTransient(state: DocumentRecord, id: string) {
     .setIn(["transient", "cellMap", id], new Immutable.Map());
 }
 
-function setNotebook(state: DocumentRecord, action: SetNotebookAction) {
+function setNotebook(state: DocumentRecord, action: SetNotebook) {
   const { payload: { notebook, filename } } = action;
 
   return state
@@ -736,7 +736,7 @@ type FocusCellActionType =
 type DocumentAction =
   | ToggleStickyCellAction
   | FocusCellActionType
-  | SetNotebookAction
+  | SetNotebook
   | ClearOutputsAction
   | AppendOutputAction
   | UpdateDisplayAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -36,7 +36,7 @@ import type {
   RemoveCell,
   FocusCell,
   NewCellAppendAction,
-  MergeCellAfterAction,
+  MergeCellAfter,
   MoveCell,
   ToggleStickyCell,
   FocusPreviousCell,
@@ -471,8 +471,8 @@ function createCellBefore(state: DocumentRecord, action: CreateCellBefore) {
   });
 }
 
-function mergeCellAfter(state: DocumentRecord, action: MergeCellAfterAction) {
-  const { id } = action;
+function mergeCellAfter(state: DocumentRecord, action: MergeCellAfter) {
+  const { id } = action.payload;
   const cellOrder: ImmutableCellOrder = state.getIn(
     ["notebook", "cellOrder"],
     Immutable.List()
@@ -754,7 +754,7 @@ type DocumentAction =
   | CreateCellAfter
   | CreateCellBefore
   | NewCellAppendAction
-  | MergeCellAfterAction
+  | MergeCellAfter
   | ToggleCellOutputVisibilityAction
   | ToggleCellInputVisibilityAction
   | UpdateCellStatusAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -16,7 +16,7 @@ import type {
   PasteCell,
   ChangeFilenameAction,
   ToggleCellExpansionAction,
-  ChangeCellTypeAction,
+  ChangeCellType,
   CutCell,
   CopyCell,
   DeleteMetadataField,
@@ -693,8 +693,8 @@ function pasteCell(state: DocumentRecord) {
     insertCellAfter(notebook, copiedCell, id, copiedId)
   );
 }
-function changeCellType(state: DocumentRecord, action: ChangeCellTypeAction) {
-  const { id, to } = action;
+function changeCellType(state: DocumentRecord, action: ChangeCellType) {
+  const { id, to } = action.payload;
   const from = state.getIn(["notebook", "cellMap", id, "cell_type"]);
 
   if (from === to) {
@@ -763,7 +763,7 @@ type DocumentAction =
   | CopyCell
   | CutCell
   | PasteCell
-  | ChangeCellTypeAction
+  | ChangeCellType
   | ToggleCellExpansionAction
   | AcceptPayloadMessage
   | SendExecuteRequest

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -15,7 +15,7 @@ import type {
   ClearAllOutputs,
   PasteCell,
   ChangeFilenameAction,
-  ToggleCellExpansionAction,
+  ToggleCellExpansion,
   ChangeCellType,
   CutCell,
   CopyCell,
@@ -717,9 +717,9 @@ function changeCellType(state: DocumentRecord, action: ChangeCellType) {
 
 function toggleOutputExpansion(
   state: DocumentRecord,
-  action: ToggleCellExpansionAction
+  action: ToggleCellExpansion
 ) {
-  const { id } = action;
+  const { id } = action.payload;
   return state.updateIn(["notebook", "cellMap"], (cells: ImmutableCellMap) =>
     cells.setIn(
       [id, "metadata", "outputExpanded"],
@@ -764,7 +764,7 @@ type DocumentAction =
   | CutCell
   | PasteCell
   | ChangeCellType
-  | ToggleCellExpansionAction
+  | ToggleCellExpansion
   | AcceptPayloadMessage
   | SendExecuteRequest
   | SaveFulfilled

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -25,7 +25,7 @@ import type {
   SetNotebook,
   NewCellAfterAction,
   NewCellBeforeAction,
-  ClearOutputsAction,
+  ClearOutputs,
   AppendOutputAction,
   SaveFulfilled,
   UpdateDisplayAction,
@@ -171,8 +171,8 @@ function focusCell(state: DocumentRecord, action: FocusCell) {
   return state.set("cellFocused", action.payload.id);
 }
 
-function clearOutputs(state: DocumentRecord, action: ClearOutputsAction) {
-  const { id } = action;
+function clearOutputs(state: DocumentRecord, action: ClearOutputs) {
+  const { id } = action.payload;
 
   const type = state.getIn(["notebook", "cellMap", id, "cell_type"]);
 
@@ -552,9 +552,13 @@ function sendExecuteRequest(state: DocumentRecord, action: SendExecuteRequest) {
 
   // * Clear outputs
   // * Set status to queued, as all we've done is submit the execution request
+  // FIXME: This is a weird pattern. We're bascially faking a dispatch here
+  // inside a reducer and then appending to the result. I think that both of
+  // these reducers should just handle the original action.
+  // TODO: #2618
   return clearOutputs(state, {
     type: "CLEAR_OUTPUTS",
-    id
+    payload: { id }
   }).setIn(["transient", "cellMap", id, "status"], "queued");
 }
 
@@ -734,7 +738,7 @@ type DocumentAction =
   | FocusCellEditorAction
   | FocusCell
   | SetNotebook
-  | ClearOutputsAction
+  | ClearOutputs
   | AppendOutputAction
   | UpdateDisplayAction
   | MoveCellAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -45,7 +45,7 @@ import type {
   UpdateCellStatusAction,
   ToggleCellInputVisibilityAction,
   ToggleCellOutputVisibilityAction,
-  SetInCellAction,
+  SetInCell,
   SendExecuteRequest
 } from "../../../actionTypes";
 
@@ -563,10 +563,10 @@ function sendExecuteRequest(state: DocumentRecord, action: SendExecuteRequest) {
   }).setIn(["transient", "cellMap", id, "status"], "queued");
 }
 
-function setInCell(state: DocumentRecord, action: SetInCellAction<*>) {
+function setInCell(state: DocumentRecord, action: SetInCell<*>) {
   return state.setIn(
-    ["notebook", "cellMap", action.id].concat(action.path),
-    action.value
+    ["notebook", "cellMap", action.payload.id].concat(action.payload.path),
+    action.payload.value
   );
 }
 
@@ -765,7 +765,7 @@ type DocumentAction =
   | SaveFulfilled
   | RestartKernel
   | ClearAllOutputs
-  | SetInCellAction<*>;
+  | SetInCell<*>;
 
 const defaultDocument: DocumentRecord = makeDocumentRecord({
   notebook: emptyNotebook

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -38,7 +38,7 @@ import type {
   NewCellAppendAction,
   MergeCellAfterAction,
   MoveCellAction,
-  ToggleStickyCellAction,
+  ToggleStickyCell,
   FocusPreviousCell,
   SetKernelInfoAction,
   SetLanguageInfoAction,
@@ -409,11 +409,8 @@ function focusPreviousCellEditor(
   return state.set("editorFocused", cellOrder.get(nextIndex));
 }
 
-function toggleStickyCell(
-  state: DocumentRecord,
-  action: ToggleStickyCellAction
-) {
-  const { id } = action;
+function toggleStickyCell(state: DocumentRecord, action: ToggleStickyCell) {
+  const { id } = action.payload;
   const stickyCells = state.get("stickyCells", Immutable.Set());
 
   if (stickyCells.has(id)) {
@@ -734,7 +731,7 @@ function changeFilename(state: DocumentRecord, action: ChangeFilenameAction) {
 }
 
 type DocumentAction =
-  | ToggleStickyCellAction
+  | ToggleStickyCell
   | FocusPreviousCellEditor
   | FocusPreviousCell
   | FocusNextCellEditor

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -21,7 +21,7 @@ import type {
   CopyCellAction,
   DeleteMetadataFieldAction,
   OverwriteMetadataFieldAction,
-  AcceptPayloadMessageAction,
+  AcceptPayloadMessage,
   SetNotebook,
   CreateCellAfter,
   CreateCellBefore,
@@ -519,9 +519,9 @@ function createCellAppend(state: DocumentRecord, action: CreateCellAppend) {
 
 function acceptPayloadMessage(
   state: DocumentRecord,
-  action: AcceptPayloadMessageAction
+  action: AcceptPayloadMessage
 ): DocumentRecord {
-  const { id, payload } = action;
+  const { id, payload } = action.payload;
 
   if (payload.source === "page") {
     // append pager
@@ -767,7 +767,7 @@ type DocumentAction =
   | PasteCellAction
   | ChangeCellTypeAction
   | ToggleCellExpansionAction
-  | AcceptPayloadMessageAction
+  | AcceptPayloadMessage
   | SendExecuteRequest
   | SaveFulfilled
   | RestartKernel
@@ -830,7 +830,7 @@ function document(
       return toggleCellOutputVisibility(state, action);
     case actionTypes.TOGGLE_CELL_INPUT_VISIBILITY:
       return toggleCellInputVisibility(state, action);
-    case actionTypes.ACCEPT_PAYLOAD_MESSAGE_ACTION:
+    case actionTypes.ACCEPT_PAYLOAD_MESSAGE:
       return acceptPayloadMessage(state, action);
     case actionTypes.UPDATE_CELL_STATUS:
       return updateCellStatus(state, action);

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -26,7 +26,7 @@ import type {
   NewCellAfterAction,
   NewCellBeforeAction,
   ClearOutputs,
-  AppendOutputAction,
+  AppendOutput,
   SaveFulfilled,
   UpdateDisplayAction,
   FocusNextCellAction,
@@ -224,9 +224,9 @@ function clearAllOutputs(
     .set("transient", transient);
 }
 
-function appendOutput(state: DocumentRecord, action: AppendOutputAction) {
-  const output = action.output;
-  const cellID = action.id;
+function appendOutput(state: DocumentRecord, action: AppendOutput) {
+  const output = action.payload.output;
+  const cellID = action.payload.id;
 
   // If it's display data and it doesn't have a display id, fold it in like non
   // display data
@@ -739,7 +739,7 @@ type DocumentAction =
   | FocusCell
   | SetNotebook
   | ClearOutputs
-  | AppendOutputAction
+  | AppendOutput
   | UpdateDisplayAction
   | MoveCellAction
   | RemoveCellAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -41,7 +41,7 @@ import type {
   ToggleStickyCell,
   FocusPreviousCell,
   SetKernelInfoAction,
-  SetLanguageInfoAction,
+  SetLanguageInfo,
   UpdateCellStatus,
   ToggleCellInputVisibility,
   ToggleCellOutputVisibility,
@@ -618,7 +618,7 @@ function updateCellStatus(state: DocumentRecord, action: UpdateCellStatus) {
   const { id, status } = action.payload;
   return state.setIn(["transient", "cellMap", id, "status"], status);
 }
-function setLanguageInfo(state: DocumentRecord, action: SetLanguageInfoAction) {
+function setLanguageInfo(state: DocumentRecord, action: SetLanguageInfo) {
   const langInfo = Immutable.fromJS(action.payload.langInfo);
   return state.setIn(["notebook", "metadata", "language_info"], langInfo);
 }
@@ -755,7 +755,7 @@ type DocumentAction =
   | ToggleCellOutputVisibility
   | ToggleCellInputVisibility
   | UpdateCellStatus
-  | SetLanguageInfoAction
+  | SetLanguageInfo
   | SetKernelInfoAction
   | OverwriteMetadataFieldAction
   | DeleteMetadataFieldAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -44,7 +44,7 @@ import type {
   SetLanguageInfoAction,
   UpdateCellStatusAction,
   ToggleCellInputVisibilityAction,
-  ToggleCellOutputVisibilityAction,
+  ToggleCellOutputVisibility,
   SetInCell,
   SendExecuteRequest
 } from "../../../actionTypes";
@@ -579,9 +579,9 @@ function setInCell(state: DocumentRecord, action: SetInCell<*>) {
 
 function toggleCellOutputVisibility(
   state: DocumentRecord,
-  action: ToggleCellOutputVisibilityAction
+  action: ToggleCellOutputVisibility
 ) {
-  const { id } = action;
+  const { id } = action.payload;
   return state.setIn(
     ["notebook", "cellMap", id, "metadata", "outputHidden"],
     !state.getIn(["notebook", "cellMap", id, "metadata", "outputHidden"])
@@ -755,7 +755,7 @@ type DocumentAction =
   | CreateCellBefore
   | CreateCellAppend
   | MergeCellAfter
-  | ToggleCellOutputVisibilityAction
+  | ToggleCellOutputVisibility
   | ToggleCellInputVisibilityAction
   | UpdateCellStatusAction
   | SetLanguageInfoAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -35,7 +35,7 @@ import type {
   FocusPreviousCellEditor,
   RemoveCell,
   FocusCell,
-  NewCellAppendAction,
+  CreateCellAppend,
   MergeCellAfter,
   MoveCell,
   ToggleStickyCell,
@@ -503,8 +503,8 @@ function mergeCellAfter(state: DocumentRecord, action: MergeCellAfter) {
   );
 }
 
-function newCellAppend(state: DocumentRecord, action: NewCellAppendAction) {
-  const { cellType } = action;
+function createCellAppend(state: DocumentRecord, action: CreateCellAppend) {
+  const { cellType } = action.payload;
   const notebook: ImmutableNotebook = state.get("notebook");
   const cellOrder: ImmutableCellOrder = notebook.get(
     "cellOrder",
@@ -753,7 +753,7 @@ type DocumentAction =
   | RemoveCell
   | CreateCellAfter
   | CreateCellBefore
-  | NewCellAppendAction
+  | CreateCellAppend
   | MergeCellAfter
   | ToggleCellOutputVisibilityAction
   | ToggleCellInputVisibilityAction
@@ -824,8 +824,8 @@ function document(
       return createCellBefore(state, action);
     case actionTypes.MERGE_CELL_AFTER:
       return mergeCellAfter(state, action);
-    case actionTypes.NEW_CELL_APPEND:
-      return newCellAppend(state, action);
+    case actionTypes.CREATE_CELL_APPEND:
+      return createCellAppend(state, action);
     case actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY:
       return toggleCellOutputVisibility(state, action);
     case actionTypes.TOGGLE_CELL_INPUT_VISIBILITY:

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -31,7 +31,7 @@ import type {
   UpdateDisplay,
   FocusNextCell,
   FocusCellEditorAction,
-  FocusNextCellEditorAction,
+  FocusNextCellEditor,
   FocusPreviousCellEditorAction,
   RemoveCellAction,
   FocusCell,
@@ -372,14 +372,14 @@ function focusCellEditor(state: DocumentRecord, action: FocusCellEditorAction) {
 
 function focusNextCellEditor(
   state: DocumentRecord,
-  action: FocusNextCellEditorAction
+  action: FocusNextCellEditor
 ) {
   const cellOrder: ImmutableCellOrder = state.getIn(
     ["notebook", "cellOrder"],
     Immutable.List()
   );
 
-  const id = action.id ? action.id : state.get("editorFocused");
+  const id = action.payload.id ? action.payload.id : state.get("editorFocused");
 
   // If for some reason we neither have an ID here or a focused editor, we just
   // keep the state consistent
@@ -735,7 +735,7 @@ type DocumentAction =
   | ToggleStickyCellAction
   | FocusPreviousCellEditorAction
   | FocusPreviousCell
-  | FocusNextCellEditorAction
+  | FocusNextCellEditor
   | FocusNextCell
   | FocusCellEditorAction
   | FocusCell

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -40,7 +40,7 @@ import type {
   MoveCell,
   ToggleStickyCell,
   FocusPreviousCell,
-  SetKernelInfoAction,
+  SetKernelInfo,
   SetLanguageInfo,
   UpdateCellStatus,
   ToggleCellInputVisibility,
@@ -623,8 +623,8 @@ function setLanguageInfo(state: DocumentRecord, action: SetLanguageInfo) {
   return state.setIn(["notebook", "metadata", "language_info"], langInfo);
 }
 
-function setKernelSpec(state: DocumentRecord, action: SetKernelInfoAction) {
-  const { kernelInfo } = action;
+function setKernelInfo(state: DocumentRecord, action: SetKernelInfo) {
+  const { kernelInfo } = action.payload;
   return state
     .setIn(
       ["notebook", "metadata", "kernelspec"],
@@ -756,7 +756,7 @@ type DocumentAction =
   | ToggleCellInputVisibility
   | UpdateCellStatus
   | SetLanguageInfo
-  | SetKernelInfoAction
+  | SetKernelInfo
   | OverwriteMetadataFieldAction
   | DeleteMetadataFieldAction
   | CopyCellAction
@@ -834,7 +834,7 @@ function document(
     case actionTypes.SET_LANGUAGE_INFO:
       return setLanguageInfo(state, action);
     case actionTypes.SET_KERNEL_INFO:
-      return setKernelSpec(state, action);
+      return setKernelInfo(state, action);
     case actionTypes.OVERWRITE_METADATA_FIELD:
       return overwriteMetadata(state, action);
     case actionTypes.DELETE_METADATA_FIELD:

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -37,7 +37,7 @@ import type {
   FocusCell,
   NewCellAppendAction,
   MergeCellAfterAction,
-  MoveCellAction,
+  MoveCell,
   ToggleStickyCell,
   FocusPreviousCell,
   SetKernelInfoAction,
@@ -419,20 +419,20 @@ function toggleStickyCell(state: DocumentRecord, action: ToggleStickyCell) {
   return state.set("stickyCells", stickyCells.add(id));
 }
 
-function moveCell(state: DocumentRecord, action: MoveCellAction) {
+function moveCell(state: DocumentRecord, action: MoveCell) {
   return state.updateIn(
     ["notebook", "cellOrder"],
     (cellOrder: ImmutableCellOrder) => {
-      const oldIndex = cellOrder.findIndex(id => id === action.id);
+      const oldIndex = cellOrder.findIndex(id => id === action.payload.id);
       const newIndex =
-        cellOrder.findIndex(id => id === action.destinationId) +
-        (action.above ? 0 : 1);
+        cellOrder.findIndex(id => id === action.payload.destinationId) +
+        (action.payload.above ? 0 : 1);
       if (oldIndex === newIndex) {
         return cellOrder;
       }
       return cellOrder
         .splice(oldIndex, 1)
-        .splice(newIndex - (oldIndex < newIndex ? 1 : 0), 0, action.id);
+        .splice(newIndex - (oldIndex < newIndex ? 1 : 0), 0, action.payload.id);
     }
   );
 }
@@ -742,7 +742,7 @@ type DocumentAction =
   | ClearOutputs
   | AppendOutput
   | UpdateDisplay
-  | MoveCellAction
+  | MoveCell
   | RemoveCellAction
   | NewCellAfterAction
   | NewCellBeforeAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -42,7 +42,7 @@ import type {
   FocusPreviousCell,
   SetKernelInfoAction,
   SetLanguageInfoAction,
-  UpdateCellStatusAction,
+  UpdateCellStatus,
   ToggleCellInputVisibility,
   ToggleCellOutputVisibility,
   SetInCell,
@@ -614,11 +614,8 @@ function toggleCellInputVisibility(
   );
 }
 
-function updateCellStatus(
-  state: DocumentRecord,
-  action: UpdateCellStatusAction
-) {
-  const { id, status } = action;
+function updateCellStatus(state: DocumentRecord, action: UpdateCellStatus) {
+  const { id, status } = action.payload;
   return state.setIn(["transient", "cellMap", id, "status"], status);
 }
 function setLanguageInfo(state: DocumentRecord, action: SetLanguageInfoAction) {
@@ -757,7 +754,7 @@ type DocumentAction =
   | MergeCellAfter
   | ToggleCellOutputVisibility
   | ToggleCellInputVisibility
-  | UpdateCellStatusAction
+  | UpdateCellStatus
   | SetLanguageInfoAction
   | SetKernelInfoAction
   | OverwriteMetadataFieldAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -32,7 +32,7 @@ import type {
   FocusNextCell,
   FocusCellEditorAction,
   FocusNextCellEditor,
-  FocusPreviousCellEditorAction,
+  FocusPreviousCellEditor,
   RemoveCellAction,
   FocusCell,
   NewCellAppendAction,
@@ -395,13 +395,15 @@ function focusNextCellEditor(
 
 function focusPreviousCellEditor(
   state: DocumentRecord,
-  action: FocusPreviousCellEditorAction
+  action: FocusPreviousCellEditor
 ) {
   const cellOrder: ImmutableCellOrder = state.getIn(
     ["notebook", "cellOrder"],
     Immutable.List()
   );
-  const curIndex = cellOrder.findIndex((id: CellID) => id === action.id);
+  const curIndex = cellOrder.findIndex(
+    (id: CellID) => id === action.payload.id
+  );
   const nextIndex = Math.max(0, curIndex - 1);
 
   return state.set("editorFocused", cellOrder.get(nextIndex));
@@ -733,7 +735,7 @@ function changeFilename(state: DocumentRecord, action: ChangeFilenameAction) {
 
 type DocumentAction =
   | ToggleStickyCellAction
-  | FocusPreviousCellEditorAction
+  | FocusPreviousCellEditor
   | FocusPreviousCell
   | FocusNextCellEditor
   | FocusNextCell

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -43,7 +43,7 @@ import type {
   SetKernelInfoAction,
   SetLanguageInfoAction,
   UpdateCellStatusAction,
-  ToggleCellInputVisibilityAction,
+  ToggleCellInputVisibility,
   ToggleCellOutputVisibility,
   SetInCell,
   SendExecuteRequest
@@ -605,9 +605,9 @@ function unhideAll(state: DocumentRecord, action: UnhideAll) {
 
 function toggleCellInputVisibility(
   state: DocumentRecord,
-  action: ToggleCellInputVisibilityAction
+  action: ToggleCellInputVisibility
 ) {
-  const { id } = action;
+  const { id } = action.payload;
   return state.setIn(
     ["notebook", "cellMap", id, "metadata", "inputHidden"],
     !state.getIn(["notebook", "cellMap", id, "metadata", "inputHidden"])
@@ -756,7 +756,7 @@ type DocumentAction =
   | CreateCellAppend
   | MergeCellAfter
   | ToggleCellOutputVisibility
-  | ToggleCellInputVisibilityAction
+  | ToggleCellInputVisibility
   | UpdateCellStatusAction
   | SetLanguageInfoAction
   | SetKernelInfoAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -729,8 +729,9 @@ function toggleOutputExpansion(
 }
 
 function changeFilename(state: DocumentRecord, action: ChangeFilenameAction) {
-  if (action.filename) {
-    return state.set("filename", action.filename);
+  const { filename } = action.payload;
+  if (filename) {
+    return state.set("filename", filename);
   }
   return state;
 }

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -17,7 +17,7 @@ import type {
   ChangeFilenameAction,
   ToggleCellExpansionAction,
   ChangeCellTypeAction,
-  CutCellAction,
+  CutCell,
   CopyCell,
   DeleteMetadataField,
   OverwriteMetadataField,
@@ -660,8 +660,8 @@ function copyCell(state: DocumentRecord, action: CopyCell) {
   return state.set("copied", Immutable.Map({ id, cell }));
 }
 
-function cutCell(state: DocumentRecord, action: CutCellAction) {
-  const { id } = action;
+function cutCell(state: DocumentRecord, action: CutCell) {
+  const { id } = action.payload;
   const cellMap = state.getIn(["notebook", "cellMap"], Immutable.Map());
   const cell: ?ImmutableCell = cellMap.get(id);
 
@@ -761,7 +761,7 @@ type DocumentAction =
   | OverwriteMetadataField
   | DeleteMetadataField
   | CopyCell
-  | CutCellAction
+  | CutCell
   | PasteCellAction
   | ChangeCellTypeAction
   | ToggleCellExpansionAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -34,7 +34,7 @@ import type {
   FocusNextCellEditorAction,
   FocusPreviousCellEditorAction,
   RemoveCellAction,
-  FocusCellAction,
+  FocusCell,
   NewCellAppendAction,
   MergeCellAfterAction,
   MoveCellAction,
@@ -167,8 +167,8 @@ function setNotebookCheckpoint(state: DocumentRecord, action: SaveFulfilled) {
   return state.set("savedNotebook", state.get("notebook"));
 }
 
-function focusCell(state: DocumentRecord, action: FocusCellAction) {
-  return state.set("cellFocused", action.id);
+function focusCell(state: DocumentRecord, action: FocusCell) {
+  return state.set("cellFocused", action.payload.id);
 }
 
 function clearOutputs(state: DocumentRecord, action: ClearOutputsAction) {
@@ -725,17 +725,14 @@ function changeFilename(state: DocumentRecord, action: ChangeFilenameAction) {
   return state;
 }
 
-type FocusCellActionType =
+type DocumentAction =
+  | ToggleStickyCellAction
   | FocusPreviousCellEditorAction
   | FocusPreviousCellAction
   | FocusNextCellEditorAction
   | FocusNextCellAction
   | FocusCellEditorAction
-  | FocusCellAction;
-
-type DocumentAction =
-  | ToggleStickyCellAction
-  | FocusCellActionType
+  | FocusCell
   | SetNotebook
   | ClearOutputsAction
   | AppendOutputAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -20,7 +20,7 @@ import type {
   CutCellAction,
   CopyCellAction,
   DeleteMetadataFieldAction,
-  OverwriteMetadataFieldAction,
+  OverwriteMetadataField,
   AcceptPayloadMessage,
   SetNotebook,
   CreateCellAfter,
@@ -571,6 +571,7 @@ function sendExecuteRequest(state: DocumentRecord, action: SendExecuteRequest) {
 }
 
 function setInCell(state: DocumentRecord, action: SetInCell<*>) {
+  // $FlowFixMe: Flow is complaining because the first arg has unknown length?
   return state.setIn(
     ["notebook", "cellMap", action.payload.id].concat(action.payload.path),
     action.payload.value
@@ -637,11 +638,11 @@ function setKernelInfo(state: DocumentRecord, action: SetKernelInfo) {
     .setIn(["notebook", "metadata", "kernel_info", "name"], kernelInfo.name);
 }
 
-function overwriteMetadata(
+function overwriteMetadataField(
   state: DocumentRecord,
-  action: OverwriteMetadataFieldAction
+  action: OverwriteMetadataField
 ) {
-  const { field, value } = action;
+  const { field, value } = action.payload;
   return state.setIn(["notebook", "metadata", field], Immutable.fromJS(value));
 }
 function deleteMetadata(
@@ -757,7 +758,7 @@ type DocumentAction =
   | UpdateCellStatus
   | SetLanguageInfo
   | SetKernelInfo
-  | OverwriteMetadataFieldAction
+  | OverwriteMetadataField
   | DeleteMetadataFieldAction
   | CopyCellAction
   | CutCellAction
@@ -836,7 +837,7 @@ function document(
     case actionTypes.SET_KERNEL_INFO:
       return setKernelInfo(state, action);
     case actionTypes.OVERWRITE_METADATA_FIELD:
-      return overwriteMetadata(state, action);
+      return overwriteMetadataField(state, action);
     case actionTypes.DELETE_METADATA_FIELD:
       return deleteMetadata(state, action);
     case actionTypes.COPY_CELL:

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -33,7 +33,7 @@ import type {
   FocusCellEditorAction,
   FocusNextCellEditor,
   FocusPreviousCellEditor,
-  RemoveCellAction,
+  RemoveCell,
   FocusCell,
   NewCellAppendAction,
   MergeCellAfterAction,
@@ -437,8 +437,8 @@ function moveCell(state: DocumentRecord, action: MoveCell) {
   );
 }
 
-function removeCellFromState(state: DocumentRecord, action: RemoveCellAction) {
-  const { id } = action;
+function removeCellFromState(state: DocumentRecord, action: RemoveCell) {
+  const { id } = action.payload;
   return cleanCellTransient(
     state.update("notebook", (notebook: ImmutableNotebook) =>
       removeCell(notebook, id)
@@ -743,7 +743,7 @@ type DocumentAction =
   | AppendOutput
   | UpdateDisplay
   | MoveCell
-  | RemoveCellAction
+  | RemoveCell
   | NewCellAfterAction
   | NewCellBeforeAction
   | NewCellAppendAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -28,7 +28,7 @@ import type {
   ClearOutputs,
   AppendOutput,
   SaveFulfilled,
-  UpdateDisplayAction,
+  UpdateDisplay,
   FocusNextCellAction,
   FocusCellEditorAction,
   FocusNextCellEditorAction,
@@ -290,8 +290,8 @@ function appendOutput(state: DocumentRecord, action: AppendOutput) {
     .setIn(["transient", "keyPathsForDisplays", displayID], keyPaths);
 }
 
-function updateDisplay(state: DocumentRecord, action: UpdateDisplayAction) {
-  const { content } = action;
+function updateDisplay(state: DocumentRecord, action: UpdateDisplay) {
+  const { content } = action.payload;
   if (!(content && content.transient && content.transient.display_id)) {
     return state;
   }
@@ -740,7 +740,7 @@ type DocumentAction =
   | SetNotebook
   | ClearOutputs
   | AppendOutput
-  | UpdateDisplayAction
+  | UpdateDisplay
   | MoveCellAction
   | RemoveCellAction
   | NewCellAfterAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -13,7 +13,7 @@ import type {
   UnhideAll,
   RestartKernel,
   ClearAllOutputs,
-  PasteCellAction,
+  PasteCell,
   ChangeFilenameAction,
   ToggleCellExpansionAction,
   ChangeCellTypeAction,
@@ -762,7 +762,7 @@ type DocumentAction =
   | DeleteMetadataField
   | CopyCell
   | CutCell
-  | PasteCellAction
+  | PasteCell
   | ChangeCellTypeAction
   | ToggleCellExpansionAction
   | AcceptPayloadMessage

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -18,7 +18,7 @@ import type {
   ToggleCellExpansionAction,
   ChangeCellTypeAction,
   CutCellAction,
-  CopyCellAction,
+  CopyCell,
   DeleteMetadataField,
   OverwriteMetadataField,
   AcceptPayloadMessage,
@@ -653,8 +653,8 @@ function deleteMetadataField(
   return state.deleteIn(["notebook", "metadata", field]);
 }
 
-function copyCell(state: DocumentRecord, action: CopyCellAction) {
-  const { id } = action;
+function copyCell(state: DocumentRecord, action: CopyCell) {
+  const { id } = action.payload;
   const cellMap = state.getIn(["notebook", "cellMap"], Immutable.Map());
   const cell = cellMap.get(id);
   return state.set("copied", Immutable.Map({ id, cell }));
@@ -760,7 +760,7 @@ type DocumentAction =
   | SetKernelInfo
   | OverwriteMetadataField
   | DeleteMetadataField
-  | CopyCellAction
+  | CopyCell
   | CutCellAction
   | PasteCellAction
   | ChangeCellTypeAction

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -29,7 +29,7 @@ import type {
   AppendOutput,
   SaveFulfilled,
   UpdateDisplay,
-  FocusNextCellAction,
+  FocusNextCell,
   FocusCellEditorAction,
   FocusNextCellEditorAction,
   FocusPreviousCellEditorAction,
@@ -318,10 +318,10 @@ function updateDisplay(state: DocumentRecord, action: UpdateDisplay) {
   );
 }
 
-function focusNextCell(state: DocumentRecord, action: FocusNextCellAction) {
+function focusNextCell(state: DocumentRecord, action: FocusNextCell) {
   const cellOrder = state.getIn(["notebook", "cellOrder"], Immutable.List());
 
-  const id = action.id ? action.id : state.get("cellFocused");
+  const id = action.payload.id ? action.payload.id : state.get("cellFocused");
   // If for some reason we neither have an ID here or a focused cell, we just
   // keep the state consistent
   if (!id) {
@@ -335,7 +335,7 @@ function focusNextCell(state: DocumentRecord, action: FocusNextCellAction) {
 
   // When at the end, create a new cell
   if (nextIndex >= cellOrder.size) {
-    if (!action.createCellIfUndefined) {
+    if (!action.payload.createCellIfUndefined) {
       return state;
     }
 
@@ -734,7 +734,7 @@ type DocumentAction =
   | FocusPreviousCellEditorAction
   | FocusPreviousCellAction
   | FocusNextCellEditorAction
-  | FocusNextCellAction
+  | FocusNextCell
   | FocusCellEditorAction
   | FocusCell
   | SetNotebook


### PR DESCRIPTION
This pr adds the *option* to add `contentRef` to a bunch of action payloads.