### PR TITLE
desktop: Don't split webpack build in production mode

### DIFF
--- a/applications/desktop/webpack.common.js
+++ b/applications/desktop/webpack.common.js
@@ -34,20 +34,7 @@ const mainConfig = {
 const rendererConfig = {
   mode: "development",
   entry: {
-    app: "./src/notebook/index.js",
-    vendor: [
-      "react",
-      "react-dnd",
-      "react-dnd-html5-backend",
-      "react-dom",
-      "react-redux",
-      "redux",
-      "redux-logger",
-      "redux-observable",
-      "immutable",
-      "rxjs",
-      "date-fns"
-    ]
+    app: "./src/notebook/index.js"
   },
   target: "electron-renderer",
   output: {

--- a/applications/desktop/webpack.dev.js
+++ b/applications/desktop/webpack.dev.js
@@ -4,6 +4,21 @@ const merge = require("webpack-merge");
 const { commonMainConfig, commonRendererConfig } = require("./webpack.common");
 
 const rendererConfig = merge(commonRendererConfig, {
+  entry: {
+    vendor: [
+      "react",
+      "react-dnd",
+      "react-dnd-html5-backend",
+      "react-dom",
+      "react-redux",
+      "redux",
+      "redux-logger",
+      "redux-observable",
+      "immutable",
+      "rxjs",
+      "date-fns"
+    ]
+  },
   plugins: [
     new webpack.SourceMapDevToolPlugin({
       filename: "[name].js.map",


### PR DESCRIPTION
This reduces the time between `first paint` and `DOMLoaded` from 1.69s to 1.52s and slightly reduces the overall bundle size.

Found while debugging #2969 