### PR TITLE
Fix run spawn:debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "app:jupyter-extension": "lerna run dev --scope nteract-on-jupyter --stream",
     "start": "npm run app:desktop",
     "spawn": "lerna run spawn --scope nteract",
+    "spawn:debug": "lerna run spawn:debug --scope nteract",
     "showcase": "lerna run dev --scope @nteract/showcase --stream",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
Noticed this wasn't working when run from the monorepo root the way `npm run spawn` does.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
