### PR TITLE
Fix props access in transform-plotly

### DIFF
--- a/packages/transform-plotly/src/index.js
+++ b/packages/transform-plotly/src/index.js
@@ -66,7 +66,10 @@ export class PlotlyTransform extends React.Component<Props> {
     if (Object.isFrozen(figure)) {
       return cloneDeep(figure);
     }
-    return figure;
+
+    const { data = {}, layout = {} } = figure;
+
+    return { data, layout };
   };
 
   render(): ?React$Element<any> {


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'layout' of undefined` error when `layout` is not passed to PlotlyTransform.
