### PR TITLE
core was missing the redux-observable dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "react-syntax-highlighter": "^7.0.1",
     "redux": "^3.7.2",
     "redux-immutable": "^4.0.0",
+    "redux-observable": "^0.18.0",
     "reselect": "^3.0.1",
     "rx-binder": "^2.0.0",
     "rx-jupyter": "^3.0.0",


### PR DESCRIPTION
Added it in. I'll be making a release after this since it currently breaks commuter and notebook-preview.