### PR TITLE
remove flow steps from gatsby transformer

### DIFF
--- a/packages/gatsby-transformer-ipynb/package.json
+++ b/packages/gatsby-transformer-ipynb/package.json
@@ -12,13 +12,12 @@
   "main": "./gatsby-node.js",
   "scripts": {
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build && npm run build:flow",
+    "prepublishOnly": "npm run build",
     "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rm -f gastby-node.js on-node-create.js",
-    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src ./",
     "build:lib": "babel -d ./ src --ignore '**/__tests__/**'",
     "build:lib:watch": "npm run build:lib -- --watch",
-    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
+    "build:watch": "npm run build:clean && npm run build:lib:watch"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/gatsby-transformer-ipynb",
   "publishConfig": {


### PR DESCRIPTION
While prepping today's release I noticed that the flow copy source was being created and making the git workspace "dirty" (untracked *.flow files). Since the gatsby transform isn't using flow, I've taken this out for now.

cc @benjaminabel 

After this is merged I'm ready to ship everything.