### PR TITLE
New records

### DIFF
--- a/nbformat.v4.json
+++ b/nbformat.v4.json
@@ -1,0 +1,450 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Jupyter Notebook v4.2 JSON schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "nbformat_minor", "nbformat", "cells"],
+  "properties": {
+    "metadata": {
+      "description": "Notebook root-level metadata.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "kernelspec": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name", "display_name"],
+          "properties": {
+            "name": {
+              "description": "Name of the kernel specification.",
+              "type": "string"
+            },
+            "display_name": {
+              "description": "Name to display in UI.",
+              "type": "string"
+            }
+          }
+        },
+        "language_info": {
+          "description": "Kernel information.",
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "description": "The programming language which this kernel runs.",
+              "type": "string"
+            },
+            "codemirror_mode": {
+              "description":
+                "The codemirror mode to use for code in this language.",
+              "oneOf": [{ "type": "string" }, { "type": "object" }]
+            },
+            "file_extension": {
+              "description": "The file extension for files in this language.",
+              "type": "string"
+            },
+            "mimetype": {
+              "description":
+                "The mimetype corresponding to files in this language.",
+              "type": "string"
+            },
+            "pygments_lexer": {
+              "description":
+                "The pygments lexer to use for code in this language.",
+              "type": "string"
+            }
+          }
+        },
+        "orig_nbformat": {
+          "description":
+            "Original notebook format (major number) before converting the notebook between versions. This should never be written to a file.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "description": "The title of the notebook document",
+          "type": "string"
+        },
+        "authors": {
+          "description": "The author(s) of the notebook document",
+          "type": "array",
+          "item": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "nbformat_minor": {
+      "description":
+        "Notebook format (minor number). Incremented for backward compatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "nbformat": {
+      "description":
+        "Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.",
+      "type": "integer",
+      "minimum": 4,
+      "maximum": 4
+    },
+    "cells": {
+      "description": "Array of cells of the current notebook.",
+      "type": "array",
+      "items": { "$ref": "#/definitions/cell" }
+    }
+  },
+
+  "definitions": {
+    "cell": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/raw_cell" },
+        { "$ref": "#/definitions/markdown_cell" },
+        { "$ref": "#/definitions/code_cell" }
+      ]
+    },
+
+    "raw_cell": {
+      "description": "Notebook raw nbconvert cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "metadata", "source"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["raw"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "format": {
+              "description": "Raw cell metadata format for nbconvert.",
+              "type": "string"
+            },
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Raw Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              }
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "attachments": { "$ref": "#/definitions/misc/attachments" },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "markdown_cell": {
+      "description": "Notebook markdown cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cell_type", "metadata", "source"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["markdown"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" },
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Markdown Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        "attachments": { "$ref": "#/definitions/misc/attachments" },
+        "source": { "$ref": "#/definitions/misc/source" }
+      }
+    },
+
+    "code_cell": {
+      "description": "Notebook code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cell_type",
+        "metadata",
+        "source",
+        "outputs",
+        "execution_count"
+      ],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "enum": ["code"]
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "jupyter": {
+              "description": "Official Jupyter Metadata for Code Cells",
+              "type": "object",
+              "additionalProperties": true,
+              "source_hidden": {
+                "description": "Whether the source is hidden.",
+                "type": "boolean"
+              },
+              "outputs_hidden": {
+                "description": "Whether the outputs are hidden.",
+                "type": "boolean"
+              }
+            },
+            "collapsed": {
+              "description": "Whether the cell is collapsed/expanded.",
+              "type": "boolean"
+            },
+            "scrolled": {
+              "description":
+                "Whether the cell's output is scrolled, unscrolled, or autoscrolled.",
+              "enum": [true, false, "auto"]
+            },
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          }
+        },
+        "source": { "$ref": "#/definitions/misc/source" },
+        "outputs": {
+          "description": "Execution, display, or stream outputs.",
+          "type": "array",
+          "items": { "$ref": "#/definitions/output" }
+        },
+        "execution_count": {
+          "description":
+            "The code cell's prompt number. Will be null if the cell has not been run.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+
+    "unrecognized_cell": {
+      "description":
+        "Unrecognized cell from a future minor-revision to the notebook format.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["cell_type", "metadata"],
+      "properties": {
+        "cell_type": {
+          "description": "String identifying the type of cell.",
+          "not": {
+            "enum": ["markdown", "code", "raw"]
+          }
+        },
+        "metadata": {
+          "description": "Cell-level metadata.",
+          "type": "object",
+          "properties": {
+            "name": { "$ref": "#/definitions/misc/metadata_name" },
+            "tags": { "$ref": "#/definitions/misc/metadata_tags" }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+
+    "output": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/execute_result" },
+        { "$ref": "#/definitions/display_data" },
+        { "$ref": "#/definitions/stream" },
+        { "$ref": "#/definitions/error" }
+      ]
+    },
+
+    "execute_result": {
+      "description": "Result of executing a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "data", "metadata", "execution_count"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["execute_result"]
+        },
+        "execution_count": {
+          "description": "A result's prompt number.",
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "data": { "$ref": "#/definitions/misc/mimebundle" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      }
+    },
+
+    "display_data": {
+      "description": "Data displayed as a result of code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "data", "metadata"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["display_data"]
+        },
+        "data": { "$ref": "#/definitions/misc/mimebundle" },
+        "metadata": { "$ref": "#/definitions/misc/output_metadata" }
+      }
+    },
+
+    "stream": {
+      "description": "Stream output from a code cell.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "name", "text"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["stream"]
+        },
+        "name": {
+          "description": "The name of the stream (stdout, stderr).",
+          "type": "string"
+        },
+        "text": {
+          "description":
+            "The stream's text output, represented as an array of strings.",
+          "$ref": "#/definitions/misc/multiline_string"
+        }
+      }
+    },
+
+    "error": {
+      "description":
+        "Output of an error that occurred during code cell execution.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["output_type", "ename", "evalue", "traceback"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "enum": ["error"]
+        },
+        "ename": {
+          "description": "The name of the error.",
+          "type": "string"
+        },
+        "evalue": {
+          "description": "The value, or message, of the error.",
+          "type": "string"
+        },
+        "traceback": {
+          "description":
+            "The error's traceback, represented as an array of strings.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+
+    "unrecognized_output": {
+      "description":
+        "Unrecognized output from a future minor-revision to the notebook format.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["output_type"],
+      "properties": {
+        "output_type": {
+          "description": "Type of cell output.",
+          "not": {
+            "enum": ["execute_result", "display_data", "stream", "error"]
+          }
+        }
+      }
+    },
+
+    "misc": {
+      "metadata_name": {
+        "description":
+          "The cell's name. If present, must be a non-empty string. Cell names are expected to be unique across all the cells in a given notebook. This criterion cannot be checked by the json schema and must be established by an additional check.",
+        "type": "string",
+        "pattern": "^.+$"
+      },
+      "metadata_tags": {
+        "description":
+          "The cell's tags. Tags must be unique, and must not contain commas.",
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+          "type": "string",
+          "pattern": "^[^,]+$"
+        }
+      },
+      "attachments": {
+        "description":
+          "Media attachments (e.g. inline images), stored as mimebundle keyed by filename.",
+        "type": "object",
+        "patternProperties": {
+          ".*": {
+            "description": "The attachment's data stored as a mimebundle.",
+            "$ref": "#/definitions/misc/mimebundle"
+          }
+        }
+      },
+      "source": {
+        "description":
+          "Contents of the cell, represented as an array of lines.",
+        "$ref": "#/definitions/misc/multiline_string"
+      },
+      "execution_count": {
+        "description":
+          "The code cell's prompt number. Will be null if the cell has not been run.",
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "mimebundle": {
+        "description": "A mime-type keyed dictionary of data",
+        "type": "object",
+        "additionalProperties": {
+          "description":
+            "mimetype output (e.g. text/plain), represented as either an array of strings or a string.",
+          "$ref": "#/definitions/misc/multiline_string"
+        },
+        "patternProperties": {
+          "^application/(.*\\+)?json$": {
+            "description": "Mimetypes with JSON output, can be any type"
+          }
+        }
+      },
+      "output_metadata": {
+        "description": "Cell output metadata.",
+        "type": "object",
+        "additionalProperties": true
+      },
+      "multiline_string": {
+        "oneOf": [
+          { "type": "string" },
+          {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/records/.npmrc
+++ b/packages/records/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/packages/records/README.md
+++ b/packages/records/README.md
@@ -1,0 +1,56 @@
+# nteract records
+
+Philosophy: create very flat records for core data types used in nteract, to be used across applications.
+
+> Wait, what about commutable?
+
+Commutable has been _awesome_ and should be borrowed from to build this up. However, commutable relied heavily on
+Immutable.Map()'s. These lose all the benefits of flow typing, defaults, and direct property access that records have.
+
+> Could we add these directly to commutable?
+
+I'd love to. However, I didn't want to make a refactor that required refactoring all the apps that use them, as well as any external usage (Hydrogen included) that would have to adapt to new interfaces.
+
+> Where should I start in helping with this effort?
+
+Look over how `src/outputs/stream.js` and `src/outputs/index.js` sets up the base types. Implement the other output types in a similar fashion.
+
+- [x] stream
+- [ ] display_data
+- [ ] execute_result
+- [ ] error
+
+## References
+
+- [nbformat v4](https://raw.githubusercontent.com/jupyter/nbformat/master/nbformat/v4/nbformat.v4.schema.json)
+- [Jupyter Message Format](http://jupyter-client.readthedocs.io/en/stable/messaging.html#general-message-format)
+- [commutable's implementation](../commutable/src/v4.js) -- `packages/commutable/src/v4.js`
+
+## Testing
+
+Run
+
+```
+npm t -- records --watch
+```
+
+to run the tests locally while watching to all changes in the records setup.
+
+## Types!
+
+If your editor isn't already helping you with this, use
+
+```
+npm run flow
+```
+
+## Documentation
+
+To help figure out where we _might_ end up with documentation for nteract libraries (as opposed to components, which use react-docgen / react-styleguidist ), use [documentation.js](https://github.com/documentationjs/documentation) to run docs for this library.
+
+```
+npm install -g documentation
+documentation serve --watch packages/records/src
+```
+
+I have a feeling we'll end up having to do some custom things with our monorepo to make this more palatable.

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -38,3 +38,50 @@ describe("stream output", () => {
     );
   });
 });
+
+describe("display_data output", () => {
+  test("can be converted from nbformat", () => {
+    expect(
+      nteractRecords.outputFromNbformat({
+        output_type: "display_data",
+        data: {
+          infinityStones: [
+            "mind\n",
+            "time\n",
+            "space\n",
+            "reality\n",
+            "power\n",
+            "soul"
+          ]
+        },
+        metadata: { "application/json": { expanded: true } }
+      })
+    ).toEqual(
+      nteractRecords.makeDisplayDataOutputRecord({
+        outputType: "display_data",
+        data: { infinityStones: "mind\ntime\nspace\nreality\npower\nsoul" },
+        metadata: { "application/json": { expanded: true } }
+      })
+    );
+  });
+
+  test("can be converted from jupyter messages", () => {
+    expect(
+      nteractRecords.displayDataRecordFromMessage({
+        header: {
+          msg_type: "display_data"
+        },
+        content: {
+          data: { anotherDay: "anotherDoug" },
+          metadata: { "application/json": { expanded: true } }
+        }
+      })
+    ).toEqual(
+      nteractRecords.makeDisplayDataOutputRecord({
+        outputType: "display_data",
+        data: { anotherDay: "anotherDoug" },
+        metadata: { "application/json": { expanded: true } }
+      })
+    );
+  });
+});

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,0 +1,40 @@
+// @flow
+import * as nteractRecords from "@nteract/records";
+
+describe("stream output", () => {
+  test("can be converted from nbformat", () => {
+    expect(
+      nteractRecords.outputFromNbformat({
+        output_type: "stream",
+        name: "stdout",
+        text: ["sup\n", "yall"]
+      })
+    ).toEqual(
+      nteractRecords.makeStreamOutputRecord({
+        outputType: "stream",
+        name: "stdout",
+        text: "sup\nyall"
+      })
+    );
+  });
+
+  test("can be converted from jupyter messages", () => {
+    expect(
+      nteractRecords.streamRecordFromMessage({
+        header: {
+          msg_type: "stream"
+        },
+        content: {
+          name: "stdout",
+          text: "it is love we must hold on to\nnever easy but we try"
+        }
+      })
+    ).toEqual(
+      nteractRecords.makeStreamOutputRecord({
+        outputType: "stream",
+        name: "stdout",
+        text: "it is love we must hold on to\nnever easy but we try"
+      })
+    );
+  });
+});

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -151,7 +151,7 @@ describe("error output", () => {
         output_type: "error",
         ename: "Thor",
         evalue: "Pirate Angel",
-        traceback: Immutable.List(["sweet", "rabbit"])
+        traceback: ["sweet", "rabbit"]
       })
     );
   });
@@ -165,7 +165,7 @@ describe("error output", () => {
         content: {
           ename: "cats",
           evalue: "good",
-          traceback: Immutable.List(["squirrel"])
+          traceback: ["squirrel"]
         }
       })
     ).toEqual(
@@ -173,7 +173,7 @@ describe("error output", () => {
         outputType: "error",
         ename: "cats",
         evalue: "good",
-        traceback: Immutable.List(["squirrel"])
+        traceback: ["squirrel"]
       })
     );
   });

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -59,7 +59,16 @@ describe("display_data output", () => {
     ).toEqual(
       nteractRecords.makeDisplayDataOutputRecord({
         outputType: "display_data",
-        data: { infinityStones: "mind\ntime\nspace\nreality\npower\nsoul" },
+        data: {
+          infinityStones: [
+            "mind\n",
+            "time\n",
+            "space\n",
+            "reality\n",
+            "power\n",
+            "soul"
+          ]
+        },
         metadata: { "application/json": { expanded: true } }
       })
     );
@@ -81,6 +90,64 @@ describe("display_data output", () => {
         outputType: "display_data",
         data: { anotherDay: "anotherDoug" },
         metadata: { "application/json": { expanded: true } }
+      })
+    );
+  });
+});
+
+describe("execute_result output", () => {
+  test("can be converted from nbformat", () => {
+    expect(
+      nteractRecords.outputFromNbformat({
+        output_type: "execute_result",
+        execute_result: 7,
+        data: {
+          infinityStones: [
+            "mind\n",
+            "time\n",
+            "space\n",
+            "reality\n",
+            "power\n",
+            "soul"
+          ]
+        },
+        metadata: { "application/json": { expanded: true } }
+      })
+    ).toEqual(
+      nteractRecords.makeExecuteResultOutputRecord({
+        outputType: "execute_result",
+        execute_result: 7,
+        data: {
+          infinityStones: [
+            "mind\n",
+            "time\n",
+            "space\n",
+            "reality\n",
+            "power\n",
+            "soul"
+          ]
+        },
+        metadata: { "application/json": { expanded: true } }
+      })
+    );
+  });
+
+  test("can be converted from jupyter messages", () => {
+    expect(
+      nteractRecords.executeResultRecordFromMessage({
+        header: {
+          msg_type: "execute_result"
+        },
+        content: {
+          data: { anotherDay: "anotherDoug" },
+          metadata: { "application/json": { expanded: false } }
+        }
+      })
+    ).toEqual(
+      nteractRecords.makeExecuteResultOutputRecord({
+        outputType: "execute_result",
+        data: { anotherDay: "anotherDoug" },
+        metadata: { "application/json": { expanded: false } }
       })
     );
   });

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,4 +1,5 @@
 // @flow
+import * as Immutable from "immutable";
 import * as nteractRecords from "@nteract/records";
 
 describe("stream output", () => {
@@ -59,17 +60,12 @@ describe("display_data output", () => {
     ).toEqual(
       nteractRecords.makeDisplayDataOutputRecord({
         outputType: "display_data",
-        data: {
-          infinityStones: [
-            "mind\n",
-            "time\n",
-            "space\n",
-            "reality\n",
-            "power\n",
-            "soul"
-          ]
-        },
-        metadata: { "application/json": { expanded: true } }
+        data: Immutable.Map({
+          infinityStones: "mind\ntime\nspace\nreality\npower\nsoul"
+        }),
+        metadata: Immutable.Map({
+          "application/json": Immutable.Map({ expanded: true })
+        })
       })
     );
   });
@@ -102,14 +98,7 @@ describe("execute_result output", () => {
         output_type: "execute_result",
         execute_result: 7,
         data: {
-          infinityStones: [
-            "mind\n",
-            "time\n",
-            "space\n",
-            "reality\n",
-            "power\n",
-            "soul"
-          ]
+          planets: ["xandar\n", "nidavellir\n", "terra"]
         },
         metadata: { "application/json": { expanded: true } }
       })
@@ -117,17 +106,12 @@ describe("execute_result output", () => {
       nteractRecords.makeExecuteResultOutputRecord({
         outputType: "execute_result",
         execute_result: 7,
-        data: {
-          infinityStones: [
-            "mind\n",
-            "time\n",
-            "space\n",
-            "reality\n",
-            "power\n",
-            "soul"
-          ]
-        },
-        metadata: { "application/json": { expanded: true } }
+        data: Immutable.Map({
+          planets: "xandar\nnidavellir\nterra"
+        }),
+        metadata: Immutable.Map({
+          "application/json": Immutable.Map({ expanded: true })
+        })
       })
     );
   });
@@ -148,6 +132,48 @@ describe("execute_result output", () => {
         outputType: "execute_result",
         data: { anotherDay: "anotherDoug" },
         metadata: { "application/json": { expanded: false } }
+      })
+    );
+  });
+});
+
+describe("error output", () => {
+  test("can be converted from nbformat", () => {
+    expect(
+      nteractRecords.outputFromNbformat({
+        output_type: "error",
+        ename: "Thor",
+        evalue: "Pirate Angel",
+        traceback: ["sweet", "rabbit"]
+      })
+    ).toEqual(
+      nteractRecords.makeErrorOutputRecord({
+        output_type: "error",
+        ename: "Thor",
+        evalue: "Pirate Angel",
+        traceback: Immutable.List(["sweet", "rabbit"])
+      })
+    );
+  });
+
+  test("can be converted from jupyter messages", () => {
+    expect(
+      nteractRecords.errorRecordFromMessage({
+        header: {
+          msg_type: "error"
+        },
+        content: {
+          ename: "cats",
+          evalue: "good",
+          traceback: Immutable.List(["squirrel"])
+        }
+      })
+    ).toEqual(
+      nteractRecords.makeErrorOutputRecord({
+        outputType: "error",
+        ename: "cats",
+        evalue: "good",
+        traceback: Immutable.List(["squirrel"])
       })
     );
   });

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@nteract/records",
+  "version": "0.0.1",
+  "description": "experimental new records",
+  "main": "lib/index.js",
+  "nteractDesktop": "src/index.js",
+  "scripts": {
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build && npm run build:flow",
+    "build": "npm run build:clean && npm run build:lib",
+    "build:clean": "rimraf lib",
+    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
+    "build:lib": "babel -d lib src --ignore '**/__tests__/**'",
+    "build:lib:watch": "npm run build:lib -- --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
+  },
+  "devDependencies": {
+    "immutable": "^4.0.0-rc.9"
+  },
+  "peerDependencies": {
+    "immutable": "^4.0.0-rc.9"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "notebooks",
+    "records",
+    "spin-it"
+  ],
+  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "license": "BSD-3-Clause"
+}

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -86,10 +86,3 @@ export function createImmutableMimeBundle(
     Immutable.Map()
   );
 }
