### PR TITLE
Finish allowing content refs

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/config-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/config-spec.js
@@ -3,7 +3,7 @@ import { ActionsObservable } from "redux-observable";
 import { saveConfigOnChangeEpic } from "../../../src/notebook/epics/config";
 
 describe("saveConfigOnChangeEpic", () => {
-  test("invokes a SAVE when the SET_CONFIG_AT_KEY action happens", done => {
+  test("invokes a SAVE_CONFIG when the SET_CONFIG_AT_KEY action happens", done => {
     const action$ = ActionsObservable.of({ type: "SET_CONFIG_AT_KEY" });
     const responseActions = saveConfigOnChangeEpic(action$);
     responseActions.subscribe(

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -14,7 +14,7 @@ describe("saveEpic", () => {
     const store = dummyStore();
 
     const responses = await saveEpic(
-      ActionsObservable.of(actions.save()),
+      ActionsObservable.of(actions.save({})),
       store
     )
       .pipe(toArray())
@@ -32,7 +32,7 @@ describe("saveAsEpic", () => {
     const store = dummyStore();
 
     const responses = await saveAsEpic(
-      ActionsObservable.of(actions.saveAs("great-filename")),
+      ActionsObservable.of(actions.saveAs({ filename: "great-filename" })),
       store
     )
       .pipe(toArray())
@@ -40,7 +40,7 @@ describe("saveAsEpic", () => {
 
     expect(responses).toEqual([
       actions.changeFilename({ filename: "great-filename" }),
-      actions.save()
+      actions.save({})
     ]);
   });
 });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -291,7 +291,7 @@ describe("menu", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
       menu.dispatchSave(store);
-      expect(store.dispatch).toHaveBeenCalledWith(actions.save());
+      expect(store.dispatch).toHaveBeenCalledWith(actions.save({}));
     });
   });
 
@@ -301,7 +301,7 @@ describe("menu", () => {
       store.dispatch = jest.fn();
       menu.dispatchSaveAs(store, {}, "test-ipynb.ipynb");
       expect(store.dispatch).toHaveBeenCalledWith(
-        actions.saveAs("test-ipynb.ipynb")
+        actions.saveAs({ filename: "test-ipynb.ipynb" })
       );
     });
   });
@@ -389,7 +389,7 @@ describe("menu", () => {
 
       menu.triggerWindowRefresh(store, filename);
 
-      expect(store.dispatch).toHaveBeenCalledWith(actions.saveAs(filename));
+      expect(store.dispatch).toHaveBeenCalledWith(actions.saveAs({ filename }));
     });
   });
 

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -212,25 +212,19 @@ describe("menu", () => {
         .document.getIn(["notebook", "cellMap"])
         .filter(cell => cell.get("cell_type") === "markdown");
       store.dispatch = jest.fn();
-
       menu.dispatchRunAllBelow(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: "EXECUTE_ALL_CELLS_BELOW"
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(
+        actions.executeAllCellsBelow({})
+      );
     });
   });
 
   describe("dispatchRunAll", () => {
-    test("dispatches EXECUTE_CELL for all cells action", () => {
+    test("dispatches executeAllCells action", () => {
       const store = dummyStore();
       store.dispatch = jest.fn();
-
       menu.dispatchRunAll(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: "EXECUTE_ALL_CELLS"
-      });
+      expect(store.dispatch).toHaveBeenCalledWith(actions.executeAllCells({}));
     });
   });
 

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -137,7 +137,8 @@ export const fetchContentEpic = (action$: ActionsObservable<*>) =>
           actions.fetchContentFulfilled({
             path: model.path,
             model,
-            kernelRef: action.payload.kernelRef
+            kernelRef: action.payload.kernelRef,
+            contentRef: action.payload.contentRef
           })
         ),
         catchError((err: Error) =>
@@ -145,7 +146,8 @@ export const fetchContentEpic = (action$: ActionsObservable<*>) =>
             actions.fetchContentFailed({
               path: filepath,
               error: err,
-              kernelRef: action.payload.kernelRef
+              kernelRef: action.payload.kernelRef,
+              contentRef: action.payload.contentRef
             })
           )
         )
@@ -168,7 +170,8 @@ export const launchKernelWhenNotebookSetEpic = (
         kernelSpecName,
         cwd,
         kernelRef: action.payload.kernelRef,
-        selectNextKernel: true
+        selectNextKernel: true,
+        contentRef: action.payload.contentRef
       });
     })
   );
