### PR TITLE
Directory Contents!

### DIFF
--- a/applications/commuter/components/contents/directory-listing.js
+++ b/applications/commuter/components/contents/directory-listing.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 
+import TimeAgo from "@nteract/timeago";
 import { Book, FileText, FileDirectory } from "@nteract/octicons";
 
 import Link from "next/link";
@@ -8,8 +9,6 @@ import Link from "next/link";
 import { theme } from "../../theme";
 
 import { groupBy } from "lodash";
-
-import TimeAgo from "@nteract/timeago";
 
 export type DirectoryListingProps = {
   contents: Array<JupyterApi$Content>,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -4,6 +4,9 @@ import * as React from "react";
 import * as Immutable from "immutable";
 const urljoin = require("url-join");
 
+import TimeAgo from "@nteract/timeago";
+import { Book, FileText, FileDirectory } from "@nteract/octicons";
+
 import { selectors, actions, state as stateModule } from "@nteract/core";
 
 // Workaround flow limitation for getting these types

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -35,7 +35,9 @@ class DirectoryEntry extends React.PureComponent<DirectoryEntryProps, *> {
     );
 
     let type = this.props.entry.type;
-    type = type === "dummy" ? this.props.entry.assumedType : type;
+    if (this.props.entry.type === "dummy") {
+      type = this.props.entry.assumedType;
+    }
 
     let Icon = FileText;
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -1,0 +1,132 @@
+// @flow
+
+import * as React from "react";
+import * as Immutable from "immutable";
+const urljoin = require("url-join");
+
+import { selectors, actions, state as stateModule } from "@nteract/core";
+
+// Workaround flow limitation for getting these types
+type ContentRef = stateModule.ContentRef;
+type ContentRecord = stateModule.ContentRecord;
+type DirectoryContentRecord = stateModule.DirectoryContentRecord;
+
+import { connect } from "react-redux";
+
+type DirectoryEntryProps = {
+  basePath: string,
+  entry: ContentRecord
+};
+
+/**
+ * Note: the URLs we create for clicking have to take into account:
+ *    Server base URL   e.g. https://j.nteract.io/user/kylek/
+ *    App base URL      e.g. /nteract/edit/
+ *    Filepath          e.g. Untitled.ipynb
+ */
+
+class DirectoryEntry extends React.PureComponent<DirectoryEntryProps, *> {
+  render() {
+    const displayName = this.props.entry.filepath.split("/").pop();
+    const href = urljoin(
+      this.props.basePath,
+      "/nteract/edit/",
+      this.props.entry.filepath
+    );
+
+    let type = this.props.entry.type;
+    type = type === "dummy" ? this.props.entry.assumedType : type;
+
+    let Icon = FileText;
+
+    switch (type) {
+      case "notebook":
+        Icon = Book;
+        break;
+      case "directory":
+        Icon = FileDirectory;
+        break;
+      case "file":
+        Icon = FileText;
+        break;
+    }
+
+    return (
+      <React.Fragment>
+        <Icon />
+        <a
+          href={href}
+          // When it's a notebook, we open a new tab
+          target={type === "notebook" ? "_blank" : undefined}
+        >
+          {displayName}
+        </a>
+        <style jsx>{`
+          a {
+            padding-left: 10px;
+            text-decoration: none;
+            color: var(--theme-app-fg);
+            background-color: var(--theme-app-bg);
+          }
+        `}</style>
+      </React.Fragment>
+    );
+  }
+}
+
+const mapStateToEntryProps = (
+  state: Object,
+  ownProps: { contentRef: ContentRef }
+): DirectoryEntryProps => {
+  const host = selectors.currentHost(state);
+  if (host.type !== "jupyter") {
+    throw new Error("This component only works with jupyter servers");
+  }
+
+  return {
+    entry: selectors.contentByRef(state, ownProps),
+    basePath: host.basePath
+  };
+};
+
+const ConnectedEntry = connect(mapStateToEntryProps)(DirectoryEntry);
+
+type DirectoryProps = {
+  content: DirectoryContentRecord
+};
+
+export class Directory extends React.PureComponent<DirectoryProps, *> {
+  render() {
+    const atRoot = this.props.content.filepath === "/";
+
+    return (
+      <ul>
+        {atRoot ? null : (
+          // When we're not at the root of the tree, show `..`
+          <a href="..">..</a>
+        )}
+        {this.props.content.model.listing.map(contentRef => (
+          <li key={contentRef}>
+            <ConnectedEntry contentRef={contentRef} />
+          </li>
+        ))}
+        <style jsx>{`
+          ul {
+            list-style-type: none;
+          }
+        `}</style>
+      </ul>
+    );
+  }
+}
+
+const mapStateToDirectoryProps = (
+  state: Object,
+  ownProps: { contentRef: ContentRef }
+): DirectoryProps => {
+  return { content: selectors.contentByRef(state, ownProps) };
+};
+
+export const ConnectedDirectory = connect(mapStateToDirectoryProps)(Directory);
+
+export default ConnectedDirectory;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -17,8 +17,9 @@ type DirectoryContentRecord = stateModule.DirectoryContentRecord;
 import { connect } from "react-redux";
 
 type DirectoryEntryProps = {
-  basePath: string,
-  entry: ContentRecord
+  type: "dummy" | "notebook" | "directory" | "file",
+  href: string,
+  displayName: string
 };
 
 /**
@@ -30,17 +31,7 @@ type DirectoryEntryProps = {
 
 class DirectoryEntry extends React.PureComponent<DirectoryEntryProps, *> {
   render() {
-    const displayName = this.props.entry.filepath.split("/").pop();
-    const href = urljoin(
-      this.props.basePath,
-      "/nteract/edit/",
-      this.props.entry.filepath
-    );
-
-    let type = this.props.entry.type;
-    if (this.props.entry.type === "dummy") {
-      type = this.props.entry.assumedType;
-    }
+    const { href, type, displayName } = this.props;
 
     let Icon = FileText;
 
@@ -88,9 +79,21 @@ const mapStateToEntryProps = (
     throw new Error("This component only works with jupyter servers");
   }
 
+  const entry = selectors.contentByRef(state, ownProps);
+  const basePath = host.basePath;
+
+  const displayName = entry.filepath.split("/").pop() || "";
+  const href = urljoin(basePath, "/nteract/edit/", entry.filepath);
+
+  let type = entry.type;
+  if (entry.type === "dummy") {
+    type = entry.assumedType;
+  }
+
   return {
-    entry: selectors.contentByRef(state, ownProps),
-    basePath: host.basePath
+    type,
+    href,
+    displayName
   };
 };
 
@@ -107,8 +110,9 @@ export class Directory extends React.PureComponent<DirectoryProps, *> {
     return (
       <ul>
         {atRoot ? null : (
+          // TODO: Create a contentRef for `..`, even though it's a placeholder
           // When we're not at the root of the tree, show `..`
-          <a href="..">..</a>
+          <DirectoryEntry href="#yolo" displayName=".." type="directory" />
         )}
         {this.props.content.model.items.map(contentRef => (
           <li key={contentRef}>

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -107,7 +107,7 @@ export class Directory extends React.PureComponent<DirectoryProps, *> {
           // When we're not at the root of the tree, show `..`
           <a href="..">..</a>
         )}
-        {this.props.content.model.listing.map(contentRef => (
+        {this.props.content.model.items.map(contentRef => (
           <li key={contentRef}>
             <ConnectedEntry contentRef={contentRef} />
           </li>

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
@@ -1,0 +1,55 @@
+// @flow
+
+import * as React from "react";
+import * as Immutable from "immutable";
+
+import { selectors, actions, state as stateModule } from "@nteract/core";
+
+// Workaround flow limitation for getting these types
+type ContentRef = stateModule.ContentRef;
+type FileContentRecord = stateModule.FileContentRecord;
+
+import { connect } from "react-redux";
+
+type FileProps = {
+  content: FileContentRecord
+};
+
+type TextFileProps = {
+  data: string
+};
+
+export class TextFile extends React.PureComponent<TextFileProps, null> {
+  static handles(mimetype: string) {
+    return mimetype.startsWith("text/");
+  }
+  render() {
+    return <pre>{this.props.data}</pre>;
+  }
+}
+
+export class File extends React.PureComponent<FileProps, *> {
+  render() {
+    if (!this.props.content.mimetype) {
+      // TODO: Redirect to /files/ endpoint for them to download the file or view
+      //       as is
+      return <pre>Can not render this file type</pre>;
+    }
+
+    const mimetype = this.props.content.mimetype;
+
+    if (TextFile.handles(mimetype)) {
+      return <TextFile data={this.props.content.model.text} />;
+    }
+
+    return <pre>Can not render this file type</pre>;
+  }
+}
+
+export const ConnectedFile = connect(
+  (state: Object, ownProps: { contentRef: ContentRef }): FileProps => {
+    return { content: selectors.contentByRef(state, ownProps) };
+  }
+)(File);
+
+export default ConnectedFile;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
@@ -21,7 +21,10 @@ type TextFileProps = {
 
 export class TextFile extends React.PureComponent<TextFileProps, null> {
   static handles(mimetype: string) {
-    return mimetype.startsWith("text/");
+    return (
+      mimetype.startsWith("text/") ||
+      mimetype.startsWith("application/javascript")
+    );
   }
   render() {
     return <pre>{this.props.data}</pre>;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
@@ -3,26 +3,25 @@
 import * as React from "react";
 import * as Immutable from "immutable";
 
-import * as selectors from "../../selectors";
-import * as actions from "../../actions";
+import {
+  state as stateModule,
+  selectors,
+  actions,
+  TitleBar,
+  NotebookApp,
+  NotebookMenu
+} from "@nteract/core";
 
-import { default as TitleBar } from "../title-bar";
-import { default as NotebookApp } from "../notebook-app";
-import { default as NotebookMenu } from "../notebook-menu";
+import { default as Directory } from "./directory";
 
-import type { ContentRef } from "../../state/refs";
+type ContentRef = stateModule.ContentRef;
+
 import { connect } from "react-redux";
 
 const mapStateToProps = (state: *, ownProps: *): * => {
   return {
-    contentType: selectors.currentContentType(state)
-    /*
-    // TODO: This could delegate to the component below to render based on
-    //       the passed in content ref
-    //       For now, notebook app still relies on currentContentRef directly
-    contentRef: selectors.currentContentRef(state),
-    currentContent: selectors.currentContent(state)
-    */
+    contentType: selectors.currentContentType(state),
+    contentRef: selectors.currentContentRef(state)
   };
 };
 
