### PR TITLE
[WIP] start working on perf & render problem with output

### DIFF
--- a/packages/notebook-app-component/src/notebook-app.js
+++ b/packages/notebook-app-component/src/notebook-app.js
@@ -218,12 +218,14 @@ class AnyCell extends React.PureComponent<AnyCellProps, *> {
             >
               <Display
                 className="outputs-display"
+                // HELLO PERF PROBLEM
                 outputs={this.props.outputs.toJS()}
                 displayOrder={this.props.displayOrder}
                 transforms={this.props.transforms}
                 theme={this.props.theme}
                 expanded={this.props.outputExpanded}
                 isHidden={this.props.outputHidden}
+                // HELLO OTHER PERF PROBLEM
                 models={this.props.models.toJS()}
               />
             </Outputs>


### PR DESCRIPTION
We're running into a massive perf issue with outputs that ends up affecting the whole notebook render.

It all comes down to these lines:

https://github.com/nteract/nteract/blob/232b9b0b402c74c2c39be72eb389fbf76353a1a0/packages/notebook-app-component/src/notebook-app.js#L221-L227

Every single time it renders the display area there, a _new_ object is created with that `toJS` call. In React terms, that makes the whole tree have to re-render. 😭 

Back when this was pure Immutable.JS it was fine. When we made the concession to switch to pure objects for display-area and transforms, this regression started happening.

To make matters worse, some transforms, like vega, will end up re-rendering and will lose their local state.

![re-render](https://user-images.githubusercontent.com/836375/41388198-abd8b44c-6f3f-11e8-910c-14f99a59d174.gif)

Opening this PR to track the work around this and come up with a pragmatic option. Long term wise, I've been aiming to change the output setup to records, following the work that @alexandercbooth and I did in #2958. 