### PR TITLE
write npm commands to install & enable jupyter ext

### DIFF
--- a/applications/jupyter-extension/package.json
+++ b/applications/jupyter-extension/package.json
@@ -3,6 +3,9 @@
   "version": "0.4.5",
   "description": "nteract on jupyter, as an extension",
   "scripts": {
+    "ext": "npm run ext:install && npm run ext:enable",
+    "ext:install": "pip install -e .",
+    "ext:enable": "jupyter serverextension enable nteract_on_jupyter",
     "build:python": "python setup.py sdist",
     "upload:pypi": "twine upload dist/*",
     "prebuild:python": "rimraf dist",


### PR DESCRIPTION
cc @mpacer 

I was thinking of how we could expose these as commands that can be run from the root of the repo so I put the `pip` and `jupyter` commands in as new `npm` scripts. Let me know what you think.