### PR TITLE
fill origin in as empty string when server side

### DIFF
--- a/packages/core/src/state/entities/hosts.js
+++ b/packages/core/src/state/entities/hosts.js
@@ -33,7 +33,7 @@ export const makeJupyterHostRecord: Immutable.RecordFactory<
   id: null,
   defaultKernelName: "python",
   token: null,
-  origin: location.origin,
+  origin: typeof location === "undefined" ? "" : location.origin,
   basePath: "/",
   crossDomain: false
 });

--- a/packages/webpack-configurator/index.js
+++ b/packages/webpack-configurator/index.js
@@ -58,6 +58,17 @@ function nextWebpack(
   config /*: WebpackConfig */,
   options /*: ?NextWebPackOptions */
 ) /*: WebpackConfig */ {
+  config.module.rules = config.module.rules.map(rule => {
+    if (
+      rule.test.source.includes("js") &&
+      typeof rule.exclude !== "undefined"
+    ) {
+      rule.exclude = exclude;
+    }
+
+    return rule;
+  });
+
   config.module.rules.push({
     test: /\.js$/,
     exclude: exclude,


### PR DESCRIPTION
This was breaking commuter on master. On a separate note, we really need to start splitting core into more packages, like having the presentational ui components separate (as commuter doesn't need to `require` these -- it happens by virtue of importing from `@nteract/core`).