### PR TITLE
Run webpack hot in dev

### DIFF
--- a/applications/jupyter-extension/README.md
+++ b/applications/jupyter-extension/README.md
@@ -69,21 +69,20 @@ We recommend running a webpack server for "hot reloading" the javascript and htm
 
 Unfortunately, any changes you make on the Python side will require that you restart the server for them to take effect.
 
-#### 3.1. All-in-one w/ hot reloading (least flexible)
+#### 3.1. All-in-one w/ hot reloading
 
-We can both from a single command from inside the nteract app:
+You can run both with a single command if you run
 
 ```
-lerna run dev --scope nteract-on-jupyter --stream
+jupyter nteract --dev
 ```
 
 This will run two servers, a webpack server for live reloading javascript and html assets and Jupyter server.
 
 Once the assets have been built, you won't need to refresh the page, but you may need to manually refresh the page if it loads before the assets are built.
 
-**N.B.**: Unfortunately, this way of starting the servers will only let you run the Jupyter server in the `nteract` repo. If you want to run notebooks in other directories you'll need to run the commands separately
 
-#### 3.2 Separate commands w/ hot reloading (most flexible)
+#### 3.2 Separate commands w/ hot reloading 
 
 First we need to run the webpack server to live reload javascript and html assets. Anywhere in the nteract repository, run
 
@@ -94,10 +93,10 @@ lerna run hot --scope nteract-on-jupyter --stream
 In another terminal, go to the directory that you want to run notebooks from and run
 
 ```
-jupyter nteract --dev
+jupyter nteract --NteractConfig.asset_url="http://localhost:8080/"
 ```
 
-The ``--dev`` flag tells the Jupyter server where the webpack server will be serving the assets.
+The ``--NteractConfig.asset_url`` flag tells the Jupyter server where the webpack server will be serving the assets.
 
 If you wait until the assets are built, you won't need to manually reload the Jupyter webpage. If you start the server before the assets have been built, you will need to manually refresh the page once before live reloading
 

--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -1,9 +1,14 @@
+
+from subprocess import Popen
+
 from notebook.notebookapp import NotebookApp, flags
 from traitlets import Unicode, Bool
 
-from . import EXT_NAME
+
+from . import EXT_NAME, PACKAGE_DIR
 from .config import NteractConfig
 from .extension import load_jupyter_server_extension
+from .utils import cmd_in_new_dir
 
 webpack_hot = {"address": 'http://localhost:8080/',
                "command":["lerna", "run", "hot",
@@ -52,6 +57,8 @@ class NteractApp(NotebookApp):
             if not self.nbserver_extensions.get(EXT_NAME, False):
                 self.log.warn(msg)
                 load_jupyter_server_extension(self)
+            with cmd_in_new_dir(PACKAGE_DIR):
+                Popen(webpack_hot["command"])
 
 
 

--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -6,7 +6,9 @@ from .config import NteractConfig
 from .extension import load_jupyter_server_extension
 
 webpack_hot = {"address": 'http://localhost:8080/',
-               "command":"`lerna run hot --scope nteract-on-jupyter --stream`"}
+               "command":["lerna", "run", "hot",
+                          "--scope", "nteract-on-jupyter",
+                          "--stream"]}
 nteract_flags = dict(flags)
 nteract_flags['dev'] = (
     {'NteractConfig': {'asset_url': webpack_hot['address']},
@@ -18,7 +20,9 @@ nteract_flags['dev'] = (
         "rebuilds the js files, and serves the new assets on:",
         "    {address}",
         "To access this server run:",
-        "    {command}"]).format(**webpack_hot)
+        "    `{command}`"]).format(address=webpack_hot["address"],
+                                   command=" ".join(webpack_hot["command"])
+        )
 )
 
 class NteractApp(NotebookApp):
@@ -34,10 +38,11 @@ class NteractApp(NotebookApp):
     dev_mode = Bool(False, config=True,
     help="""Whether to start the app in dev mode. Expects resources to be loaded
     from webpack's hot reloading server at {address}. Run
-    {command}
+    `{command}`
     To serve your assets.
     This is only useful if NteractApp is installed editably e.g., using `pip install -e .`.
-    """.format(**webpack_hot))
+    """.format(address=webpack_hot["address"],
+               command=" ".join(webpack_hot["command"])))
 
 
     def init_server_extensions(self):

--- a/applications/jupyter-extension/nteract_on_jupyter/utils.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/utils.py
@@ -1,0 +1,9 @@
+import os
+from contextlib import contextmanager
+
+@contextmanager
+def cmd_in_new_dir(newdir):
+    cur_dir = os.getcwd()
+    os.chdir(newdir)
+    yield
+    os.chdir(cur_dir)


### PR DESCRIPTION
This adds functionality to `jupyter nteract --dev` where it will automatically run the webpack server in a subprocess as part of starting up the server.

This starts after loading the extension.

I also updated the docs to reflect the new functionality.