-
-// export function sanitize(o: ExecuteResult | DisplayData) {
-//   if (o.metadata) {
-//     return { metadata: Immutable.fromJS(o.metadata) };
-//   }
-//   return {};
-// }

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -7,7 +7,48 @@ export type ImmutableMimeBundle = ImmutableMap<string, any>;
 // Straight from nbformat
 export type MultilineString = string | Array<string>;
 
-export type MimeBundle = { [key: string]: string | Array<string> | Object };
+export type OnDiskMimebundle = {
+  [key: string]: string | Array<string> | Object
+};
+
+// Enumerating over all the possible
+export type MimeBundle = {
+  "text/plain"?: string,
+  "text/html"?: string,
+  "text/latex"?: string,
+  "text/markdown"?: string,
+
+  "application/javascript"?: string,
+
+  "image/png"?: string,
+  "image/jpeg"?: string,
+  "image/gif"?: string,
+  "image/svg+xml"?: string,
+
+  // The JSON mimetype has some corner cases because of the protocol / format assuming the values
+  // in a mimebundle are either:
+  //
+  //   * A string, which would be deserialized
+  //   * An array, which would have to be assumed to be a multiline string
+  //
+  "application/json"?: Object,
+
+  // TODO: These can all be more fully typed
+  "application/vdom.v1+json"?: Object,
+  "application/vnd.dataresource+json"?: Object,
+
+  "text/vnd.plotly.v1+html"?: string,
+  "application/vnd.plotly.v1+json"?: Object,
+  "application/geo+json"?: Object,
+
+  "application/x-nteract-model-debug+json"?: Object,
+
+  "application/vnd.vega.v2+json"?: Object,
+  "application/vnd.vega.v3+json"?: Object,
+  "application/vnd.vegalite.v1+json"?: Object,
+  "application/vnd.vegalite.v2+json"?: Object,
+  [key: string]: string | Array<string> | Object // all others
+};
 
 /**
  * Turn nbformat multiline strings (arrays of strings for simplifying diffs) into strings

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -1,7 +1,10 @@
 // @flow
 
+const Immutable = require("immutable");
 // Straight from nbformat
 export type MultilineString = string | Array<string>;
+
+export type MimeBundle = { [key: string]: string | Array<string> | Object };
 
 /**
  * Turn nbformat multiline strings (arrays of strings for simplifying diffs) into strings
@@ -23,4 +26,67 @@ export function remultiline(s: string | Array<string>): Array<string> {
   }
   // Use positive lookahead regex to split on newline and retain newline char
   return s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== "");
+}
+
+function isJSONKey(key) {
+  return /^application\/(.*\+)?json$/.test(key);
+}
+
+export function cleanMimeData(
+  key: string,
+  data: string | Array<string> | Object
+) {
+  // See https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L368
+  if (isJSONKey(key)) {
+    // Data stays as is for JSON types
+    return data;
+  }
+
+  if (typeof data === "string" || Array.isArray(data)) {
+    return demultiline(data);
+  }
+
+  throw new TypeError(
+    `Data for ${key} is expected to be a string or an Array of strings`
+  );
+}
+
+export function cleanMimeAtKey(
+  mimeBundle: MimeBundle,
+  previous: ImmutableMimeBundle,
+  key: string
+): ImmutableMimeBundle {
+  return previous.set(key, cleanMimeData(key, mimeBundle[key]));
+}
+
+export function createImmutableMimeBundle(
+  mimeBundle: MimeBundle
+): ImmutableMimeBundle {
+  // Map over all the mimetypes, turning them into our in-memory format
+  //
+  // {
+  //   "application/json": {"a": 3, "b": 2},
+  //   "text/html": ["<p>\n", "Hey\n", "</p>"],
+  //   "text/plain": "Hey"
+  // }
+  //
+  // to
+  //
+  // {
+  //   "application/json": {"a": 3, "b": 2},
+  //   "text/html": "<p>\nHey\n</p>",
+  //   "text/plain": "Hey"
+  // }
+  //
+  return Object.keys(mimeBundle).reduce(
+    cleanMimeAtKey.bind(null, mimeBundle),
+    Immutable.Map()
+  );
+}
+
+export function sanitize(o: ExecuteResult | DisplayData) {
+  if (o.metadata) {
+    return { metadata: Immutable.fromJS(o.metadata) };
+  }
+  return {};
 }

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -1,6 +1,9 @@
 // @flow
 
 const Immutable = require("immutable");
+import { Map as ImmutableMap } from "immutable";
+export type ImmutableMimeBundle = ImmutableMap<string, any>;
+
 // Straight from nbformat
 export type MultilineString = string | Array<string>;
 
@@ -84,9 +87,9 @@ export function createImmutableMimeBundle(
   );
 }
 
-export function sanitize(o: ExecuteResult | DisplayData) {
-  if (o.metadata) {
-    return { metadata: Immutable.fromJS(o.metadata) };
-  }
-  return {};
-}
+// export function sanitize(o: ExecuteResult | DisplayData) {
+//   if (o.metadata) {
+//     return { metadata: Immutable.fromJS(o.metadata) };
+//   }
+//   return {};
+// }

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -1,0 +1,26 @@
+// @flow
+
+// Straight from nbformat
+export type MultilineString = string | Array<string>;
+
+/**
+ * Turn nbformat multiline strings (arrays of strings for simplifying diffs) into strings
+ */
+export function demultiline(s: string | Array<string>): string {
+  if (Array.isArray(s)) {
+    return s.join("");
+  }
+  return s;
+}
+
+/**
+ * Split string into a list of strings delimited by newlines, useful for on-disk git comparisons
+ */
+export function remultiline(s: string | Array<string>): Array<string> {
+  if (Array.isArray(s)) {
+    // Assume
+    return s;
+  }
+  // Use positive lookahead regex to split on newline and retain newline char
+  return s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== "");
+}

