### PR TITLE
clean out unneccessary webpack bits

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -40,13 +40,6 @@ module.exports = {
     new webpack.DefinePlugin({
       "process.env.ASSET_PATH": JSON.stringify(ASSET_PATH)
     }),
-    new webpack.HashedModuleIdsPlugin(),
-
-    new webpack.IgnorePlugin(/\.(css|less)$/),
-
-    new webpack.SourceMapDevToolPlugin({
-      filename: "[name].js.map",
-      exclude: ["vendor.js"]
-    })
+    new webpack.IgnorePlugin(/\.(css|less)$/)
   ]
 };

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = {
     alias: configurator.mergeDefaultAliases()
   },
   plugins: [
+    new LodashModuleReplacementPlugin(),
     new webpack.DefinePlugin({
       "process.env.ASSET_PATH": JSON.stringify(ASSET_PATH)
     }),


### PR DESCRIPTION
We've got `devtool` set above using webpack 4 default goodness. We also had lodash's webpack module available -- time to incoporate it again.