@@ -194,7 +197,11 @@ export const newNotebookEpic = (action$: ActionsObservable<*>) =>
         notebook = notebook.setIn(["metadata", "kernelspec"], spec);
       }
 
-      // TODO: #2618
-      return actions.setNotebook({ filename: null, notebook, kernelRef });
+      return actions.setNotebook({
+        filename: null,
+        notebook,
+        kernelRef,
+        contentRef: action.payload.contentRef
+      });
     })
   );

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -47,11 +47,18 @@ export function saveEpic(
               level: "success"
             });
           }
-          // TODO: #2618
-          return actions.saveFulfilled({});
+          return actions.saveFulfilled({
+            contentRef: action.payload.contentRef
+          });
         }),
-        // TODO: #2618
-        catchError((error: Error) => of(actions.saveFailed({ error })))
+        catchError((error: Error) =>
+          of(
+            actions.saveFailed({
+              error,
+              contentRef: action.payload.contentRef
+            })
+          )
+        )
       );
     })
   );
@@ -69,10 +76,13 @@ export function saveAsEpic(action$: ActionsObservable<*>) {
       return [
         // order matters here, since we need the filename set in the state
         // before we save the document
-        // TODO: #2618
-        actions.changeFilename({ filename: action.payload.filename }),
-        // TODO: #2618
-        actions.save({})
+        actions.changeFilename({
+          filename: action.payload.filename,
+          contentRef: action.payload.contentRef
+        }),
+        actions.save({
+          contentRef: action.payload.contentRef
+        })
       ];
     })
   );

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -50,7 +50,8 @@ export function saveEpic(
           // TODO: #2618
           return actions.saveFulfilled({});
         }),
-        catchError((error: Error) => of(actions.saveFailed(error)))
+        // TODO: #2618
+        catchError((error: Error) => of(actions.saveFailed({ error })))
       );
     })
   );
