### PR TITLE
start react component documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "react-markdown": "^3.1.4",
     "react-notification-system": "^0.2.16",
     "react-redux": "^5.0.7",
+    "react-styleguidist": "^7.0.14",
     "react-syntax-highlighter": "^7.0.1",
     "react-test-renderer": "^16.2.0",
     "react-virtualized": "9.19.1",

--- a/packages/presentational-components/src/components/prompt.js
+++ b/packages/presentational-components/src/components/prompt.js
@@ -1,0 +1,69 @@
+// @flow
+
+import * as React from "react";
+import css from "styled-jsx/css";
+
+const promptStyle = css`
+  .prompt {
+    font-family: monospace;
+    font-size: 12px;
+    line-height: 22px;
+
+    width: var(--prompt-width, 50px);
+    padding: 9px 0;
+
+    text-align: center;
+
+    color: var(--theme-cell-prompt-fg, black);
+    background-color: var(--theme-cell-prompt-bg, #fafafa);
+  }
+`;
+
+// Totally fake component for consistency with indents of the editor area
+
+export function promptText(props: PromptProps) {
+  if (props.running) {
+    return "[*]";
+  }
+  if (props.queued) {
+    return "[…]";
+  }
+  if (typeof props.counter === "number") {
+    return `[${props.counter}]`;
+  }
+  return "[ ]";
+}
+
+type PromptProps = {
+  counter: number | null,
+  running: boolean,
+  queued: boolean
+};
+
+export class Prompt extends React.Component<PromptProps, null> {
+  static defaultProps = {
+    counter: null,
+    running: false,
+    queued: false
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <div className="prompt">{promptText(this.props)}</div>
+        <style jsx>{promptStyle}</style>
+      </React.Fragment>
+    );
+  }
+}
+
+export class PromptBuffer extends React.Component<any, null> {
+  render() {
+    return (
+      <React.Fragment>
+        <div className="prompt" />
+        <style jsx>{promptStyle}</style>
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/presentational-components/src/components/prompt.md
+++ b/packages/presentational-components/src/components/prompt.md
@@ -1,0 +1,23 @@
+Display an empty prompt
+
+```
+<Prompt />
+```
+
+Set the counter to 12
+
+```js
+<Prompt counter={12} />
+```
+
+Mark this prompt as "running"
+
+```js
+<Prompt counter={12} running />
+```
+
+Mark this prompt as "queued"
+
+```js
+<Prompt counter={12} queued />
+```

--- a/packages/presentational-components/src/index.js
+++ b/packages/presentational-components/src/index.js
@@ -2,11 +2,12 @@
 import * as React from "react";
 
 import Highlighter from "./syntax-highlighter";
+import { Prompt, PromptBuffer } from "./components/prompt.js";
 
 export * from "./styles";
 
 import * as themes from "./themes";
-export { themes };
+export { themes, Prompt, PromptBuffer };
 
 export type PagersProps = {
   children: React.Node,
@@ -203,43 +204,6 @@ export class Outputs extends React.Component<OutputsProps> {
     }
 
     return null;
-  }
-}
-// Totally fake component for consistency with indents of the editor area
-export class PromptBuffer extends React.Component<*> {
-  render() {
-    return <div className="prompt" />;
-  }
-}
-
-export function promptText(props: PromptProps) {
-  if (props.running) {
-    return "[*]";
-  }
-  if (props.queued) {
-    return "[…]";
-  }
-  if (typeof props.counter === "number") {
-    return `[${props.counter}]`;
-  }
-  return "[ ]";
-}
-
-type PromptProps = {
-  counter: number | null,
-  running: boolean,
-  queued: boolean
-};
-
-export class Prompt extends React.Component<PromptProps> {
-  static defaultProps = {
-    counter: null,
-    running: false,
-    queued: false
-  };
-
-  render() {
-    return <div className="prompt">{promptText(this.props)}</div>;
   }
 }
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  components: "packages/presentational-components/src/components/*.js",
+  webpackConfig: {
+    module: {
+      rules: [
+        // Babel loader, will use your project’s .babelrc
+        {
+          test: /\.jsx?$/,
+          exclude: /node_modules/,
+          loader: "babel-loader"
+        }
+      ]
+    }
+  }
+};


### PR DESCRIPTION
@willingc and I gave [React Styleguidist](https://react-styleguidist.js.org/docs/documenting.html) a spin and we really like it.

In this PR we've set up exactly one component, the `<Prompt />` from `@nteract/presentational-components`. To do this we needed `<Prompt />` to be in its own js file and have a matching `prompt.md`.

Running:

```
$ npx styleguidist server
(node:28043) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
You can now view your style guide in the browser:

  Local:            http://localhost:6060/
  On your network:  http://10.174.45.118:6060/

 DONE  Compiled successfully!
```

Rendered Page:

![screen shot 2018-05-30 at 7 17 43 am](https://user-images.githubusercontent.com/836375/40725959-93a5b5b2-63d9-11e8-8c71-06fa37fca5f6.png)
