### PR TITLE
delete unused MonacoEnvironment

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file.js
@@ -58,12 +58,6 @@ export class TextFile extends React.PureComponent<
     this.props.handleChange(source);
   }
   componentDidMount() {
-    let oldEnv = window.MonacoEnvironment;
-    window.MonacoEnvironment = {
-      getWorkerUrl: function(moduleId, label) {
-        return window.assetURL + oldEnv.getWorkerUrl(moduleId, label);
-      }
-    };
     import(/* webpackChunkName: "monaco-editor" */ "@nteract/monaco-editor").then(
       module => {
         this.setState({ Editor: module.default });


### PR DESCRIPTION
While trying to make Monaco's webworkers resolve when on subpaths I found out Monaco wasn't actually wasn't picking this up so I've cleaned it up.