### PR TITLE
Simplify directory listing component docs

### DIFF
--- a/applications/commuter/components/contents/directory-listing.js
+++ b/applications/commuter/components/contents/directory-listing.js
@@ -102,7 +102,7 @@ const DirectoryListing = (props: DirectoryListingProps) => {
             <Entry key={index}>
               <Icon fileType={entry.type} />
               <Name>{link}</Name>
-              <LastSaved last_modified={entry.last_modified} />
+              <LastSaved lastModified={entry.last_modified} />
             </Entry>
           );
         })}

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -102,7 +102,7 @@ export class DirectoryApp extends React.PureComponent<DirectoryProps, null> {
                 <Entry key={index}>
                   <Icon fileType={entry.type} />
                   <Name>{link}</Name>
-                  <LastSaved last_modified={entry.last_modified} />
+                  <LastSaved lastModified={entry.last_modified} />
                 </Entry>
               );
             })}

--- a/packages/directory-listing/__tests__/__snapshots__/index-spec.js.snap
+++ b/packages/directory-listing/__tests__/__snapshots__/index-spec.js.snap
@@ -6,6 +6,7 @@ exports[`Entry accepts props and renders entries in directory 1`] = `
 >
   <Icon
     className="directory-entry-field"
+    color="#0366d6"
     fileType="directory"
     key=".0"
   />
@@ -18,6 +19,7 @@ exports[`Entry accepts props and renders entries in directory 1`] = `
   <LastSaved
     className="directory-entry-field"
     key=".2"
+    lastModified={null}
     last_modified="Fri Jun 22 2018 00:15:55 GMT-0400 (Eastern Daylight Time)"
   />
   <JSXStyle

--- a/packages/directory-listing/src/components/entry.md
+++ b/packages/directory-listing/src/components/entry.md
@@ -1,20 +1,19 @@
 ```jsx static
-import { Entry } from "@nteract/directory-listing"
+import { Entry } from "@nteract/directory-listing";
 ```
+
 This component is used to create individual entries in a directory. It is not meant to be used alone, but rather as children of the Listing component and renders children of it's own. In nteract, we use it as the parent of Icon, Name and LastSaved components.
 
-
-
 Display an Icon, Name, and time since last saved of an entry in a directory.
+
 ```jsx
-const link = (
-                <a href={"http://nteract.io"}>
-                  {"Example-Notebook.ipynb"}
-                </a>
-              );
-<Entry key={0}>
-    <Icon fileType={"notebook"} />
-    <Name>{link}</Name>
-    <LastSaved last_modified={new Date()} />
-</Entry>
+<Listing>
+  <Entry>
+    <Icon fileType="notebook" />
+    <Name>
+      <a href="http://nteract.io">Example-Notebook.ipynb</a>
+    </Name>
+    <LastSaved lastModified={new Date("2018-07-04")} />
+  </Entry>
+</Listing>
 ```

