### PR TITLE
Current content ref cleanup

### DIFF
--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -62,14 +62,13 @@ function publishGist(
 export const publishEpic = (action$: ActionsObservable<*>, store: any) => {
   return action$.pipe(
     ofType(actionTypes.PUBLISH_GIST),
-    mergeMap(action => {
+    mergeMap((action: actionTypes.PublishGist) => {
       const state = store.getState();
 
       const filepath = selectors.currentFilepath(state);
       const notificationSystem = selectors.notificationSystem(state);
 
-      // TODO: Switch GitHub publishing actions to content refs
-      const contentRef = selectors.currentContentRef(state);
+      const contentRef = action.payload.contentRef;
       if (!contentRef) {
         return empty();
       }

--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.js
@@ -7,14 +7,15 @@ import NotificationSystem from "react-notification-system";
 
 import { Styles, themes } from "@nteract/presentational-components";
 import { default as Contents } from "./contents";
+import type { ContentRef } from "@nteract/core";
 
-class App extends React.Component<null, null> {
+class App extends React.Component<{ contentRef: ContentRef }, null> {
   notificationSystem: NotificationSystem;
   render() {
     return (
       <React.Fragment>
         <Styles>
-          <Contents />
+          <Contents contentRef={this.props.contentRef} />
         </Styles>
         <NotificationSystem
           ref={notificationSystem => {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
@@ -39,8 +39,11 @@ type ContentsProps = {
   appBase: string
 };
 
-const mapStateToProps = (state: AppState, ownProps: *): ContentsProps => {
-  const contentRef = selectors.currentContentRef(state);
+const mapStateToProps = (
+  state: AppState,
+  ownProps: { contentRef: ContentRef }
+): ContentsProps => {
+  const contentRef = ownProps.contentRef;
   const host = state.app.host;
   if (host.type !== "jupyter") {
     throw new Error("this component only works with jupyter apps");

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.js
@@ -137,7 +137,7 @@ export default class Notebook extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <NotebookMenu />
+        <NotebookMenu contentRef={this.props.contentRef} />
         <App
           contentRef={this.props.contentRef}
           displayOrder={this.state.displayOrder}

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -128,7 +128,7 @@ function main(rootEl: Element, dataEl: Node | null) {
 
   ReactDOM.render(
     <Provider store={store}>
-      <App />
+      <App contentRef={contentRef} />
     </Provider>,
     rootEl
   );

--- a/packages/connected-components/src/notebook-menu/index.js
+++ b/packages/connected-components/src/notebook-menu/index.js
@@ -6,6 +6,7 @@ import Menu, { SubMenu, Divider, MenuItem } from "rc-menu";
 import { actions, selectors } from "@nteract/core";
 
 import type {
+  AppState,
   ContentRef,
   KernelRef,
   KernelspecsRef,
@@ -448,17 +449,10 @@ class PureNotebookMenu extends React.Component<Props, State> {
   }
 }
 
-// TODO: this forces the menu to re-render on cell focus. The better option is
-// to alter how the actions work to just target the currently focused cell.
-// That said, we *may* not have a great way of getting around this as we'll need
-// information about the current document to decide which menu items are
-// available...
-const mapStateToProps = state => {
-  const contentRef = selectors.currentContentRef(state);
-  if (!contentRef) {
-    throw new Error("There must be a contentRef for this menu");
-  }
-
+const mapStateToProps = (
+  state: AppState,
+  { contentRef }: { contentRef: ContentRef }
+) => {
   return {
     currentKernelRef: selectors.currentKernelRef(state),
     currentContentRef: contentRef,


### PR DESCRIPTION
We've made good strides in adapting to the `contentRef` setup. A bunch of components were still using `currentContentRef`. As much as possible I've tried to clean these up to use passed around `contentRef`s.

* [x] Switch gist publishing to `contentRef` -- action already had it, epic needed to make use of it
* [x] Adapt the Jupyter Extension to passing the `contentRef` into `<Contents />`
* [x] Adapt the notebook menu (webapp) to using `contentRef`
* [x] Autosave emits save actions for all files and notebooks in our store

The main reason I'm going after this is to make sure we're ready for react-router on the jupyter extension and in turn are also ready for changing the title and path we're on.

----

One big area that needs clean up in this regard is the desktop app -- the menu system (on the renderer side) uses `currentContentRef` all over. If we passed in the `contentRef` early on, we'd have it all over and not have to pull it from the store. That'll be another PR.