### PR TITLE
Sessions!

### DIFF
--- a/packages/core/__mocks__/rx-jupyter.js
+++ b/packages/core/__mocks__/rx-jupyter.js
@@ -54,5 +54,9 @@ module.exports = {
   },
   kernelspecs: {
     list: config => of({ response: mockListReponse })
+  },
+  sessions: {
+    create: (config, payload) =>
+      of({ response: { id: "1", kernel: { id: "0" } } })
   }
 };

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -20,7 +20,7 @@ import { from } from "rxjs/observable/from";
 import { merge } from "rxjs/observable/merge";
 import { empty } from "rxjs/observable/empty";
 
-import { kernels, shutdown } from "rx-jupyter";
+import { kernels, shutdown, sessions } from "rx-jupyter";
 import { v4 as uuid } from "uuid";
 
 import * as actions from "../actions";
@@ -44,18 +44,41 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
         // Dismiss any usage that isn't targeting a jupyter server
         return empty();
       }
-      const config = selectors.serverConfig(host);
+      const serverConfig = selectors.serverConfig(host);
 
-      const { payload: { kernelSpecName, cwd, kernelRef } } = action;
+      const {
+        payload: { kernelSpecName, cwd, kernelRef, contentRef }
+      } = action;
 
-      return kernels.start(config, kernelSpecName, cwd).pipe(
+      const content = selectors.content(state, { contentRef });
+      if (!content || content.type !== "notebook") {
+        return empty();
+      }
+
+      // TODO: Create a START_SESSION action instead (?)
+      const sessionPayload = {
+        kernel: {
+          id: null,
+          name: kernelSpecName
+        },
+        name: "",
+        path: content.filepath,
+        type: "notebook"
+      };
+
+      // TODO: Handle failure cases here
+      return sessions.create(serverConfig, sessionPayload).pipe(
         mergeMap(data => {
-          const session = uuid();
+          const session = data.response;
 
-          const kernel = Object.assign({}, data.response, {
+          const kernel = Object.assign({}, session.kernel, {
             type: "websocket",
             cwd,
-            channels: kernels.connect(config, data.response.id, session),
+            channels: kernels.connect(
+              serverConfig,
+              session.kernel.id,
+              session.id
+            ),
             kernelSpecName
           });
 
@@ -130,6 +153,7 @@ export const interruptKernelEpic = (action$: *, store: *) =>
   );
 
 export const killKernelEpic = (action$: *, store: *) =>
+  // TODO: Use the sessions API for this
   action$.pipe(
     ofType(actionTypes.KILL_KERNEL),
     // This epic can only interrupt kernels on jupyter websockets

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -26,6 +26,7 @@ import { v4 as uuid } from "uuid";
 import * as actions from "../actions";
 import * as selectors from "../selectors";
 import * as actionTypes from "../actionTypes";
+import { castToSessionId } from "../state/ids";
 
 import { executeRequest, kernelInfoRequest } from "@nteract/messaging";
 
@@ -71,13 +72,15 @@ export const launchWebSocketKernelEpic = (action$: *, store: *) =>
         mergeMap(data => {
           const session = data.response;
 
+          const sessionId = castToSessionId(session.id);
+
           const kernel = Object.assign({}, session.kernel, {
             type: "websocket",
             cwd,
             channels: kernels.connect(
               serverConfig,
               session.kernel.id,
-              session.id
+              sessionId
             ),
             kernelSpecName
           });

--- a/packages/core/src/state/entities/kernels.js
+++ b/packages/core/src/state/entities/kernels.js
@@ -2,7 +2,7 @@
 import * as Immutable from "immutable";
 import type { ChildProcess } from "child_process";
 import type { HostRef, KernelRef } from "../refs";
-import type { KernelId } from "../ids";
+import type { KernelId, SessionId } from "../ids";
 import { Subject } from "rxjs/Subject";
 
 export type LocalKernelProps = {
@@ -51,6 +51,7 @@ export type RemoteKernelProps = {
   //   shutting down, not connected.
   status: ?string,
   type: "websocket",
+  sessionId: ?SessionId,
   id: ?KernelId
 };
 
@@ -64,6 +65,7 @@ export const makeRemoteKernelRecord: Immutable.RecordFactory<
   hostRef: null,
   lastActivity: null,
   channels: new Subject(),
+  sessionId: null,
   status: null
 });
 

--- a/packages/core/src/state/ids.js
+++ b/packages/core/src/state/ids.js
@@ -9,6 +9,8 @@
 
 export opaque type HostId: string = string;
 export opaque type KernelId: string = string;
+export opaque type SessionId: string = string;
 
 export const castToHostId = (id: string): HostId => id;
 export const castToKernelId = (id: string): KernelId => id;
+export const castToSessionId = (id: string): SessionId => id;

--- a/packages/rx-jupyter/src/sessions.js
+++ b/packages/rx-jupyter/src/sessions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { ajax } from "rxjs/observable/dom/ajax";
-import Observable from "rxjs/Observable";
 
 import { createAJAXSettings } from "./base";
 
@@ -14,7 +13,7 @@ import { createAJAXSettings } from "./base";
  *
  * @return  {Object}  An Observable with the request response
  */
-export function list(serverConfig: Object): Observable<*> {
+export function list(serverConfig: Object): rxjs$Observable<*> {
   return ajax(createAJAXSettings(serverConfig, "/api/sessions"));
 }
 
@@ -27,7 +26,10 @@ export function list(serverConfig: Object): Observable<*> {
  *
  * @return  {Object}  An Observable with the request/response
  */
-export function get(serverConfig: Object, sessionID: string): Observable<*> {
+export function get(
+  serverConfig: Object,
+  sessionID: string
+): rxjs$Observable<*> {
   return ajax(createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`));
 }
 
@@ -43,7 +45,7 @@ export function get(serverConfig: Object, sessionID: string): Observable<*> {
 export function destroy(
   serverConfig: Object,
   sessionID: string
-): Observable<*> {
+): rxjs$Observable<*> {
   return ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
       method: "DELETE"
@@ -67,7 +69,7 @@ export function update(
   serverConfig: Object,
   sessionID: string,
   body: Object
-): Observable<*> {
+): rxjs$Observable<*> {
   return ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
       method: "PATCH",
@@ -89,7 +91,7 @@ export function update(
  *
  * @return {Object} - An Observable with the request/response
  */
-export function create(serverConfig: Object, body: Object): Observable<*> {
+export function create(serverConfig: Object, body: Object): rxjs$Observable<*> {
   return ajax(
     createAJAXSettings(serverConfig, "/api/sessions", {
       method: "POST",


### PR DESCRIPTION
Introduce the concept of sessions. Definitely a work in progress here.

* [x] Track session ID inside the Remote kernel object (?)
  * We put the session ID in the contents records in our plan document, whereas when we say to kill a kernel we pass the kernelRef onward
* [x] Creating a kernel should be done via the session API
* [x] Stopping a kernel should be done by `DELETE`ing a session
* [x] Ensure restart works properly