### PR TITLE
render <kbd> kinda like a keyboard key

### DIFF
--- a/packages/core/src/components/presentational.js
+++ b/packages/core/src/components/presentational.js
@@ -98,6 +98,16 @@ export class Outputs extends React.Component<OutputsProps> {
               max-width: 100%;
             }
 
+            .outputs :global(kbd) {
+              display: inline-block;
+              border: 1px solid #ccc;
+              border-radius: 4px;
+              padding: 0.1em 0.5em;
+              margin: 0 0.2em;
+              box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
+              background-color: #f7f7f7;
+            }
+
             .outputs :global(table) {
               border-collapse: collapse;
             }


### PR DESCRIPTION
Added some `<kbd>` style since the default looks like a `pre` block.

<img width="779" alt="screen shot 2018-04-12 at 12 17 35 pm" src="https://user-images.githubusercontent.com/836375/38698983-a6765592-3e4b-11e8-96ac-1078985723f5.png">

🎉 ⌨️ 