### PR TITLE
redirect to notebook if window.open failed

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
@@ -180,7 +180,13 @@ class Contents extends React.Component<ContentsProps, null> {
           );
 
           // Always open new notebooks in new windows
-          window.open(url, "_blank");
+          const win = window.open(url, "_blank");
+
+          // If they block pop-ups, then we weren't allowed to open the window
+          if (win === null) {
+            // TODO: Show a link at the top to let the user open the notebook directly
+            window.location = url;
+          }
         })
       )
       .subscribe();


### PR DESCRIPTION
On Safari, pop-ups are all-or-nothing. We need a better UI for when popups are disabled (a top bar?). For now, I've set our new notebook nav on the web app to just redirect when `window.open` fails.