### PR TITLE
Autoenable dev

### DIFF
--- a/applications/jupyter-extension/README.md
+++ b/applications/jupyter-extension/README.md
@@ -114,7 +114,7 @@ lerna run build --scope nteract-on-jupyter --stream
 If you want the build to go as quickly as possible and don't want optimized javascript, (in the `nteract` repo) you can run:
 
 ```
-lerna run build:impatient --scope nteract-on-jupyter --stream
+lerna run build:asap --scope nteract-on-jupyter --stream
 ```
 
 Then you will want to use the `jupyter nteract` command.

--- a/applications/jupyter-extension/nteract_on_jupyter/__init__.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/__init__.py
@@ -5,7 +5,9 @@ PACKAGE_DIR = os.path.realpath(os.path.dirname(__file__))
 from ._version import __version__
 from .extension import load_jupyter_server_extension
 
+EXT_NAME = "nteract_on_jupyter"
+
 def _jupyter_server_extension_paths():
     return [{
-        "module": "nteract_on_jupyter"
+        "module": EXT_NAME
 }]

--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -5,10 +5,19 @@ from . import EXT_NAME
 from .config import NteractConfig
 from .extension import load_jupyter_server_extension
 
+webpack_hot = {"address": 'http://localhost:8080/',
+               "command":"`lerna run hot --scope nteract-on-jupyter --stream`"}
 nteract_flags = dict(flags)
 nteract_flags['dev'] = (
-    {'NteractConfig': {'asset_url':'http://localhost:8080/'}},
-    "Start nteract in dev mode, running off your source code, with hot reloads."
+    {'NteractConfig': {'asset_url': webpack_hot['address']},
+    },
+    "\n".join([
+        "Start nteract in dev mode, serving assets built from your source code.",
+        "This is a hot reloading server that watches for changes to your source,",
+        "rebuilds the js files, and serves the new assets on:",
+        "    {address}",
+        "To access this server run:",
+        "    {command}"]).format(**webpack_hot)
 )
 
 class NteractApp(NotebookApp):

--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -1,7 +1,9 @@
 from notebook.notebookapp import NotebookApp, flags
 from traitlets import Unicode
 
+from . import EXT_NAME
 from .config import NteractConfig
+from .extension import load_jupyter_server_extension
 
 nteract_flags = dict(flags)
 nteract_flags['dev'] = (
@@ -19,6 +21,12 @@ class NteractApp(NotebookApp):
     classes = [*NotebookApp.classes, NteractConfig]
     flags = nteract_flags
 
+    def init_server_extensions(self):
+        super(NteractApp, self).init_server_extensions()
+        msg = 'NteractApp server extension not enabled, manually loading...'
+        if not self.nbserver_extensions.get(EXT_NAME, False):
+            self.log.warn(msg)
+            load_jupyter_server_extension(self)
 
 main = launch_new_instance = NteractApp.launch_instance
 


### PR DESCRIPTION
This improves developer experience while working on the app. 

Previously if you editably installed and were going to run the app in dev mode, you needed to separately enable the extension. Now this checks if you are in `dev_mode` (also settable via traitlet) and will automatically load the server extension for you. 

It also improves the documentation around dev mode making it easier to know what to do if you (for example) weren't reading the README but were running `jupyter nteract --help`.