### PR TITLE
Font loader

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -114,7 +114,8 @@
     "ijavascript": "^5.0.17",
     "jmp": "^1.0.0",
     "mathjax-electron": "^2.0.1",
-    "nteract-assets": "^4.0.0"
+    "nteract-assets": "^4.0.0",
+    "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "@nteract/commutable": "^4.0.0",

--- a/applications/desktop/src/notebook/fonts.js
+++ b/applications/desktop/src/notebook/fonts.js
@@ -1,0 +1,16 @@
+// @flow
+
+const WebFont = require("webfontloader");
+const path = require("path");
+
+const assetPage = path.resolve(path.dirname(require.resolve("nteract-assets")));
+
+WebFont.load({
+  custom: {
+    families: ["Source Sans Pro", "Source Code Pro"],
+    urls: [
+      path.join(assetPage, "fonts", "source-sans-pro", "source-sans-pro.css"),
+      path.join(assetPage, "fonts", "source-code-pro", "source-code-pro.css")
+    ]
+  }
+});

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -4,6 +4,9 @@ import ReactDOM from "react-dom";
 import { ipcRenderer as ipc, remote } from "electron";
 import { Provider } from "react-redux";
 
+// Load the nteract fonts
+require("./fonts");
+
 import MathJax from "@nteract/mathjax";
 
 import { Map as ImmutableMap } from "immutable";

--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -2,8 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="../node_modules/nteract-assets/fonts/source-code-pro/source-code-pro.css" />
-    <link rel="stylesheet" href="../node_modules/nteract-assets/fonts/source-sans-pro/source-sans-pro.css" />
     <style>
     /* The following is an excerpt from normalize.css v7.0.0, MIT License */
     /*! normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */

--- a/applications/jupyter-extension/nteract_on_jupyter/app/fonts.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/fonts.js
@@ -1,0 +1,11 @@
+// @flow
+
+// TODO: There is the potential to have a Flash-of-Unstyled-Content since this is
+//       now async
+const WebFont = require("webfontloader");
+
+WebFont.load({
+  google: {
+    families: ["Source Sans Pro", "Source Serif Pro", "Source Code Pro"]
+  }
+});

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -13,6 +13,8 @@ import { Styles, actions, state } from "@nteract/core";
 
 import { default as Contents } from "./contents";
 
+import("./fonts");
+
 function createApp(store: *) {
   class App extends React.Component<*> {
     notificationSystem: NotificationSystem;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -13,7 +13,7 @@ import { Styles, actions, state } from "@nteract/core";
 
 import { default as Contents } from "./contents";
 
-import("./fonts");
+require("./fonts");
 
 function createApp(store: *) {
   class App extends React.Component<*> {

--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -12,8 +12,6 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title}}{% endblock %}</title>
 
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans|Source+Code+Pro|Source+Sans+Pro|Source+Serif+Pro" rel="stylesheet">
-
   <script id="jupyter-config-data" type="application/json">{
     {% for key, value in page_config.items() -%}
     "{{ key }}": "{{ value }}",

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -37,6 +37,7 @@
     "rxjs": "^5.5.6",
     "styled-jsx": "^2.2.5",
     "url-join": "^4.0.0",
+    "webfontloader": "^1.6.28",
     "webpack": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -208,5 +208,8 @@
     "xhr2": "*",
     "xmlhttprequest": "^1.8.0",
     "yargs": "^11.0.0"
+  },
+  "dependencies": {
+    "webfontloader": "^1.6.28"
   }
 }


### PR DESCRIPTION
Switch to using a font-loader instead of blocking page rendering. This will likely cause [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) on first load.