--- a/packages/records/src/index.js
+++ b/packages/records/src/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+import * as Immutable from "immutable";
+
+export * from "./outputs";

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -2,7 +2,6 @@
 
 import * as Immutable from "immutable";
 import * as common from "../common";
-
 /**
  * Let this declare the way for well typed records for outputs
  *
@@ -24,14 +23,14 @@ export const DISPLAYDATA = "display_data";
 type DisplayDataOutput = {
   outputType: DisplayDataType,
   data: common.MimeBundle,
-  metadata: JSONObject
+  metadata: mixed
 };
 
 // On disk
 export type NbformatDisplayDataOutput = {
   output_type: DisplayDataType,
   data: common.MimeBundle,
-  metadata: JSONObject
+  metadata: mixed
 };
 
 type DisplayDataMessage = {
@@ -40,7 +39,7 @@ type DisplayDataMessage = {
   },
   content: {
     data: common.MimeBundle,
-    metadata: JSONObject
+    metadata: mixed
   }
 };
 
@@ -70,10 +69,9 @@ export function displayDataRecordFromNbformat(
       {},
       {
         outputType: s.output_type,
-        data: s.data,
-        metadata: s.metadata
+        data: common.createImmutableMimeBundle(s.data),
+        metadata: Immutable.fromJS(s.metadata)
       }
-      //common.sanitize(s)
     )
   );
 }

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -1,0 +1,88 @@
+// @flow
+
+import * as Immutable from "immutable";
+import * as common from "../common";
+
+/**
+ * Let this declare the way for well typed records for outputs
+ *
+ * General organization is:
+ *
+ *   - Declare the in-memory type
+ *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
+ *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
+ *   - Write a way to go from nbformat to these records
+ *   - Write a way to go from message spec to these records
+ *
+ */
+
+export type DisplayDataType = "display_data";
+
+export const DISPLAYDATA = "display_data";
+
+// In-memory version
+type DisplayDataOutput = {
+  outputType: DisplayDataType,
+  data: common.MimeBundle,
+  metadata: JSONObject
+};
+
+// On disk
+export type NbformatDisplayDataOutput = {
+  output_type: DisplayDataType,
+  data: common.MimeBundle,
+  metadata: JSONObject
+};
+
+type DisplayDataMessage = {
+  header: {
+    msg_type: DisplayDataType
+  },
+  content: {
+    data: common.MimeBundle,
+    metadata: JSONObject
+  }
+};
+
+export type DisplayDataOutputRecord = Immutable.RecordOf<DisplayDataOutput>;
+
+// NOTE: No export, as the values here should get overridden by an exact version
+//       passed into makeDisplayDataOutputRecord
+const displayDataOutputRecordMaker: Immutable.RecordFactory<
+  DisplayDataOutput
+> = Immutable.Record({
+  outputType: DISPLAYDATA,
+  data: {},
+  metadata: {}
+});
+
+export function makeDisplayDataOutputRecord(
+  displayDataOutput: DisplayDataOutput
+): DisplayDataOutputRecord {
+  return displayDataOutputRecordMaker(displayDataOutput);
+}
+
+export function displayDataRecordFromNbformat(
+  s: NbformatDisplayDataOutput
+): DisplayDataOutputRecord {
+  return makeDisplayDataOutputRecord(
+    Object.assign(
+      {},
+      {
+        outputType: s.output_type,
+        data: common.createImmutableMimeBundle(s.data)
+      },
+      common.sanitize(s)
+    )
+  );
+}
+
+export function displayDataRecordFromMessage(
+  msg: DisplayDataMessage
+): DisplayDataOutputRecord {
+  return makeDisplayDataOutputRecord({
+    outputType: DISPLAYDATA,
+    data: msg.content.data,
+    metadata: msg.content.metadata
+  });
+}

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -70,9 +70,10 @@ export function displayDataRecordFromNbformat(
       {},
       {
         outputType: s.output_type,
-        data: common.createImmutableMimeBundle(s.data)
-      },
-      common.sanitize(s)
+        data: s.data,
+        metadata: s.metadata
+      }
+      //common.sanitize(s)
     )
   );
 }

