### PR TITLE
dont allow running binder ES on the serverside

### DIFF
--- a/applications/play/redux/epics.js
+++ b/applications/play/redux/epics.js
@@ -9,6 +9,7 @@ import { from } from "rxjs/observable/from";
 import { merge } from "rxjs/observable/merge";
 
 import {
+  filter,
   catchError,
   ignoreElements,
   map,
@@ -21,11 +22,15 @@ import { v4 as uuid } from "uuid";
 import { executeRequest, kernelInfoRequest } from "@nteract/messaging";
 import objectPath from "object-path";
 
+declare var EventSource: (url: string) => *;
+
 const activateServerEpic = action$ =>
   action$.pipe(
     ofType(actionTypes.ACTIVATE_SERVER),
+    // Definitely do not run this on the server side
+    filter(() => typeof window !== "undefined"),
     switchMap(({ payload: { serverId, oldServerId, repo, gitref } }) => {
-      return binder({ repo, gitref }, window.EventSource).pipe(
+      return binder({ repo, gitref }, EventSource).pipe(
         mergeMap(message => {
           const actionsArray = [
             actions.addServerMessage({ serverId, message })

--- a/packages/rx-binder/src/index.js
+++ b/packages/rx-binder/src/index.js
@@ -35,7 +35,7 @@ function formBinderURL({
 }
 
 const eventSourceFallback =
-  window && window.EventSource
+  typeof window !== "undefined" && window.EventSource
     ? window.EventSource
     : function(url) {
         throw new Error(


### PR DESCRIPTION
I tore out the EventSource polyfill and discovered something unintentional -- we were dispatching an action on the server side that was running an epic that... asked binder for a new jupyter server. This makes that not happen by filtering out non-`window` runtimes. There's probably a better way to do this with the top-level component, the next redux setup was a bit complicated for me to try to sneak through `isServer` so I just filtered instead.