### PR TITLE
switch recentdocuments casing

### DIFF
--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -392,19 +392,17 @@ export function loadFullMenu(store: * = global.store) {
         role: "close"
       }
     );
-  }
-  else if (process.platform === "darwin") {
+  } else if (process.platform === "darwin") {
     file.submenu.splice(2, 0, {
-        label: 'Open Recent',
-        role: 'recentDocuments',
-        submenu: [
-          {
-            label: 'Clear Recent',
-            role: 'clearRecentDocuments'
-          }
-        ]
-      }
-    );
+      label: "Open Recent",
+      role: "recentdocuments",
+      submenu: [
+        {
+          label: "Clear Recent",
+          role: "clearrecentdocuments"
+        }
+      ]
+    });
   }
 
   const edit = {
@@ -629,20 +627,17 @@ export function loadFullMenu(store: * = global.store) {
         role: "close"
       }
     );
-  }
-  else if (process.platform === "darwin") {
-    fileWithNew.submenu.splice(2, 0,
-      {
-        label: 'Open Recent',
-        role: 'recentDocuments',
-        submenu: [
-          {
-            label: 'Clear Recent',
-            role: 'clearRecentDocuments'
-          }
-        ]
-      }
-    );
+  } else if (process.platform === "darwin") {
+    fileWithNew.submenu.splice(2, 0, {
+      label: "Open Recent",
+      role: "recentdocuments",
+      submenu: [
+        {
+          label: "Clear Recent",
+          role: "clearrecentdocuments"
+        }
+      ]
+    });
   }
 
   template.push(fileWithNew);


### PR DESCRIPTION
In my hope to see recent documents working on my machine I made the casing match that of
https://github.com/electron/electron/blob/18362eb948ef91e002e286a835663fd6a3977048/lib/browser/api/menu-item-roles.js

I'm still only seeing recently opened documents in the dock though, so maybe we're running into https://github.com/electron/electron/pull/11166#issuecomment-394115690 ?

~~Perhaps there is an even later version of electron we have to upgrade to?~~ Apparently 2.0.2 is the latest.

cc @piercefreeman 


