### PR TITLE
[jext] cut plotly out of blocking assets

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -13,7 +13,6 @@ Distributed under the terms of the Modified BSD License.
   <title>{% block title %}{{page_title}}{% endblock %}</title>
 
   <link href="https://fonts.googleapis.com/css?family=Open+Sans|Source+Code+Pro|Source+Sans+Pro|Source+Serif+Pro" rel="stylesheet">
-  <script src="https://cdn.plot.ly/plotly-latest.min.js" type="text/javascript" charset="utf-8"></script>
 
   <script id="jupyter-config-data" type="application/json">{
     {% for key, value in page_config.items() -%}


### PR DESCRIPTION
If the network is slow, loading plotly can block loading the app. Since we're not using the plotly transform in the jupyter extension yet, I'd like to take it off the page (for now).