### PR TITLE
Data explorer cleanup

### DIFF
--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -36,7 +36,7 @@
     "moment": "^2.18.1",
     "react-hot-loader": "^4.1.2",
     "react-virtualized": "9.18.5",
-    "semiotic": "^1.10.4",
+    "semiotic": "^1.10.5",
     "tv4": "^1.3.0"
   }
 }

--- a/packages/transform-dataresource/src/HTMLLegend.js
+++ b/packages/transform-dataresource/src/HTMLLegend.js
@@ -1,13 +1,12 @@
 /* @flow */
 import * as React from "react";
 
-export default ({
-  values,
-  colorHash
-}: {
+type HTMLLegendProps = {
   values: Array<string>,
   colorHash: Object
-}) => (
+};
+
+const HTMLLegend = ({ values, colorHash }: HTMLLegendProps) => (
   <div style={{ marginTop: "20px" }}>
     {(values.length > 18
       ? [...values.filter((d, i) => i < 18), "Other"]
@@ -33,3 +32,5 @@ export default ({
     ))}
   </div>
 );
+
+export default HTMLLegend;

--- a/packages/transform-dataresource/src/charts.js
+++ b/packages/transform-dataresource/src/charts.js
@@ -21,12 +21,34 @@ function combineTopAnnotations(
   topSecondQ: Array<Object>,
   dim2: string
 ): any[] {
-  return [...topQ, ...topSecondQ].map(d => ({
-    type: "react-annotation",
-    label: d[dim2],
-    id: d[dim2],
-    ...d
-  }));
+  const combinedAnnotations = [];
+  const combinedHash = {};
+  [...topQ, ...topSecondQ].forEach(d => {
+    const hashD = combinedHash[d[dim2]];
+
+    if (hashD) {
+      const newCoordinates = (hashD.coordinates && [
+        ...hashD.coordinates,
+        d
+      ]) || [d, hashD];
+      Object.keys(combinedHash[d[dim2]]).forEach(k => {
+        delete combinedHash[d[dim2]][k];
+      });
+      combinedHash[d[dim2]].id = d[dim2];
+      combinedHash[d[dim2]].label = d[dim2];
+      combinedHash[d[dim2]].type = "react-annotation";
+      combinedHash[d[dim2]].coordinates = newCoordinates;
+    } else {
+      combinedHash[d[dim2]] = {
+        type: "react-annotation",
+        label: d[dim2],
+        id: d[dim2],
+        ...d
+      };
+      combinedAnnotations.push(combinedHash[d[dim2]]);
+    }
+  });
+  return combinedAnnotations;
 }
 
 function stringOrFnAccessor(d: Object, accessor: string | Function) {
@@ -696,7 +718,9 @@ const semioticScatterplot = (
     size: [height + 200, height + 50],
     margin: { left: 75, bottom: 50, right: 150, top: 30 },
     annotations: !hexbin && annotations,
-    annotationSettings: { layout: { type: "marginalia", orient: "right" } },
+    annotationSettings: {
+      layout: { type: "marginalia", orient: "right", marginOffset: 30 }
+    },
     tooltipContent: (hexbin && areaTooltip) || pointTooltip,
     ...additionalSettings
   };

--- a/packages/transform-dataresource/src/charts.js
+++ b/packages/transform-dataresource/src/charts.js
@@ -24,6 +24,7 @@ function combineTopAnnotations(
   return [...topQ, ...topSecondQ].map(d => ({
     type: "react-annotation",
     label: d[dim2],
+    id: d[dim2],
     ...d
   }));
 }


### PR DESCRIPTION
* Made the flow types into a separate object and `HTMLLegend` declared and then exported
* Fixed how annotations were displaying in scatterplot
* Update Semiotic version to correct some graphical nonsense