### PR TITLE
auto save files and notebooks for the user

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -25,7 +25,12 @@ describe("saveEpic", () => {
     // TODO: This should be testing that the mocks for fs were called with the
     // filename and notebook from the state tree
 
-    expect(responses).toEqual([actions.saveFulfilled({ contentRef })]);
+    expect(responses).toEqual([
+      actions.saveFulfilled({
+        contentRef,
+        model: { last_modified: expect.any(Date) }
+      })
+    ]);
   });
 });
 

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -58,7 +58,10 @@ export function saveEpic(
             });
           }
           return actions.saveFulfilled({
-            contentRef: action.payload.contentRef
+            contentRef: action.payload.contentRef,
+            model: {
+              last_modified: new Date()
+            }
           });
         }),
         catchError((error: Error) =>

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
@@ -95,11 +95,6 @@ const mapDispatchToTextFileProps = (dispatch, ownProps) => ({
         contentRef: ownProps.contentRef
       })
     );
-    dispatch(
-      actions.save({
-        contentRef: ownProps.contentRef
-      })
-    );
   }
 });
 

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -613,7 +613,11 @@ export type SaveFailed = {
 export const SAVE_FULFILLED = "SAVE_FULFILLED";
 export type SaveFulfilled = {
   type: "SAVE_FULFILLED",
-  payload: { contentRef: ContentRef }
+  payload: {
+    contentRef: ContentRef,
+    // Literal response from contents API, for use with
+    model: any
+  }
 };
 
 export const NEW_NOTEBOOK = "NEW_NOTEBOOK";

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -778,7 +778,8 @@ export function saveFailed(payload: {
 }
 
 export function saveFulfilled(payload: {
-  contentRef: ContentRef
+  contentRef: ContentRef,
+  model: any
 }): actionTypes.SaveFulfilled {
   return {
     type: actionTypes.SAVE_FULFILLED,

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -24,7 +24,11 @@ import {
 
 import { fetchKernelspecsEpic } from "./kernelspecs";
 
-import { fetchContentEpic, saveContentEpic } from "./contents";
+import {
+  fetchContentEpic,
+  saveContentEpic,
+  autoSaveCurrentContentEpic
+} from "./contents";
 
 // Because `@nteract/core` ends up being a commonjs import, we can't currently
 // rely on `import { epics } from ""@nteract/core"`
@@ -44,7 +48,8 @@ const allEpics = [
   restartKernelEpic,
   fetchKernelspecsEpic,
   fetchContentEpic,
-  saveContentEpic
+  saveContentEpic,
+  autoSaveCurrentContentEpic
 ];
 
 export {
@@ -63,5 +68,6 @@ export {
   restartKernelEpic,
   fetchKernelspecsEpic,
   fetchContentEpic,
-  saveContentEpic
+  saveContentEpic,
+  autoSaveCurrentContentEpic
 };


### PR DESCRIPTION
Saves files and notebooks every 7 seconds.

NOTE: This is only provided for the jupyter extension at the moment, not the desktop app.

TODO and TODONE:

* [x] Create an autosaving epic
* [x] Don't save over files that have been saved elsewhere
* [x] Ensure that saved files get updated last_modified
* [x] Remove current save on file change behavior in the editor