### PR TITLE
Dynamic Transforms

### DIFF
--- a/packages/transform-dataresource/src/charts.js
+++ b/packages/transform-dataresource/src/charts.js
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import { nest } from "d3-collection";
 import { scaleLinear } from "d3-scale";
 import {

--- a/packages/transform-dataresource/src/icons.js
+++ b/packages/transform-dataresource/src/icons.js
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { SVGWrapper } from "@nteract/octicons";
 import {
   XYFrame,

--- a/packages/transform-dataresource/src/virtualized-grid.js
+++ b/packages/transform-dataresource/src/virtualized-grid.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React from "react";
+import * as React from "react";
 import { MultiGrid, AutoSizer, ColumnSizer } from "react-virtualized";
 import { infer } from "./infer";
 

--- a/packages/transform-dataresource/src/virtualized-table.js
+++ b/packages/transform-dataresource/src/virtualized-table.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint no-confusing-arrow: 0 */
 /* eslint no-nested-ternary: 0 */
-import React from "react";
+import * as React from "react";
 import { Table, Column, SortDirection, AutoSizer } from "react-virtualized";
 import { infer } from "./infer";
 
@@ -93,7 +93,9 @@ export default class VirtualizedTable extends React.Component<Props, State> {
             height={
               this.props.expanded
                 ? EXPANDED_HEIGHT
-                : height < COLLAPSED_HEIGHT ? height : COLLAPSED_HEIGHT
+                : height < COLLAPSED_HEIGHT
+                  ? height
+                  : COLLAPSED_HEIGHT
             }
             // noRowsRenderer={this._noRowsRenderer}
             // overscanRowCount={overscanRowCount}


### PR DESCRIPTION
This uses `import()` to load all the special output transforms asynchronously.  On startup, any output matching these media types won't be rendered until they're loaded. 

If the output has a mimetype that is yet to be loaded then it will be rendered as null. If `text/html` or `application/javascript` is in an output bundle alongside one of the higher priority display types, we don't render the js or html, avoiding side effects on the page.

For example, if an output had `application/vnd.plotly.v1+json` and `text/html` or `application/javascript` then we will render nothing until the Plotly transform is loaded.

