### PR TITLE
Add: Open recent to file menu on osx

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -128,7 +128,7 @@
     "@nteract/webpack-configurator": "^1.1.0",
     "cross-env": "^5.1.3",
     "date-fns": "^1.29.0",
-    "electron": "1.8.7",
+    "electron": "2.0.2",
     "electron-builder": "^20.0.0",
     "electron-context-menu": "^0.9.1",
     "electron-log": "^2.2.13",

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -231,6 +231,7 @@ export function loadFullMenu(store: * = global.store) {
         dialog.showOpenDialog(opts, fname => {
           if (fname) {
             launch(fname[0]);
+            app.addRecentDocument(fname[0]);
           }
         });
       },
@@ -389,6 +390,19 @@ export function loadFullMenu(store: * = global.store) {
         label: "Exit",
         accelerator: "Alt+F4",
         role: "close"
+      }
+    );
+  }
+  else if (process.platform === "darwin") {
+    file.submenu.splice(2, 0, {
+        label: 'Open Recent',
+        role: 'recentDocuments',
+        submenu: [
+          {
+            label: 'Clear Recent',
+            role: 'clearRecentDocuments'
+          }
+        ]
       }
     );
   }
@@ -613,6 +627,20 @@ export function loadFullMenu(store: * = global.store) {
         label: "Exit",
         accelerator: "Alt+F4",
         role: "close"
+      }
+    );
+  }
+  else if (process.platform === "darwin") {
+    fileWithNew.submenu.splice(2, 0,
+      {
+        label: 'Open Recent',
+        role: 'recentDocuments',
+        submenu: [
+          {
+            label: 'Clear Recent',
+            role: 'clearRecentDocuments'
+          }
+        ]
       }
     );
   }

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "date-fns": "^1.29.0",
     "deepmerge": "^2.0.1",
     "elasticsearch": "^12.1.3",
-    "electron": "1.8.7",
+    "electron": "2.0.2",
     "electron-context-menu": "^0.9.1",
     "electron-log": "^2.2.13",
     "enzyme": "^3.3.0",


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

As proposed in #263, this PR adds an open recent menu to macOS.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->