### PR TITLE
Improve <Prompt /> Documentation

### DIFF
--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -49,6 +49,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
           hidden={false}
         >
           <Prompt
+            blank={false}
             counter={11}
             queued={false}
             running={false}
@@ -296,6 +297,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
           hidden={false}
         >
           <Prompt
+            blank={false}
             counter={11}
             queued={false}
             running={false}

--- a/packages/presentational-components/src/components/prompt.js
+++ b/packages/presentational-components/src/components/prompt.js
@@ -1,27 +1,10 @@
 // @flow
-
 import * as React from "react";
-import css from "styled-jsx/css";
 
-const promptStyle = css`
-  .prompt {
-    font-family: monospace;
-    font-size: 12px;
-    line-height: 22px;
-
-    width: var(--prompt-width, 50px);
-    padding: 9px 0;
-
-    text-align: center;
-
-    color: var(--theme-cell-prompt-fg, black);
-    background-color: var(--theme-cell-prompt-bg, #fafafa);
-  }
-`;
-
-// Totally fake component for consistency with indents of the editor area
-
-export function promptText(props: PromptProps) {
+/**
+ * Generate what text goes inside the prompt based on the props to the prompt
+ */
+export function promptText(props: PromptProps): string {
   if (props.running) {
     return "[*]";
   }
@@ -37,33 +20,42 @@ export function promptText(props: PromptProps) {
 type PromptProps = {
   counter: number | null,
   running: boolean,
-  queued: boolean
+  queued: boolean,
+  blank: boolean
 };
 
 export class Prompt extends React.Component<PromptProps, null> {
   static defaultProps = {
     counter: null,
     running: false,
-    queued: false
+    queued: false,
+    blank: false
   };
 
   render() {
     return (
       <React.Fragment>
-        <div className="prompt">{promptText(this.props)}</div>
-        <style jsx>{promptStyle}</style>
+        <div className="prompt">
+          {this.props.blank ? null : promptText(this.props)}
+        </div>
+        <style jsx>{`
+          .prompt {
+            font-family: monospace;
+            font-size: 12px;
+            line-height: 22px;
+
+            width: var(--prompt-width, 50px);
+            padding: 9px 0;
+
+            text-align: center;
+
+            color: var(--theme-cell-prompt-fg, black);
+            background-color: var(--theme-cell-prompt-bg, #fafafa);
+          }
+        `}</style>
       </React.Fragment>
     );
   }
 }
 
-export class PromptBuffer extends React.Component<any, null> {
-  render() {
-    return (
-      <React.Fragment>
-        <div className="prompt" />
-        <style jsx>{promptStyle}</style>
-      </React.Fragment>
-    );
-  }
-}
+export const PromptBuffer = () => <Prompt blank />;

--- a/packages/presentational-components/src/components/prompt.js
+++ b/packages/presentational-components/src/components/prompt.js
@@ -18,9 +18,32 @@ export function promptText(props: PromptProps): string {
 }
 
 type PromptProps = {
-  counter: number | null,
+  /**
+   * Typically used to show what execution count the user is on. When working at
+   * the `IPython` or `jupyter console` for example, it's the number between the
+   * `[ ]`:
+   *
+   * ```
+   * In [1]: 2 + 2
+   * Out[1]: 4
+   *
+   * In [2]: "woohoo"
+   * Out[2]: 'woohoo'
+   * ```
+   *
+   */
+  counter: ?number,
+  /**
+   * Show that execution is currently happening related to this prompt
+   */
   running: boolean,
+  /**
+   * Show that execution is queued up
+   */
   queued: boolean,
+  /**
+   * Create a prompt without the `[]`. Used with markdown cells.
+   */
   blank: boolean
 };
 

--- a/packages/presentational-components/src/index.js
+++ b/packages/presentational-components/src/index.js
@@ -272,18 +272,6 @@ export class Input extends React.Component<InputProps> {
           }
 
           .input-container :global(.prompt) {
-            font-family: monospace;
-            font-size: 12px;
-            line-height: 22px;
-
-            width: var(--prompt-width, 50px);
-            padding: 9px 0;
-
-            text-align: center;
-
-            color: var(--theme-cell-prompt-fg, black);
-            background-color: var(--theme-cell-prompt-bg, #fafafa);
-
             flex: 0 0 auto;
           }
 


### PR DESCRIPTION
While extracting `<Prompt />` for documentation I noticed a few things that should be cleaned up:

* `<PromptBuffer />` can be a special case of `<Prompt />`
* The `<Input />` component shouldn't have to contain the `<Prompt />` styles
* We can provide a description for each of the props with multiline comments

🎉 

![screen shot 2018-05-30 at 9 09 25 am](https://user-images.githubusercontent.com/836375/40732873-2bb9b844-63e9-11e8-87bb-82a172ffc93a.png)
