### PR TITLE
(fix): sort file>new by kernel display_name

### DIFF
--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -231,10 +231,12 @@ export function loadFullMenu(store: * = global.store) {
     generateSubMenu
   );
 
-  const newNotebookItems = Object.keys(kernelSpecs).map(kernelSpecName => ({
-    label: kernelSpecs[kernelSpecName].spec.display_name,
-    click: () => launchNewNotebook(kernelSpecs[kernelSpecName])
-  }));
+  const newNotebookItems = sortBy(kernelSpecs, "spec.display_name").map(
+    kernel => ({
+      label: kernel.spec.display_name,
+      click: () => launchNewNotebook(kernel)
+    })
+  );
 
   const fileSubMenus = {
     new: {


### PR DESCRIPTION
Not sure how I missed this when I PR'd for runtime>kernel sort. The code is top of each other :laughing: 

Sorting file>new the same way runtime>kernels are sorted