### PR TITLE
upgrade vega embed and tear out d3

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "codemirror": "5.37.0",
     "cross-env": "^5.1.3",
     "css-loader": "^0.28.10",
-    "d3": "^3.5.17",
     "d3-dsv": "^1.0.7",
     "d3-time-format": "^2.0.5",
     "date-fns": "^1.29.0",

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -21,9 +21,8 @@
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-vega",
   "dependencies": {
     "@nteract/vega-embed2": "^1.0.1",
-    "d3": "^3.5.17",
     "lodash": "^4.17.4",
-    "vega-embed": "^3.0.0-rc7"
+    "vega-embed": "^3.7.0"
   },
   "peerDependencies": {
     "react": "^16.2.0"


### PR DESCRIPTION
Since we're no longer using d3 directly in our codebase, I've taken the liberty of ripping out the direct dependency while also upgrading vega-embed (which does use it under the covers).

We were facing an issue with some vega charts not rendering right. I finally noticed we were on a release candidate of the newer vega embed. This fixes up the examples that weren't working well. I'll plan to get a release out for this in the next few days.

Fixes #2694 