### PR TITLE
share source observable of cell messages with subs

### DIFF
--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -33,7 +33,8 @@ import {
   takeUntil,
   catchError,
   concatMap,
-  tap
+  tap,
+  share
 } from "rxjs/operators";
 
 import { ofType } from "redux-observable";
@@ -79,7 +80,7 @@ export function executeCellStream(
   const executeRequest = message;
 
   // All the streams intended for all frontends
-  const cellMessages = channels.pipe(childOf(executeRequest));
+  const cellMessages = channels.pipe(childOf(executeRequest), share());
 
   // All the payload streams, intended for one user
   const payloadStream = cellMessages.pipe(payloads());


### PR DESCRIPTION
While looking at something on the spec with a `tap` of the cellMessages, I noticed that my `tap` was being called multiple times. After `share`-ing the original `cellMessages` observable, that behavior went away. I _think_ this is saving us from a flurry of messages we're handling repeatedly.