### PR TITLE
Create new `jupyter nteract` application; better install and hot reload integration

### DIFF
--- a/applications/jupyter-extension/README.md
+++ b/applications/jupyter-extension/README.md
@@ -4,37 +4,43 @@ nteract as an extension to the jupyter notebook server
 
 ## Installation
 
+Install `nteract_on_jupyter` with `pip`:
+
 ```
 pip install nteract_on_jupyter
-jupyter serverextension enable nteract_on_jupyter
 ```
 
-### Configuration
+## Usage
 
-When you launch the jupyter notebook server, there is a new `NteractConfig` that allows setting:
+Run
 
-* `ga_code` - Google Analytics code to track usage
-* `asset_url` - Where to load nteract js from
+and you're running nteract on jupyter!
 
-Example:
-
-```
-jupyter notebook --NteractConfig.asset_url="http://localhost:8080/" --NteractConfig.ga_code="GA-SOME-NUMBERS"
-```
+You can run `jupyter nteract` just like you would run `jupyter notebook`.
 
 ## Development
 
 All code snippets assume you're starting from the root of the nteract/nteract monorepo.
 
-### 1. Install Monorepo (JS)
+### 1. Install the `nteract` monorepo (JS)
+
+At the base directory of the `nteract` repo install the monorepo's dependencies:
 
 ```
 npm install
 ```
 
-### 2. Install/enable jupyter-extension (Python)
+You will also want to install `lerna` globally so you can run `lerna` from anywhere in the nteract repo. The rest of the instructions assume you have done this.
 
-Install the python package locally from here.
+```
+npm install -g lerna
+```
+
+For more details see the instructions in the [base README](../../README.md#set-the-monorepo-up-in-dev-mode)
+
+### 2. Install/enable `nteract_on_jupyter` (Python)
+
+Install the python package locally from the `nteract/applications/jupyter-extension/` directory (you should see a `setup.py` here).
 
 ```
 cd applications/jupyter-extension
@@ -42,19 +48,89 @@ pip install -e .
 jupyter serverextension enable nteract_on_jupyter
 ```
 
-### 3. Run notebook server (Python)
+### 3. Build assets and run the Jupyter server
 
-In one terminal, start up a notebook server.
+We have two more steps:
+
+1. build the javascript and html assets with `webpack`
+2. run the Jupyter server
+
+In all the ways we describe below, the jupyter server may start before the assets are done building. That means that the first page you'll land on will be blank. **Don't worry**. All you need to do is to wait until the assets have been built and manually refresh the page.
+
+Look on your console for a log message like
 
 ```
-cd applications/jupyter-extension
-jupyter notebook
+nteract-on-jupyter: [0] ℹ ｢wdm｣: Compiled successfully.
 ```
 
-### 4. Run jupyter-extension (JS)
+to indicate that the assets are done building.
+
+We recommend running a webpack server for "hot reloading" the javascript and html assets. This will recompile the javascript so that any changes that you make locally will be reflected on the website without you needing to refresh the page or restart the server.
+
+Unfortunately, any changes you make on the Python side will require that you restart the server for them to take effect.
+
+#### 3.1. All-in-one w/ hot reloading (least flexible)
+
+We can both from a single command from inside the nteract app:
 
 ```
-npm run app:jupyter-extension
+lerna run dev --scope nteract-on-jupyter --stream
 ```
 
-This both runs a live reload webpack server and a jupyter notebook server. Once the jupyter server is up, it will load a page that isn't really ready until the initial webpack bundle is built. You'll need to reload the page after.
+This will run two servers, a webpack server for live reloading javascript and html assets and Jupyter server.
+
+Once the assets have been built, you won't need to refresh the page, but you may need to manually refresh the page if it loads before the assets are built.
+
+**N.B.**: Unfortunately, this way of starting the servers will only let you run the Jupyter server in the `nteract` repo. If you want to run notebooks in other directories you'll need to run the commands separately
+
+#### 3.2 Separate commands w/ hot reloading (most flexible)
+
+First we need to run the webpack server to live reload javascript and html assets. Anywhere in the nteract repository, run
+
+```
+lerna run hot --scope nteract-on-jupyter --stream
+```
+
+In another terminal, go to the directory that you want to run notebooks from and run
+
+```
+jupyter nteract --dev
+```
+
+The ``--dev`` flag tells the Jupyter server where the webpack server will be serving the assets.
+
+If you wait until the assets are built, you won't need to manually reload the Jupyter webpage. If you start the server before the assets have been built, you will need to manually refresh the page once before live reloading
+
+#### 3.2 Separate commands w/o hot reloading
+
+If you don't want to run the webpack server, you will still need to build the assets once (to start). You will need rebuild assets and refresh the page in order for changes to take effect.  
+
+To create an optimized build that will run faster in the browser but will take more time to complete, (in the `nteract` repo) run:
+
+```
+lerna run build --scope nteract-on-jupyter --stream
+```
+
+If you want the build to go as quickly as possible and don't want optimized javascript, (in the `nteract` repo) you can run:
+
+```
+lerna run build:impatient --scope nteract-on-jupyter --stream
+```
+
+Then you will want to use the `jupyter nteract` command.
+
+**Note** Do not use the `--dev` flag, or your assets will never load, since there is no webpack server to serve those assets.
+
+### Configuration for deploying nteract_on_jupyter
+
+When you launch the Jupyter notebook server, there is a new `NteractConfig` that allows setting a number of things. In particular it allows setting:
+
+* `asset_url` - Where to load nteract js from
+* `ga_code` - Google Analytics code to track usage
+
+
+Example:
+
+```
+jupyter nteract --NteractConfig.asset_url="http://localhost:8080/" --NteractConfig.ga_code="GA-SOME-NUMBERS"
+```

--- a/applications/jupyter-extension/jupyter-config/jupyter_notebook_config.d/nteract_on_jupyter.json
+++ b/applications/jupyter-extension/jupyter-config/jupyter_notebook_config.d/nteract_on_jupyter.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "nteract_on_jupyter": true
+    }
+  }
+}