--- a/packages/records/src/outputs/error.js
+++ b/packages/records/src/outputs/error.js
@@ -1,0 +1,92 @@
+// @flow
+
+import * as Immutable from "immutable";
+import * as common from "../common";
+
+/**
+ * Let this declare the way for well typed records for outputs
+ *
+ * General organization is:
+ *
+ *   - Declare the in-memory type
+ *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
+ *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
+ *   - Write a way to go from nbformat to these records
+ *   - Write a way to go from message spec to these records
+ *
+ */
+
+export type ErrorType = "error" | "pyerr";
+
+export const ERROR = "error";
+
+// In-memory version
+type ErrorOutput = {
+  outputType: ErrorType,
+  ename: string,
+  evalue: string,
+  traceback: Immutable.List<string>
+};
+
+// On disk
+export type NbformatErrorOutput = {
+  output_type: ErrorType,
+  ename: string,
+  evalue: string,
+  traceback: Immutable.List<string>
+};
+
+type ErrorMessage = {
+  header: {
+    msg_type: ErrorType
+  },
+  content: {
+    ename: string,
+    evalue: string,
+    traceback: Immutable.List<string>
+  }
+};
+
+export type ErrorOutputRecord = Immutable.RecordOf<ErrorOutput>;
+
+// NOTE: No export, as the values here should get overridden by an exact version
+//       passed into makeErrorOutputRecord
+const errorOutputRecordMaker: Immutable.RecordFactory<
+  ErrorOutput
+> = Immutable.Record({
+  outputType: ERROR,
+  ename: "",
+  evalue: "",
+  traceback: Immutable.List()
+});
+
+export function makeErrorOutputRecord(
+  errorOutput: ErrorOutput
+): ErrorOutputRecord {
+  return errorOutputRecordMaker(errorOutput);
+}
+
+export function errorRecordFromNbformat(
+  s: NbformatErrorOutput
+): ErrorOutputRecord {
+  return makeErrorOutputRecord(
+    Object.assign(
+      {},
+      {
+        outputType: s.output_type,
+        ename: s.ename,
+        evalue: s.evalue,
+        traceback: Immutable.List(s.traceback)
+      }
+    )
+  );
+}
+
+export function errorRecordFromMessage(msg: ErrorMessage): ErrorOutputRecord {
+  return makeErrorOutputRecord({
+    outputType: ERROR,
+    ename: msg.content.ename,
+    evalue: msg.content.evalue,
+    traceback: msg.content.traceback
+  });
+}

