### PR TITLE
provide a clean command instead of git clean -xfd

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ rebuild those using [the instructions for building specific packages](#building-
 
 > I upgraded my developer installation and things are broken!
 
-* Try `git clean -xdf && npm i`
+- Try `npm run clean && npm i`
 
 > I want to debug redux actions and state changes.
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "prettify": "prettier --write '**/*.{js,json}' '!**/{dist,lib,.git,.next,package.json,build,flow-typed,mathjax-electron}/**'",
     "pack": "lerna run pack --scope nteract --stream",
     "dist": "lerna run dist --scope nteract --stream",
-    "dist:all": "lerna run dist:all --scope nteract --stream"
+    "dist:all": "lerna run dist:all --scope nteract --stream",
+    "clean": "lerna clean --yes && rm -rf node_modules"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Using `git clean -xfd` will nuke the `.egg-info` file that you need for the developer install of `nteract_on_jupyter`. I've made a command called `npm run clean` that you can use instead to make a "healthy" state.