--- a/applications/jupyter-extension/nteract_on_jupyter/__init__.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/__init__.py
@@ -1,3 +1,8 @@
+import os
+
+PACKAGE_DIR = os.path.realpath(os.path.dirname(__file__))
+
+from ._version import __version__
 from .extension import load_jupyter_server_extension
 
 def _jupyter_server_extension_paths():

--- a/applications/jupyter-extension/nteract_on_jupyter/_version.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/_version.py
@@ -4,9 +4,9 @@ import os
 version_info = (0, 0, 0)
 __version__ = "0.0.0"
 
-here = os.path.dirname(__file__)
+from . import PACKAGE_DIR
 
-with open(os.path.join(here, "package.json")) as f:
+with open(os.path.join(PACKAGE_DIR, "package.json")) as f:
     packageJSON = json.load(f)
     __version__ = packageJSON['version']
 

--- a/applications/jupyter-extension/nteract_on_jupyter/extension.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/extension.py
@@ -9,31 +9,18 @@ from notebook.utils import url_path_join as ujoin
 from os.path import join as pjoin
 from jupyter_core.paths import ENV_JUPYTER_PATH, jupyter_config_path
 
+from . import PACKAGE_DIR
 from ._version import __version__
-
 from .config import NteractConfig
-
 from .handlers import add_handlers
 
-
-def get_app_dir(app_dir=None):
-    """Get the configured nteract app directory.
-    """
-    app_dir = app_dir or os.environ.get('NTERACT_DIR')
-    app_dir = app_dir or pjoin(ENV_JUPYTER_PATH[0], 'nteract')
-    return os.path.realpath(app_dir)
 
 
 def load_jupyter_server_extension(nbapp):
     """Load the JupyterLab server extension.
     """
-
-    here = os.path.dirname(__file__)
+    here = PACKAGE_DIR
     nbapp.log.info('nteract extension loaded from %s' % here)
-
-    #app_dir = get_app_dir()
-    #if hasattr(nbapp, 'app_dir'):
-    #    app_dir = get_app_dir(nbapp.app_dir)
 
     app_dir = here  # bundle is part of the python package
 

--- a/applications/jupyter-extension/nteract_on_jupyter/extension.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/extension.py
@@ -52,5 +52,4 @@ def load_jupyter_server_extension(nbapp):
 
     web_app.settings['nteract_config'] = config
 
-
     add_handlers(web_app, config)

--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -38,7 +38,6 @@ class NAppHandler(IPythonHandler):
         base_url = self.settings['base_url']
         url = ujoin(base_url, config.page_url, '/static/')
 
-
         # Handle page config data.
         page_config = dict()
         page_config.update(self.settings.get('page_config_data', {}))
@@ -80,7 +79,6 @@ def add_handlers(web_app, config):
     base_url = web_app.settings['base_url']
     url = ujoin(base_url, config.page_url)
     assets_dir = config.assets_dir
-
 
     package_file = os.path.join(assets_dir, 'package.json')
     with open(package_file) as fid:

--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -6,7 +6,6 @@ HTTPError = web.HTTPError
 
 import notebook
 
