### PR TITLE
Change initial state

### DIFF
--- a/packages/transform-dataresource/src/index.js
+++ b/packages/transform-dataresource/src/index.js
@@ -223,7 +223,7 @@ class DataResourceTransform extends React.Component<Props, State> {
       .filter(d => !props.data.schema.primaryKey.find(p => p === d.name));
 
     this.state = {
-      view: "parallel",
+      view: "grid",
       lineType: "line",
       selectedDimensions: [],
       selectedMetrics: [],


### PR DESCRIPTION
The change in `state.view` was to test parallel coordinates, it should default to `grid` to begin with
