### PR TITLE
suggest names for our chunks

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
@@ -64,9 +64,11 @@ export class TextFile extends React.PureComponent<
         return window.assetURL + oldEnv.getWorkerUrl(moduleId, label);
       }
     };
-    import("@nteract/monaco-editor").then(module => {
-      this.setState({ Editor: module.default });
-    });
+    import(/* webpackChunkName: "monaco-editor" */ "@nteract/monaco-editor").then(
+      module => {
+        this.setState({ Editor: module.default });
+      }
+    );
   }
   render() {
     const Editor = this.state.Editor;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.js
@@ -82,36 +82,44 @@ export default class Notebook extends React.Component<Props, State> {
   }
 
   loadApp() {
-    import("@nteract/notebook-app-component").then(module => {
-      this.setState({ App: module.default });
-    });
+    import(/* webpackChunkName: "notebook-app-component" */ "@nteract/notebook-app-component").then(
+      module => {
+        this.setState({ App: module.default });
+      }
+    );
   }
 
   loadTransforms() {
-    import("@nteract/transform-plotly").then(module => {
-      this.registerTransform(module.default);
-      this.registerTransform(module.PlotlyNullTransform);
-    });
+    import(/* webpackChunkName: "plotly" */ "@nteract/transform-plotly").then(
+      module => {
+        this.registerTransform(module.default);
+        this.registerTransform(module.PlotlyNullTransform);
+      }
+    );
+
+    import(/* webpackChunkName: "tabular-dataresource" */ "@nteract/transform-dataresource").then(
+      module => {
+        this.registerTransform(module.default);
+      }
+    );
 
     import("@nteract/transform-model-debug").then(module => {
       this.registerTransform(module.default);
     });
 
-    import("@nteract/transform-dataresource").then(module => {
-      this.registerTransform(module.default);
-    });
-
-    import("@nteract/transform-vega").then(module => {
-      this.setState({
-        transforms: {
-          ...this.state.transforms,
-          [module.VegaLite1.MIMETYPE]: module.VegaLite1,
-          [module.VegaLite1.MIMETYPE]: module.VegaLite2,
-          [module.VegaLite1.MIMETYPE]: module.Vega2,
-          [module.VegaLite1.MIMETYPE]: module.Vega3
-        }
-      });
-    });
+    import(/* webpackChunkName: "vega-transform" */ "@nteract/transform-vega").then(
+      module => {
+        this.setState({
+          transforms: {
+            ...this.state.transforms,
+            [module.VegaLite1.MIMETYPE]: module.VegaLite1,
+            [module.VegaLite1.MIMETYPE]: module.VegaLite2,
+            [module.VegaLite1.MIMETYPE]: module.Vega2,
+            [module.VegaLite1.MIMETYPE]: module.Vega3
+          }
+        });
+      }
+    );
 
     // TODO: The geojson transform will likely need some work because of the basemap URL(s)
     // import GeoJSONTransform from "@nteract/transform-geojson";

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
   target: "web",
   output: {
     // Note: this gets overriden by our use of __webpack_public_path__ later
-    publicPath: ASSET_PATH
+    publicPath: ASSET_PATH,
+    chunkFilename: "[name]-[chunkhash].bundle.js"
   },
   module: {
     rules: [


### PR DESCRIPTION
Give webpack a bit more context so that we can see which chunks are which on disk:

```
$ $ ls -lSh *.js | head -n 20
-rw-r--r--  1 kylek  staff   4.0M May  2 14:11 55-2935dd33bb8432f98d1d.bundle.js
-rw-r--r--  1 kylek  staff   4.0M May  2 11:59 55.js
-rw-r--r--  1 kylek  staff   3.4M May  2 14:11 typescript.worker.js
-rw-r--r--  1 kylek  staff   2.2M May  2 12:40 2-1d6d8270ae5fa19fb8d6.bundle.js
-rw-r--r--  1 kylek  staff   2.2M May  2 11:59 2.js
-rw-r--r--  1 kylek  staff   2.2M May  2 14:11 vendors~monaco-editor-1b28c8ef056d061f86b7.bundle.js
-rw-r--r--  1 kylek  staff   2.1M May  2 11:59 0.js
-rw-r--r--  1 kylek  staff   2.1M May  2 14:11 vendors~plotly-ff6afe7ca61e4d55299f.bundle.js
-rw-r--r--  1 kylek  staff   1.6M May  2 14:11 17-d27d3f295ac078ae6098.bundle.js
-rw-r--r--  1 kylek  staff   1.6M May  2 11:59 17.js
-rw-r--r--  1 kylek  staff   1.5M May  2 11:59 4.js
-rw-r--r--  1 kylek  staff   1.5M May  2 14:11 vendors~vega-transform-b77a2bd4a48d8057f22b.bundle.js
-rw-r--r--  1 kylek  staff   1.3M May  2 14:11 app.js
-rw-r--r--  1 kylek  staff   1.1M May  2 11:59 3.js
-rw-r--r--  1 kylek  staff   1.1M May  2 14:11 vendors~tabular-dataresource-24a83b53c1b5fd181c1e.bundle.js
-rw-r--r--  1 kylek  staff   565K May  2 14:11 css.worker.js
-rw-r--r--  1 kylek  staff   490K May  2 12:40 1-ef2517859d3d040c65d5.bundle.js
-rw-r--r--  1 kylek  staff   490K May  2 11:59 1.js
-rw-r--r--  1 kylek  staff   490K May  2 14:11 vendors~notebook-app-component-cbfc164eb2face2987b4.bundle.js
-rw-r--r--  1 kylek  staff   244K May  2 14:11 html.worker.js
```

The numbered ones largely come from Monaco's webpack plugin (I think).