### PR TITLE
ES transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ packages/*/yarn.lock
 .next
 
 .DS_Store
+
+# allow generated flow defs to be read like other @nteract packages for our styles
+packages/styles/src/index.js

--- a/packages/ansi-to-react/__tests__/index-spec.js
+++ b/packages/ansi-to-react/__tests__/index-spec.js
@@ -1,8 +1,6 @@
-const Ansi = require("../src/index");
-const React = require("react");
-const enzyme = require("enzyme");
-
-import { configure } from "enzyme";
+import Ansi from "../src/index";
+import * as React from "react";
+import { configure, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 
 configure({ adapter: new Adapter() });
@@ -13,13 +11,13 @@ const RESET = "\u001b[0;m";
 
 describe("Ansi", () => {
   test("hello world", () => {
-    const el = enzyme.shallow(React.createElement(Ansi, null, "hello world"));
+    const el = shallow(React.createElement(Ansi, null, "hello world"));
     expect(el).not.toBeNull();
     expect(el.text()).toBe("hello world");
   });
 
   test("can color", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(Ansi, null, `hello ${GREEN_FG}world`)
     );
     expect(el).not.toBeNull();
@@ -30,7 +28,7 @@ describe("Ansi", () => {
   });
 
   test("can have className", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(Ansi, { className: "my-class" }, `hello world`)
     );
     expect(el).not.toBeNull();
@@ -41,7 +39,7 @@ describe("Ansi", () => {
   });
 
   test("can nest", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(
         Ansi,
         null,
@@ -56,7 +54,7 @@ describe("Ansi", () => {
   });
 
   test("can handle carriage symbol", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(
         Ansi,
         null,
@@ -68,7 +66,7 @@ describe("Ansi", () => {
   });
 
   test("can linkify", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(
         Ansi,
         { linkify: true },
@@ -83,7 +81,7 @@ describe("Ansi", () => {
   });
 
   test("can distinguish URL-ish text", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(
         Ansi,
         { linkify: true },
@@ -95,7 +93,7 @@ describe("Ansi", () => {
   });
 
   test("can distinguish URL-ish text", () => {
-    const el = enzyme.shallow(
+    const el = shallow(
       React.createElement(
         Ansi,
         { linkify: true },

--- a/packages/ansi-to-react/src/index.js
+++ b/packages/ansi-to-react/src/index.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-const React = require("react");
-const Anser = require("anser");
-const escapeCarriageReturn = require("escape-carriage");
+import * as React from "react";
+import { ansiToJson } from "anser";
+import { escapeCarriageReturn } from "escape-carriage";
 
 /**
  * ansiToJson
@@ -15,7 +15,7 @@ const escapeCarriageReturn = require("escape-carriage");
  */
 function ansiToJSON(input) {
   input = escapeCarriageReturn(input);
-  return Anser.ansiToJson(input, {
+  return ansiToJson(input, {
     json: true,
     remove_empty: true
   });
@@ -79,7 +79,7 @@ function inlineBundleToReact(bundle, key) {
 }
 
 type Props = {
-  children?: React.Node,
+  children: React.Node,
   className?: string,
   linkify?: boolean
 };
@@ -96,4 +96,4 @@ function Ansi(props: Props) {
   );
 }
 
-module.exports = Ansi;
+export default Ansi;

--- a/packages/commutable/index.js
+++ b/packages/commutable/index.js
@@ -1,1 +1,0 @@
-module.exports = require("./lib");

--- a/packages/commutable/src/index.js
+++ b/packages/commutable/src/index.js
@@ -125,23 +125,24 @@ function stringifyNotebook(notebook: v4Notebook): string {
   return JSON.stringify(notebook, null, 2);
 }
 
-module.exports = {
+const createImmutableOutput = v4.createImmutableOutput;
+const createImmutableMimeBundle = v4.createImmutableMimeBundle;
+
+export {
   emptyCodeCell,
   emptyMarkdownCell,
   emptyNotebook,
   monocellNotebook,
   toJS,
   fromJS,
-
   createCodeCell,
   parseNotebook,
   stringifyNotebook,
-
   insertCellAt,
   insertCellAfter,
   removeCell,
   appendCell,
   appendCellToNotebook,
-  createImmutableOutput: v4.createImmutableOutput,
-  createImmutableMimeBundle: v4.createImmutableMimeBundle
+  createImmutableOutput,
+  createImmutableMimeBundle
 };

--- a/packages/commutable/src/structures.js
+++ b/packages/commutable/src/structures.js
@@ -56,22 +56,24 @@ const defaultMarkdownCell = Object.freeze({
   source: ""
 });
 
-function createCodeCell(cell: CodeCell = defaultCodeCell): ImmutableCodeCell {
+export function createCodeCell(
+  cell: CodeCell = defaultCodeCell
+): ImmutableCodeCell {
   // $FlowFixMe: Immutable
   return Immutable.Map(cell);
 }
 
-function createMarkdownCell(
+export function createMarkdownCell(
   cell: MarkdownCell = defaultMarkdownCell
 ): ImmutableMarkdownCell {
   // $FlowFixMe: Immutable
   return Immutable.Map(cell);
 }
 
-const emptyCodeCell = createCodeCell();
-const emptyMarkdownCell = createMarkdownCell();
+export const emptyCodeCell = createCodeCell();
+export const emptyMarkdownCell = createMarkdownCell();
 
-const defaultNotebook = Object.freeze({
+export const defaultNotebook = Object.freeze({
   nbformat: 4,
   nbformat_minor: 4,
   metadata: new Immutable.Map(),
@@ -79,14 +81,14 @@ const defaultNotebook = Object.freeze({
   cellMap: new Immutable.Map()
 });
 
-function createNotebook(
+export function createNotebook(
   notebook: Notebook = defaultNotebook
 ): ImmutableNotebook {
   // $FlowFixMe: Immutable
   return Immutable.Map(notebook);
 }
 
-const emptyNotebook = createNotebook();
+export const emptyNotebook = createNotebook();
 
 export type CellStructure = {
   cellOrder: ImmutableCellOrder,
@@ -94,7 +96,7 @@ export type CellStructure = {
 };
 
 // Intended to make it easy to use this with (temporary mutable cellOrder + cellMap)
-function appendCell(
+export function appendCell(
   cellStructure: CellStructure,
   immutableCell: ImmutableCell,
   id: string = uuidv4()
@@ -105,7 +107,7 @@ function appendCell(
   };
 }
 
-function appendCellToNotebook(
+export function appendCellToNotebook(
   immnb: ImmutableNotebook,
   immCell: ImmutableCell
 ): ImmutableNotebook {
@@ -121,7 +123,7 @@ function appendCellToNotebook(
   });
 }
 
-function insertCellAt(
+export function insertCellAt(
   notebook: ImmutableNotebook,
   cell: ImmutableCell,
   cellID: string,
@@ -135,7 +137,7 @@ function insertCellAt(
   );
 }
 
-function insertCellAfter(
+export function insertCellAfter(
   notebook: ImmutableNotebook,
   cell: ImmutableCell,
   cellID: string,
@@ -150,7 +152,7 @@ function insertCellAfter(
   );
 }
 
-function removeCell(notebook: ImmutableNotebook, cellID: string) {
+export function removeCell(notebook: ImmutableNotebook, cellID: string) {
   return notebook
     .removeIn(["cellMap", cellID])
     .update("cellOrder", (cellOrder: ImmutableCellOrder) =>
@@ -158,21 +160,7 @@ function removeCell(notebook: ImmutableNotebook, cellID: string) {
     );
 }
 
-const monocellNotebook = appendCellToNotebook(emptyNotebook, emptyCodeCell);
-
-module.exports = {
-  emptyCodeCell,
-  emptyMarkdownCell,
+export const monocellNotebook = appendCellToNotebook(
   emptyNotebook,
-  monocellNotebook,
-
-  createCodeCell,
-  createMarkdownCell,
-  createNotebook,
-
-  removeCell,
-  insertCellAfter,
-  insertCellAt,
-  appendCellToNotebook,
-  appendCell
-};
+  emptyCodeCell
+);

--- a/packages/display-area/__tests__/output-spec.js
+++ b/packages/display-area/__tests__/output-spec.js
@@ -1,11 +1,10 @@
-import React from "react";
+import * as React from "react";
 
 import { shallow } from "enzyme";
 
 import Output from "../src/output";
 import RichestMime from "../src/richest-mime";
-
-const Ansi = require("ansi-to-react");
+import Ansi from "ansi-to-react";
 
 describe("Output", () => {
   it("handles display data", () => {

--- a/packages/display-area/src/index.js
+++ b/packages/display-area/src/index.js
@@ -3,8 +3,4 @@ import Display from "./display";
 import RichestMime from "./richest-mime";
 import Output from "./output";
 
-module.exports = {
-  Display,
-  RichestMime,
-  Output
-};
+export { Display, RichestMime, Output };

--- a/packages/markdown/__tests__/remark-math-spec.js
+++ b/packages/markdown/__tests__/remark-math-spec.js
@@ -1,9 +1,8 @@
-const math = require("../src/remark-math");
-
-const unified = require("unified");
-const parse = require("remark-parse");
-const stringify = require("remark-stringify");
-const u = require("unist-builder");
+import math from "../src/remark-math";
+import unified from "unified";
+import parse from "remark-parse";
+import stringify from "remark-stringify";
+import u from "unist-builder";
 
 function remark() {
   return unified()

--- a/packages/markdown/src/remark-math/block.js
+++ b/packages/markdown/src/remark-math/block.js
@@ -1,5 +1,5 @@
 // @flow
-var trim = require("trim-trailing-lines");
+import trim from "trim-trailing-lines";
 
 var C_NEWLINE = "\n";
 var C_TAB = "\t";
@@ -9,7 +9,7 @@ var C_DOLLAR = "$";
 var MIN_FENCE_COUNT = 2;
 var CODE_INDENT_COUNT = 4;
 
-module.exports = function blockPlugin(opts: Object) {
+export function blockPlugin(opts: Object) {
   function blockTokenizer(eat, value, silent) {
     var length = value.length + 1;
     var index = 0;
@@ -225,4 +225,6 @@ module.exports = function blockPlugin(opts: Object) {
       return "$$\n" + node.value + "\n$$";
     };
   }
-};
+}
+
+export default blockPlugin;

--- a/packages/markdown/src/remark-math/index.js
+++ b/packages/markdown/src/remark-math/index.js
@@ -1,9 +1,11 @@
 // @flow
 
-const inlinePlugin = require("./inline");
-const blockPlugin = require("./block");
+import inlinePlugin from "./inline.js";
+import blockPlugin from "./block.js";
 
-module.exports = function mathPlugin(opts: Object = {}) {
+export function mathPlugin(opts: Object = {}) {
   blockPlugin.call(this, opts);
   inlinePlugin.call(this, opts);
-};
+}
+
+export default mathPlugin;

--- a/packages/markdown/src/remark-math/inline.js
+++ b/packages/markdown/src/remark-math/inline.js
@@ -8,7 +8,7 @@ const ESCAPED_INLINE_MATH = /^\\\$/;
 const INLINE_MATH = /^\$((?:\\\$|[^$])+)\$/;
 const INLINE_MATH_DOUBLE = /^\$\$((?:\\\$|[^$])+)\$\$/;
 
-module.exports = function inlinePlugin(opts: Object) {
+export function inlinePlugin(opts: Object) {
   function inlineTokenizer(eat, value, silent) {
     let isDouble = true;
     let match = INLINE_MATH_DOUBLE.exec(value);
@@ -110,4 +110,6 @@ module.exports = function inlinePlugin(opts: Object) {
       return "$" + node.value + "$";
     };
   }
-};
+}
+
+export default inlinePlugin;

--- a/packages/mathjax/src/load-script.js
+++ b/packages/mathjax/src/load-script.js
@@ -20,7 +20,7 @@ const defaultOptions = {
   attrs: undefined
 };
 
-function load(src: string, opts: ?Options | ?Callback, cb: ?Callback) {
+export function load(src: string, opts: ?Options | ?Callback, cb: ?Callback) {
   var head = document.head || document.getElementsByTagName("head")[0];
   var script = document.createElement("script");
 
@@ -85,4 +85,4 @@ function ieOnEnd(script, cb: Callback) {
   };
 }
 
-module.exports = load;
+export default load;

--- a/packages/presentational-components/src/syntax-highlighter/theme.js
+++ b/packages/presentational-components/src/syntax-highlighter/theme.js
@@ -1,5 +1,6 @@
 // @flow
-module.exports = {
+
+export default {
   hljs: {
     display: "block",
     overflowX: "auto",

--- a/packages/presentational-components/src/themes/dark.js
+++ b/packages/presentational-components/src/themes/dark.js
@@ -1,5 +1,5 @@
 // @flow
-module.exports = `
+export default `
 
   --theme-app-bg: #2b2b2b;
   --theme-app-fg: var(--nt-color-midnight-lightest);

--- a/packages/presentational-components/src/themes/index.js
+++ b/packages/presentational-components/src/themes/index.js
@@ -1,8 +1,5 @@
 // @flow
-const dark = require("./dark");
-const light = require("./light");
+import dark from "./dark.js";
+import light from "./light.js";
 
-module.exports = {
-  dark,
-  light
-};
+export { dark, light };

--- a/packages/presentational-components/src/themes/light.js
+++ b/packages/presentational-components/src/themes/light.js
@@ -6,7 +6,7 @@
  * Every thing below is more component specific. They should attempt to reuse
  * the general styles above as much as possible.
  */
-module.exports = `
+export default `
 
   --theme-app-bg: white;
   --theme-app-fg: var(--nt-color-midnight);

--- a/packages/rx-binder/src/index.js
+++ b/packages/rx-binder/src/index.js
@@ -21,7 +21,7 @@ type BinderOptions = {
 }
 */
 
-function formBinderURL({
+export function formBinderURL({
   repo = "jupyter/notebook",
   ref = "master",
   binderURL = mybinderURL
@@ -43,7 +43,7 @@ const eventSourceFallback =
         );
       };
 
-function binder(
+export function binder(
   options /*: BinderOptions */,
   /** Allow overriding EventSource for testing and ponyfilling **/
   EventSourceDI /* :* */ = eventSourceFallback
@@ -91,8 +91,3 @@ function binder(
     };
   });
 }
-
-module.exports = {
-  formBinderURL,
-  binder
-};

--- a/packages/styles/buildStyles.js
+++ b/packages/styles/buildStyles.js
@@ -5,6 +5,7 @@ const path = require("path");
 
 const BUILD_DIR = path.join(__dirname, "build");
 const CSS_PATH = path.join(BUILD_DIR, "index.js");
+const FLOW_PATH = path.join("src", "index.js");
 const DECLARATIONS_PATH = path.join(BUILD_DIR, "declarations.json");
 const VARIABLES_PATH = path.join(BUILD_DIR, "variables.json");
 
@@ -86,22 +87,22 @@ if (!fs.existsSync(BUILD_DIR)) {
   fs.mkdirSync(BUILD_DIR);
 }
 
-fs.writeFileSync(CSS_PATH, '"use strict";\n\n');
-
-// Generate themeable css. Overwrite the whole file for the first write.
-[
-  "// This file is auto-generated. See buildStyles.js for details.\n\n",
+const lines = [
+  "// @flow",
+  "// This file is auto-generated. See buildStyles.js for details.",
   // Ensure this ends up as an es module for nice webpack usage
-  'Object.defineProperty(exports, "__esModule", {\n',
-  "  value: true\n",
-  "});\n"
-].map(line => fs.appendFileSync(CSS_PATH, line));
+  "export default `",
+  ":root {"
+].concat(
+  // Generated CSS from our config
+  lodash
+    .toPairs(declarations)
+    .map(([cssProperty, cssValue]) => `  ${cssProperty}: ${cssValue};`),
+  ["}", "`;"]
+);
 
-fs.appendFileSync(CSS_PATH, "exports.default = `\n:root {\n");
-lodash.toPairs(declarations).forEach(([cssProperty, cssValue]) => {
-  fs.appendFileSync(CSS_PATH, `  ${cssProperty}: ${cssValue};\n`);
-});
-fs.appendFileSync(CSS_PATH, "}\n`;\n");
+fs.writeFileSync(CSS_PATH, lines.join("\n"));
+fs.writeFileSync(FLOW_PATH, lines.join("\n"));
 
 // Generate variable file for validation.
 fs.writeFileSync(

--- a/packages/styles/buildStyles.js
+++ b/packages/styles/buildStyles.js
@@ -1,9 +1,10 @@
+// Note: This file is ES5 because it doesn't get transpiled, only gets used for building the module
 const config = require("./src/config.json");
 const fs = require("fs");
 const path = require("path");
 
 const BUILD_DIR = path.join(__dirname, "build");
-const CSS_PATH = path.join(BUILD_DIR, "styles.js");
+const CSS_PATH = path.join(BUILD_DIR, "index.js");
 const DECLARATIONS_PATH = path.join(BUILD_DIR, "declarations.json");
 const VARIABLES_PATH = path.join(BUILD_DIR, "variables.json");
 
@@ -85,12 +86,18 @@ if (!fs.existsSync(BUILD_DIR)) {
   fs.mkdirSync(BUILD_DIR);
 }
 
+fs.writeFileSync(CSS_PATH, '"use strict";\n\n');
+
 // Generate themeable css. Overwrite the whole file for the first write.
-fs.writeFileSync(
-  CSS_PATH,
-  "// This file is auto-generated. See buildStyles.js for details.\n\n"
-);
-fs.appendFileSync(CSS_PATH, "module.exports = `\n:root {\n");
+[
+  "// This file is auto-generated. See buildStyles.js for details.\n\n",
+  // Ensure this ends up as an es module for nice webpack usage
+  'Object.defineProperty(exports, "__esModule", {\n',
+  "  value: true\n",
+  "});\n"
+].map(line => fs.appendFileSync(CSS_PATH, line));
+
+fs.appendFileSync(CSS_PATH, "exports.default = `\n:root {\n");
 lodash.toPairs(declarations).forEach(([cssProperty, cssValue]) => {
   fs.appendFileSync(CSS_PATH, `  ${cssProperty}: ${cssValue};\n`);
 });

--- a/packages/styles/index.js
+++ b/packages/styles/index.js
@@ -1,1 +1,0 @@
-module.exports = require("./lib/styles");

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -2,7 +2,7 @@
   "name": "@nteract/styles",
   "version": "1.0.1",
   "description": "Root style package to supply custom CSS Properties.",
-  "main": "index.js",
+  "main": "lib/index.js",
   "files": [
     "lib"
   ],

--- a/packages/transform-plotly/src/index.js
+++ b/packages/transform-plotly/src/index.js
@@ -2,7 +2,7 @@
 /* eslint class-methods-use-this: 0 */
 import React from "react";
 
-const cloneDeep = require("lodash").cloneDeep;
+import { cloneDeep } from "lodash";
 
 type Props = {
   data: string | Object

--- a/packages/transform-vega/src/index.js
+++ b/packages/transform-vega/src/index.js
@@ -1,9 +1,8 @@
 /* @flow */
 import * as React from "react";
 
-const merge = require("lodash").merge;
-
-const vegaEmbed2 = require("@nteract/vega-embed2");
+import { merge } from "lodash";
+import vegaEmbed2 from "@nteract/vega-embed2";
 import vegaEmbed3 from "vega-embed";
 
 const MIMETYPE_VEGA2 = "application/vnd.vega.v2+json";

--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import TextDisplay from "./text";
-import JsonDisplay from "./json";
-import JavaScriptDisplay from "./javascript";
-import HTMLDisplay from "./html";
-import MarkdownDisplay from "./markdown";
-import LaTeXDisplay from "./latex";
-import SVGDisplay from "./svg";
-import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image";
+import TextDisplay from "./text.js";
+import JsonDisplay from "./json.js";
+import JavaScriptDisplay from "./javascript.js";
+import HTMLDisplay from "./html.js";
+import MarkdownDisplay from "./markdown.js";
+import LaTeXDisplay from "./latex.js";
+import SVGDisplay from "./svg.js";
+import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image.js";
 import VDOMDisplay from "@nteract/transform-vdom";
 
 type Transform = {

--- a/packages/vega-embed2/src/index.js
+++ b/packages/vega-embed2/src/index.js
@@ -1,1 +1,3 @@
-module.exports = require("vega-embed");
+// @flow
+import vegaEmbed from "vega-embed";
+export default vegaEmbed;


### PR DESCRIPTION
I found out that the webpack builds for commonjs exports were pretty poor -- many times they end up in one large `eval` block. As much as possible we should be using ES export and import. I know that several folks have asked about which is preferred and I kind of waved my hands at it, not really sure if it mattered. As it turns out, not having clean non-commonjs prevents us from using dynamic `import()`s. There are more to adapt across the code base, this should kick things off well though.