### PR TITLE
check subprocess when using jupyter nteract --dev

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -4,21 +4,25 @@ from subprocess import Popen
 from notebook.notebookapp import NotebookApp, flags
 from traitlets import Unicode, Bool
 
+import time
+
 
 from . import EXT_NAME, PACKAGE_DIR
 from .config import NteractConfig
 from .extension import load_jupyter_server_extension
 from .utils import cmd_in_new_dir
 
-webpack_hot = {"address": 'http://localhost:8080/',
-               "command":["lerna", "run", "hot",
-                          "--scope", "nteract-on-jupyter",
-                          "--stream"]}
+webpack_port = 8357
+
+webpack_hot = {"address": f'http://localhost:{webpack_port}/',
+               "command": ["lerna", "run", "hot",
+                           "--scope", "nteract-on-jupyter",
+                           "--stream", "--", "--", "--port", str(webpack_port)]}
 nteract_flags = dict(flags)
 nteract_flags['dev'] = (
     {'NteractConfig': {'asset_url': webpack_hot['address']},
      'NteractApp': {'dev_mode': True}
-    },
+     },
     "\n".join([
         "Start nteract in dev mode, serving assets built from your source code.",
         "This is a hot reloading server that watches for changes to your source,",
@@ -27,8 +31,9 @@ nteract_flags['dev'] = (
         "To access this server run:",
         "    `{command}`"]).format(address=webpack_hot["address"],
                                    command=" ".join(webpack_hot["command"])
-        )
+                                   )
 )
+
 
 class NteractApp(NotebookApp):
     """Application for runing nteract on a jupyter notebook server.
@@ -41,14 +46,13 @@ class NteractApp(NotebookApp):
     flags = nteract_flags
 
     dev_mode = Bool(False, config=True,
-    help="""Whether to start the app in dev mode. Expects resources to be loaded
+                    help="""Whether to start the app in dev mode. Expects resources to be loaded
     from webpack's hot reloading server at {address}. Run
     `{command}`
     To serve your assets.
     This is only useful if NteractApp is installed editably e.g., using `pip install -e .`.
     """.format(address=webpack_hot["address"],
                command=" ".join(webpack_hot["command"])))
-
 
     def init_server_extensions(self):
         super(NteractApp, self).init_server_extensions()
@@ -58,8 +62,23 @@ class NteractApp(NotebookApp):
                 self.log.warn(msg)
                 load_jupyter_server_extension(self)
             with cmd_in_new_dir(PACKAGE_DIR):
-                Popen(webpack_hot["command"])
+                p = Popen(webpack_hot["command"])
+                self.log.info('waiting for the hot webpack server to start')
+                # Wait a little bit to allow the initial command to run
+                # NOTE: It would be better if we could run this on a thread and
+                # inform the dev server when it has closed using proc.wait()
+                # and an onExit callback
+                time.sleep(3)
+                exit_code = p.poll()
+                if exit_code is None:
+                    # The process is up, we're (possibly) good
+                    pass
+                else:
+                    raise Exception(
+                        f"Webpack dev server exited - return code {exit_code}")
 
+                # Now wait for webpack to have the initial bundle mostly ready
+                time.sleep(5)
 
 
 main = launch_new_instance = NteractApp.launch_instance


### PR DESCRIPTION
This checks to see if the webpack-dev-server has exited early during the initial startup when using `jupyter nteract --dev`. Additionally, it waits just long enough (at least for the cases I'm on) so that you don't have to refresh your `localhost:8888/nteract/edit` page, webpack will reload the page once the bundle is ready.

Also took the liberty of switching the ports so it doesn't overlap with RethinkDB's admin page nor other default webpack servers.