### PR TITLE
get rid of all other uses of currentContentRef

### DIFF
--- a/applications/desktop/__mocks__/electron.js
+++ b/applications/desktop/__mocks__/electron.js
@@ -3,6 +3,20 @@ module.exports = {
   match: jest.fn(),
   app: jest.fn(),
   remote: {
+    BrowserWindow: () => {
+      return {
+        show: jest.fn(),
+        getURL: jest.fn(() => {
+          return "";
+        }),
+        webContents: {
+          on: jest.fn((s, callback) => {
+            callback();
+          })
+        },
+        loadURL: jest.fn()
+      };
+    },
     app: {
       getPath: key => {
         if (key === "home") {

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -17,12 +17,14 @@ import { catchError, toArray } from "rxjs/operators";
 describe("saveEpic", () => {
   test("saves the file using the notebook in the state tree", async function() {
     const contentRef = "123";
+    const notificationSystem = { addNotification: jest.fn() };
 
     const store = {
       dispatch: jest.fn(),
       getState: () => ({
         app: Immutable.Map({
-          version: "0.0.0-test"
+          version: "0.0.0-test",
+          notificationSystem
         }),
         core: {
           entities: {

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -1,8 +1,13 @@
 jest.mock("fs");
 import { ActionsObservable } from "redux-observable";
-import { dummyStore, dummyCommutable } from "@nteract/core/dummy";
 
-import { actions } from "@nteract/core";
+import {
+  actions,
+  createContentRef,
+  makeNotebookContentRecord
+} from "@nteract/core";
+
+import * as Immutable from "immutable";
 
 import { saveEpic, saveAsEpic } from "../../../src/notebook/epics/saving";
 
@@ -11,9 +16,30 @@ import { catchError, toArray } from "rxjs/operators";
 
 describe("saveEpic", () => {
   test("saves the file using the notebook in the state tree", async function() {
-    const store = dummyStore();
+    const contentRef = "123";
 
-    const contentRef = store.getState().core.currentContentRef;
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        app: Immutable.Map({
+          version: "0.0.0-test"
+        }),
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": makeNotebookContentRecord()
+              })
+            },
+            kernels: {
+              byRef: Immutable.Map({
+                k1: {}
+              })
+            }
+          }
+        }
+      })
+    };
 
     const responses = await saveEpic(
       ActionsObservable.of(actions.save({ contentRef })),
@@ -36,11 +62,34 @@ describe("saveEpic", () => {
 
 describe("saveAsEpic", () => {
   test("works when passed actions of type SAVE_AS", async function() {
-    const store = dummyStore();
+    const contentRef = "123";
+
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        app: Immutable.Map({
+          version: "0.0.0-test"
+        }),
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": makeNotebookContentRecord()
+              })
+            },
+            kernels: {
+              byRef: Immutable.Map({
+                k1: {}
+              })
+            }
+          }
+        }
+      })
+    };
 
     const responses = await saveAsEpic(
       ActionsObservable.of(
-        actions.saveAs({ filepath: "great-filename", contentRef: "567" })
+        actions.saveAs({ filepath: "great-filename", contentRef })
       ),
       store
     )
@@ -48,8 +97,8 @@ describe("saveAsEpic", () => {
       .toPromise();
 
     expect(responses).toEqual([
-      actions.changeFilename({ filepath: "great-filename", contentRef: "567" }),
-      actions.save({ contentRef: "567" })
+      actions.changeFilename({ filepath: "great-filename", contentRef }),
+      actions.save({ contentRef })
     ]);
   });
 });

--- a/applications/desktop/__tests__/renderer/global-events-spec.js
+++ b/applications/desktop/__tests__/renderer/global-events-spec.js
@@ -1,23 +1,65 @@
-import { dummyStore } from "@nteract/core/dummy";
 import * as globalEvents from "../../src/notebook/global-events";
+import * as Immutable from "immutable";
+
+import {
+  createContentRef,
+  makeStateRecord,
+  makeEntitiesRecord,
+  makeContentsRecord,
+  makeNotebookContentRecord,
+  makeDocumentRecord
+} from "@nteract/core";
+
+const createStore = (contentRef, content) => ({
+  getState: () => ({
+    core: makeStateRecord({
+      entities: makeEntitiesRecord({
+        contents: makeContentsRecord({
+          byRef: Immutable.Map({
+            // $FlowFixMe: This really is a content ref, Flow can't handle typing it though
+            [contentRef]: content
+          })
+        })
+      })
+    })
+  })
+});
 
 describe("beforeUnload", () => {
   test("should set event.returnValue if notebook is modified to prevent unload", () => {
-    const store = dummyStore({ saved: false });
+    const contentRef = createContentRef();
+    const store = createStore(
+      contentRef,
+      makeNotebookContentRecord({
+        model: makeDocumentRecord({
+          notebook: "not same",
+          savedNotebook: "different"
+        })
+      })
+    );
 
     const event = {};
 
-    globalEvents.beforeUnload(store, event);
+    globalEvents.beforeUnload(contentRef, store, event);
 
     expect(event.returnValue).toBeDefined();
   });
 
   test("should should not set event.returnValue if notebook is saved", () => {
-    const store = dummyStore({ saved: true });
+    const contentRef = createContentRef();
+    const store = createStore(
+      contentRef,
+      makeNotebookContentRecord({
+        model: makeDocumentRecord({
+          notebook: "same",
+          savedNotebook: "same"
+        })
+      })
+    );
 
     const event = {};
 
-    globalEvents.beforeUnload(store, event);
+    globalEvents.beforeUnload(contentRef, store, event);
 
     expect(event.returnValue).toBeUndefined();
   });
@@ -25,8 +67,10 @@ describe("beforeUnload", () => {
 
 describe("initGlobalHandlers", () => {
   test("adds an unload poperty to the window object", () => {
-    const store = dummyStore();
-    globalEvents.initGlobalHandlers(store);
+    const contentRef = createContentRef();
+    const store = createStore(contentRef);
+
+    globalEvents.initGlobalHandlers(contentRef, store);
     expect(global.window.onunload).toBeDefined();
     expect(global.window.onbeforeunload).toBeDefined();
   });

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -1,476 +1,728 @@
 import { webFrame, ipcRenderer as ipc } from "electron";
 jest.mock("fs");
-import { dummyStore } from "@nteract/core/dummy";
 import * as menu from "../../src/notebook/menu";
 import { selectors, actions, actionTypes } from "@nteract/core";
 
-describe("menu", () => {
-  describe("dispatchCreateCellAfter", () => {
-    test("dispatches a CREATE_CELL_AFTER with code action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchCreateCellAfter(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.createCellAfter({
-          cellType: "code",
-          source: "",
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
+import * as Immutable from "immutable";
+
+describe("dispatchCreateCellAfter", () => {
+  test("dispatches a CREATE_CELL_AFTER with code action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCreateCellAfter(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.createCellAfter({
+        cellType: "code",
+        source: "",
+        contentRef: props.contentRef
+      })
+    );
+  });
+});
+
+describe("dispatchCreateTextCellAfter", () => {
+  test("dispatches a CREATE_CELL_AFTER with markdown action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCreateTextCellAfter(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.createCellAfter({
+        cellType: "markdown",
+        source: "",
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchPasteCell", () => {
+  test("dispatches a pasteCell action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchPasteCell(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.pasteCell({
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchCutCell", () => {
+  test("dispatches a cutCell action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCutCell(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.cutCell({
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchCopyCell", () => {
+  test("dispatches a copyCell action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+    menu.dispatchCopyCell(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.copyCell({
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchSetTheme", () => {
+  test("dispatches a SET_CONFIG_AT_KEY action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchSetTheme(props, store, {}, "test_theme");
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.SET_CONFIG_AT_KEY,
+      key: "theme",
+      value: "test_theme"
     });
   });
+});
+describe("dispatchSetCursorBlink", () => {
+  test("dispatches a SET_CONFIG_AT_KEY action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
 
-  describe("dispatchCreateTextCellAfter", () => {
-    test("dispatches a CREATE_CELL_AFTER with markdown action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchCreateTextCellAfter(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.createCellAfter({
-          cellType: "markdown",
-          source: "",
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
+    menu.dispatchSetCursorBlink(props, store, {}, 42);
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.SET_CONFIG_AT_KEY,
+      key: "cursorBlinkRate",
+      value: 42
     });
   });
+});
 
-  describe("dispatchPasteCell", () => {
-    test("dispatches a pasteCell action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchPasteCell(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.pasteCell({
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
+describe("dispatchLoadConfig", () => {
+  test("dispatches a LOAD_CONFIG action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchLoadConfig(props, store);
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: "LOAD_CONFIG"
     });
   });
+});
 
-  describe("dispatchCutCell", () => {
-    test("dispatches a cutCell action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchCutCell(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.cutCell({
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
+describe("dispatchZoomOut", () => {
+  test("executes zoom out", () => {
+    webFrame.setZoomLevel.mockReset();
+    menu.dispatchZoomOut();
+    expect(webFrame.setZoomLevel).toHaveBeenCalled();
   });
+});
 
-  describe("dispatchCopyCell", () => {
-    test("dispatches a copyCell action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchCopyCell(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.copyCell({
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
+describe("dispatchZoomIn", () => {
+  test("executes zoom in", () => {
+    webFrame.setZoomLevel.mockReset();
+    menu.dispatchZoomIn();
+    expect(webFrame.setZoomLevel).toHaveBeenCalled();
   });
+});
 
-  describe("dispatchSetTheme", () => {
-    test("dispatches a SET_CONFIG_AT_KEY action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchSetTheme(store, {}, "test_theme");
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.SET_CONFIG_AT_KEY,
-        key: "theme",
-        value: "test_theme"
-      });
-    });
+describe("dispatchZoomReset", () => {
+  test("executes zoom reset", () => {
+    webFrame.setZoomLevel.mockReset();
+    menu.dispatchZoomReset();
+    expect(webFrame.setZoomLevel).toHaveBeenCalledWith(0);
   });
-  describe("dispatchSetCursorBlink", () => {
-    test("dispatches a SET_CONFIG_AT_KEY action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
+});
 
-      menu.dispatchSetCursorBlink(store, {}, 42);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.SET_CONFIG_AT_KEY,
-        key: "cursorBlinkRate",
-        value: 42
-      });
-    });
-  });
-
-  describe("dispatchLoadConfig", () => {
-    test("dispatches a LOAD_CONFIG action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchLoadConfig(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: "LOAD_CONFIG"
-      });
-    });
-  });
-
-  describe("dispatchZoomOut", () => {
-    test("executes zoom out", () => {
-      webFrame.setZoomLevel.mockReset();
-      menu.dispatchZoomOut();
-      expect(webFrame.setZoomLevel).toHaveBeenCalled();
-    });
-  });
-
-  describe("dispatchZoomIn", () => {
-    test("executes zoom in", () => {
-      webFrame.setZoomLevel.mockReset();
-      menu.dispatchZoomIn();
-      expect(webFrame.setZoomLevel).toHaveBeenCalled();
-    });
-  });
-
-  describe("dispatchZoomReset", () => {
-    test("executes zoom reset", () => {
-      webFrame.setZoomLevel.mockReset();
-      menu.dispatchZoomReset();
-      expect(webFrame.setZoomLevel).toHaveBeenCalledWith(0);
-    });
-  });
-
-  describe("dispatchRestartClearAll", () => {
-    test("dispatches RESTART_KERNEL with clearOutputs set to true", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchRestartClearAll(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.RESTART_KERNEL,
-        payload: {
-          clearOutputs: true,
-          kernelRef: expect.any(String),
-          contentRef: selectors.currentContentRef(store.getState())
-        }
-      });
-    });
-  });
-
-  describe("dispatchRestartKernel", () => {
-    test("dispatches restart kernel with clearOutputs set to false", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchRestartKernel(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.RESTART_KERNEL,
-        payload: {
-          clearOutputs: false,
-          kernelRef: expect.any(String),
-          contentRef: selectors.currentContentRef(store.getState())
-        }
-      });
-    });
-  });
-
-  describe("dispatchInterruptKernel", () => {
-    test("dispatches INTERRUPT_KERNEL actions", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchInterruptKernel(store);
-
-      if (process.platform !== "win32") {
-        expect(store.dispatch).toHaveBeenCalledWith({
-          type: actionTypes.INTERRUPT_KERNEL,
-          payload: {
-            kernelRef: expect.any(String)
+describe("dispatchRestartClearAll", () => {
+  test("dispatches RESTART_KERNEL with clearOutputs set to true", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": {
+                  filepath: "yep.ipynb",
+                  model: {
+                    type: "notebook",
+                    kernelRef: "k1"
+                  }
+                }
+              })
+            },
+            kernels: {
+              byRef: Immutable.Map({
+                k1: {}
+              })
+            }
           }
-        });
+        }
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchRestartClearAll(props, store);
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.RESTART_KERNEL,
+      payload: {
+        clearOutputs: true,
+        kernelRef: "k1",
+        contentRef: "123"
       }
     });
   });
+});
 
-  describe("dispatchKillKernel", () => {
-    test("dispatches KILL_KERNEL actions", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
+describe("dispatchRestartKernel", () => {
+  test("dispatches restart kernel with clearOutputs set to false", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": {
+                  filepath: "yep.ipynb",
+                  model: {
+                    type: "notebook",
+                    kernelRef: "k1"
+                  }
+                }
+              })
+            },
+            kernels: {
+              byRef: Immutable.Map({
+                k1: {}
+              })
+            }
+          }
+        }
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
 
-      menu.dispatchKillKernel(store);
+    menu.dispatchRestartKernel(props, store);
 
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.RESTART_KERNEL,
+      payload: {
+        clearOutputs: false,
+        kernelRef: "k1",
+        contentRef: "123"
+      }
+    });
+  });
+});
+
+describe("dispatchInterruptKernel", () => {
+  test("dispatches INTERRUPT_KERNEL actions", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        app: Immutable.Map(),
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": {
+                  filepath: "yep.ipynb",
+                  model: {
+                    type: "notebook",
+                    kernelRef: "k1"
+                  }
+                }
+              })
+            },
+            kernels: {
+              byRef: Immutable.Map({
+                k1: {}
+              })
+            }
+          }
+        }
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchInterruptKernel(props, store);
+
+    if (process.platform !== "win32") {
       expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.KILL_KERNEL,
+        type: actionTypes.INTERRUPT_KERNEL,
         payload: {
-          restarting: false,
-          kernelRef: expect.any(String)
+          kernelRef: "k1"
         }
       });