--- a/packages/records/src/outputs/error.js
+++ b/packages/records/src/outputs/error.js
@@ -25,7 +25,7 @@ type ErrorOutput = {
   outputType: ErrorType,
   ename: string,
   evalue: string,
-  traceback: Immutable.List<string>
+  traceback: Iterable<string>
 };
 
 // On disk
@@ -33,7 +33,7 @@ export type NbformatErrorOutput = {
   output_type: ErrorType,
   ename: string,
   evalue: string,
-  traceback: Immutable.List<string>
+  traceback: Iterable<string>
 };
 
 type ErrorMessage = {
@@ -43,7 +43,7 @@ type ErrorMessage = {
   content: {
     ename: string,
     evalue: string,
-    traceback: Immutable.List<string>
+    traceback: Iterable<string>
   }
 };
 
@@ -57,7 +57,7 @@ const errorOutputRecordMaker: Immutable.RecordFactory<
   outputType: ERROR,
   ename: "",
   evalue: "",
-  traceback: Immutable.List()
+  traceback: []
 });
 
 export function makeErrorOutputRecord(
@@ -76,7 +76,7 @@ export function errorRecordFromNbformat(
         outputType: s.output_type,
         ename: s.ename,
         evalue: s.evalue,
-        traceback: Immutable.List(s.traceback)
+        traceback: s.traceback
       }
     )
   );