@@ -69,8 +70,9 @@ export function saveAsEpic(action$: ActionsObservable<*>) {
         // order matters here, since we need the filename set in the state
         // before we save the document
         // TODO: #2618
-        actions.changeFilename({ filename: action.filename }),
-        actions.save()
+        actions.changeFilename({ filename: action.payload.filename }),
+        // TODO: #2618
+        actions.save({})
       ];
     })
   );

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -184,11 +184,13 @@ export function dispatchPublishUserGist(
  * @param {Object} store - The Redux store
  */
 export function dispatchRunAllBelow(store: *) {
-  store.dispatch(actions.executeAllCellsBelow());
+  // TODO: #2618
+  store.dispatch(actions.executeAllCellsBelow({}));
 }
 
 export function dispatchRunAll(store: *) {
-  store.dispatch(actions.executeAllCells());
+  // TODO: #2618
+  store.dispatch(actions.executeAllCells({}));
 }
 
 export function dispatchClearAll(store: *) {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -22,7 +22,7 @@ export function cwdKernelFallback() {
 }
 
 export function dispatchSaveAs(store: *, evt: Event, filename: string) {
-  store.dispatch(actions.saveAs(filename));
+  store.dispatch(actions.saveAs({ filename }));
 }
 
 const dialog = remote.dialog;
@@ -71,7 +71,7 @@ export function triggerWindowRefresh(store: *, filename: string) {
   if (!filename) {
     return;
   }
-  store.dispatch(actions.saveAs(filename));
+  store.dispatch(actions.saveAs({ filename }));
 }
 
 export function dispatchRestartKernel(store: *) {
@@ -137,7 +137,8 @@ export function dispatchSave(store: *) {
   if (!filename) {
     triggerSaveAs(store);
   } else {
-    store.dispatch(actions.save());
+    // TODO: #2618
+    store.dispatch(actions.save({}));
   }
 }
 

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -484,24 +484,25 @@ describe("toggleOutputExpansion", () => {
 
 describe("save", () => {
   test("creates a SAVE action", () => {
-    expect(actions.save()).toEqual({
-      type: actionTypes.SAVE
+    expect(actions.save({})).toEqual({
+      type: actionTypes.SAVE,
+      payload: {}
     });
   });
 
   test("creates a SAVE_AS action", () => {
-    expect(actions.saveAs("foo.ipynb")).toEqual({
+    expect(actions.saveAs({ filename: "foo.ipynb" })).toEqual({
       type: actionTypes.SAVE_AS,
-      filename: "foo.ipynb"
+      payload: { filename: "foo.ipynb" }
     });
   });
 
   test("creates a SAVE_FAILED action", () => {
     const error = new Error("fake");
-    expect(actions.saveFailed(error)).toEqual({
+    expect(actions.saveFailed({ error })).toEqual({
       type: actionTypes.SAVE_FAILED,
       error: true,
-      payload: error
+      payload: { error }
     });
   });
 

--- a/packages/core/__tests__/app-spec.js
+++ b/packages/core/__tests__/app-spec.js
@@ -15,7 +15,7 @@ describe("save", () => {
         connectionFile: false
       })
     });
-    const state = reducers.app(originalState, actions.save());
+    const state = reducers.app(originalState, actions.save({}));
     expect(state.isSaving).toBe(true);
   });
 });
@@ -26,7 +26,7 @@ describe("saveFailed", () => {
       isSaving: true
     });
 
-    const state = reducers.app(originalState, actions.saveFailed());
+    const state = reducers.app(originalState, actions.saveFailed({}));
     expect(state.isSaving).toBe(false);
   });
 });

--- a/packages/core/__tests__/components/notebook-menu-spec.js
+++ b/packages/core/__tests__/components/notebook-menu-spec.js
@@ -80,7 +80,7 @@ describe("PureNotebookMenu ", () => {
       expect(props.executeAllCells).not.toHaveBeenCalled();
       executeAllCellsItem.simulate("click");
       expect(props.executeAllCells).toHaveBeenCalledTimes(1);
-      expect(props.executeAllCells).toHaveBeenCalledWith();
+      expect(props.executeAllCells).toHaveBeenCalledWith({});
 
       const executeAllCellsBelowItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.EXECUTE_ALL_CELLS_BELOW })
@@ -88,7 +88,7 @@ describe("PureNotebookMenu ", () => {
       expect(props.executeAllCellsBelow).not.toHaveBeenCalled();
       executeAllCellsBelowItem.simulate("click");
       expect(props.executeAllCellsBelow).toHaveBeenCalledTimes(1);
-      expect(props.executeAllCellsBelow).toHaveBeenCalledWith();
+      expect(props.executeAllCellsBelow).toHaveBeenCalledWith({});
 
       const cutCellItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.CUT_CELL })

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -715,33 +715,40 @@ export type SetGithubTokenAction = {
   githubToken: string
 };
 
+// TODO: #2618
 export const RESTART_KERNEL = "RESTART_KERNEL";
 export type RestartKernel = {
   type: "RESTART_KERNEL",
   payload: {
     clearOutputs: boolean,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 
+// TODO: #2618
 export const RESTART_KERNEL_FAILED = "RESTART_KERNEL_FAILED";
 export type RestartKernelFailed = {
   type: "RESTART_KERNEL_FAILED",
   payload: {
     error: Error,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   },
   error: true
 };
 
+// TODO: #2618
 export const RESTART_KERNEL_SUCCESSFUL = "RESTART_KERNEL_SUCCESSFUL";
 export type RestartKernelSuccessful = {
   type: "RESTART_KERNEL_SUCCESSFUL",
   payload: {
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 
+// TODO: #2618
 export const LAUNCH_KERNEL = "LAUNCH_KERNEL";
 export type LaunchKernelAction = {
   type: "LAUNCH_KERNEL",
@@ -749,10 +756,12 @@ export type LaunchKernelAction = {
     kernelRef: KernelRef,
     kernelSpec: Object,
     cwd: string,
-    selectNextKernel: boolean
+    selectNextKernel: boolean,
+    contentRef?: ContentRef
   }
 };
 
+// TODO: #2618
 export const LAUNCH_KERNEL_BY_NAME = "LAUNCH_KERNEL_BY_NAME";
 export type LaunchKernelByNameAction = {
   type: "LAUNCH_KERNEL_BY_NAME",
@@ -760,26 +769,31 @@ export type LaunchKernelByNameAction = {
     kernelSpecName: string,
     cwd: string,
     kernelRef: KernelRef,
-    selectNextKernel: boolean
+    selectNextKernel: boolean,
+    contentRef?: ContentRef
   }
 };
 
+// TODO: #2618
 export const LAUNCH_KERNEL_FAILED = "LAUNCH_KERNEL_FAILED";
 export type LaunchKernelFailed = {
   type: "LAUNCH_KERNEL_FAILED",
   payload: {
     error: Error,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   },
   error: true
 };
 
+// TODO: #2618
 export const LAUNCH_KERNEL_SUCCESSFUL = "LAUNCH_KERNEL_SUCCESSFUL";
 export type NewKernelAction = {
   type: "LAUNCH_KERNEL_SUCCESSFUL",
   payload: {
     kernel: LocalKernelProps | RemoteKernelProps,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -590,14 +590,33 @@ export type SetNotificationSystemAction = {
   notificationSystem: Object
 };
 
+// TODO: #2618
 export const SAVE = "SAVE";
-export type Save = { type: "SAVE" };
+export type Save = {
+  type: "SAVE",
+  payload: {
+    contentRef?: ContentRef
+  }
+};
 
+// TODO: #2618
 export const SAVE_AS = "SAVE_AS";
-export type SaveAs = { type: "SAVE_AS", filename: string };
+export type SaveAs = {
+  type: "SAVE_AS",
+  payload: {
+    filename: string,
+    contentRef?: ContentRef
+  }
+};
 
+// TODO: #2618
 export const SAVE_FAILED = "SAVE_FAILED";
-export type SaveFailed = { type: "SAVE_FAILED" };
+export type SaveFailed = {
+  type: "SAVE_FAILED",
+  payload: {
+    contentRef?: ContentRef
+  }
+};
 
 // TODO: #2618
 export const SAVE_FULFILLED = "SAVE_FULFILLED";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -317,37 +317,62 @@ export type SendExecuteRequest = {
   }
 };
 
+// TODO: #2618
 export const EXECUTE_CELL = "EXECUTE_CELL";
-export type ExecuteCellAction = {
+export type ExecuteCell = {
   type: "EXECUTE_CELL",
-  id: CellID
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
 };
 
+// TODO: #2618
 export const EXECUTE_ALL_CELLS = "EXECUTE_ALL_CELLS";
 export type ExecuteAllCells = {
-  type: "EXECUTE_ALL_CELLS"
+  type: "EXECUTE_ALL_CELLS",
+  payload: {
+    contentRef?: ContentRef
+  }
 };
 
+// TODO: #2618
 export const EXECUTE_ALL_CELLS_BELOW = "EXECUTE_ALL_CELLS_BELOW";
 export type ExecuteAllCellsBelow = {
-  type: "EXECUTE_ALL_CELLS_BELOW"
+  type: "EXECUTE_ALL_CELLS_BELOW",
+  payload: {
+    contentRef?: ContentRef
+  }
 };
 
+// TODO: #2618
 export const EXECUTE_FOCUSED_CELL = "EXECUTE_FOCUSED_CELL";
-export type ExecuteFocusedCellAction = {
-  type: "EXECUTE_FOCUSED_CELL"
+export type ExecuteFocusedCell = {
+  type: "EXECUTE_FOCUSED_CELL",
+  payload: {
+    contentRef?: ContentRef
+  }
 };
 
+// TODO: #2618
 export const EXECUTE_CANCELED = "EXECUTE_CANCELED";
 export type ExecuteCanceled = {
-  type: "EXECUTE_CANCELED"
+  type: "EXECUTE_CANCELED",
+  payload: {
+    id: CellID,
+    contentRef?: ContentRef
+  }
 };
 
+// TODO: #2618
 export const EXECUTE_FAILED = "EXECUTE_FAILED";
 export type ExecuteFailed = {
   type: "EXECUTE_FAILED",
-  error: true,
-  payload: Error
+  payload: {
+    error: Error,
+    contentRef?: ContentRef
+  },
+  error: true
 };
 
 // TODO: #2618

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -625,12 +625,14 @@ export type SaveFulfilled = {
   payload: { contentRef?: ContentRef }
 };
 
+// TODO: #2618
 export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
 export type NewNotebook = {
   type: "NEW_NOTEBOOK",
   payload: {
     kernelSpec: Object,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -53,33 +53,39 @@ export type AddHost = {
   payload: { hostRef: HostRef, host: HostRecord }
 };
 
+// TODO: #2618
 export const FETCH_CONTENT = "CORE/FETCH_CONTENT";
 export type FetchContent = {
   type: "CORE/FETCH_CONTENT",
   payload: {
     path: string,
     params: Object,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 
+// TODO: #2618
 export const FETCH_CONTENT_FULFILLED = "CORE/FETCH_CONTENT_FULFILLED";
 export type FetchContentFulfilled = {
   type: "CORE/FETCH_CONTENT_FULFILLED",
   payload: {
     path: string,
     model: any, // literal response from API
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   }
 };
 
+// TODO: #2618
 export const FETCH_CONTENT_FAILED = "CORE/FETCH_CONTENT_FAILED";
 export type FetchContentFailed = {
   type: "CORE/FETCH_CONTENT_FAILED",
   payload: {
     path: string,
     error: Error,
-    kernelRef: KernelRef
+    kernelRef: KernelRef,
+    contentRef?: ContentRef
   },
   error: true
 };

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -795,23 +795,33 @@ export function changeFilename(payload: {
   };
 }
 
-export function save(): Save {
+// TODO: #2618
+export function save(payload: { contentRef?: ContentRef }): Save {
   return {
-    type: actionTypes.SAVE
+    type: actionTypes.SAVE,
+    payload
   };
 }
 
-export function saveAs(filename: string): SaveAs {
+// TODO: #2618
+export function saveAs(payload: {
+  filename: string,
+  contentRef?: ContentRef
+}): SaveAs {
   return {
     type: actionTypes.SAVE_AS,
-    filename
+    payload
   };
 }
 
-export function saveFailed(error: Error): SaveFailed {
+// TODO: #2618
+export function saveFailed(payload: {
+  error: Error,
+  contentRef?: ContentRef
+}): SaveFailed {
   return {
     type: actionTypes.SAVE_FAILED,
-    payload: error,
+    payload,
     error: true
   };
 }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -194,9 +194,11 @@ export const fetchKernelspecsFailed = (payload: {
   payload
 });
 
+// TODO: #2618
 export function launchKernelFailed(payload: {
   error: Error,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): LaunchKernelFailed {
   return {
     type: actionTypes.LAUNCH_KERNEL_FAILED,
@@ -205,9 +207,11 @@ export function launchKernelFailed(payload: {
   };
 }
 
+// TODO: #2618
 export function launchKernelSuccessful(payload: {
   kernel: LocalKernelProps | RemoteKernelProps,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): NewKernelAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_SUCCESSFUL,
@@ -215,11 +219,13 @@ export function launchKernelSuccessful(payload: {
   };
 }
 
+// TODO: #2618
 export function launchKernel(payload: {
   kernelSpec: any,
   cwd: string,
   kernelRef: KernelRef,
-  selectNextKernel: boolean
+  selectNextKernel: boolean,
+  contentRef?: ContentRef
 }): LaunchKernelAction {
   return {
     type: actionTypes.LAUNCH_KERNEL,
@@ -227,11 +233,13 @@ export function launchKernel(payload: {
   };
 }
 
+// TODO: #2618
 export function launchKernelByName(payload: {
   kernelSpecName: any,
   cwd: string,
   kernelRef: KernelRef,
-  selectNextKernel: boolean
+  selectNextKernel: boolean,
+  contentRef?: ContentRef
 }): LaunchKernelByNameAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_BY_NAME,
@@ -1030,9 +1038,11 @@ export function shutdownReplyTimedOut(payload: {
   };
 }
 
+// TODO: #2618
 export function restartKernel(payload: {
   clearOutputs: boolean,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): RestartKernel {
   return {
     type: actionTypes.RESTART_KERNEL,
@@ -1040,9 +1050,11 @@ export function restartKernel(payload: {
   };
 }
 
+// TODO: #2618
 export function restartKernelFailed(payload: {
   error: Error,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): RestartKernelFailed {
   return {
     type: actionTypes.RESTART_KERNEL_FAILED,
@@ -1051,8 +1063,10 @@ export function restartKernelFailed(payload: {
   };
 }
 
+// TODO: #2618
 export function restartKernelSuccessful(payload: {
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): RestartKernelSuccessful {
   return {
     type: actionTypes.RESTART_KERNEL_SUCCESSFUL,

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -709,6 +709,18 @@ export function toggleOutputExpansion(payload: {
 }
 
 // TODO: #2618
+export function sendExecuteRequest(payload: {
+  id: string,
+  message: *,
+  contentRef?: ContentRef
+}): SendExecuteRequest {
+  return {
+    type: actionTypes.SEND_EXECUTE_REQUEST,
+    payload
+  };
+}
+
+// TODO: #2618
 export function executeCell(payload: {
   id: string,
   contentRef?: ContentRef
@@ -735,18 +747,6 @@ export function executeAllCellsBelow(payload: {
 }): ExecuteAllCellsBelow {
   return {
     type: actionTypes.EXECUTE_ALL_CELLS_BELOW,
-    payload
-  };
-}
-
-// TODO: #2618
-export function sendExecuteRequest(payload: {
-  id: string,
-  message: *,
-  contentRef?: ContentRef
-}): SendExecuteRequest {
-  return {
-    type: actionTypes.SEND_EXECUTE_REQUEST,
     payload
   };
 }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -134,28 +134,34 @@ export const addHost = (payload: {
   payload
 });
 
+// TODO: #2618
 export const fetchContent = (payload: {
   path: string,
   params: Object,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): FetchContent => ({
   type: actionTypes.FETCH_CONTENT,
   payload
 });
 
+// TODO: #2618
 export const fetchContentFulfilled = (payload: {
   path: string,
   model: any,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): FetchContentFulfilled => ({
   type: actionTypes.FETCH_CONTENT_FULFILLED,
   payload
 });
 
+// TODO: #2618
 export const fetchContentFailed = (payload: {
   path: string,
   error: Error,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): FetchContentFailed => ({
   type: actionTypes.FETCH_CONTENT_FAILED,
   payload,

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -840,7 +840,8 @@ export function saveFulfilled(payload: {
 export function newNotebook(payload: {
   kernelSpec: Object,
   cwd: string,
-  kernelRef: KernelRef
+  kernelRef: KernelRef,
+  contentRef?: ContentRef
 }): NewNotebook {
   return {
     type: actionTypes.NEW_NOTEBOOK,
@@ -850,7 +851,8 @@ export function newNotebook(payload: {
         payload.cwd ||
         // TODO: Does it matter that this is our fallback when targeting the web app
         process.cwd(),
-      kernelRef: payload.kernelRef
+      kernelRef: payload.kernelRef,
+      contentRef: payload.contentRef
     }
   };
 }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -34,8 +34,8 @@ import type {
   ShutdownReplySucceeded,
   DeleteConnectionFileFailedAction,
   DeleteConnectionFileSuccessfulAction,
-  ExecuteCellAction,
-  ExecuteFocusedCellAction,
+  ExecuteCell,
+  ExecuteFocusedCell,
   ExecuteAllCells,
   ExecuteAllCellsBelow,
   ExecuteCanceled,
@@ -708,28 +708,34 @@ export function toggleOutputExpansion(payload: {
   };
 }
 
-export function executeCell(id: string): ExecuteCellAction {
+// TODO: #2618
+export function executeCell(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ExecuteCell {
   return {
     type: actionTypes.EXECUTE_CELL,
-    id
+    payload
   };
 }
 
-export function executeAllCells(): ExecuteAllCells {
+// TODO: #2618
+export function executeAllCells(payload: {
+  contentRef?: ContentRef
+}): ExecuteAllCells {
   return {
-    type: actionTypes.EXECUTE_ALL_CELLS
+    type: actionTypes.EXECUTE_ALL_CELLS,
+    payload
   };
 }
 
-export function executeAllCellsBelow(): ExecuteAllCellsBelow {
+// TODO: #2618
+export function executeAllCellsBelow(payload: {
+  contentRef?: ContentRef
+}): ExecuteAllCellsBelow {
   return {
-    type: actionTypes.EXECUTE_ALL_CELLS_BELOW
-  };
-}
-
-export function executeFocusedCell(): ExecuteFocusedCellAction {
-  return {
-    type: actionTypes.EXECUTE_FOCUSED_CELL
+    type: actionTypes.EXECUTE_ALL_CELLS_BELOW,
+    payload
   };
 }
 
@@ -745,17 +751,36 @@ export function sendExecuteRequest(payload: {
   };
 }
 
-export function executeCanceled(): ExecuteCanceled {
+// TODO: #2618
+export function executeFocusedCell(payload: {
+  contentRef?: ContentRef
+}): ExecuteFocusedCell {
   return {
-    type: actionTypes.EXECUTE_CANCELED
+    type: actionTypes.EXECUTE_FOCUSED_CELL,
+    payload
   };
 }
 
-export function executeFailed(error: Error): ExecuteFailed {
+// TODO: #2618
+export function executeCanceled(payload: {
+  id: string,
+  contentRef?: ContentRef
+}): ExecuteCanceled {
+  return {
+    type: actionTypes.EXECUTE_CANCELED,
+    payload
+  };
+}
+
+// TODO: #2618
+export function executeFailed(payload: {
+  error: Error,
+  contentRef?: ContentRef
+}): ExecuteFailed {
   return {
     type: actionTypes.EXECUTE_FAILED,
     error: true,
-    payload: error
+    payload
   };
 }
 

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -307,7 +307,7 @@ type NotebookStateProps = {
 type NotebookDispatchProps = {
   moveCell: (payload: *) => *,
   focusCell: (payload: *) => *,
-  executeFocusedCell: () => *,
+  executeFocusedCell: (payload: *) => *,
   focusNextCell: (*) => *,
   focusNextCellEditor: (*) => *
 };
@@ -332,7 +332,8 @@ const mapStateToProps = (
 const mapDispatchToProps = (dispatch: Dispatch<*>): NotebookDispatchProps => ({
   moveCell: (payload: *) => dispatch(actions.moveCell(payload)),
   focusCell: (payload: *) => dispatch(actions.focusCell(payload)),
-  executeFocusedCell: () => dispatch(actions.executeFocusedCell()),
+  executeFocusedCell: (payload: *) =>
+    dispatch(actions.executeFocusedCell(payload)),
   focusNextCell: (payload: *) => dispatch(actions.focusNextCell(payload)),
   focusNextCellEditor: (payload: *) =>
     dispatch(actions.focusNextCellEditor(payload))
@@ -392,7 +393,8 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
 
     // NOTE: Order matters here because we need it to execute _before_ we
     // focus the next cell
-    executeFocusedCell();
+    // TODO: #2618
+    executeFocusedCell({});
 
     if (e.shiftKey) {
       // Couldn't focusNextCell just do focusing of both?

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -23,9 +23,9 @@ type Props = {
   cellFocused: ?string,
   currentKernelRef: ?KernelRef,
   saveNotebook: ?() => void,
-  executeCell: ?(cellId: ?string) => void,
-  executeAllCells: ?() => void,
-  executeAllCellsBelow: ?() => void,
+  executeCell: ?(payload: *) => void,
+  executeAllCells: ?(payload: *) => void,
+  executeAllCellsBelow: ?(payload: *) => void,
   clearAllOutputs: ?(payload: *) => void,
   unhideAll: ?(*) => void,
   cutCell: ?(payload: *) => void,
@@ -158,12 +158,14 @@ class PureNotebookMenu extends React.Component<Props> {
         break;
       case MENU_ITEM_ACTIONS.EXECUTE_ALL_CELLS:
         if (executeAllCells) {
-          executeAllCells();
+          // TODO: #2618
+          executeAllCells({});
         }
         break;
       case MENU_ITEM_ACTIONS.EXECUTE_ALL_CELLS_BELOW:
         if (executeAllCellsBelow) {
-          executeAllCellsBelow();
+          // TODO: #2618
+          executeAllCellsBelow({});
         }
         break;
       case MENU_ITEM_ACTIONS.UNHIDE_ALL:
@@ -370,9 +372,10 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   saveNotebook: () => dispatch(actions.save()),
-  executeCell: cellId => dispatch(actions.executeCell(cellId)),
-  executeAllCells: () => dispatch(actions.executeAllCells()),
-  executeAllCellsBelow: () => dispatch(actions.executeAllCellsBelow()),
+  executeCell: (payload: *) => dispatch(actions.executeCell(payload)),
+  executeAllCells: (payload: *) => dispatch(actions.executeAllCells(payload)),
+  executeAllCellsBelow: (payload: *) =>
+    dispatch(actions.executeAllCellsBelow(payload)),
   clearAllOutputs: (payload: *) => dispatch(actions.clearAllOutputs(payload)),
   unhideAll: payload => dispatch(actions.unhideAll(payload)),
   cutCell: (payload: *) => dispatch(actions.cutCell(payload)),

--- a/packages/core/src/components/notebook-menu/index.js
+++ b/packages/core/src/components/notebook-menu/index.js
@@ -22,7 +22,7 @@ type Props = {
   openKeys?: Array<string>,
   cellFocused: ?string,
   currentKernelRef: ?KernelRef,
-  saveNotebook: ?() => void,
+  saveNotebook: ?(payload: *) => void,
   executeCell: ?(payload: *) => void,
   executeAllCells: ?(payload: *) => void,
   executeAllCellsBelow: ?(payload: *) => void,
@@ -102,7 +102,8 @@ class PureNotebookMenu extends React.Component<Props> {
     switch (action) {
       case MENU_ITEM_ACTIONS.SAVE_NOTEBOOK:
         if (saveNotebook) {
-          saveNotebook();
+          // TODO: #2618
+          saveNotebook({});
         }
         break;
       case MENU_ITEM_ACTIONS.DOWNLOAD_NOTEBOOK:
@@ -371,7 +372,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  saveNotebook: () => dispatch(actions.save()),
+  saveNotebook: (payload: *) => dispatch(actions.save(payload)),
   executeCell: (payload: *) => dispatch(actions.executeCell(payload)),
   executeAllCells: (payload: *) => dispatch(actions.executeAllCells(payload)),
   executeAllCellsBelow: (payload: *) =>

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -265,7 +265,8 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
   toggleStickyCell: () => dispatch(actions.toggleStickyCell({ id })),
   // TODO: #2618
   removeCell: () => dispatch(actions.removeCell({ id })),
-  executeCell: () => dispatch(actions.executeCell(id)),
+  // TODO: #2618
+  executeCell: () => dispatch(actions.executeCell({ id })),
   // TODO: #2618
   clearOutputs: () => dispatch(actions.clearOutputs({ id })),
   // TODO: #2618

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -268,8 +268,9 @@ const mapDispatchToProps = (dispatch, { id, type }) => ({
   executeCell: () => dispatch(actions.executeCell(id)),
   // TODO: #2618
   clearOutputs: () => dispatch(actions.clearOutputs({ id })),
-  toggleCellInputVisibility: () =>
-    dispatch(actions.toggleCellInputVisibility(id)),
+  // TODO: #2618
+  toggleCellOutputVisibility: () =>
+    dispatch(actions.toggleCellOutputVisibility({ id })),
   // TODO: #2618
   toggleCellInputVisibility: () =>
     dispatch(actions.toggleCellInputVisibility({ id })),

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -80,7 +80,9 @@ export function saveContentEpic(
       // TODO: this will likely make more sense when this becomes less
       // notebook-centric.
       if (!currentNotebook) {
-        return of(actions.saveFailed(new Error("Notebook was not set.")));
+        return of(
+          actions.saveFailed({ error: new Error("Notebook was not set.") })
+        );
       }
 
       const filename = selectors.currentFilename(state);
@@ -102,7 +104,7 @@ export function saveContentEpic(
       return contents.save(serverConfig, filename, model).pipe(
         // TODO: #2618
         mapTo(actions.saveFulfilled({})),
-        catchError((error: Error) => of(actions.saveFailed(error)))
+        catchError((error: Error) => of(actions.saveFailed({ error })))
       );
     })
   );

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -133,7 +133,8 @@ export const launchKernelWhenNotebookSetEpic = (
         kernelSpecName,
         cwd,
         kernelRef: action.payload.kernelRef,
-        selectNextKernel: true
+        selectNextKernel: true,
+        contentRef: action.payload.contentRef
       });
     })
   );
@@ -183,7 +184,8 @@ export const restartKernelEpic = (action$: ActionsObservable<*>, store: *) =>
           kernelSpecName: oldKernel.kernelSpecName,
           cwd: oldKernel.cwd,
           kernelRef: createKernelRef(),
-          selectNextKernel: true
+          selectNextKernel: true,
+          contentRef: action.payload.contentRef
         })
       );
     })

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -53,7 +53,13 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
 
           kernel.channels.next(kernelInfoRequest());
 
-          return of(actions.launchKernelSuccessful({ kernel, kernelRef }));
+          return of(
+            actions.launchKernelSuccessful({
+              kernel,
+              kernelRef,
+              contentRef: action.payload.contentRef
+            })
+          );
         })
       );
     })


### PR DESCRIPTION
OK. This step is done. All the actions that need content refs:

1. Allow them according to flow types
2. Use `action.payload` to nest the action information.

... I'm also sneaking the handling of contentRefs in epics here

- [x] make all content-y actions take optional `contentRef?: ContentRef`
- [x] pass contentRefs through all epics
