### PR TITLE
add bdist_wheel to the python build step

### DIFF
--- a/applications/jupyter-extension/package.json
+++ b/applications/jupyter-extension/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.6",
   "description": "nteract on jupyter, as an extension",
   "scripts": {
-    "build:python": "python setup.py sdist",
+    "build:python": "python setup.py sdist && python setup.py bdist_wheel",
     "upload:pypi": "twine upload dist/*",
     "prebuild:python": "rimraf dist",
     "publish": "echo 'not really publishing'"


### PR DESCRIPTION
Improves the python step to build both a wheel and a sdist. Twine will still pick up both of them from `dist/*`.