@@ -87,6 +87,6 @@ export function errorRecordFromMessage(msg: ErrorMessage): ErrorOutputRecord {
     outputType: ERROR,
     ename: msg.content.ename,
     evalue: msg.content.evalue,
-    traceback: Immutable.List(msg.content.traceback)
+    traceback: msg.content.traceback
   });
 }

--- a/packages/records/src/outputs/error.js
+++ b/packages/records/src/outputs/error.js
@@ -87,6 +87,6 @@ export function errorRecordFromMessage(msg: ErrorMessage): ErrorOutputRecord {
     outputType: ERROR,
     ename: msg.content.ename,
     evalue: msg.content.evalue,
-    traceback: msg.content.traceback
+    traceback: Immutable.List(msg.content.traceback)
   });
 }

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -1,0 +1,95 @@
+// @flow
+
+import * as Immutable from "immutable";
+import * as common from "../common";
+
+/**
+ * Let this declare the way for well typed records for outputs
+ *
+ * General organization is:
+ *
+ *   - Declare the in-memory type
+ *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
+ *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
+ *   - Write a way to go from nbformat to these records
+ *   - Write a way to go from message spec to these records
+ *
+ */
+
+export type ExecuteResultType = "execute_result";
+export type ExecutionCount = number | null;
+
+export const EXECUTERESULT = "execute_result";
+
+// In-memory version
+type ExecuteResultOutput = {
+  outputType: ExecuteResultType,
+  executionCount: ExecutionCount,
+  data: common.MimeBundle,
+  metadata: JSONObject
+};
+
+// On disk
+export type NbformatExecuteResultOutput = {
+  output_type: ExecuteResultType,
+  execution_count: ExecutionCount,
+  data: common.MimeBundle,
+  metadata: JSONObject
+};
+
+type ExecuteResultMessage = {
+  header: {
+    msg_type: ExecuteResultType
+  },
+  content: {
+    execution_count: number,
+    data: common.MimeBundle,
+    metadata: JSONObject
+  }
+};
+
+export type ExecuteResultOutputRecord = Immutable.RecordOf<ExecuteResultOutput>;
+
+// NOTE: No export, as the values here should get overridden by an exact version
+//       passed into makeExecuteResultOutputRecord
+const executeResultOutputRecordMaker: Immutable.RecordFactory<
+  ExecuteResultOutput
+> = Immutable.Record({
+  outputType: EXECUTERESULT,
+  executionCount: null,
+  data: {},
+  metadata: {}
+});
+
+export function makeExecuteResultOutputRecord(
+  executeResultOutput: ExecuteResultOutput
+): ExecuteResultOutputRecord {
+  return executeResultOutputRecordMaker(executeResultOutput);
+}
+
+export function executeResultRecordFromNbformat(
+  s: NbformatExecuteResultOutput
+): ExecuteResultOutputRecord {
+  return makeExecuteResultOutputRecord(
+    Object.assign(
+      {},
+      {
+        outputType: s.output_type,
+        executionCount: s.execution_count,
+        data: s.data,
+        metadata: s.metadata
+      }
+    )
+  );
+}
+
+export function executeResultRecordFromMessage(
+  msg: ExecuteResultMessage
+): ExecuteResultOutputRecord {
+  return makeExecuteResultOutputRecord({
+    outputType: EXECUTERESULT,
+    executionCount: msg.content.execution_count,
+    data: msg.content.data,
+    metadata: msg.content.metadata
+  });
+}

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -26,7 +26,7 @@ type ExecuteResultOutput = {
   outputType: ExecuteResultType,
   executionCount: ExecutionCount,
   data: common.MimeBundle,
-  metadata: JSONObject
+  metadata: mixed
 };
 
 // On disk