-    });
+    }
   });
+});
 
-  describe("dispatchClearAll", () => {
-    test("dispatches CLEAR_ALL_OUTPUTS actions", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchClearAll(store);
-
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.clearAllOutputs({
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
-  });
-
-  describe("dispatchRunAllBelow", () => {
-    test("runs all code cells below the focused cell", () => {
-      const store = dummyStore({ codeCellCount: 4, markdownCellCount: 4 });
-      const state = store.getState();
-      store.dispatch = jest.fn();
-      menu.dispatchRunAllBelow(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.executeAllCellsBelow({
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
-  });
-
-  describe("dispatchRunAll", () => {
-    test("dispatches executeAllCells action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchRunAll(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.executeAllCells({
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
-  });
-
-  describe("dispatchUnhideAll", () => {
-    test("", () => {
-      const store = dummyStore({ hideAll: true });
-      store.dispatch = jest.fn();
-      menu.dispatchUnhideAll(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.unhideAll({
-          outputHidden: false,
-          inputHidden: false,
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
-  });
-
-  describe("dispatchPublishUserGist", () => {
-    test("dispatches setUserGithub and publishes gist", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchPublishGist(store, {});
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.PUBLISH_GIST,
-        payload: {
-          contentRef: selectors.currentContentRef(store.getState())
+describe("dispatchKillKernel", () => {
+  test("dispatches KILL_KERNEL actions", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": {
+                  filepath: "yep.ipynb",
+                  model: {
+                    type: "notebook",
+                    kernelRef: "k1"
+                  }
+                }
+              })
+            },
+            kernels: {
+              byRef: Immutable.Map({
+                k1: {}
+              })
+            }
+          }
         }
-      });
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchKillKernel(props, store);
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.KILL_KERNEL,
+      payload: {
+        restarting: false,
+        kernelRef: "k1"
+      }
     });
   });
+});
 
-  describe("dispatchNewKernel", () => {
-    test("dispatches LAUNCH_KERNEL action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
+describe("dispatchClearAll", () => {
+  test("dispatches CLEAR_ALL_OUTPUTS actions", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
 
-      menu.dispatchNewKernel(store, {}, { spec: "hokey" });
+    menu.dispatchClearAll(props, store);
 
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: actionTypes.LAUNCH_KERNEL,
-        payload: {
-          kernelSpec: { spec: "hokey" },
-          cwd: process.cwd(),
-          selectNextKernel: true,
-          kernelRef: expect.any(String),
-          contentRef: selectors.currentContentRef(store.getState())
-        }
-      });
-    });
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.clearAllOutputs({
+        contentRef: "123"
+      })
+    );
   });
+});
 
-  describe("dispatchSave", () => {
-    test("sends as SAVE request if given a filename", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchSave(store);
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.save({
-          contentRef: selectors.currentContentRef(store.getState())
+describe("dispatchRunAllBelow", () => {
+  test("runs all code cells below the focused cell", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchRunAllBelow(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.executeAllCellsBelow({
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchRunAll", () => {
+  test("dispatches executeAllCells action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+    menu.dispatchRunAll(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.executeAllCells({
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchUnhideAll", () => {
+  test("", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+    menu.dispatchUnhideAll(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.unhideAll({
+        outputHidden: false,
+        inputHidden: false,
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+// FIXME LEFT OFF HERE needing to either mock more or move more of the github logic to an epic
+describe("dispatchPublishUserGist", () => {
+  test("dispatches setUserGithub and publishes gist", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        app: Immutable.Map({
+          githubToken: "MYTOKEN"
         })
-      );
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchPublishGist(props, store, {});
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.PUBLISH_GIST,
+      payload: {
+        contentRef: "123"
+      }
     });
   });
+});
 
-  describe("dispatchSaveAs", () => {
-    test("dispatches SAVE_AS action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-      menu.dispatchSaveAs(store, {}, "test-ipynb.ipynb");
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.saveAs({
-          filepath: "test-ipynb.ipynb",
-          contentRef: selectors.currentContentRef(store.getState())
-        })
-      );
-    });
-  });
-
-  describe("dispatchLoad", () => {
-    test("dispatches LOAD action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchLoad(store, {}, "test-ipynb.ipynb");
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: "CORE/FETCH_CONTENT",
-        payload: {
-          filepath: "test-ipynb.ipynb",
-          params: {},
-          kernelRef: expect.any(String),
-          contentRef: selectors.currentContentRef(store.getState())
+describe("dispatchNewKernel", () => {
+  test("dispatches LAUNCH_KERNEL action", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map()
+            },
+            kernels: {
+              byRef: {}
+            }
+          }
         }
-      });
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchNewKernel(props, store, {}, { spec: "hokey" });
+
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: actionTypes.LAUNCH_KERNEL,
+      payload: {
+        kernelSpec: { spec: "hokey" },
+        cwd: process.cwd(),
+        selectNextKernel: true,
+        kernelRef: expect.any(String),
+        contentRef: "123"
+      }
     });
   });
+});
 
-  describe("dispatchNewNotebook", () => {
-    test("dispatches a NEW_NOTEBOOK action", () => {
-      const store = dummyStore();
-      store.dispatch = jest.fn();
-
-      menu.dispatchNewNotebook(store, {}, { spec: "hokey" });
-      expect(store.dispatch).toHaveBeenCalledWith({
-        type: "NEW_NOTEBOOK",
-        payload: {
-          kernelSpec: { spec: "hokey" },
-          cwd: process.cwd(),
-          kernelRef: expect.any(String),
-          contentRef: selectors.currentContentRef(store.getState())
+// FIXME COME BACK TO THIS -- make sure save is in a good state
+describe("dispatchSave", () => {
+  test("sends as SAVE request if given a filename", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": {
+                  filepath: "yep.ipynb"
+                }
+              })
+            },
+            kernels: {
+              byRef: {}
+            }
+          }
         }
-      });
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+    menu.dispatchSave(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.save({
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchSaveAs", () => {
+  test("dispatches SAVE_AS action", () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map()
+            },
+            kernels: {
+              byRef: {}
+            }
+          }
+        }
+      })
+    };
+    const props = {
+      contentRef: "123"
+    };
+    menu.dispatchSaveAs(props, store, {}, "test-ipynb.ipynb");
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.saveAs({
+        filepath: "test-ipynb.ipynb",
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchLoad", () => {
+  test("dispatches LOAD action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchLoad(props, store, {}, "test-ipynb.ipynb");
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: "CORE/FETCH_CONTENT",
+      payload: {
+        filepath: "test-ipynb.ipynb",
+        params: {},
+        kernelRef: expect.any(String),
+        contentRef: "123"
+      }
     });
   });
+});
 
-  describe("initMenuHandlers", () => {
-    test("registers the menu events", () => {
-      const store = dummyStore();
-      ipc.on = jest.fn();
-      menu.initMenuHandlers(store);
-      [
-        "main:load-config",
-        "menu:exportPDF",
-        "menu:new-kernel",
-        "menu:run-all",
-        "menu:clear-all",
-        "menu:unhide-all",
-        "menu:save",
-        "menu:save-as",
-        "menu:new-code-cell",
-        "menu:copy-cell",
-        "menu:cut-cell",
-        "menu:paste-cell",
-        "menu:kill-kernel",
-        "menu:interrupt-kernel",
-        "menu:restart-kernel",
-        "menu:restart-and-clear-all",
-        "menu:publish:gist",
-        "menu:zoom-in",
-        "menu:zoom-out",
-        "menu:theme",
-        "menu:set-blink-rate",
-        "main:load",
-        "main:new"
-      ].forEach(name => {
-        expect(ipc.on).toHaveBeenCalledWith(name, expect.any(Function));
-      });
+describe("dispatchNewNotebook", () => {
+  test("dispatches a NEW_NOTEBOOK action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchNewNotebook(props, store, {}, { spec: "hokey" });
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: "NEW_NOTEBOOK",
+      payload: {
+        kernelSpec: { spec: "hokey" },
+        cwd: process.cwd(),
+        kernelRef: expect.any(String),
+        contentRef: "123"
+      }
     });
   });
+});
 
-  describe("triggerWindowRefresh", () => {
-    test("does nothing if no filename is given", () => {
-      const store = dummyStore();
+describe("initMenuHandlers", () => {
+  test("registers the menu events", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
 
-      expect(menu.triggerWindowRefresh(store, null)).toBeUndefined();
+    ipc.on = jest.fn();
+
+    menu.initMenuHandlers(props.contentRef, store);
+    [
+      "main:load-config",
+      "menu:exportPDF",
+      "menu:new-kernel",
+      "menu:run-all",
+      "menu:clear-all",
+      "menu:unhide-all",
+      "menu:save",
+      "menu:save-as",
+      "menu:new-code-cell",
+      "menu:copy-cell",
+      "menu:cut-cell",
+      "menu:paste-cell",
+      "menu:kill-kernel",
+      "menu:interrupt-kernel",
+      "menu:restart-kernel",
+      "menu:restart-and-clear-all",
+      "menu:publish:gist",
+      "menu:zoom-in",
+      "menu:zoom-out",
+      "menu:theme",
+      "menu:set-blink-rate",
+      "main:load",
+      "main:new"
+    ].forEach(name => {
+      expect(ipc.on).toHaveBeenCalledWith(name, expect.any(Function));
     });
-    test("sends a SAVE_AS action if given filename", () => {
-      const store = dummyStore();
-      const filepath = "dummy-nb.ipynb";
-      store.dispatch = jest.fn();
+  });
+});
 
-      menu.triggerWindowRefresh(store, filepath);
+describe("triggerWindowRefresh", () => {
+  test("does nothing if no filename is given", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
 
-      expect(store.dispatch).toHaveBeenCalledWith(
-        actions.saveAs({
-          filepath,
-          contentRef: selectors.currentContentRef(store.getState())
+    expect(menu.triggerWindowRefresh(store, null)).toBeUndefined();
+  });
+  test("sends a SAVE_AS action if given filename", () => {
+    const props = {
+      contentRef: "123"
+    };
+
+    const store = {
+      dispatch: jest.fn()
+    };
+    const filepath = "dummy-nb.ipynb";
+
+    menu.triggerWindowRefresh(props, store, filepath);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.saveAs({
+        filepath,
+        contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("exportPDF", () => {
+  test.skip("it notifies a user upon successful write", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const notificationSystem = { addNotification: jest.fn() };
+    const filepath = "thisisafilename.ipynb";
+    menu.exportPDF(store, filepath, notificationSystem);
+    expect(notificationSystem.addNotification).toHaveBeenCalledWith({
+      title: "PDF exported",
+      message: `Notebook ${filepath} has been exported as a pdf.`,
+      dismissible: true,
+      position: "tr",
+      level: "success"
+    });
+  });
+});
+
+describe("storeToPDF", () => {
+  test("triggers notification when not saved", () => {
+    const config = { noFilename: true };
+    const props = {
+      contentRef: "123"
+    };
+
+    const notificationSystem = { addNotification: jest.fn() };
+
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        core: {
+          entities: {
+            contents: {
+              byRef: Immutable.Map({
+                "123": {
+                  filepath: null
+                }
+              })
+            }
+          }
+        },
+        app: Immutable.Map({
+          notificationSystem
         })
-      );
-    });
-  });
+      })
+    };
 
-  describe("exportPDF", () => {
-    test.skip("it notifies a user upon successful write", () => {
-      const store = dummyStore();
-      const notificationSystem = { addNotification: jest.fn() };
-      const filepath = "thisisafilename.ipynb";
-      menu.exportPDF(store, filepath, notificationSystem);
-      expect(notificationSystem.addNotification).toHaveBeenCalledWith({
-        title: "PDF exported",
-        message: `Notebook ${filepath} has been exported as a pdf.`,
-        dismissible: true,
-        position: "tr",
-        level: "success"
-      });
-    });
-  });
-
-  describe("storeToPDF", () => {
-    test("triggers notification when not saved", () => {
-      const config = { noFilename: true };
-      const store = dummyStore(config);
-      const notificationSystem = store.getState().app.get("notificationSystem");
-
-      notificationSystem.addNotification = jest.fn();
-
-      menu.storeToPDF(store);
-      expect(notificationSystem.addNotification).toHaveBeenCalledWith({
-        action: { callback: expect.any(Function), label: "Save As" },
-        title: "File has not been saved!",
-        message: [
-          "Click the button below to save the notebook such that it can be ",
-          "exported as a PDF."
-        ],
-        dismissible: true,
-        position: "tr",
-        level: "warning"
-      });
-    });
-    test.skip("calls export PDF when filename exists", () => {
-      const store = dummyStore();
-      const addNotification = store.getState().app.get("notificationSystem")
-        .addNotification;
-      menu.storeToPDF(store);
-      expect(addNotification).toHaveBeenCalledWith({
-        title: "PDF exported",
-        message: "Notebook dummy-store-nb has been exported as a pdf.",
-        dismissible: true,
-        position: "tr",
-        level: "success"
-      });
+    menu.storeToPDF(props, store);
+    expect(notificationSystem.addNotification).toHaveBeenCalledWith({
+      action: { callback: expect.any(Function), label: "Save As" },
+      title: "File has not been saved!",
+      message: [
+        "Click the button below to save the notebook so that it can be ",
+        "exported as a PDF."
+      ],
+      dismissible: true,
+      position: "tr",
+      level: "warning"
     });
   });
 });

--- a/applications/desktop/__tests__/renderer/native-window-spec.js
+++ b/applications/desktop/__tests__/renderer/native-window-spec.js
@@ -84,7 +84,9 @@ describe("createTitleFeed", () => {
 
     const state$ = of(state);
 
-    const attributes = await nativeWindow.createTitleFeed(state$).toPromise();
+    const attributes = await nativeWindow
+      .createTitleFeed(currentContentRef, state$)
+      .toPromise();
     expect(attributes).toEqual({
       modified: false,
       fullpath: "titled.ipynb",

--- a/applications/desktop/__tests__/renderer/native-window-spec.js
+++ b/applications/desktop/__tests__/renderer/native-window-spec.js
@@ -50,7 +50,7 @@ describe("setTitleFromAttributes", () => {
 describe("createTitleFeed", () => {
   test("creates an observable that updates title attributes for modified notebook", async function() {
     const kernelRef = stateModule.createKernelRef();
-    const currentContentRef = stateModule.createContentRef();
+    const contentRef = stateModule.createContentRef();
 
     const notebook = new Immutable.Map().setIn(
       ["metadata", "kernelspec", "display_name"],
@@ -59,12 +59,11 @@ describe("createTitleFeed", () => {
     const state = {
       core: stateModule.makeStateRecord({
         kernelRef,
-        currentContentRef,
         entities: stateModule.makeEntitiesRecord({
           contents: stateModule.makeContentsRecord({
             byRef: Immutable.Map({
               // $FlowFixMe: This really is a content ref, Flow can't handle typing it though
-              [currentContentRef]: stateModule.makeNotebookContentRecord({
+              [contentRef]: stateModule.makeNotebookContentRecord({
                 filepath: "titled.ipynb"
               })
             })
@@ -85,7 +84,7 @@ describe("createTitleFeed", () => {
     const state$ = of(state);
 
     const attributes = await nativeWindow
-      .createTitleFeed(currentContentRef, state$)
+      .createTitleFeed(contentRef, state$)
       .toPromise();
     expect(attributes).toEqual({
       modified: false,

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -65,9 +65,6 @@ export const publishEpic = (action$: ActionsObservable<*>, store: any) => {
     mergeMap((action: actionTypes.PublishGist) => {
       const state = store.getState();
 
-      const filepath = selectors.currentFilepath(state);
-      const notificationSystem = selectors.notificationSystem(state);
-
       const contentRef = action.payload.contentRef;
       if (!contentRef) {
         return empty();
@@ -80,6 +77,9 @@ export const publishEpic = (action$: ActionsObservable<*>, store: any) => {
       if (!content || content.type !== "notebook") {
         return empty();
       }
+
+      const filepath = content.filepath;
+      const notificationSystem = selectors.notificationSystem(state);
 
       const model = content.model;
 

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -27,7 +27,16 @@ export function saveEpic(
       const state = store.getState();
       const contentRef = action.payload.contentRef;
 
-      const model = selectors.model(state, { contentRef });
+      const content = selectors.content(state, { contentRef });
+      if (!content) {
+        return of(
+          actions.saveFailed({
+            error: new Error("no notebook loaded to save"),
+            contentRef: action.payload.contentRef
+          })
+        );
+      }
+      const model = content.model;
 
       if (!model || model.type !== "notebook") {
         return of(
@@ -38,7 +47,7 @@ export function saveEpic(
         );
       }
 
-      const filepath = selectors.currentFilepath(state);
+      const filepath = content.filepath;
       // TODO: this default version should probably not be here.
       const appVersion = selectors.appVersion(state) || "0.0.0-beta";
       const notebook = stringifyNotebook(

--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -10,16 +10,21 @@ import type { AppState, KernelRef, ContentRef } from "@nteract/core";
 import { killKernelImmediately } from "./epics/zeromq-kernels";
 
 export function unload(store: Store<AppState, Action>) {
-  const kernel = selectors.currentKernel(store.getState());
-  if (kernel && kernel.type === "zeromq") {
-    // TODO: Do we need to provide a KernelRef here?
-    killKernelImmediately(kernel);
-  } else if (kernel && kernel.type) {
-    // Since desktop doesn't implement websocket backed kernels and this path
-    // would be hidden without a loud error, we're using an alert on exit
-    alert("ERROR: kernel existed yet was not zeromq backed");
-  }
-  return;
+  const state = store.getState();
+
+  state.core.entities.kernels.byRef.forEach((kernel, kernelRef) => {
+    if (kernel.type === "zeromq") {
+      try {
+        killKernelImmediately(kernel);
+      } catch (e) {
+        alert(`Trouble shutting down - ${e.message}`);
+      }
+    } else {
+      alert(
+        "Need to implement a way to shutdown non-zeromq kernels on desktop"
+      );
+    }
+  });
 }
 
 export function beforeUnload(

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -68,7 +68,7 @@ const store = configureStore({
 // Register for debugging
 window.store = store;
 
-initNativeHandlers(store);
+initNativeHandlers(contentRef, store);
 initMenuHandlers(store);
 initGlobalHandlers(contentRef, store);
 

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -56,7 +56,6 @@ const store = configureStore({
     theme: "light"
   }),
   core: makeStateRecord({
-    currentContentRef: contentRef,
     entities: makeEntitiesRecord({
       contents: makeContentsRecord({
         byRef: initialRefs

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -69,7 +69,7 @@ const store = configureStore({
 window.store = store;
 
 initNativeHandlers(contentRef, store);
-initMenuHandlers(store);
+initMenuHandlers(contentRef, store);
 initGlobalHandlers(contentRef, store);
 
 export default class App extends React.PureComponent<Object, Object> {

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -70,7 +70,7 @@ window.store = store;
 
 initNativeHandlers(store);
 initMenuHandlers(store);
-initGlobalHandlers(store);
+initGlobalHandlers(contentRef, store);
 
 export default class App extends React.PureComponent<Object, Object> {
   notificationSystem: NotificationSystem;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -93,7 +93,6 @@ function main(rootEl: Element, dataEl: Node | null) {
       theme: "light"
     }),
     core: makeStateRecord({
-      currentContentRef: contentRef,
       entities: makeEntitiesRecord({
         hosts: makeHostsRecord({
           byRef: Immutable.Map().set(hostRef, jupyterHostRecord)

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -184,7 +184,6 @@ describe("executeCellEpic", () => {
       state: {
         core: stateModule.makeStateRecord({
           kernelRef: "fake",
-          currentContentRef: "fakeContent",
           entities: stateModule.makeEntitiesRecord({
             contents: stateModule.makeContentsRecord({
               byRef: Immutable.Map({

--- a/packages/core/src/dummy/index.js
+++ b/packages/core/src/dummy/index.js
@@ -102,17 +102,16 @@ export function dummyStore(config: *) {
   const channels = mockShell;
 
   const kernelRef = createKernelRef();
-  const currentContentRef = createContentRef();
+  const contentRef = createContentRef();
 
   return createStore(rootReducer, {
     core: makeStateRecord({
       kernelRef,
-      currentContentRef,
       entities: makeEntitiesRecord({
         contents: makeContentsRecord({
           byRef: Immutable.Map({
             // $FlowFixMe: This really is a content ref, Flow can't handle typing it though
-            [currentContentRef]: makeNotebookContentRecord({
+            [contentRef]: makeNotebookContentRecord({
               model: makeDocumentRecord({
                 notebook: dummyNotebook,
                 savedNotebook:

--- a/packages/core/src/reducers/core/index.js
+++ b/packages/core/src/reducers/core/index.js
@@ -22,16 +22,6 @@ const kernelRef = (state = null, action) => {
   }
 };
 
-const currentContentRef = (state = null, action) => {
-  switch (action.type) {
-    case actionTypes.NEW_NOTEBOOK:
-    case actionTypes.FETCH_CONTENT:
-      return action.payload.contentRef;
-    default:
-      return state;
-  }
-};
-
 const currentKernelspecsRef = (state = null, action) => {
   switch (action.type) {
     case actionTypes.FETCH_KERNELSPECS:
@@ -44,7 +34,6 @@ const currentKernelspecsRef = (state = null, action) => {
 const core = combineReducers(
   {
     communication,
-    currentContentRef,
     currentKernelspecsRef,
     entities,
     kernelRef

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -66,17 +66,6 @@ export const model = (
   return content.model;
 };
 
-export const currentContentRef = (state: AppState) =>
-  state.core.currentContentRef;
-
-export const currentContent: (
-  state: AppState
-) => ?ContentRecord = createSelector(
-  currentContentRef,
-  contentByRef,
-  (contentRef, byRef) => (contentRef ? byRef.get(contentRef) : null)
-);
-
 export const kernelRefByContentRef = (
   state: AppState,
   ownProps: { contentRef: ContentRef }
@@ -168,25 +157,6 @@ export const comms = createSelector((state: AppState) => state.comms, identity);
 // NOTE: These are comm models, not contents models
 export const models = createSelector([comms], comms => comms.get("models"));
 
-export const currentModel: (state: AppState) => ContentModel = createSelector(
-  (state: AppState) => currentContent(state),
-  currentContent => {
-    return currentContent ? currentContent.model : makeEmptyModel();
-  }
-);
-
-export const currentContentType: (
-  state: AppState
-) => "notebook" | "dummy" | "directory" | "file" | null = createSelector(
-  (state: AppState) => currentContent(state),
-  content => (content ? content.type : null)
-);
-
-export const currentLastSaved = createSelector(
-  (state: AppState) => currentContent(state),
-  currentContent => (currentContent ? currentContent.lastSaved : null)
-);
-
 export const filepath = (
   state: *,
   ownProps: { contentRef: ContentRef }
@@ -197,13 +167,6 @@ export const filepath = (
   }
   return c.filepath;
 };
-
-/*export const currentFilepath: (state: *) => string = createSelector(
-  (state: AppState) => currentContent(state),
-  currentContent => {
-    return currentContent ? currentContent.filepath : "";
-  }
-);*/
 
 export const modalType = createSelector(
   (state: AppState) => state.core.entities.modals.modalType,

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -77,6 +77,22 @@ export const currentContent: (
   (contentRef, byRef) => (contentRef ? byRef.get(contentRef) : null)
 );
 
+export const kernelRefByContentRef = (
+  state: AppState,
+  ownProps: { contentRef: ContentRef }
+): ?KernelRef => {
+  const c = content(state, ownProps);
+  // TODO: When kernels can be associated on other content types, we'll
+  //      allow those too. For now, because of how flow works we have to
+  //      check the "type" field rather than try to check if `kernelRef` is
+  //      a property of the model. There might be some way though. 🤔
+  if (c && c.model && c.model.type === "notebook") {
+    return c.model.kernelRef;
+  }
+
+  return null;
+};
+
 export const currentKernelspecsRef = (state: AppState) =>
   state.core.currentKernelspecsRef;
 
@@ -171,12 +187,23 @@ export const currentLastSaved = createSelector(
   currentContent => (currentContent ? currentContent.lastSaved : null)
 );
 
-export const currentFilepath: (state: *) => string = createSelector(
+export const filepath = (
+  state: *,
+  ownProps: { contentRef: ContentRef }
+): ?string => {
+  const c = content(state, ownProps);
+  if (!c) {
+    return null;
+  }
+  return c.filepath;
+};
+
+/*export const currentFilepath: (state: *) => string = createSelector(
   (state: AppState) => currentContent(state),
   currentContent => {
     return currentContent ? currentContent.filepath : "";
   }
-);
+);*/
 
 export const modalType = createSelector(
   (state: AppState) => state.core.entities.modals.modalType,

--- a/packages/core/src/state/index.js
+++ b/packages/core/src/state/index.js
@@ -79,7 +79,6 @@ export type ConfigState = Immutable.Map<string, any>;
 
 export type StateRecordProps = {
   kernelRef: ?KernelRef,
-  currentContentRef: ?ContentRef,
   currentKernelspecsRef: ?KernelspecsRef,
   communication: Immutable.RecordOf<CommunicationRecordProps>,
   entities: Immutable.RecordOf<EntitiesRecordProps>
@@ -89,7 +88,6 @@ export const makeStateRecord: Immutable.RecordFactory<
   StateRecordProps
 > = Immutable.Record({
   kernelRef: null,
-  currentContentRef: null,
   currentKernelspecsRef: null,
   communication: makeCommunicationRecord(),
   entities: makeEntitiesRecord()


### PR DESCRIPTION
Definitely a work in progress.

It also dawns on me that we still have `currentKernel` and `currentKernelRef`, when right now we should be associating the kernelRef on a contents model.