### PR TITLE
Lock closed after 60 days

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 120
+daysUntilLock: 60
 # Comment to post before locking. Set to `false` to disable
 lockComment: >
   Howdy! I'm 🔓🤖!


### PR DESCRIPTION
We make releases certainly more often than every 2 months, so let's clean up old closed issues every 60 days.
