### PR TITLE
Fix transpile

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -11,7 +11,7 @@
     "prepublishOnly": "npm run build && npm run build:flow",
     "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf lib",
-    "build:lib": "node buildStyles.js && npm run build:copy-files && babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib": "node buildStyles.js && npm run build:copy-files && babel -d lib src --ignore '**/__tests__/**' && babel -d lib build",
     "build:copy-files": "mkdir -p ./lib && mkdir -p ./build && cp ./src/*.json ./lib/ && cp ./build/* ./lib/",
     "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
     "build:lib:watch": "npm run build:lib -- --watch",


### PR DESCRIPTION
The way the `/packages/styles/buildStyles.js` currently works gives a "Failed to minify" error when using this package in a `create-react-app` application.

This changes the output from `/packages/styles/buildStyles.js` so that it outputs on a single line so that the file can be minified.

This closes issue https://github.com/nteract/nteract/issues/2655