### PR TITLE
Use <header>, not <nav> for header element

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/components/nav.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/components/nav.js
@@ -42,7 +42,7 @@ type NavProps = {
 export class Nav extends React.Component<NavProps, null> {
   render() {
     return (
-      <nav className="nteract-nav">
+      <header className="nteract-nav">
         <ul>
           {React.Children.map(this.props.children, child => {
             return <li className="top-nav-item">{child}</li>;
@@ -50,7 +50,7 @@ export class Nav extends React.Component<NavProps, null> {
         </ul>
 
         <style jsx>{`
-          nav {
+          header {
             background-color: var(--theme-title-bar-bg, rgb(250, 250, 250));
             padding: var(--nt-spacing-m) var(--nt-spacing-xl);
             box-sizing: border-box;
@@ -67,7 +67,7 @@ export class Nav extends React.Component<NavProps, null> {
             padding: 0px 0px;
             margin: 0 auto;
           }
-          nav > ul {
+          header > ul {
           }
           li {
             display: flex;
@@ -75,7 +75,7 @@ export class Nav extends React.Component<NavProps, null> {
             padding: 0px 0px;
           }
         `}</style>
-      </nav>
+      </header>
     );
   }
 }


### PR DESCRIPTION
`<nav>` is an implicit ARIA Landmark (https://www.marcozehe.de/2009/10/31/easy-aria-tip-4-landmarks/),
with special behavior from screen readers. However, things inside
a nav should all be navigational elements only, since they are
given fairly high priority by screen reader & spoken as 'navigation
links'. Currently, almost none of the links in the header are
navigation (except for the 'Home' link).


`<header>` sidesteps this problem, and is also the more appropriate
tag to use here. If / When we have actual navigational elements
inside the header, those can live inside a `<nav>`

Discovered via #2844 
