### PR TITLE
allow configuring a remote for js assets and GA

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/config.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/config.py
@@ -1,6 +1,7 @@
 from traitlets import HasTraits, Unicode, Bool
+from traitlets.config import Configurable
 
-class Config(HasTraits):
+class NteractConfig(Configurable):
     """The nteract application configuration object
     """
     name = Unicode('nteract',
@@ -20,3 +21,11 @@ class Config(HasTraits):
 
     dev_mode = Bool(False,
         help='Whether the application is in dev mode')
+
+    asset_url = Unicode('',
+        config=True,
+        help='Remote URL for loading assets')
+
+    ga_code = Unicode('',
+        config=True,
+        help="Google Analytics tracking code")

--- a/applications/jupyter-extension/nteract_on_jupyter/extension.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/extension.py
@@ -11,7 +11,7 @@ from jupyter_core.paths import ENV_JUPYTER_PATH, jupyter_config_path
 
 from ._version import __version__
 
-from .config import Config
+from .config import NteractConfig
 
 from .handlers import add_handlers
 
@@ -27,7 +27,7 @@ def get_app_dir(app_dir=None):
 def load_jupyter_server_extension(nbapp):
     """Load the JupyterLab server extension.
     """
-    # Print messages.
+
     here = os.path.dirname(__file__)
     nbapp.log.info('nteract extension loaded from %s' % here)
 
@@ -38,7 +38,7 @@ def load_jupyter_server_extension(nbapp):
     app_dir = here  # bundle is part of the python package
 
     web_app = nbapp.web_app
-    config = Config()
+    config = NteractConfig(parent=nbapp)
 
     # original
     # config.assets_dir = os.path.join(app_dir, 'static')
@@ -60,5 +60,10 @@ def load_jupyter_server_extension(nbapp):
 
     web_app.settings.setdefault('page_config_data', dict())
     web_app.settings['page_config_data']['token'] = nbapp.token
+    web_app.settings['page_config_data']['ga_code'] = config.ga_code
+    web_app.settings['page_config_data']['asset_url'] = config.asset_url
+
+    web_app.settings['nteract_config'] = config
+
 
     add_handlers(web_app, config)

--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -38,6 +38,9 @@ class NAppHandler(IPythonHandler):
         base_url = self.settings['base_url']
         url = ujoin(base_url, config.page_url, '/static/')
 
+
+
+
         # Handle page config data.
         page_config = dict()
         page_config.update(self.settings.get('page_config_data', {}))
@@ -47,7 +50,18 @@ class NAppHandler(IPythonHandler):
         mathjax_config = self.settings.get('mathjax_config',
                                            'TeX-AMS_HTML-full,Safe')
 
+        asset_url = config.asset_url
+        
+        if asset_url is "":
+            asset_url = base_url
+
+        # Ensure there's a trailing slash
+        if not asset_url.endswith('/'):
+            asset_url = asset_url + '/'
+
         config = dict(
+            ga_code=config.ga_code,
+            asset_url=asset_url,
             page_title=config.page_title,
             mathjax_url=self.mathjax_url,
             mathjax_config=mathjax_config,

--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -53,6 +53,20 @@ Distributed under the terms of the Modified BSD License.
 
 <body>
 
+{% if ga_code %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ga_code}}"></script>
+<script>
+window.dataLayer = window.dataLayer || [];
+function gtag() {
+  dataLayer.push(arguments);
+}
+gtag("js", new Date());
+
+gtag("config", "{{ga_code}}");
+</script>
+{% endif %}
+
 <script type="text/javascript">
 function _remove_token_from_url() {
   if (window.location.search.length <= 1) {
@@ -83,8 +97,8 @@ _remove_token_from_url();
 <div id="root">
 </div>
 
-<script src="{{ base_url }}nteract/static/lib/vendor.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{ base_url }}nteract/static/lib/app.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{ asset_url }}nteract/static/lib/vendor.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{ asset_url }}nteract/static/lib/app.js" type="text/javascript" charset="utf-8"></script>
 
 
 </body>


### PR DESCRIPTION
This allows for simple configuration of:

* Setting a Google Analytics tracking code
* Pulling the JavaScript for the nteract web app from a remote server

For testing I deployed https://yup-jyusaxdvps.now.sh/ which just has

```
.
└── nteract
    └── static
        └── lib
            ├── app.js
            ├── app.js.map
            ├── vendor.js
            └── vendor.js.map
```

/cc @yuvipanda 

Admittedly, I was only going to do asset url here then realized I'd have an easier time figuring out configuration with only google analytics at first.