### PR TITLE
switch logger to es

### DIFF
--- a/applications/desktop/src/main/store.js
+++ b/applications/desktop/src/main/store.js
@@ -2,14 +2,13 @@
 import { createStore, applyMiddleware, compose } from "redux";
 import { electronEnhancer } from "redux-electron-store";
 
-import reducers from "./reducers";
+import reducers from "./reducers.js";
+import logger from "../notebook/logger.js";
 
 const middlewares = [];
 
 /* istanbul ignore if -- only used for debugging */
 if (process.env.DEBUG === "true") {
-  const logger = require("../notebook/logger"); // eslint-disable-line global-require
-
   middlewares.push(logger());
 }
 

--- a/applications/desktop/src/notebook/logger.js
+++ b/applications/desktop/src/notebook/logger.js
@@ -3,7 +3,7 @@ import { isCollection } from "immutable";
 
 import { createLogger } from "redux-logger";
 
-module.exports = function clogger() {
+export function clogger() {
   const logger = createLogger({
     // predicate: (getState, action) => action.type.includes('COMM'),
     stateTransformer: state =>
@@ -16,4 +16,6 @@ module.exports = function clogger() {
       )
   });
   return logger;
-};
+}
+
+export default clogger;

--- a/applications/desktop/src/notebook/middlewares.js
+++ b/applications/desktop/src/notebook/middlewares.js
@@ -3,7 +3,8 @@ import { middlewares as coreMiddlewares } from "@nteract/core";
 
 import { createEpicMiddleware, combineEpics } from "redux-observable";
 
-import epics from "./epics";
+import logger from "./logger.js";
+import epics from "./epics/index.js";
 
 const rootEpic = combineEpics(...epics);
 
@@ -17,8 +18,6 @@ const middlewares = [
 ];
 
 if (process.env.DEBUG === "true") {
-  const logger = require("./logger"); // eslint-disable-line global-require
-
   middlewares.push(logger());
 }
 

--- a/packages/core/__mocks__/rx-jupyter.js
+++ b/packages/core/__mocks__/rx-jupyter.js
@@ -44,19 +44,21 @@ const mockListReponse = {
   }
 };
 
-module.exports = {
-  kernels: {
-    start: (config, kernelSpecName, cwd) => of({ response: { id: "0" } }),
-    connect: (config, id, session) => new Subject(),
-    interrupt: (config, id) =>
-      // successful interrupt
-      of({ response: null, responseType: "json", status: 204 })
-  },
-  kernelspecs: {
-    list: config => of({ response: mockListReponse })
-  },
-  sessions: {
-    create: (config, payload) =>
-      of({ response: { id: "1", kernel: { id: "0" } } })
-  }
+const kernels = {
+  start: (config, kernelSpecName, cwd) => of({ response: { id: "0" } }),
+  connect: (config, id, session) => new Subject(),
+  interrupt: (config, id) =>
+    // successful interrupt
+    of({ response: null, responseType: "json", status: 204 })
 };
+
+const kernelspecs = {
+  list: config => of({ response: mockListReponse })
+};
+
+const sessions = {
+  create: (config, payload) =>
+    of({ response: { id: "1", kernel: { id: "0" } } })
+};
+
+export { kernels, kernelspecs, sessions };

--- a/packages/enchannel-zmq-backend/__mocks__/jmp.js
+++ b/packages/enchannel-zmq-backend/__mocks__/jmp.js
@@ -19,14 +19,13 @@ class Socket extends EventEmitter {
   close() {}
 }
 
-module.exports = {
-  Message: msg => ({
-    header: { ...msg.header },
-    parent_header: { ...msg.parent_header },
-    content: { ...msg.content },
-    metadata: { ...msg.metadata },
-    buffers: [],
-    idents: []
-  }),
-  Socket
-};
+const Message = msg => ({
+  header: { ...msg.header },
+  parent_header: { ...msg.parent_header },
+  content: { ...msg.content },
+  metadata: { ...msg.metadata },
+  buffers: [],
+  idents: []
+});
+
+export { Message, Socket };

--- a/packages/transform-plotly/__mocks__/@nteract/plotly.js
+++ b/packages/transform-plotly/__mocks__/@nteract/plotly.js
@@ -1,4 +1,4 @@
-module.exports = {
-  newPlot: jest.fn(),
-  redraw: jest.fn()
-};
+const newPlot = jest.fn();
+const redraw = jest.fn();
+
+export { newPlot, redraw };


### PR DESCRIPTION
This looks like one of the last relevant modules to switch off from `module.exports` style. Commuter still has a bunch on the "server side". I didn't want to refactor that out of nowhere though since I'm only doing the switch to ES instead of CommonJS for the sake of the notebook apps.