--- a/packages/directory-listing/src/components/icon.js
+++ b/packages/directory-listing/src/components/icon.js
@@ -4,12 +4,14 @@ import * as React from "react";
 import { Book, FileText, FileDirectory } from "@nteract/octicons";
 
 type IconProps = {
+  color: string,
   fileType: "unknown" | "notebook" | "directory" | "file" | "dummy"
 };
 
 export class Icon extends React.Component<IconProps, null> {
   static defaultProps = {
-    fileType: "file"
+    fileType: "file",
+    color: "#0366d6"
   };
 
   render() {
@@ -29,7 +31,7 @@ export class Icon extends React.Component<IconProps, null> {
     }
 
     return (
-      <td className="icon">
+      <td className="icon" style={{ color: this.props.color }}>
         {icon}
         <style jsx>{`
           :global(.icon) {

--- a/packages/directory-listing/src/components/icon.md
+++ b/packages/directory-listing/src/components/icon.md
@@ -1,7 +1,9 @@
 ```jsx static
-import { Icon } from "@nteract/directory-listing"
+import { Icon } from "@nteract/directory-listing";
 ```
+
 Display an icon
+
 ```jsx
-<Icon fileType={"notebook"} />
+<Icon fileType="notebook" />
 ```

--- a/packages/directory-listing/src/components/lastsaved.js
+++ b/packages/directory-listing/src/components/lastsaved.js
@@ -4,18 +4,18 @@ import * as React from "react";
 import TimeAgo from "@nteract/timeago";
 
 type LastSavedProps = {
-  last_modified: Date
+  lastModified: Date
 };
 
 export class LastSaved extends React.Component<LastSavedProps, null> {
   static defaultProps = {
-    last_modified: null
+    lastModified: null
   };
 
   render() {
     return (
       <td className="timeago">
-        <TimeAgo date={this.props.last_modified} />
+        <TimeAgo date={this.props.lastModified} />
         <style jsx>{`
           .timeago {
             text-align: right;

--- a/packages/directory-listing/src/components/lastsaved.md
+++ b/packages/directory-listing/src/components/lastsaved.md
@@ -1,7 +1,9 @@
 ```jsx static
-import { LastSaved } from "@nteract/directory-listing"
+import { LastSaved } from "@nteract/directory-listing";
 ```
+
 Display time since last saved
+
 ```jsx
-<LastSaved last_modified={"1986-03-27T16:21:25.354Z"} />
+<LastSaved lastModified={"1986-03-27T16:21:25.354Z"} />
 ```

--- a/packages/directory-listing/src/components/listing.md
+++ b/packages/directory-listing/src/components/listing.md
@@ -8,7 +8,7 @@ import {
 } from "@nteract/directory-listing";
 ```
 
-This component is used to create a directory listing. It is meant to be the parent to the Entry component. It will render a styled table of directory entries.
+Show any listing of directories and files in a tabular layout for users. Works best with `<Entry>` for each item in a content listing.
 
 ```jsx
 <Listing>
@@ -32,6 +32,13 @@ This component is used to create a directory listing. It is meant to be the pare
     <Icon fileType="file" />
     <Name>
       <a href="#listing">component.js</a>
+    </Name>
+    <LastSaved lastModified={new Date("2018-05-27T16:21:25.354Z")} />
+  </Entry>
+  <Entry>
+    <Icon fileType="file" color="gray" />
+    <Name>
+      <i style={{ color: "gray" }}>no-permission-file.md</i>
     </Name>
     <LastSaved lastModified={new Date("2018-05-27T16:21:25.354Z")} />
   </Entry>

--- a/packages/directory-listing/src/components/listing.md
+++ b/packages/directory-listing/src/components/listing.md
@@ -1,37 +1,39 @@
 ```jsx static
-import { Entry, Listing, Icon, Name, LastSaved } from "@nteract/directory-listing"
+import {
+  Entry,
+  Listing,
+  Icon,
+  Name,
+  LastSaved
+} from "@nteract/directory-listing";
 ```
-This component is used to create a directory listing. It is meant to be the parent to the Entry component. It will render a styled table of directory entries. 
+
+This component is used to create a directory listing. It is meant to be the parent to the Entry component. It will render a styled table of directory entries.
 
 ```jsx
-const nb = (
-    <a href={"#listing"}>{"GANS-for-days.ipynb"}</a>
-    );
-    
-const mydir = (
-    <a href={"#listing"}>{"home"}</a>
-    );
+<Listing>
+  <Entry>
+    <Icon fileType="notebook" />
+    <Name>
+      <a href="#listing">GANS-for-days.ipynb</a>
+    </Name>
+    <LastSaved lastModified="2018-06-27T16:21:25.354Z" />
+  </Entry>
 
-const greatfile = (
-    <a href={"#listing"}>{"component.js"}</a>
-    );
- <Listing>
-    <Entry key={0}>
-        <Icon fileType={"notebook"} />
-        <Name>{nb}</Name>
-        <LastSaved last_modified={"2018-06-27T16:21:25.354Z"} />
-    </Entry>
+  <Entry>
+    <Icon fileType="directory" />
+    <Name>
+      <a href="#listing">home</a>
+    </Name>
+    <LastSaved lastModified="2018-03-27T16:21:25.354Z" />
+  </Entry>
 
-    <Entry key={1}>
-        <Icon fileType={"directory"} />
-        <Name>{mydir}</Name>
-        <LastSaved last_modified={"2018-03-27T16:21:25.354Z"} />
-    </Entry>
-
-    <Entry key={2}>
-        <Icon fileType={"file"} />
-        <Name>{greatfile}</Name>
-        <LastSaved last_modified={"2018-05-27T16:21:25.354Z"} />
-    </Entry>
+  <Entry>
+    <Icon fileType="file" />
+    <Name>
+      <a href="#listing">component.js</a>
+    </Name>
+    <LastSaved lastModified={new Date("2018-05-27T16:21:25.354Z")} />
+  </Entry>
 </Listing>
 ```

--- a/packages/directory-listing/src/components/name.md
+++ b/packages/directory-listing/src/components/name.md
@@ -2,7 +2,7 @@
 import { Name } from "@nteract/directory-listing";
 ```
 
-Display a name and link to file
+Use to show a stylized name of the file or directory in a listing.
 
 ```jsx
 <Name>

--- a/packages/directory-listing/src/components/name.md
+++ b/packages/directory-listing/src/components/name.md
@@ -1,13 +1,11 @@
 ```jsx static
-import { Name } from "@nteract/directory-listing"
+import { Name } from "@nteract/directory-listing";
 ```
-Display a name and link to file
-```jsx
-const link = (
-                <a href={"#name"}>
-                  {"Example-Notebook.ipynb"}
-                </a>
-              );
-    <Name>{link}</Name>
 
+Display a name and link to file
+
+```jsx
+<Name>
+  <a href="#name">Example-Notebook.ipynb</a>
+</Name>
 ```


### PR DESCRIPTION
* Switch to regular strings in component docs for the directory listing components. `a href="blah"` instead of `<a href={"blah"}`
* Adhered `<LastSaved />`'s `lastModified` prop to `camelCase`(when it's `snake_case` it's because it came from the Pythonic jupyter API)
* Wrapped the `<Entry />` example in a `<Listing />` for style nicety.
* Allowed `<Icon />` to take a color prop, to make it easier to have it match nearby text. This might not be the easiest interface.

Let me know what you think @alexandercbooth!