### PR TITLE
switch cell creator to using explicit binds

### DIFF
--- a/packages/notebook-app-component/src/cell-creator.js
+++ b/packages/notebook-app-component/src/cell-creator.js
@@ -7,7 +7,7 @@ import type { ContentRef } from "@nteract/core";
 
 type Props = {
   above: boolean,
-  createCell: (type: string) => void,
+  createCell: (type: "code" | "markdown") => void,
   mergeCell: () => void
 };
 
@@ -27,110 +27,126 @@ import {
   DownArrowOcticon
 } from "@nteract/octicons";
 
-export const PureCellCreator = (props: Props) => (
-  <div className="creator-hover-mask">
-    <div className="creator-hover-region">
-      <div className="cell-creator">
-        <button
-          onClick={() => props.createCell("markdown")}
-          title="create text cell"
-          className="add-text-cell"
-        >
-          <span className="octicon">
-            <MarkdownOcticon />
-          </span>
-        </button>
-        <button
-          onClick={() => props.createCell("code")}
-          title="create code cell"
-          className="add-code-cell"
-        >
-          <span className="octicon">
-            <CodeOcticon />
-          </span>
-        </button>
-        {props.above ? null : (
-          <button
-            onClick={() => props.mergeCell()}
-            title="merge cells"
-            className="merge-cell"
-          >
-            <span className="octicon">
-              <DownArrowOcticon />
-            </span>
-          </button>
-        )}
+export class PureCellCreator extends React.Component<Props, null> {
+  constructor(props: Props) {
+    super(props);
+
+    (this: any).createMarkdownCell = this.createMarkdownCell.bind(this);
+    (this: any).createCodeCell = this.createCodeCell.bind(this);
+  }
+
+  createMarkdownCell() {
+    this.props.createCell("markdown");
+  }
+
+  createCodeCell() {
+    this.props.createCell("code");
+  }
+
+  render() {
+    return (
+      <div className="creator-hover-mask">
+        <div className="creator-hover-region">
+          <div className="cell-creator">
+            <button
+              onClick={this.createMarkdownCell}
+              title="create text cell"
+              className="add-text-cell"
+            >
+              <span className="octicon">
+                <MarkdownOcticon />
+              </span>
+            </button>
+            <button
+              onClick={this.createCodeCell}
+              title="create code cell"
+              className="add-code-cell"
+            >
+              <span className="octicon">
+                <CodeOcticon />
+              </span>
+            </button>
+            {this.props.above ? null : (
+              <button
+                onClick={this.props.mergeCell}
+                title="merge cells"
+                className="merge-cell"
+              >
+                <span className="octicon">
+                  <DownArrowOcticon />
+                </span>
+              </button>
+            )}
+          </div>
+        </div>
+        <style jsx>{`
+          .creator-hover-mask {
+            display: block;
+            position: relative;
+            overflow: visible;
+            height: 0px;
+          }
+
+          .creator-hover-region {
+            position: relative;
+            overflow: visible;
+            top: -10px;
+            height: 60px;
+            text-align: center;
+          }
+
+          .cell-creator {
+            display: none;
+            background: var(--theme-cell-creator-bg);
+            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+            pointer-events: all;
+            position: relative;
+            top: -5px;
+          }
+
+          .cell-creator button {
+            display: inline-block;
+
+            width: 22px;
+            height: 20px;
+            padding: 0px 4px;
+
+            text-align: center;
+
+            border: none;
+            outline: none;
+            background: none;
+          }
+
+          .cell-creator button span {
+            font-size: 15px;
+            line-height: 1;
+
+            color: var(--theme-cell-creator-fg);
+          }
+
+          .cell-creator button span:hover {
+            color: var(--theme-cell-creator-fg-hover);
+          }
+
+          .creator-hover-region:hover > .cell-creator {
+            display: inline-block;
+          }
+
+          .octicon {
+            transition: color 0.5s;
+          }
+        `}</style>
       </div>
-    </div>
-    <style jsx>{`
-      .creator-hover-mask {
-        display: block;
-        position: relative;
-        overflow: visible;
-        height: 0px;
-      }
-
-      .creator-hover-region {
-        position: relative;
-        overflow: visible;
-        top: -10px;
-        height: 60px;
-        text-align: center;
-      }
-
-      .cell-creator {
-        display: none;
-        background: var(--theme-cell-creator-bg);
-        box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
-        pointer-events: all;
-        position: relative;
-        top: -5px;
-      }
-
-      .cell-creator button {
-        display: inline-block;
-
-        width: 22px;
-        height: 20px;
-        padding: 0px 4px;
-
-        text-align: center;
-
-        border: none;
-        outline: none;
-        background: none;
-      }
-
-      .cell-creator button span {
-        font-size: 15px;
-        line-height: 1;
-
-        color: var(--theme-cell-creator-fg);
-      }
-
-      .cell-creator button span:hover {
-        color: var(--theme-cell-creator-fg-hover);
-      }
-
-      .creator-hover-region:hover > .cell-creator {
-        display: inline-block;
-      }
-
-      .octicon {
-        transition: color 0.5s;
-      }
-    `}</style>
-  </div>
-);
+    );
+  }
+}
 
 class CellCreator extends React.Component<ConnectedProps> {
-  createCell: (type: string) => void;
-  mergeCell: () => void;
-
   constructor(): void {
     super();
-    this.createCell = this.createCell.bind(this);
-    this.mergeCell = this.mergeCell.bind(this);
+    (this: any).createCell = this.createCell.bind(this);
+    (this: any).mergeCell = this.mergeCell.bind(this);
   }
 
   createCell(type: "code" | "markdown"): void {


### PR DESCRIPTION
Just like #2892, this switches over to using (this: any) for component method bindings. It also ensures that we're not creating a new function on every render (though that's a bit of an optimization we probably don't have to worry about on this component).