@@ -34,7 +34,7 @@ export type NbformatExecuteResultOutput = {
   output_type: ExecuteResultType,
   execution_count: ExecutionCount,
   data: common.MimeBundle,
-  metadata: JSONObject
+  metadata: mixed
 };
 
 type ExecuteResultMessage = {
@@ -44,7 +44,7 @@ type ExecuteResultMessage = {
   content: {
     execution_count: number,
     data: common.MimeBundle,
-    metadata: JSONObject
+    metadata: mixed
   }
 };
 
@@ -76,8 +76,8 @@ export function executeResultRecordFromNbformat(
       {
         outputType: s.output_type,
         executionCount: s.execution_count,
-        data: s.data,
-        metadata: s.metadata
+        data: common.createImmutableMimeBundle(s.data),
+        metadata: Immutable.fromJS(s.metadata)
       }
     )
   );

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -1,0 +1,22 @@
+// @flow
+
+import * as stream from "./stream";
+import * as unrecognized from "./unrecognized";
+
+export * from "./stream";
+
+type NbformatOutput = stream.NbformatStreamOutput;
+type OutputRecord = stream.StreamOutputRecord;
+
+/**
+ * Turn any output that was in nbformat into a record
+ */
+export function outputFromNbformat(output: NbformatOutput): OutputRecord {
+  switch (output.output_type) {
+    case stream.STREAM:
+      return stream.streamRecordFromNbformat(output);
+    default:
+      // $FlowAllowFeatureDetection: At runtime, allow fallback
+      return unrecognized.unrecognizedRecordFromNbformat(output);
+  }
+}

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -2,17 +2,21 @@
 
 import * as stream from "./stream";
 import * as displayData from "./display-data";
+import * as executeResult from "./execute-result";
 import * as unrecognized from "./unrecognized";
 
 export * from "./stream";
 export * from "./display-data";
+export * from "./execute-result";
 
 type NbformatOutput =
   | stream.NbformatStreamOutput
-  | displayData.NbformatDisplayDataOutput;
+  | displayData.NbformatDisplayDataOutput
+  | executeResult.NbformatExecuteResultOutput;
 type OutputRecord =
   | stream.StreamOutputRecord
-  | displayData.DisplayDataOutputRecord;
+  | displayData.DisplayDataOutputRecord
+  | executeResult.ExecuteResultOutputRecord;
 
 /**
  * Turn any output that was in nbformat into a record
@@ -23,6 +27,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputRecord {
       return stream.streamRecordFromNbformat(output);
     case displayData.DISPLAYDATA:
       return displayData.displayDataRecordFromNbformat(output);
+    case executeResult.EXECUTERESULT:
+      return executeResult.executeResultRecordFromNbformat(output);
     default:
       // $FlowAllowFeatureDetection: At runtime, allow fallback
       return unrecognized.unrecognizedRecordFromNbformat(output);

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -3,20 +3,24 @@
 import * as stream from "./stream";
 import * as displayData from "./display-data";
 import * as executeResult from "./execute-result";
+import * as error from "./error";
 import * as unrecognized from "./unrecognized";
 
 export * from "./stream";
 export * from "./display-data";
 export * from "./execute-result";
+export * from "./error";
 
 type NbformatOutput =
   | stream.NbformatStreamOutput
   | displayData.NbformatDisplayDataOutput
-  | executeResult.NbformatExecuteResultOutput;
+  | executeResult.NbformatExecuteResultOutput
+  | error.NbformatErrorOutput;
 type OutputRecord =
   | stream.StreamOutputRecord
   | displayData.DisplayDataOutputRecord
-  | executeResult.ExecuteResultOutputRecord;
+  | executeResult.ExecuteResultOutputRecord
+  | error.ErrorOutputRecord;
 
 /**
  * Turn any output that was in nbformat into a record
@@ -29,6 +33,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputRecord {
       return displayData.displayDataRecordFromNbformat(output);
     case executeResult.EXECUTERESULT:
       return executeResult.executeResultRecordFromNbformat(output);
+    case error.ERROR:
+      return error.errorRecordFromNbformat(output);
     default:
       // $FlowAllowFeatureDetection: At runtime, allow fallback
       return unrecognized.unrecognizedRecordFromNbformat(output);

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -1,12 +1,18 @@
 // @flow
 
 import * as stream from "./stream";
+import * as displayData from "./display-data";
 import * as unrecognized from "./unrecognized";
 
 export * from "./stream";
+export * from "./display-data";
 
-type NbformatOutput = stream.NbformatStreamOutput;
-type OutputRecord = stream.StreamOutputRecord;
+type NbformatOutput =
+  | stream.NbformatStreamOutput
+  | displayData.NbformatDisplayDataOutput;
+type OutputRecord =
+  | stream.StreamOutputRecord
+  | displayData.DisplayDataOutputRecord;
 
 /**
  * Turn any output that was in nbformat into a record
@@ -15,6 +21,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputRecord {
   switch (output.output_type) {
     case stream.STREAM:
       return stream.streamRecordFromNbformat(output);
+    case displayData.DISPLAYDATA:
+      return displayData.displayDataRecordFromNbformat(output);
     default:
       // $FlowAllowFeatureDetection: At runtime, allow fallback
       return unrecognized.unrecognizedRecordFromNbformat(output);

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { JupyterMessage } from "@nteract/messaging";
+
 import * as stream from "./stream";
 import * as displayData from "./display-data";
 import * as executeResult from "./execute-result";
@@ -38,5 +40,25 @@ export function outputFromNbformat(output: NbformatOutput): OutputRecord {
     default:
       // $FlowAllowFeatureDetection: At runtime, allow fallback
       return unrecognized.unrecognizedRecordFromNbformat(output);
+  }
+}
+
+/**
+ * Turn any output that was in JupyterMessage into a record
+ */
+export function outputFromMessage(msg: JupyterMessage<*, *>): OutputRecord {
+  const msg_type = msg.header.msg_type;
+  switch (msg_type) {
+    case stream.STREAM:
+      return stream.streamRecordFromMessage(msg);
+    case displayData.DISPLAYDATA:
+      return displayData.displayDataRecordFromMessage(msg);
+    case executeResult.EXECUTERESULT:
+      return executeResult.executeResultRecordFromMessage(msg);
+    case error.ERROR:
+      return error.errorRecordFromMessage(msg);
+    default:
+      // $FlowAllowFeatureDetection: At runtime, allow fallback
+      return null;
   }
 }