-
 from notebook.base.handlers import (
     IPythonHandler,
     FileFindHandler,
@@ -20,8 +19,9 @@ from jinja2 import FileSystemLoader
 from notebook.utils import url_path_join as ujoin
 from traitlets import HasTraits, Unicode, Bool
 
-HERE = os.path.dirname(__file__)
-FILE_LOADER = FileSystemLoader(HERE)
+from . import PACKAGE_DIR
+
+FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 
 class NAppHandler(IPythonHandler):
     """Render the nteract view"""
@@ -37,8 +37,6 @@ class NAppHandler(IPythonHandler):
 
         base_url = self.settings['base_url']
         url = ujoin(base_url, config.page_url, '/static/')
-
-
 
 
         # Handle page config data.
@@ -74,7 +72,6 @@ class NAppHandler(IPythonHandler):
 
     def get_template(self, name):
         return FILE_LOADER.load(self.settings['jinja2_env'], name)
-
 
 
 def add_handlers(web_app, config):

--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -1,0 +1,26 @@
+from notebook.notebookapp import NotebookApp, flags
+from traitlets import Unicode
+
+from .config import NteractConfig
+
+nteract_flags = dict(flags)
+nteract_flags['dev'] = (
+    {'NteractConfig': {'asset_url':'http://localhost:8080/'}},
+    "Start nteract in dev mode, running off your source code, with hot reloads."
+)
+
+class NteractApp(NotebookApp):
+    """Application for runing nteract on a jupyter notebook server.
+
+    """
+    default_url = Unicode('/nteract/edit',
+                          help="nteract's default starting location")
+
+    classes = [*NotebookApp.classes, NteractConfig]
+    flags = nteract_flags
+
+
+main = launch_new_instance = NteractApp.launch_instance
+
+if __name__ == '__main__':
+    main()

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -5,8 +5,10 @@
   "main": "app/index.js",
   "scripts": {
     "build": "NODE_ENV=production webpack",
+    "build:asap": "webpack",
     "build:watch": "webpack --watch",
-    "dev": "concurrently \"webpack-dev-server --hot\" \"jupyter notebook --NteractConfig.asset_url='http://localhost:8080/' --NotebookApp.default_url='/nteract/edit/'\"",
+    "dev": "concurrently \"npm run hot\" \"jupyter nteract --dev\"",
+    "hot": "webpack-dev-server --hot",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/applications/jupyter-extension/setup.py
+++ b/applications/jupyter-extension/setup.py
@@ -31,5 +31,11 @@ setuptools.setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[],
-    data_files=data_files
+    data_files=data_files,
+    entry_points={
+        'console_scripts': [
+            'jupyter-nteract = nteract_on_jupyter.nteractapp:main'
+        ]
+    }
+
 )

--- a/applications/jupyter-extension/setup.py
+++ b/applications/jupyter-extension/setup.py
@@ -6,15 +6,16 @@ import json
 import os
 
 version = '0.0.0-dev'
+name = "nteract_on_jupyter"
 
-here = os.path.dirname(__file__)
+here = os.path.realpath(os.path.dirname(__file__))
 
-with open(os.path.join(here, "nteract_on_jupyter", "package.json")) as f:
+with open(os.path.join(here, name, "package.json")) as f:
     packageJSON = json.load(f)
     version = packageJSON['version']
 
 setuptools.setup(
-  name="nteract_on_jupyter",
+  name=name,
   version=version,
   url="https://github.com/nteract/nteract",
   author="nteract contributors",

--- a/applications/jupyter-extension/setup.py
+++ b/applications/jupyter-extension/setup.py
@@ -14,15 +14,22 @@ with open(os.path.join(here, name, "package.json")) as f:
     packageJSON = json.load(f)
     version = packageJSON['version']
 
+config_d_filepath = os.path.join('jupyter-config',
+                                 'jupyter_notebook_config.d',
+                                 'nteract_on_jupyter.json')
+data_files = [('etc/jupyter/jupyter_notebook_config.d', [config_d_filepath]),
+]
+
 setuptools.setup(
-  name=name,
-  version=version,
-  url="https://github.com/nteract/nteract",
-  author="nteract contributors",
-  author_email="jupyter@googlegroups.com",
-  description="Extension for the jupyter notebook server and nteract",
-  packages=setuptools.find_packages(),
-  include_package_data=True,
-  zip_safe=False,
-  install_requires=[]
+    name=name,
+    version=version,
+    url="https://github.com/nteract/nteract",
+    author="nteract contributors",
+    author_email="jupyter@googlegroups.com",
+    description="Extension for the jupyter notebook server and nteract",
+    packages=setuptools.find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[],
+    data_files=data_files
 )


### PR DESCRIPTION
This adds `NteractApp` to the `nteract_on_jupyter` library. 

It also adds a `jupyter-nteract` command, allowing you to run 

```
jupyter nteract
```

as you would run `jupyter notebook` or `jupyter lab`.

It adds a new config file (matching the config.d spec) for autoenabling the extension when someone runs `pip install nteract_on_jupyter`. **Note**: this will not work if you editably install.

It adds a `--dev` flag for the `jupyter-nteract` command that allows you to look for assets where they are served by the webpack hot reloading server.  

It also adds two new `npm run` commands to the `package.json`:
- `hot`:  runs the webpack hot reloading server
- `build:asap` webpacks the nteract_on_jupyter js bundle in a non-optimised way (for faster single static builds)

Finally, it updates the README to reflect all of this.