### PR TITLE
Add core contents

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -89,6 +89,9 @@ describe("newNotebookEpic", () => {
         type: actionTypes.SET_NOTEBOOK,
         payload: {
           filename: null,
+          name: null,
+          created: null,
+          lastSaved: null,
           notebook: monocellNotebook.setIn(
             ["metadata", "kernel_info", "name"],
             "hylang"

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -201,7 +201,10 @@ export const newNotebookEpic = (action$: ActionsObservable<*>) =>
         filename: null,
         notebook,
         kernelRef,
-        contentRef: action.payload.contentRef
+        contentRef: action.payload.contentRef,
+        created: null,
+        lastSaved: null,
+        name: null
       });
     })
   );

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -27,8 +27,9 @@ function createApp(jupyterConfigData: JupyterConfigData) {
   class App extends React.Component<*> {
     notificationSystem: NotificationSystem;
 
-    componentDidMount(): void {
+    componentWillMount(): void {
       const hostRef = state.createHostRef();
+      const contentRef = state.createContentRef();
       const kernelRef = state.createKernelRef();
       const kernelspecsRef = state.createKernelspecsRef();
       store.dispatch(
@@ -51,7 +52,8 @@ function createApp(jupyterConfigData: JupyterConfigData) {
         actions.fetchContent({
           path: jupyterConfigData.contentsPath,
           params: {},
-          kernelRef
+          kernelRef,
+          contentRef
         })
       );
       store.dispatch(actions.fetchKernelspecs({ hostRef, kernelspecsRef }));

--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.js
@@ -2,6 +2,8 @@
 import { combineReducers, createStore, applyMiddleware, compose } from "redux";
 import { createEpicMiddleware, combineEpics } from "redux-observable";
 
+import { state as stateModule } from "@nteract/core";
+
 import { List as ImmutableList, Map as ImmutableMap } from "immutable";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -18,7 +20,7 @@ export type JupyterConfigData = {
 
 const rootReducer = combineReducers({
   app: reducers.app,
-  document: reducers.document,
+  document: (state = stateModule.makeDocumentRecord()) => state,
   comms: reducers.comms,
   config: reducers.config,
   core: reducers.core

--- a/packages/core/__tests__/selectors-spec.js
+++ b/packages/core/__tests__/selectors-spec.js
@@ -1,24 +1,48 @@
 import Immutable from "immutable";
 import { dummyCommutable } from "../src/dummy";
 import * as selectors from "../src/selectors";
+import * as stateModule from "../src/state";
 
 describe("codeMirrorMode", () => {
   test("determines the right mode from the notebook metadata", () => {
     // TODO: better way to get dummy state?
+    const notebookContentRef = stateModule.createContentRef();
     const state1 = {
-      document: Immutable.Map({
-        notebook: dummyCommutable
+      core: stateModule.makeStateRecord({
+        currentContentRef: notebookContentRef,
+        entities: stateModule.makeEntitiesRecord({
+          contents: stateModule.makeContentsRecord({
+            byRef: Immutable.Map({
+              [notebookContentRef]: stateModule.makeNotebookContentRecord({
+                model: stateModule.makeDocumentRecord({
+                  notebook: dummyCommutable
+                })
+              })
+            })
+          })
+        })
       })
     };
     const mode = selectors.codeMirrorMode(state1);
     expect(mode).toEqual(Immutable.fromJS({ name: "ipython", version: 3 }));
 
     const state2 = {
-      document: Immutable.Map({
-        notebook: dummyCommutable.setIn(
-          ["metadata", "language_info", "codemirror_mode", "name"],
-          "r"
-        )
+      core: stateModule.makeStateRecord({
+        currentContentRef: notebookContentRef,
+        entities: stateModule.makeEntitiesRecord({
+          contents: stateModule.makeContentsRecord({
+            byRef: Immutable.Map({
+              [notebookContentRef]: stateModule.makeNotebookContentRecord({
+                model: stateModule.makeDocumentRecord({
+                  notebook: dummyCommutable.setIn(
+                    ["metadata", "language_info", "codemirror_mode", "name"],
+                    "r"
+                  )
+                })
+              })
+            })
+          })
+        })
       })
     };
     const lang2 = selectors.codeMirrorMode(state2);

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -652,7 +652,10 @@ export type SetNotebook = {
     notebook: ImmutableNotebook,
     filename: ?string,
     kernelRef: KernelRef,
-    contentRef?: ContentRef
+    contentRef?: ContentRef,
+    lastSaved: ?Date,
+    name: ?string,
+    created: ?Date
   }
 };
 

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -877,7 +877,10 @@ export const setNotebook = (payload: {
   filename: ?string,
   notebook: ImmutableNotebook,
   kernelRef: KernelRef,
-  contentRef?: ContentRef
+  contentRef?: ContentRef,
+  lastSaved: ?Date,
+  name: ?string,
+  created: ?Date
 }): SetNotebook => ({
   type: actionTypes.SET_NOTEBOOK,
   payload

--- a/packages/core/src/components/cell-creator.js
+++ b/packages/core/src/components/cell-creator.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { connect } from "react-redux";
 import * as actions from "../actions";
+import type { ContentRef } from "../state/refs";
 
 type Props = {
   above: boolean,
@@ -15,7 +16,8 @@ type ConnectedProps = {
   createCellBefore: (payload: *) => void,
   createCellAfter: (payload: *) => void,
   mergeCellAfter: (payload: *) => void,
-  id?: string
+  id?: string,
+  contentRef?: ContentRef
 };
 
 import {
@@ -136,28 +138,26 @@ class CellCreator extends React.Component<ConnectedProps> {
       createCellAfter,
       createCellAppend,
       createCellBefore,
-      id
+      id,
+      contentRef
     } = this.props;
 
     if (!id) {
-      // TODO: #2618
-      createCellAppend({ cellType: type });
+      createCellAppend({ cellType: type, contentRef });
       return;
     }
 
-    // TODO: #2618
     above
-      ? createCellBefore({ cellType: type, id })
-      : createCellAfter({ cellType: type, id, source: "" });
+      ? createCellBefore({ cellType: type, id, contentRef })
+      : createCellAfter({ cellType: type, id, source: "", contentRef });
   }
 
   mergeCell(): void {
-    const { mergeCellAfter, id } = this.props;
+    const { mergeCellAfter, id, contentRef } = this.props;
 
     // We can't merge cells if we don't have a cell ID
     if (id) {
-      // TODO: #2618
-      mergeCellAfter({ id });
+      mergeCellAfter({ id, contentRef });
     }
   }
 

--- a/packages/core/src/components/draggable-cell.js
+++ b/packages/core/src/components/draggable-cell.js
@@ -4,6 +4,7 @@
 
 import * as React from "react";
 import { DragSource, DropTarget } from "react-dnd";
+import type { ContentRef } from "../state/refs";
 
 /**
   The cell drag preview image is just a little stylized version of
@@ -44,7 +45,8 @@ type Props = {|
   isDragging: boolean,
   isOver: boolean,
   moveCell: (payload: *) => Object,
-  children: React.Element<any>
+  children: React.Element<any>,
+  contentRef: ContentRef
 |};
 
 type State = {|
@@ -74,11 +76,11 @@ const cellTarget = {
     if (monitor) {
       const hoverUpperHalf = isDragUpper(props, monitor, component.el);
       // DropTargetSpec monitor definition could be undefined. we'll need a check for monitor in order to pass validation.
-      // TODO: #2618
       props.moveCell({
         id: monitor.getItem().id,
         destinationId: props.id,
-        above: hoverUpperHalf
+        above: hoverUpperHalf,
+        contentRef: props.contentRef
       });
     }
   },
@@ -125,8 +127,8 @@ class DraggableCellView extends React.Component<Props, State> {
   }
 
   selectCell = () => {
-    // TODO: #2618
-    this.props.focusCell({ id: this.props.id });
+    const { focusCell, id, contentRef } = this.props;
+    focusCell({ id, contentRef });
   };
 
   render(): ?React$Element<any> {

--- a/packages/core/src/components/editor.js
+++ b/packages/core/src/components/editor.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { connect } from "react-redux";
 import * as selectors from "../selectors";
+import type { ContentRef } from "../state/refs";
 
 import { focusCell, focusCellEditor, updateCellSource } from "../actions";
 
@@ -15,7 +16,8 @@ type Props = CodeMirrorEditorProps & {
   cellFocused: boolean,
   channels: any,
   kernelStatus: string,
-  options: Object
+  options: Object,
+  contentRef?: ContentRef
 };
 
 function mapStateToProps(
@@ -45,20 +47,17 @@ class Editor extends React.Component<Props> {
   }
 
   onChange(text: string): void {
-    const { dispatch, id } = this.props;
-    // TODO: #2618
-    dispatch(updateCellSource({ id, value: text }));
+    const { dispatch, id, contentRef } = this.props;
+    dispatch(updateCellSource({ id, value: text, contentRef }));
   }
 
   onFocusChange(focused: boolean): void {
-    const { cellFocused, dispatch, id } = this.props;
+    const { cellFocused, dispatch, id, contentRef } = this.props;
 
     if (focused) {
-      // TODO: #2618
-      dispatch(focusCellEditor({ id }));
+      dispatch(focusCellEditor({ id, contentRef }));
       if (!cellFocused) {
-        // TODO: #2618
-        dispatch(focusCell({ id }));
+        dispatch(focusCell({ id, contentRef }));
       }
     }
   }

--- a/packages/core/src/components/toolbar.js
+++ b/packages/core/src/components/toolbar.js
@@ -7,6 +7,7 @@
 // TODO: All the `<li>` below that have role button should just be `<button>` with proper styling
 
 import * as React from "react";
+import type { ContentRef } from "../state/refs";
 
 import { connect } from "react-redux";
 import * as actions from "../actions";
@@ -33,7 +34,8 @@ export type PureToolbarProps = {|
   toggleCellInputVisibility: () => void,
   toggleCellOutputVisibility: () => void,
   toggleOutputExpansion: () => void,
-  changeCellType: () => void
+  changeCellType: () => void,
+  contentRef?: ContentRef
 |};
 
 export class PureToolbar extends React.Component<PureToolbarProps> {
@@ -260,31 +262,26 @@ type ConnectedProps = {
   toggleOutputExpansion: () => void
 };
 
-const mapDispatchToProps = (dispatch, { id, type }) => ({
-  // TODO: #2618
-  toggleStickyCell: () => dispatch(actions.toggleStickyCell({ id })),
-  // TODO: #2618
-  removeCell: () => dispatch(actions.removeCell({ id })),
-  // TODO: #2618
-  executeCell: () => dispatch(actions.executeCell({ id })),
-  // TODO: #2618
-  clearOutputs: () => dispatch(actions.clearOutputs({ id })),
-  // TODO: #2618
+const mapDispatchToProps = (dispatch, { id, type, contentRef }) => ({
+  toggleStickyCell: () =>
+    dispatch(actions.toggleStickyCell({ id, contentRef })),
+  removeCell: () => dispatch(actions.removeCell({ id, contentRef })),
+  executeCell: () => dispatch(actions.executeCell({ id, contentRef })),
+  clearOutputs: () => dispatch(actions.clearOutputs({ id, contentRef })),
   toggleCellOutputVisibility: () =>
-    dispatch(actions.toggleCellOutputVisibility({ id })),
-  // TODO: #2618
+    dispatch(actions.toggleCellOutputVisibility({ id, contentRef })),
   toggleCellInputVisibility: () =>
-    dispatch(actions.toggleCellInputVisibility({ id })),
-  // TODO: #2618
+    dispatch(actions.toggleCellInputVisibility({ id, contentRef })),
   changeCellType: () =>
     dispatch(
       actions.changeCellType({
         id,
-        to: type === "markdown" ? "code" : "markdown"
+        to: type === "markdown" ? "code" : "markdown",
+        contentRef
       })
     ),
-  // TODO: #2618
-  toggleOutputExpansion: () => dispatch(actions.toggleOutputExpansion({ id }))
+  toggleOutputExpansion: () =>
+    dispatch(actions.toggleOutputExpansion({ id, contentRef }))
 });
 
 export default connect(null, mapDispatchToProps)(PureToolbar);

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -146,7 +146,10 @@ export function setNotebookEpic(
         filename: action.payload.path,
         notebook: fromJS(action.payload.model.content),
         kernelRef: action.payload.kernelRef,
-        contentRef: action.payload.contentRef
+        contentRef: action.payload.contentRef,
+        lastSaved: action.payload.model.last_modified,
+        name: action.payload.model.name,
+        created: action.payload.model.created
       })
     ),
     catchError((xhrError: any) =>

--- a/packages/core/src/reducers/core/communication/contents.js
+++ b/packages/core/src/reducers/core/communication/contents.js
@@ -1,0 +1,99 @@
+// @flow
+import {
+  makeContentCommunicationRecord,
+  makeContentsCommunicationRecord
+} from "../../../state/communication/contents";
+import * as actionTypes from "../../../actionTypes";
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
+const byRef = (state = Immutable.Map(), action) => {
+  switch (action.type) {
+    case actionTypes.FETCH_CONTENT:
+      // TODO: #2618
+      if (!action.payload.contentRef) {
+        return state;
+      }
+      return state.set(
+        action.payload.contentRef,
+        makeContentCommunicationRecord({
+          loading: true,
+          saving: false,
+          error: null
+        })
+      );
+    case actionTypes.FETCH_CONTENT_FULFILLED:
+      // TODO: #2618
+      if (!action.payload.contentRef) {
+        return state;
+      }
+      return state.set(
+        action.payload.contentRef,
+        makeContentCommunicationRecord({
+          loading: false,
+          saving: false,
+          error: null
+        })
+      );
+    case actionTypes.FETCH_CONTENT_FAILED:
+      // TODO: #2618
+      if (!action.payload.contentRef) {
+        return state;
+      }
+      return state.set(
+        action.payload.contentRef,
+        makeContentCommunicationRecord({
+          loading: false,
+          saving: false,
+          error: action.payload.error
+        })
+      );
+    case actionTypes.SAVE:
+    case actionTypes.SAVE_AS:
+      // TODO: #2618
+      if (!action.payload.contentRef) {
+        return state;
+      }
+      return state.set(
+        action.payload.contentRef,
+        makeContentCommunicationRecord({
+          loading: false,
+          saving: true,
+          error: null
+        })
+      );
+    case actionTypes.SAVE_FULFILLED:
+      // TODO: #2618
+      if (!action.payload.contentRef) {
+        return state;
+      }
+      return state.set(
+        action.payload.contentRef,
+        makeContentCommunicationRecord({
+          loading: false,
+          saving: false,
+          error: null
+        })
+      );
+    case actionTypes.SAVE_FAILED:
+      // TODO: #2618
+      if (!action.payload.contentRef) {
+        return state;
+      }
+      return state.set(
+        action.payload.contentRef,
+        makeContentCommunicationRecord({
+          loading: false,
+          saving: false,
+          error: action.payload.error
+        })
+      );
+    default:
+      return state;
+  }
+};
+
+export const contents = combineReducers(
+  { byRef },
+  makeContentsCommunicationRecord
+);

--- a/packages/core/src/reducers/core/communication/index.js
+++ b/packages/core/src/reducers/core/communication/index.js
@@ -1,11 +1,13 @@
 // @flow
 import { combineReducers } from "redux-immutable";
+import { contents } from "./contents";
 import { kernels } from "./kernels";
 import { kernelspecs } from "./kernelspecs";
 import { makeCommunicationRecord } from "../../../state/communication";
 
 export const communication = combineReducers(
   {
+    contents,
     kernels,
     kernelspecs
   },

--- a/packages/core/src/reducers/core/entities/index.js
+++ b/packages/core/src/reducers/core/entities/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { combineReducers } from "redux-immutable";
 import { makeEntitiesRecord } from "../../../state/entities";
+import { contents } from "./contents";
 import { hosts } from "./hosts";
 import { kernels } from "./kernels";
 import { kernelspecs } from "./kernelspecs";
@@ -8,6 +9,7 @@ import { modals } from "./modals";
 
 export const entities = combineReducers(
   {
+    contents,
     hosts,
     kernels,
     kernelspecs,

--- a/packages/core/src/reducers/core/index.js
+++ b/packages/core/src/reducers/core/index.js
@@ -5,6 +5,7 @@ import { communication } from "./communication";
 import { entities } from "./entities";
 import { makeStateRecord } from "../../state";
 
+// TODO: #2618: This should at a minimum be moved into a contents entry.
 // TODO: This is temporary until we have sessions in place. Ideally, we point to
 // a document, which knows about its session and that session knows about its
 // kernel. For now, we need to keep a reference to the currently targeted kernel
@@ -19,9 +20,20 @@ const kernelRef = (state = null, action) => {
   }
 };
 
+const currentContentRef = (state = null, action) => {
+  switch (action.type) {
+    case actionTypes.FETCH_CONTENT:
+      // TODO: #2618 We should not need the `null` guard.
+      return action.payload.contentRef || null;
+    default:
+      return state;
+  }
+};
+
 const core = combineReducers(
   {
     communication,
+    currentContentRef,
     entities,
     kernelRef
   },

--- a/packages/core/src/state/communication/contents.js
+++ b/packages/core/src/state/communication/contents.js
@@ -1,0 +1,30 @@
+// @flow
+import * as Immutable from "immutable";
+import type { ContentRef } from "../refs";
+
+export type ContentCommunicationRecordProps = {
+  loading: boolean,
+  saving: boolean,
+  error: ?Object
+};
+
+export const makeContentCommunicationRecord: Immutable.RecordFactory<
+  ContentCommunicationRecordProps
+> = Immutable.Record({
+  loading: false,
+  saving: false,
+  error: null
+});
+
+export type ContentsCommunicationRecordProps = {
+  byRef: Immutable.Map<
+    ContentRef,
+    Immutable.RecordOf<ContentCommunicationRecordProps>
+  >
+};
+
+export const makeContentsCommunicationRecord: Immutable.RecordFactory<
+  ContentsCommunicationRecordProps
+> = Immutable.Record({
+  byRef: Immutable.Map()
+});

--- a/packages/core/src/state/communication/index.js
+++ b/packages/core/src/state/communication/index.js
@@ -1,14 +1,18 @@
 // @flow
 import * as Immutable from "immutable";
+import type { ContentsCommunicationRecordProps } from "./contents";
 import type { KernelsCommunicationRecordProps } from "./kernels";
 import type { KernelspecsCommunicationRecordProps } from "./kernelspecs";
+import { makeContentsCommunicationRecord } from "./contents";
 import { makeKernelsCommunicationRecord } from "./kernels";
 import { makeKernelspecsCommunicationRecord } from "./kernelspecs";
 
+export * from "./contents";
 export * from "./kernels";
 export * from "./kernelspecs";
 
 export type CommunicationRecordProps = {
+  contents: Immutable.RecordOf<ContentsCommunicationRecordProps>,
   kernels: Immutable.RecordOf<KernelsCommunicationRecordProps>,
   kernelspecs: Immutable.RecordOf<KernelspecsCommunicationRecordProps>
 };
@@ -16,6 +20,7 @@ export type CommunicationRecordProps = {
 export const makeCommunicationRecord: Immutable.RecordFactory<
   CommunicationRecordProps
 > = Immutable.Record({
+  contents: makeContentsCommunicationRecord(),
   kernels: makeKernelsCommunicationRecord(),
   kernelspecs: makeKernelspecsCommunicationRecord()
 });

--- a/packages/core/src/state/entities/contents.js
+++ b/packages/core/src/state/entities/contents.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+import type { ContentRef } from "../refs";
 import { emptyNotebook } from "@nteract/commutable";
 
 export type DocumentRecordProps = {
@@ -35,3 +36,64 @@ export const makeDocumentRecord: Immutable.RecordFactory<
 });
 
 export type DocumentRecord = Immutable.RecordOf<DocumentRecordProps>;
+
+export type NotebookContentRecordProps = {
+  created: ?Date,
+  format: "json",
+  lastSaved: ?Date,
+  model: ?DocumentRecord,
+  name: ?string,
+  path: ?string,
+  type: "notebook",
+  writable: boolean
+};
+
+export const makeNotebookContentRecord: Immutable.RecordFactory<
+  NotebookContentRecordProps
+> = Immutable.Record({
+  created: null,
+  format: "json",
+  lastSaved: null,
+  model: makeDocumentRecord(),
+  name: null,
+  path: "",
+  type: "notebook",
+  writable: true
+});
+
+// TODO: this will be a merger of notebook, directory, and file eventually.
+export type ContentRecordProps = {
+  created: ?Date,
+  format: null | "json",
+  lastSaved: ?Date,
+  mimetype: ?string,
+  model: DocumentRecord | Immutable.Map<*, *>,
+  name: ?string,
+  path: ?string,
+  type: "notebook",
+  writable: boolean
+};
+
+export const makeContentRecord: Immutable.RecordFactory<
+  ContentRecordProps
+> = Immutable.Record({
+  created: null,
+  format: null,
+  lastSaved: null,
+  mimetype: null,
+  model: Immutable.Map(),
+  name: null,
+  path: ".",
+  type: "notebook",
+  writable: true
+});
+
+export type ContentsRecordProps = {
+  byRef: Immutable.Map<ContentRef, Immutable.RecordOf<ContentRecordProps>>
+};
+
+export const makeContentsRecord: Immutable.RecordFactory<
+  ContentsRecordProps
+> = Immutable.Record({
+  byRef: Immutable.Map()
+});

--- a/packages/core/src/state/entities/index.js
+++ b/packages/core/src/state/entities/index.js
@@ -1,9 +1,11 @@
 // @flow
 import * as Immutable from "immutable";
+import type { ContentsRecordProps } from "./contents";
 import type { HostsRecordProps } from "./hosts";
 import type { KernelsRecordProps } from "./kernels";
 import type { KernelspecsRecordProps } from "./kernelspecs";
 import type { ModalsRecordProps } from "./modals";
+import { makeContentsRecord } from "./contents";
 import { makeHostsRecord } from "./hosts";
 import { makeKernelsRecord } from "./kernels";
 import { makeKernelspecsRecord } from "./kernelspecs";
@@ -16,6 +18,7 @@ export * from "./kernelspecs";
 export * from "./modals";
 
 export type EntitiesRecordProps = {
+  contents: Immutable.RecordOf<ContentsRecordProps>,
   hosts: Immutable.RecordOf<HostsRecordProps>,
   kernels: Immutable.RecordOf<KernelsRecordProps>,
   kernelspecs: Immutable.RecordOf<KernelspecsRecordProps>,
@@ -25,6 +28,7 @@ export type EntitiesRecordProps = {
 export const makeEntitiesRecord: Immutable.RecordFactory<
   EntitiesRecordProps
 > = Immutable.Record({
+  contents: makeContentsRecord(),
   hosts: makeHostsRecord(),
   kernels: makeKernelsRecord(),
   kernelspecs: makeKernelspecsRecord(),

--- a/packages/core/src/state/index.js
+++ b/packages/core/src/state/index.js
@@ -7,7 +7,7 @@ import type {
   LocalKernelProps,
   RemoteKernelProps
 } from "./entities";
-import type { KernelRef } from "./refs";
+import type { ContentRef, KernelRef } from "./refs";
 import type {
   LocalHostRecordProps,
   JupyterHostRecordProps
@@ -101,6 +101,7 @@ export type ConfigState = Immutable.Map<string, any>;
 
 export type StateRecordProps = {
   kernelRef: ?KernelRef,
+  currentContentRef: ?ContentRef,
   communication: Immutable.RecordOf<CommunicationRecordProps>,
   entities: Immutable.RecordOf<EntitiesRecordProps>
 };
@@ -109,6 +110,7 @@ export const makeStateRecord: Immutable.RecordFactory<
   StateRecordProps
 > = Immutable.Record({
   kernelRef: null,
+  currentContentRef: null,
   communication: makeCommunicationRecord(),
   entities: makeEntitiesRecord()
 });

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -21,7 +21,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
     >
       <Cell
         isSelected={false}
-        key="3"
+        key="4"
       >
         <div
           className="jsx-2513275823 content-margin"
@@ -40,7 +40,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
       </Cell>
       <Cell
         isSelected={false}
-        key="4"
+        key="5"
       >
         <PapermillView />
         <Input
@@ -266,7 +266,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
     >
       <Cell
         isSelected={false}
-        key="14"
+        key="15"
       >
         <div
           className="jsx-2513275823 content-margin"
@@ -285,7 +285,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
       </Cell>
       <Cell
         isSelected={false}
-        key="15"
+        key="16"
       >
         <PapermillView />
         <Input


### PR DESCRIPTION
~This broke desktop, haven't looked into it yet!~

This switches the Jupyter extension to using `state.core.entities.contents.byRef` for content stuff.