### PR TITLE
include import code at the top of each example

### DIFF
--- a/packages/presentational-components/src/components/cell.md
+++ b/packages/presentational-components/src/components/cell.md
@@ -1,3 +1,7 @@
+```jsx static
+import { Cell } from "@nteract/presentational-components"
+```
+
 All by itself, this component doesn't do anything. Used with `<Input />`, `<Source />`, and `<Outputs />`, it brings styling to the children
 based on hover and **selected** states.
 

--- a/packages/presentational-components/src/components/cells.md
+++ b/packages/presentational-components/src/components/cells.md
@@ -1,3 +1,8 @@
+```jsx static
+import { Cells } from "@nteract/presentational-components"
+```
+
+
 `<Cells />` is a wrapper component to provide buffers between cells if you're building a notebook app.
 
 ```js

--- a/packages/presentational-components/src/components/input.md
+++ b/packages/presentational-components/src/components/input.md
@@ -1,3 +1,7 @@
+```jsx static
+import { Input } from "@nteract/presentational-components"
+```
+
 Display an input area
 
 ```

--- a/packages/presentational-components/src/components/outputs.md
+++ b/packages/presentational-components/src/components/outputs.md
@@ -1,3 +1,7 @@
+```jsx static
+import { Outputs } from "@nteract/presentational-components"
+```
+
 Display an output area
 
 ```

--- a/packages/presentational-components/src/components/pagers.md
+++ b/packages/presentational-components/src/components/pagers.md
@@ -1,3 +1,7 @@
+```jsx static
+import { Pagers } from "@nteract/presentational-components"
+```
+
 Display a pager area
 
 ```

--- a/packages/presentational-components/src/components/prompt.md
+++ b/packages/presentational-components/src/components/prompt.md
@@ -1,3 +1,7 @@
+```jsx static
+import { Prompt } from "@nteract/presentational-components"
+```
+
 Display an empty prompt
 
 ```

--- a/packages/presentational-components/src/components/source.md
+++ b/packages/presentational-components/src/components/source.md
@@ -1,3 +1,7 @@
+```jsx static
+import { Source } from "@nteract/presentational-components"
+```
+
 Syntax highlight source code. Pass a child component to override with your own editor or syntax highlighting implementation.
 
 ### Syntax Highlight


### PR DESCRIPTION
Hey look @willingc, we can render static `jsx`!

<img width="830" alt="screen shot 2018-05-31 at 6 29 54 am" src="https://user-images.githubusercontent.com/836375/40784986-1341f408-649c-11e8-80d5-e2d65a4151d8.png">

I put `import { Thing } from "@nteract/presentational-components` at the top of each of our documented components.