### PR TITLE
Lessen our lock bot "spam"

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,22 +1,12 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 60
+daysUntilLock: 91
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  Howdy! I'm 🔓🤖!
-  
-  
-  In order to keep information timely (based on the most recent release), we want
-  all activity to be added to either new issues or open issues and PRs. In service
-  to that goal, I, the lock bot close inactive closed issues when they haven't had
-  activity in 120 days.
-  
-  
-  Feel free to open a new issue for related bugs and link to relevant comments from
-  this thread.
+lockComment: false
 # Issues or pull requests with these labels will not be locked
 exemptLabels:
   - no-locking
 # Limit to only `issues` or `pulls`
 # only: issues
+lockLabel: 'outdated'


### PR DESCRIPTION
Apparently there are no notifications for plain locking (without comment), so I'd like to just disable the comment altogether.

Suggested in https://www.henryzoo.com/blog/2018/05/06/an-issue-with-issues.html