### PR TITLE
log stdout/err streams from raw kernel process

### DIFF
--- a/packages/core/src/state/refs.js
+++ b/packages/core/src/state/refs.js
@@ -8,10 +8,10 @@ import uuid from "uuid";
 // However, _outside_ this file, they are no longer `string`, but actually the
 // opaque types that we've set.
 // See https://flow.org/en/docs/types/opaque-types/#toc-within-the-defining-file
-export opaque type HostRef = string;
-export opaque type KernelRef = string;
-export opaque type KernelspecsRef = string;
-export opaque type ContentRef = string;
+export opaque type HostRef: string = string;
+export opaque type KernelRef: string = string;
+export opaque type KernelspecsRef: string = string;
+export opaque type ContentRef: string = string;
 
 export const createHostRef = (): HostRef => uuid.v4();
 export const createKernelRef = (): KernelRef => uuid.v4();


### PR DESCRIPTION
A little collapsible logger inside the console dev tools:

![screen shot 2018-03-07 at 9 55 20 am](https://user-images.githubusercontent.com/836375/37109196-127e62a4-21ee-11e8-8c53-6d00fbcd9923.png)


/cc @Jaykul for review

I also had to make the kernelRefs have a [subtyping constraint](https://flow.org/en/docs/types/opaque-types/#toc-subtyping-constraints) to allow them to be coerced to strings (for logging).