### PR TITLE
Kernel communication

### DIFF
--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -43,7 +43,7 @@ import type { NewKernelAction } from "@nteract/core/src/actionTypes";
 
 import type { KernelInfo, LocalKernelProps } from "@nteract/core/src/state";
 
-import { selectors, actions, actionTypes, state } from "@nteract/core";
+import { selectors, actions, actionTypes } from "@nteract/core";
 
 import {
   createMessage,
@@ -92,7 +92,7 @@ export function launchKernelObservable(
           observer.next(actions.setNotebookKernelInfo(kernelSpec));
 
           const kernel: LocalKernelProps = {
-            kernelRef: state.createKernelRef(),
+            kernelRef,
             type: "zeromq",
             hostRef: null,
             channels,

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -367,7 +367,7 @@ export function watchSpawn(action$: *, store: *) {
           // We both set the state and make it easy for us to log the error
           observer.next(
             actions.setExecutionState({
-              kernelStatus: "errored",
+              kernelStatus: "process errored",
               kernelRef: action.payload.kernelRef
             })
           );
@@ -377,7 +377,7 @@ export function watchSpawn(action$: *, store: *) {
         spawn.on("exit", () => {
           observer.next(
             actions.setExecutionState({
-              kernelStatus: "exited",
+              kernelStatus: "process exited",
               kernelRef: action.payload.kernelRef
             })
           );
@@ -386,7 +386,7 @@ export function watchSpawn(action$: *, store: *) {
         spawn.on("disconnect", () => {
           observer.next(
             actions.setExecutionState({
-              kernelStatus: "disconnected",
+              kernelStatus: "process disconnected",
               kernelRef: action.payload.kernelRef
             })
           );

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -188,10 +188,10 @@ export const launchKernelEpic = (
       // TODO: Do the async version of `ipc.send`, potentially coordinate with main process
       ipc.send("nteract:ping:kernel", action.payload.kernelSpec);
 
-      let cleanupOldKernel$ = empty();
-
-      // Kill the old kernel by emitting the action to kill it
       const oldKernelRef = selectors.currentKernelRef(store.getState());
+
+      // Kill the old kernel by emitting the action to kill it if it exists
+      let cleanupOldKernel$ = empty();
       if (oldKernelRef && oldKernelRef !== action.payloadRef) {
         cleanupOldKernel$ = of(
           actions.killKernel({ restarting: false, kernelRef: oldKernelRef })

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -109,7 +109,6 @@ export function promptUserAboutNewKernel(
           const kernelRef = stateModule.createKernelRef();
 
           store.dispatch(
-            // TODO: get a KernelRef here and use it in action.
             actions.launchKernelByName({
               kernelSpecName: kernel.kernelSpecName,
               cwd,

--- a/packages/core/src/reducers/core/entities/kernels.js
+++ b/packages/core/src/reducers/core/entities/kernels.js
@@ -23,6 +23,11 @@ const byRef = (state = Immutable.Map(), action) => {
         [action.payload.kernelRef, "status"],
         "failed to kill"
       );
+    case actionTypes.RESTART_KERNEL:
+      return state.setIn([action.payload.kernelRef, "status"], "restarting");
+    case actionTypes.LAUNCH_KERNEL:
+    case actionTypes.LAUNCH_KERNEL_BY_NAME:
+      return state.setIn([action.payload.kernelRef, "status"], "launching");
     case actionTypes.SET_EXECUTION_STATE:
       return state.setIn(
         [action.payload.kernelRef, "status"],

--- a/packages/core/src/reducers/core/entities/kernels.js
+++ b/packages/core/src/reducers/core/entities/kernels.js
@@ -16,6 +16,13 @@ const byRef = (state = Immutable.Map(), action) => {
     case actionTypes.SET_LANGUAGE_INFO:
       // TODO: Should the kernel hold language info?
       return state;
+    case actionTypes.KILL_KERNEL_SUCCESSFUL:
+      return state.setIn([action.payload.kernelRef, "status"], "killed");
+    case actionTypes.KILL_KERNEL_FAILED:
+      return state.setIn(
+        [action.payload.kernelRef, "status"],
+        "failed to kill"
+      );
     case actionTypes.SET_EXECUTION_STATE:
       return state.setIn(
         [action.payload.kernelRef, "status"],


### PR DESCRIPTION
* improve messaging about kernel state
  * when it's the underlying process that has exited, denote it in the status
  * set the status when `KILL_KERNEL_(SUCCESSFUL|FAILED)`
* 🐛 the zeromq launch kernel epic was creating a brand new `kernelRef` instead of the one already specified