### PR TITLE
Relax save interval

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@ types
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment= \\(.\\|\n\\)*\\$FlowAllowFeatureDetection
 module.name_mapper='^@nteract/\(.+\)$' -> '<PROJECT_ROOT>/packages/\1/src'
 module.name_mapper='^ansi-to-react$' -> '<PROJECT_ROOT>/packages/ansi-to-react/src'
 module.name_mapper='^enchannel-zmq-backend$' -> '<PROJECT_ROOT>/packages/enchannel-zmq-backend/src'

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -99,8 +99,8 @@ export function autoSaveCurrentContentEpic(
   action$: ActionsObservable<Action>,
   store: Store<AppState, *>
 ) {
-  // Save every seven seconds, regardless of contentType
-  return interval(3000).pipe(
+  // Save every 30 seconds, regardless of contentType
+  return interval(30 * 1000).pipe(
     // TODO: Once we're switched to the coming redux observable 1.0.0 release,
     // we should use the state$ stream to only save when the content has changed
     mergeMap(() => {


### PR DESCRIPTION
* [x] Relaxes the autosave interval to near 30s (also keeping on prime intervals to lessen chance of overlapping saves with another tab)
* [x] Only trigger autosave when page is visible

cc @mpacer 