--- a/packages/records/src/outputs/stream.js
+++ b/packages/records/src/outputs/stream.js
@@ -1,0 +1,88 @@
+// @flow
+
+import * as Immutable from "immutable";
+import * as common from "../common";
+
+/**
+ * Let this declare the way for well typed records for outputs
+ *
+ * General organization is:
+ *
+ *   - Declare the in-memory type
+ *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
+ *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
+ *   - Write a way to go from nbformat to these records
+ *   - Write a way to go from message spec to these records
+ *
+ */
+
+export type StreamName = "stdout" | "stderr";
+
+export const STDOUT = "stdout";
+export const STDERR = "stderr";
+
+export type StreamType = "stream";
+
+export const STREAM = "stream";
+
+// In-memory version
+type StreamOutput = {
+  outputType: StreamType,
+  name: StreamName,
+  text: string
+};
+
+// On disk
+export type NbformatStreamOutput = {
+  output_type: StreamType,
+  name: StreamName,
+  text: common.MultilineString
+};
+
+type StreamMessage = {
+  header: {
+    msg_type: StreamType
+  },
+  content: {
+    name: StreamName,
+    text: string
+  }
+};
+
+export type StreamOutputRecord = Immutable.RecordOf<StreamOutput>;
+
+// NOTE: No export, as the values here should get overridden by an exact version
+//       passed into makeStreamOutputRecord
+const streamOutputRecordMaker: Immutable.RecordFactory<
+  StreamOutput
+> = Immutable.Record({
+  outputType: STREAM,
+  name: STDOUT,
+  text: ""
+});
+
+export function makeStreamOutputRecord(
+  streamOutput: StreamOutput
+): StreamOutputRecord {
+  return streamOutputRecordMaker(streamOutput);
+}
+
+export function streamRecordFromNbformat(
+  s: NbformatStreamOutput
+): StreamOutputRecord {
+  return makeStreamOutputRecord({
+    outputType: s.output_type,
+    name: s.name,
+    text: common.demultiline(s.text)
+  });
+}
+
+export function streamRecordFromMessage(
+  msg: StreamMessage
+): StreamOutputRecord {
+  return makeStreamOutputRecord({
+    outputType: STREAM,
+    name: msg.content.name,
+    text: msg.content.text
+  });
+}

--- a/packages/records/src/outputs/unrecognized.js
+++ b/packages/records/src/outputs/unrecognized.js
@@ -1,0 +1,43 @@
+// @flow
+
+// Unrecognized output from a future minor-revision to the notebook format.
+
+import * as Immutable from "immutable";
+
+// In-memory version
+type UnrecognizedOutput = {
+  outputType: string,
+  /* The raw output, for writing back to disk properly */
+  raw: Immutable.Map<any, any>
+};
+
+// On disk
+export type NbformatUnrecognizedOutput = {
+  output_type: string // Technically, not one of "execute_result", "display_data", "stream", or "error"
+};
+
+export type UnrecognizedOutputRecord = Immutable.RecordOf<UnrecognizedOutput>;
+
+const unrecognizedOutputRecordMaker: Immutable.RecordFactory<
+  UnrecognizedOutput
+> = Immutable.Record({
+  outputType: "unrecognized",
+  // This must get overridden below
+  raw: Immutable.Map()
+});
+
+export function makeUnrecognizedOutputRecord(
+  unrecognizedOutput: UnrecognizedOutput
+): UnrecognizedOutputRecord {
+  return unrecognizedOutputRecordMaker(unrecognizedOutput);
+}
+
+export function unrecognizedRecordFromNbformat(
+  s: NbformatUnrecognizedOutput
+): UnrecognizedOutputRecord {
+  return makeUnrecognizedOutputRecord({
+    outputType: s.output_type,
+    // ⚠️ This has the potential of being mutated within since we're only turning it into a top level Immutable.Map
+    raw: Immutable.Map(s)
+  });
+}


### PR DESCRIPTION
# New Records for nteract

Philosophy: create very flat records for core data types used in nteract, to be used across applications.

> Wait, what about commutable?

Commutable has been _awesome_ and should be borrowed from to build this up. However, commutable relied heavily on `Immutable.Map`'s. These lose all the benefits of flow typing, defaults, and direct property access that records have.

> Could we add these directly to commutable?

I'd love to. However, I didn't want to make changes that required refactoring all the apps that use them, as well as any external usage (Hydrogen included) that would have to adapt to new interfaces.

> Where should I start in helping with this effort?

Look over how `src/outputs/stream.js` and `src/outputs/index.js` sets up the base types. Implement the other output types in a similar fashion.

- [x] stream
- [x] display_data
- [x] execute_result
- [x] error

## References

- [nbformat v4](https://raw.githubusercontent.com/jupyter/nbformat/master/nbformat/v4/nbformat.v4.schema.json)
- [Jupyter Message Format](http://jupyter-client.readthedocs.io/en/stable/messaging.html#general-message-format)
- [commutable's implementation](../commutable/src/v4.js) -- `packages/commutable/src/v4.js`

## Testing

Run

```
npm t -- records --watch
```

to run the tests locally while watching to all changes in the records setup.

## Types!

If your editor isn't already helping you with this, use

```
npm run flow
```

## Documentation

To help figure out where we _might_ end up with documentation for nteract libraries (as opposed to components, which use react-docgen / react-styleguidist ), use [documentation.js](https://github.com/documentationjs/documentation) to run docs for this library.

```
npm install -g documentation
documentation serve --watch packages/records/src
```

I have a feeling we'll end up having to do some custom things with our monorepo to make this more palatable.