@@ -48,7 +47,7 @@ class Contents extends React.PureComponent<*, *> {
         return (
           <React.Fragment>
             <TitleBar />
-            <div>it is a directory!</div>
+            <Directory contentRef={this.props.contentRef} />
           </React.Fragment>
         );
       default:

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
@@ -13,6 +13,7 @@ import {
 } from "@nteract/core";
 
 import { default as Directory } from "./directory";
+import { default as File } from "./file";
 
 type ContentRef = stateModule.ContentRef;
 
@@ -25,7 +26,7 @@ const mapStateToProps = (state: *, ownProps: *): * => {
   };
 };
 
-class Contents extends React.PureComponent<*, *> {
+class Contents extends React.Component<*, *> {
   render() {
     switch (this.props.contentType) {
       case "notebook":
@@ -34,6 +35,13 @@ class Contents extends React.PureComponent<*, *> {
             <TitleBar />
             <NotebookMenu />
             <NotebookApp />
+          </React.Fragment>
+        );
+      case "file":
+        return (
+          <React.Fragment>
+            <TitleBar />
+            <File contentRef={this.props.contentRef} />
           </React.Fragment>
         );
       case "dummy":

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -9,7 +9,9 @@ import NotificationSystem from "react-notification-system";
 
 import configureStore from "./store";
 
-import { Contents, Styles, actions, state } from "@nteract/core";
+import { Styles, actions, state } from "@nteract/core";
+
+import { default as Contents } from "./contents";
 
 function createApp(store: *) {
   class App extends React.Component<*> {
@@ -105,7 +107,8 @@ function main(rootEl: Element, dataEl: Node | null) {
     type: "jupyter",
     defaultKernelName: "python",
     token: config.token,
-    serverUrl: location.origin + config.baseUrl
+    origin: location.origin,
+    basePath: config.baseUrl
   });
 
   const hostRef = state.createHostRef();

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -31,7 +31,8 @@
     "redux": "^3.7.2",
     "redux-observable": "^0.18.0",
     "rx-jupyter": "^3.0.0",
-    "rxjs": "^5.5.6"
+    "rxjs": "^5.5.6",
+    "url-join": "^4.0.0"
   },
   "devDependencies": {
     "next": "^5.0.0",

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -18,6 +18,8 @@
     "@nteract/commutable": "^4.0.0",
     "@nteract/core": "^4.0.5",
     "@nteract/notebook-preview": "^7.0.5",
+    "@nteract/octicons": "^0.2.0",
+    "@nteract/timeago": "^3.4.9",
     "@nteract/transform-dataresource": "^3.0.2",
     "@nteract/transform-vega": "^3.1.0",
     "@nteract/transforms": "^4.0.1",
@@ -28,14 +30,13 @@
     "react-dom": "^16.2.0",
     "react-notification-system": "^0.2.16",
     "react-redux": "^5.0.7",
+    "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
     "redux-observable": "^0.18.0",
     "rx-jupyter": "^3.0.0",
     "rxjs": "^5.5.6",
-    "url-join": "^4.0.0"
-  },
-  "devDependencies": {
-    "next": "^5.0.0",
-    "styled-jsx": "^2.2.5"
+    "styled-jsx": "^2.2.5",
+    "url-join": "^4.0.0",
+    "webpack": "^4.0.1"
   }
 }

--- a/flow-typed/npm/react-router-dom_v4.x.x.js
+++ b/flow-typed/npm/react-router-dom_v4.x.x.js
@@ -1,0 +1,158 @@
+// flow-typed signature: 7ef7e99bfa7953a438470755d51dc345
+// flow-typed version: 107feb8c45/react-router-dom_v4.x.x/flow_>=v0.53.x
+
+declare module "react-router-dom" {
+  declare export class BrowserRouter extends React$Component<{
+    basename?: string,
+    forceRefresh?: boolean,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Node
+  }> {}
+
+  declare export class HashRouter extends React$Component<{
+    basename?: string,
+    getUserConfirmation?: GetUserConfirmation,
+    hashType?: "slash" | "noslash" | "hashbang",
+    children?: React$Node
+  }> {}
+
+  declare export class Link extends React$Component<{
+    to: string | LocationShape,
+    replace?: boolean,
+    children?: React$Node
+  }> {}
+
+  declare export class NavLink extends React$Component<{
+    to: string | LocationShape,
+    activeClassName?: string,
+    className?: string,
+    activeStyle?: Object,
+    style?: Object,
+    isActive?: (match: Match, location: Location) => boolean,
+    children?: React$Node,
+    exact?: boolean,
+    strict?: boolean
+  }> {}
+
+  // NOTE: Below are duplicated from react-router. If updating these, please
+  // update the react-router and react-router-native types as well.
+  declare export type Location = {
+    pathname: string,
+    search: string,
+    hash: string,
+    state?: any,
+    key?: string
+  };
+
+  declare export type LocationShape = {
+    pathname?: string,
+    search?: string,
+    hash?: string,
+    state?: any
+  };
+
+  declare export type HistoryAction = "PUSH" | "REPLACE" | "POP";
+
+  declare export type RouterHistory = {
+    length: number,
+    location: Location,
+    action: HistoryAction,
+    listen(
+      callback: (location: Location, action: HistoryAction) => void
+    ): () => void,
+    push(path: string | LocationShape, state?: any): void,
+    replace(path: string | LocationShape, state?: any): void,
+    go(n: number): void,
+    goBack(): void,
+    goForward(): void,
+    canGo?: (n: number) => boolean,
+    block(
+      callback: (location: Location, action: HistoryAction) => boolean
+    ): void,
+    // createMemoryHistory
+    index?: number,
+    entries?: Array<Location>
+  };
+
+  declare export type Match = {
+    params: { [key: string]: ?string },
+    isExact: boolean,
+    path: string,
+    url: string
+  };
+
+  declare export type ContextRouter = {|
+    history: RouterHistory,
+    location: Location,
+    match: Match
+  |};
+
+  declare export type GetUserConfirmation = (
+    message: string,
+    callback: (confirmed: boolean) => void
+  ) => void;
+
+  declare type StaticRouterContext = {
+    url?: string
+  };
+
+  declare export class StaticRouter extends React$Component<{
+    basename?: string,
+    location?: string | Location,
+    context: StaticRouterContext,
+    children?: React$Node
+  }> {}
+
+  declare export class MemoryRouter extends React$Component<{
+    initialEntries?: Array<LocationShape | string>,
+    initialIndex?: number,
+    getUserConfirmation?: GetUserConfirmation,
+    keyLength?: number,
+    children?: React$Node
+  }> {}
+
+  declare export class Router extends React$Component<{
+    history: RouterHistory,
+    children?: React$Node
+  }> {}
+
+  declare export class Prompt extends React$Component<{
+    message: string | ((location: Location) => string | boolean),
+    when?: boolean
+  }> {}
+
+  declare export class Redirect extends React$Component<{
+    to: string | LocationShape,
+    push?: boolean
+  }> {}
+
+  declare export class Route extends React$Component<{
+    component?: React$ComponentType<*>,
+    render?: (router: ContextRouter) => React$Node,
+    children?: React$ComponentType<ContextRouter> | React$Node,
+    path?: string,
+    exact?: boolean,
+    strict?: boolean
+  }> {}
+
+  declare export class Switch extends React$Component<{
+    children?: React$Node
+  }> {}
+
+  declare export function withRouter<P>(
+    Component: React$ComponentType<{| ...ContextRouter, ...P |}>
+  ): React$ComponentType<P>;
+
+  declare type MatchPathOptions = {
+    path?: string,
+    exact?: boolean,
+    sensitive?: boolean,
+    strict?: boolean
+  };
+
+  declare export function matchPath(
+    pathname: string,
+    options?: MatchPathOptions | string
+  ): null | Match;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "rx-binder": "^2.0.0",
     "rx-jupyter": "^3.0.0",
     "rxjs": "^5.5.6",
+    "url-join": "^4.0.0",
     "uuid": "^3.1.0"
   },
   "peerDependencies": {

--- a/packages/core/src/components/contents/index.js
+++ b/packages/core/src/components/contents/index.js
@@ -44,8 +44,17 @@ class Contents extends React.PureComponent<*, *> {
             <div>loading...</div>
           </React.Fragment>
         );
+      case "directory":
+        return (
+          <React.Fragment>
+            <TitleBar />
+            <div>it is a directory!</div>
+          </React.Fragment>
+        );
       default:
-        return <div>loading or something</div>;
+        return (
+          <div>{`content type ${this.props.contentType} not implemented`}</div>
+        );
     }
   }
 }

--- a/packages/core/src/components/index.js
+++ b/packages/core/src/components/index.js
@@ -6,4 +6,3 @@ export { default as NotebookMenu } from "./notebook-menu";
 export { default as TitleBar, TitleBar as PureTitleBar } from "./title-bar";
 export { default as ModalController } from "./modal-controller";
 export { default as NotebookApp } from "./notebook-app";
-export { default as Contents } from "./contents";

--- a/packages/core/src/components/notebook-app.js
+++ b/packages/core/src/components/notebook-app.js
@@ -74,9 +74,15 @@ const mapStateToCellProps = (state, { id }) => {
   const outputExpanded =
     cellType === "code" && cell.getIn(["metadata", "outputExpanded"]);
 
-  const pager = selectors
-    .currentModel(state)
-    .getIn(["cellPagers", id], Immutable.List());
+  const model = selectors.currentModel(state);
+
+  if (model.type !== "notebook") {
+    throw new Error(
+      "Cell components should not be used with non-notebook models"
+    );
+  }
+
+  const pager = model.getIn(["cellPagers", id], Immutable.List());
 
   return {
     cellType,

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -36,7 +36,14 @@ export function fetchContentEpic(
       }
     }),
     switchMap((action: FetchContent) => {
-      const serverConfig = selectors.serverConfig(store.getState());
+      const state = store.getState();
+
+      const host = selectors.currentHost(state);
+      if (host.type !== "jupyter") {
+        // Dismiss any usage that isn't targeting a jupyter server
+        return empty();
+      }
+      const serverConfig = selectors.serverConfig(host);
 
       return contents
         .get(serverConfig, action.payload.filepath, action.payload.params)
@@ -77,6 +84,14 @@ export function saveContentEpic(
     ofType(actionTypes.SAVE),
     mergeMap((action: Save) => {
       const state = store.getState();
+
+      const host = selectors.currentHost(state);
+      if (host.type !== "jupyter") {
+        // Dismiss any usage that isn't targeting a jupyter server
+        return empty();
+      }
+      const serverConfig = selectors.serverConfig(host);
+
       const currentNotebook = selectors.currentNotebook(state);
 
       // TODO: this will likely make more sense when this becomes less
@@ -98,8 +113,6 @@ export function saveContentEpic(
       const notebook = toJS(
         currentNotebook.setIn(["metadata", "nteract", "version"], appVersion)
       );
-
-      const serverConfig = selectors.serverConfig(state);
 
       const model = {
         content: notebook,

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -30,12 +30,15 @@ export function fetchContentEpic(
 ) {
   return action$.pipe(
     ofType(actionTypes.FETCH_CONTENT),
-    tap((action: FetchContent) => {
-      if (!action.payload || !action.payload.filepath) {
-        throw new Error("fetching content needs a path");
-      }
-    }),
     switchMap((action: FetchContent) => {
+      if (!action.payload || typeof action.payload.filepath !== "string") {
+        return of({
+          type: "ERROR",
+          error: true,
+          payload: { error: new Error("fetching content needs a payload") }
+        });
+      }
+
       const state = store.getState();
 
       const host = selectors.currentHost(state);

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -969,7 +969,7 @@ const byRef = (state = Immutable.Map(), action) => {
                 makeDirectoryContentRecord({
                   model: makeDirectoryModel({
                     // The listing is all these contents in aggregate
-                    listing: Immutable.Set(dummyRecords.keys())
+                    items: Immutable.List(dummyRecords.keys())
                   }),
                   filepath: action.payload.filepath,
                   lastSaved: action.payload.model.last_modified,

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -9,12 +9,16 @@ import type { DocumentRecord } from "../../../state/entities/contents";
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 import { escapeCarriageReturnSafe } from "escape-carriage";
 import {
-  makeContentRecord,
   makeDummyContentRecord,
   makeContentsRecord,
+  makeDirectoryContentRecord,
+  makeDirectoryModel,
   makeDocumentRecord,
   makeNotebookContentRecord
 } from "../../../state/entities/contents";
+
+import { createContentRef } from "../../../state/refs";
+
 import { combineReducers } from "redux-immutable";
 
 // TODO: With the new document plan, I think it starts to make sense to decouple
@@ -913,6 +917,52 @@ const byRef = (state = Immutable.Map(), action) => {
         })
       );
     case actionTypes.FETCH_CONTENT_FULFILLED:
+      if (action.payload.model.type === "directory") {
+        // TODO
+        // For each entry in the directory listing, create a new contentRef
+        // and a "filler" contents object
+        // Optional: run through all the current contents to see if they're
+        //           a file we already have (?)
+        const listingDraft: Array<Object> = action.payload.model.content;
+
+        // Create a map of <ContentRef, ContentRecord> that we merge into the
+        // content refs state
+        const dummyRecords = Immutable.Map(
+          listingDraft.map(entry => {
+            return [
+              createContentRef(),
+              makeDummyContentRecord({
+                // TODO: We can store the type of this content,
+                // it just doesn't have a model
+                // entry.type
+                assumedType: entry.type,
+                lastSaved: entry.last_modified,
+                filepath: entry.path
+              })
+            ];
+          })
+        );
+
+        return (
+          state
+            // Bring in all the listed records
+            .merge(dummyRecords)
+            // Set up the base directory
+            .set(
+              action.payload.contentRef,
+              makeDirectoryContentRecord({
+                model: makeDirectoryModel({
+                  // The listing is all these contents in aggregate
+                  listing: Immutable.Set(dummyRecords.keys())
+                }),
+                filepath: action.payload.filepath,
+                lastSaved: action.payload.model.last_modified,
+                created: action.payload.model.created
+              })
+            )
+        );
+      }
+
       // TODO: we *should* be able to handle this for non-notebook types in the
       // future. The reason we cannot do this for notebooks now is that we need
       // the in-memory notebook mirrored here (from the old state.document). We

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -9,6 +9,8 @@ import type { DocumentRecord } from "../../../state/entities/contents";
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 import { escapeCarriageReturnSafe } from "escape-carriage";
 import {
+  makeFileContentRecord,
+  makeFileModelRecord,
   makeDummyContentRecord,
   makeContentsRecord,
   makeDirectoryContentRecord,
@@ -917,6 +919,21 @@ const byRef = (state = Immutable.Map(), action) => {
         })
       );
     case actionTypes.FETCH_CONTENT_FULFILLED:
+      if (action.payload.model.type === "file") {
+        return state.set(
+          action.payload.contentRef,
+          makeFileContentRecord({
+            mimetype: action.payload.model.mimetype,
+            created: action.payload.model.created,
+            lastSaved: action.payload.model.last_modified,
+            filepath: action.payload.filepath,
+            model: makeFileModelRecord({
+              text: action.payload.model.content
+            })
+          })
+        );
+      }
+
       if (action.payload.model.type === "directory") {
         // TODO
         // For each entry in the directory listing, create a new contentRef
@@ -932,6 +949,7 @@ const byRef = (state = Immutable.Map(), action) => {
             return [
               createContentRef(),
               makeDummyContentRecord({
+                mimetype: entry.mimetype,
                 // TODO: We can store the type of this content,
                 // it just doesn't have a model
                 // entry.type

--- a/packages/core/src/reducers/core/entities/contents.js
+++ b/packages/core/src/reducers/core/entities/contents.js
@@ -959,6 +959,17 @@ const byRef = (state = Immutable.Map(), action) => {
             })
           );
 
+          const items = Immutable.List(dummyRecords.keys());
+          const sorted = items.sort((aRef, bRef) => {
+            const a = dummyRecords.get(aRef);
+            const b = dummyRecords.get(bRef);
+
+            if (a.assumedType === b.assumedType) {
+              return a.filepath.localeCompare(b.filepath);
+            }
+            return a.assumedType.localeCompare(b.assumedType);
+          });
+
           return (
             state
               // Bring in all the listed records
@@ -969,7 +980,7 @@ const byRef = (state = Immutable.Map(), action) => {
                 makeDirectoryContentRecord({
                   model: makeDirectoryModel({
                     // The listing is all these contents in aggregate
-                    items: Immutable.List(dummyRecords.keys())
+                    items: sorted
                   }),
                   filepath: action.payload.filepath,
                   lastSaved: action.payload.model.last_modified,

--- a/packages/core/src/reducers/core/entities/hosts.js
+++ b/packages/core/src/reducers/core/entities/hosts.js
@@ -3,7 +3,6 @@ import * as Immutable from "immutable";
 import * as actionTypes from "../../../actionTypes";
 import { combineReducers } from "redux-immutable";
 import {
-  makeBinderHostRecord,
   makeHostsRecord,
   makeJupyterHostRecord,
   makeLocalHostRecord
@@ -23,12 +22,6 @@ const byRef = (state = Immutable.Map(), action) => {
           return state.set(
             action.payload.hostRef,
             makeLocalHostRecord(action.payload.host)
-          );
-        }
-        case "binder": {
-          return state.set(
-            action.payload.hostRef,
-            makeBinderHostRecord(action.payload.host)
           );
         }
         default:

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -1,12 +1,7 @@
 // @flow
 
 import type { ContentRef, KernelRef } from "../state/refs";
-import type {
-  ContentRecord,
-  DocumentRecord,
-  DirectoryModelRecord,
-  EmptyModelRecord
-} from "../state/entities/contents";
+import type { ContentRecord, ContentModel } from "../state/entities/contents";
 
 import type { AppRecord, HostRecord, JupyterHostRecord } from "../state";
 
@@ -128,9 +123,7 @@ export const comms = createSelector((state: AppState) => state.comms, identity);
 // NOTE: These are comm models, not contents models
 export const models = createSelector([comms], comms => comms.get("models"));
 
-export const currentModel: (
-  state: AppState
-) => DocumentRecord | DirectoryModelRecord | EmptyModelRecord = createSelector(
+export const currentModel: (state: AppState) => ContentModel = createSelector(
   (state: AppState) => currentContent(state),
   currentContent => {
     return currentContent ? currentContent.model : makeEmptyModel();
@@ -139,7 +132,7 @@ export const currentModel: (
 
 export const currentContentType: (
   state: AppState
-) => "notebook" | "dummy" | "directory" | null = createSelector(
+) => "notebook" | "dummy" | "directory" | "file" | null = createSelector(
   (state: AppState) => currentContent(state),
   content => (content ? content.type : null)
 );

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -1,16 +1,5 @@
 // @flow
 
-// FIXME FIXME FIXME SUPER WRONG FIXME FIXME FIXME
-type AppState = {
-  // The new way
-  core: any,
-
-  // The old way
-  app: Object,
-  comms: *,
-  config: Object
-};
-
 import type { ContentRef, KernelRef } from "../state/refs";
 import type {
   ContentRecord,
@@ -18,6 +7,19 @@ import type {
   DirectoryModelRecord,
   EmptyModelRecord
 } from "../state/entities/contents";
+
+import type { AppRecord, HostRecord, JupyterHostRecord } from "../state";
+
+// FIXME FIXME FIXME SUPER WRONG FIXME FIXME FIXME
+type AppState = {
+  // The new way
+  core: any,
+
+  // The old way
+  app: AppRecord,
+  comms: *,
+  config: Object
+};
 
 import { makeEmptyModel } from "../state/entities/contents";
 
@@ -29,18 +31,13 @@ function identity<T>(thing: T): T {
   return thing;
 }
 
-const serverUrl = (state: AppState) => state.app.host.serverUrl;
-const crossDomain = (state: AppState) => state.app.host.crossDomain;
-const token = (state: AppState) => state.app.host.token;
-
-export const serverConfig = createSelector(
-  [serverUrl, crossDomain, token],
-  (serverUrl, crossDomain, token) => ({
-    endpoint: serverUrl,
-    crossDomain,
-    token
-  })
-);
+export const serverConfig = (host: JupyterHostRecord) => {
+  return {
+    endpoint: host.origin + host.basePath,
+    crossDomain: host.crossDomain,
+    token: host.token
+  };
+};
 
 export const userPreferences = createSelector(
   (state: AppState) => state.config,

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -12,7 +12,14 @@ type AppState = {
 };
 
 import type { ContentRef, KernelRef } from "../state/refs";
-import type { ContentRecord, DocumentRecord } from "../state/entities/contents";
+import type {
+  ContentRecord,
+  DocumentRecord,
+  DirectoryModelRecord,
+  EmptyModelRecord
+} from "../state/entities/contents";
+
+import { makeEmptyModel } from "../state/entities/contents";
 
 import { toJS, stringifyNotebook } from "@nteract/commutable";
 import * as Immutable from "immutable";
@@ -126,19 +133,16 @@ export const models = createSelector([comms], comms => comms.get("models"));
 
 export const currentModel: (
   state: AppState
-) => DocumentRecord | Immutable.Map<string, any> = createSelector(
+) => DocumentRecord | DirectoryModelRecord | EmptyModelRecord = createSelector(
   (state: AppState) => currentContent(state),
   currentContent => {
-    // TODO: The app assumes that the model is not null. HOWEVER, the model
-    // should really *be* nullable. I.e., components should check
-    // communication before accessing nested values here.
-    return currentContent ? currentContent.model : Immutable.Map();
+    return currentContent ? currentContent.model : makeEmptyModel();
   }
 );
 
 export const currentContentType: (
   state: AppState
-) => "notebook" | "dummy" | null = createSelector(
+) => "notebook" | "dummy" | "directory" | null = createSelector(
   (state: AppState) => currentContent(state),
   content => (content ? content.type : null)
 );
@@ -147,12 +151,14 @@ export const currentContentType: (
 // notebook object to get. Do we return null? Throw an error?
 export const currentNotebook: (
   state: AppState
-) => ?Immutable.Map<string, any> = createSelector(currentModel, model =>
-  model.get("notebook", null)
+) => ?Immutable.Map<string, any> = createSelector(
+  currentModel,
+  model => (model.type === "notebook" ? model.notebook : null)
 );
 
-export const currentSavedNotebook = createSelector(currentModel, model =>
-  model.get("savedNotebook")
+export const currentSavedNotebook = createSelector(
+  currentModel,
+  model => (model.type === "notebook" ? model.savedNotebook : null)
 );
 
 export const hasBeenSaved = createSelector(
@@ -166,8 +172,12 @@ export const currentLastSaved = createSelector(
   currentContent => (currentContent ? currentContent.lastSaved : null)
 );
 
-export const currentNotebookMetadata = createSelector(currentModel, model =>
-  model.getIn(["notebook", "metadata"], Immutable.Map())
+export const currentNotebookMetadata = createSelector(
+  currentModel,
+  model =>
+    model.type === "notebook"
+      ? model.notebook.get("metadata", Immutable.Map())
+      : Immutable.Map()
 );
 
 const CODE_MIRROR_MODE_DEFAULT = "text";
@@ -212,16 +222,22 @@ export const currentNotebookString = createSelector(
   }
 );
 
-export const currentFocusedCellId = createSelector(currentModel, model =>
-  model.get("cellFocused")
+export const currentFocusedCellId = createSelector(
+  currentModel,
+  model => (model.type === "notebook" ? model.cellFocused : null)
 );
 
-export const currentFocusedEditorId = createSelector(currentModel, model =>
-  model.get("editorFocused")
+export const currentFocusedEditorId = createSelector(
+  currentModel,
+  model => (model.type === "notebook" ? model.editorFocused : null)
 );
 
-export const transientCellMap = createSelector(currentModel, model =>
-  model.getIn(["transient", "cellMap"], Immutable.Map())
+export const transientCellMap = createSelector(
+  currentModel,
+  model =>
+    model.type === "notebook"
+      ? model.transient.get("cellMap", Immutable.Map())
+      : Immutable.Map()
 );
 
 export const currentCellMap = createSelector([currentNotebook], notebook => {

--- a/packages/core/src/state/entities/contents/directory.js
+++ b/packages/core/src/state/entities/contents/directory.js
@@ -6,13 +6,22 @@ import type { ContentRef } from "../../refs";
 
 export type DirectoryModelRecordProps = {
   type: "directory",
-  listing: Immutable.Set<ContentRef>
+  // TODO: when we want the directory "app" to show how they're sorted,
+  //       reflect that with a property like "sortedBy". For example:
+  //
+  //         sortedBy: "created" | "lastSaved" | "type" | "name"
+  //
+  //       could also group them by type, etc.
+  //
+  //         groupedBy: "type" | "mimetype"
+  //
+  items: Immutable.List<ContentRef>
 };
 export const makeDirectoryModel: Immutable.RecordFactory<
   DirectoryModelRecordProps
 > = Immutable.Record({
   type: "directory",
-  listing: Immutable.Set()
+  items: Immutable.List()
 });
 export type DirectoryModelRecord = Immutable.RecordOf<
   DirectoryModelRecordProps

--- a/packages/core/src/state/entities/contents/directory.js
+++ b/packages/core/src/state/entities/contents/directory.js
@@ -19,6 +19,7 @@ export type DirectoryModelRecord = Immutable.RecordOf<
 >;
 
 export type DirectoryContentRecordProps = {
+  mimetype: null,
   type: "directory",
   created: ?Date,
   format: "json",
@@ -29,6 +30,7 @@ export type DirectoryContentRecordProps = {
 export const makeDirectoryContentRecord: Immutable.RecordFactory<
   DirectoryContentRecordProps
 > = Immutable.Record({
+  mimetype: null,
   type: "directory",
   created: null,
   format: "json",

--- a/packages/core/src/state/entities/contents/directory.js
+++ b/packages/core/src/state/entities/contents/directory.js
@@ -1,0 +1,41 @@
+// @flow
+
+import * as Immutable from "immutable";
+
+import type { ContentRef } from "../../refs";
+
+export type DirectoryModelRecordProps = {
+  type: "directory",
+  listing: Immutable.Set<ContentRef>
+};
+export const makeDirectoryModel: Immutable.RecordFactory<
+  DirectoryModelRecordProps
+> = Immutable.Record({
+  type: "directory",
+  listing: Immutable.Set()
+});
+export type DirectoryModelRecord = Immutable.RecordOf<
+  DirectoryModelRecordProps
+>;
+
+export type DirectoryContentRecordProps = {
+  type: "directory",
+  created: ?Date,
+  format: "json",
+  lastSaved: null,
+  filepath: string,
+  model: DirectoryModelRecord
+};
+export const makeDirectoryContentRecord: Immutable.RecordFactory<
+  DirectoryContentRecordProps
+> = Immutable.Record({
+  type: "directory",
+  created: null,
+  format: "json",
+  lastSaved: null,
+  filepath: "",
+  model: makeDirectoryModel()
+});
+export type DirectoryContentRecord = Immutable.RecordOf<
+  DirectoryContentRecordProps
+>;

--- a/packages/core/src/state/entities/contents/dummy.js
+++ b/packages/core/src/state/entities/contents/dummy.js
@@ -16,6 +16,7 @@ export type EmptyModelRecord = Immutable.RecordOf<EmptyModelRecordProps>;
 export type DummyContentRecordProps = {
   type: "dummy",
   assumedType: "unknown" | "directory" | "notebook" | "file",
+  mimetype: ?string,
   lastSaved: null,
   filepath: string,
   model: EmptyModelRecord
@@ -24,6 +25,7 @@ export const makeDummyContentRecord: Immutable.RecordFactory<
   DummyContentRecordProps
 > = Immutable.Record({
   type: "dummy",
+  mimetype: null,
   assumedType: "unknown",
   lastSaved: null,
   filepath: "",

--- a/packages/core/src/state/entities/contents/dummy.js
+++ b/packages/core/src/state/entities/contents/dummy.js
@@ -1,0 +1,32 @@
+// @flow
+
+import * as Immutable from "immutable";
+
+export type EmptyModelRecordProps = {
+  type: "unknown"
+};
+
+export const makeEmptyModel: Immutable.RecordFactory<
+  EmptyModelRecordProps
+> = Immutable.Record({
+  type: "unknown"
+});
+export type EmptyModelRecord = Immutable.RecordOf<EmptyModelRecordProps>;
+
+export type DummyContentRecordProps = {
+  type: "dummy",
+  assumedType: "unknown" | "directory" | "notebook" | "file",
+  lastSaved: null,
+  filepath: string,
+  model: EmptyModelRecord
+};
+export const makeDummyContentRecord: Immutable.RecordFactory<
+  DummyContentRecordProps
+> = Immutable.Record({
+  type: "dummy",
+  assumedType: "unknown",
+  lastSaved: null,
+  filepath: "",
+  model: makeEmptyModel()
+});
+export type DummyContentRecord = Immutable.RecordOf<DummyContentRecordProps>;

--- a/packages/core/src/state/entities/contents/file.js
+++ b/packages/core/src/state/entities/contents/file.js
@@ -1,0 +1,38 @@
+// @flow
+
+import * as Immutable from "immutable";
+
+export type FileModelRecordProps = {
+  type: "file",
+  text: string
+};
+export const makeFileModelRecord: Immutable.RecordFactory<
+  FileModelRecordProps
+> = Immutable.Record({
+  type: "file",
+  text: ""
+});
+export type FileModelRecord = Immutable.RecordOf<FileModelRecordProps>;
+
+export type FileContentRecordProps = {
+  type: "file",
+  mimetype: ?string,
+  created: ?Date,
+  format: "json",
+  lastSaved: null,
+  filepath: string,
+  model: FileModelRecord
+};
+export const makeFileContentRecord: Immutable.RecordFactory<
+  FileContentRecordProps
+> = Immutable.Record({
+  type: "file",
+  mimetype: null,
+  created: null,
+  format: "json",
+  lastSaved: null,
+  filepath: "",
+  model: makeFileModelRecord()
+});
+
+export type FileContentRecord = Immutable.RecordOf<FileContentRecordProps>;

--- a/packages/core/src/state/entities/contents/index.js
+++ b/packages/core/src/state/entities/contents/index.js
@@ -1,0 +1,27 @@
+// @flow
+import * as Immutable from "immutable";
+import type { ContentRef } from "../../refs";
+
+import type { NotebookContentRecord } from "./notebook";
+import type { DirectoryContentRecord } from "./directory";
+import type { DummyContentRecord } from "./dummy";
+
+export * from "./notebook";
+export * from "./directory";
+export * from "./dummy";
+
+// TODO: this will be a merger of notebook, directory, and file eventually.
+export type ContentRecord =
+  | NotebookContentRecord
+  | DummyContentRecord
+  | DirectoryContentRecord;
+
+export type ContentsRecordProps = {
+  byRef: Immutable.Map<ContentRef, ContentRecord>
+};
+
+export const makeContentsRecord: Immutable.RecordFactory<
+  ContentsRecordProps
+> = Immutable.Record({
+  byRef: Immutable.Map()
+});

--- a/packages/core/src/state/entities/contents/index.js
+++ b/packages/core/src/state/entities/contents/index.js
@@ -2,18 +2,29 @@
 import * as Immutable from "immutable";
 import type { ContentRef } from "../../refs";
 
-import type { NotebookContentRecord } from "./notebook";
-import type { DirectoryContentRecord } from "./directory";
-import type { DummyContentRecord } from "./dummy";
+import type {
+  NotebookContentRecord,
+  DocumentRecord as NotebookModel
+} from "./notebook";
+import type { DirectoryContentRecord, DirectoryModelRecord } from "./directory";
+import type { DummyContentRecord, EmptyModelRecord } from "./dummy";
+import type { FileContentRecord, FileModelRecord } from "./file";
 
 export * from "./notebook";
 export * from "./directory";
 export * from "./dummy";
+export * from "./file";
 
-// TODO: this will be a merger of notebook, directory, and file eventually.
+export type ContentModel =
+  | NotebookModel
+  | DirectoryModelRecord
+  | FileModelRecord
+  | EmptyModelRecord;
+
 export type ContentRecord =
   | NotebookContentRecord
   | DummyContentRecord
+  | FileContentRecord
   | DirectoryContentRecord;
 
 export type ContentsRecordProps = {

--- a/packages/core/src/state/entities/contents/notebook.js
+++ b/packages/core/src/state/entities/contents/notebook.js
@@ -1,9 +1,10 @@
 // @flow
 import * as Immutable from "immutable";
-import type { ContentRef } from "../refs";
+
 import { emptyNotebook } from "@nteract/commutable";
 
 export type DocumentRecordProps = {
+  type: "notebook",
   // TODO: This _needs_ to become a Record
   notebook: Immutable.Map<string, any>,
   savedNotebook: Immutable.Map<string, any>,
@@ -16,10 +17,10 @@ export type DocumentRecordProps = {
   cellFocused: any,
   copied: Immutable.Map<any, any>
 };
-
 export const makeDocumentRecord: Immutable.RecordFactory<
   DocumentRecordProps
 > = Immutable.Record({
+  type: "notebook",
   notebook: emptyNotebook,
   savedNotebook: emptyNotebook,
   transient: Immutable.Map({
@@ -30,7 +31,6 @@ export const makeDocumentRecord: Immutable.RecordFactory<
   cellFocused: null,
   copied: Immutable.Map()
 });
-
 export type DocumentRecord = Immutable.RecordOf<DocumentRecordProps>;
 
 export type NotebookContentRecordProps = {
@@ -42,24 +42,6 @@ export type NotebookContentRecordProps = {
   type: "notebook",
   writable: boolean
 };
-
-export type DummyContentRecordProps = {
-  type: "dummy",
-  lastSaved: null,
-  filepath: string,
-  model: Immutable.Map<string, any>
-};
-
-export const makeDummyContentRecord: Immutable.RecordFactory<
-  DummyContentRecordProps
-> = Immutable.Record({
-  type: "dummy",
-  lastSaved: null,
-  filepath: "",
-  model: Immutable.Map()
-});
-
-export type DummyContentRecord = Immutable.RecordOf<DummyContentRecordProps>;
 
 export const makeNotebookContentRecord: Immutable.RecordFactory<
   NotebookContentRecordProps
@@ -73,21 +55,6 @@ export const makeNotebookContentRecord: Immutable.RecordFactory<
   writable: true
 });
 
-export const makeContentRecord = makeNotebookContentRecord;
-
 export type NotebookContentRecord = Immutable.RecordOf<
   NotebookContentRecordProps
 >;
-
-// TODO: this will be a merger of notebook, directory, and file eventually.
-export type ContentRecord = NotebookContentRecord | DummyContentRecord; // || DirectoryContentRecord
-
-export type ContentsRecordProps = {
-  byRef: Immutable.Map<ContentRef, ContentRecord>
-};
-
-export const makeContentsRecord: Immutable.RecordFactory<
-  ContentsRecordProps
-> = Immutable.Record({
-  byRef: Immutable.Map()
-});

--- a/packages/core/src/state/entities/contents/notebook.js
+++ b/packages/core/src/state/entities/contents/notebook.js
@@ -34,6 +34,7 @@ export const makeDocumentRecord: Immutable.RecordFactory<
 export type DocumentRecord = Immutable.RecordOf<DocumentRecordProps>;
 
 export type NotebookContentRecordProps = {
+  mimetype: ?string,
   created: ?Date,
   format: "json",
   lastSaved: ?Date,
@@ -46,6 +47,7 @@ export type NotebookContentRecordProps = {
 export const makeNotebookContentRecord: Immutable.RecordFactory<
   NotebookContentRecordProps
 > = Immutable.Record({
+  mimetype: null,
   created: null,
   format: "json",
   lastSaved: null,

--- a/packages/core/src/state/entities/hosts.js
+++ b/packages/core/src/state/entities/hosts.js
@@ -3,6 +3,16 @@ import * as Immutable from "immutable";
 import type { HostId } from "../ids";
 import type { HostRef } from "../refs";
 
+export type EmptyHost = {
+  type: "empty"
+};
+export type EmptyHostRecord = Immutable.RecordOf<EmptyHost>;
+export const makeEmptyHostRecord: Immutable.RecordFactory<
+  EmptyHost
+> = Immutable.Record({
+  type: "empty"
+});
+
 export type BaseHostProps = {
   id: ?HostId,
   defaultKernelName: string
@@ -11,7 +21,8 @@ export type BaseHostProps = {
 export type JupyterHostRecordProps = BaseHostProps & {
   type: "jupyter",
   token: ?string,
-  serverUrl: ?string,
+  origin: string,
+  basePath: string,
   crossDomain: ?boolean
 };
 
@@ -22,34 +33,12 @@ export const makeJupyterHostRecord: Immutable.RecordFactory<
   id: null,
   defaultKernelName: "python",
   token: null,
-  serverUrl: null,
+  origin: location.origin,
+  basePath: "/",
   crossDomain: false
 });
 
 export type JupyterHostRecord = Immutable.RecordOf<JupyterHostRecordProps>;
-
-export type BinderHostRecordProps = BaseHostProps & {
-  // TODO: figure out if this belong here, it was brought over by play
-  type: "binder",
-  token: ?string,
-  serverUrl: ?string,
-  crossDomain: ?boolean,
-  messages: Immutable.List<string>
-};
-
-export const makeBinderHostRecord: Immutable.RecordFactory<
-  BinderHostRecordProps
-> = Immutable.Record({
-  type: "binder",
-  id: null,
-  defaultKernelName: "python",
-  token: null,
-  serverUrl: null,
-  crossDomain: false,
-  messages: Immutable.List()
-});
-
-export type BinderHostRecord = Immutable.RecordOf<BinderHostRecordProps>;
 
 export type LocalHostRecordProps = BaseHostProps & {
   type: "local"
@@ -65,11 +54,9 @@ export const makeLocalHostRecord: Immutable.RecordFactory<
 
 export type LocalHostRecord = Immutable.RecordOf<LocalHostRecordProps>;
 
-export type HostRecordProps =
-  | LocalHostRecordProps
-  | JupyterHostRecordProps
-  | BinderHostRecordProps;
-export type HostRecord = LocalHostRecord | JupyterHostRecord | BinderHostRecord;
+export type HostRecordProps = LocalHostRecordProps | JupyterHostRecordProps;
+
+export type HostRecord = LocalHostRecord | JupyterHostRecord | EmptyHostRecord;
 
 export type HostsRecordProps = {
   byRef: Immutable.Map<HostRef, HostRecord>,

--- a/packages/core/src/state/index.js
+++ b/packages/core/src/state/index.js
@@ -8,12 +8,14 @@ import type {
 } from "./entities";
 import type { ContentRef, KernelRef } from "./refs";
 import type {
+  HostRecord,
   LocalHostRecordProps,
   JupyterHostRecordProps
 } from "./entities/hosts";
 import type { Subject } from "rxjs/Subject";
+
 import { makeCommunicationRecord } from "./communication";
-import { makeEntitiesRecord } from "./entities";
+import { makeEntitiesRecord, makeEmptyHostRecord } from "./entities";
 
 export * from "./communication";
 export * from "./entities";
@@ -115,9 +117,7 @@ export const makeStateRecord: Immutable.RecordFactory<
 });
 
 export type AppRecordProps = {
-  host:
-    | ?Immutable.RecordOf<LocalHostRecordProps>
-    | ?Immutable.RecordOf<JupyterHostRecordProps>,
+  host: HostRecord,
   githubToken: ?string,
   notificationSystem: { addNotification: Function },
   isSaving: boolean,
@@ -131,7 +131,7 @@ export type AppRecordProps = {
 export const makeAppRecord: Immutable.RecordFactory<
   AppRecordProps
 > = Immutable.Record({
-  host: null,
+  host: makeEmptyHostRecord(),
   githubToken: null,
   notificationSystem: {
     addNotification: (msg: { level?: "error" | "warning" }) => {
@@ -156,12 +156,11 @@ export const makeAppRecord: Immutable.RecordFactory<
 });
 
 export type AppRecord = Immutable.RecordOf<AppRecordProps>;
-
 export type CoreRecord = Immutable.RecordOf<StateRecordProps>;
 
 export type AppState = {
-  app: Immutable.RecordOf<AppRecordProps>,
-  comms: Immutable.RecordOf<CommsRecordProps>,
+  app: AppRecord,
+  comms: CommsRecord,
   config: ConfigState,
   core: CoreRecord
 };


### PR DESCRIPTION
![directory-navigation](https://user-images.githubusercontent.com/836375/37691865-1d9da18e-2c72-11e8-9ec3-689dbca39b2f.gif)

Note: the above GIF I cut loading out to make it appear smoother. It's fully loading the entire app (including notebook stuff...) in development mode, so it loads really _slow_. 

* [x] Show directory listings in the jupyter extension
* [x] Navigate between directories, notebooks, and files
* [x] View files (in `<pre>` blocks, no editors yet)
* [x] Create records for files, directories, and our placeholder
* [x] Open notebooks in a new tab
* [x] Put mimetype field on `Contents` objects
* [x] Only render files we know we can render for sure
* [x] Replace inferred `*` types with explicit state
* [x] ~Comment on why we turn `config.contentsPath` set to `""` into `/`~ Relax rx-jupyter to allow contents path of `""`, as it reflects the actual contents API `""` is `"/"`
* [x] Rely on our themes in the directory components
* [ ] Unify the unknowables (`empty`, `dummy`, `unknown`, etc.)

Future PRs:

* Incorporate react router
* use `import("moduleName")` with webpack to only load components we need