### PR TITLE
provide a docs:promote command to alias the deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "docs:build": "styleguidist build",
     "predocs:deploy": "npm run docs:build",
     "docs:deploy": "now ./styleguide",
+    "docs:promote": "cd ./styleguide && now alias",
     "test": "jest",
     "test:unit": "npm run test",
     "test:coverage": "npm run test -- --coverage",


### PR DESCRIPTION
Now to build and promote the docs we run:

```
npm run docs:deploy
```

Then check the site it returns to make sure all went well. If it's working, promote it!

```
npm run docs:promote
```

:boom: It will now be live at components.nteract.io

------


~~NOTE: I'm trying the now integration to see what it's like to check out a now deployment on every PR.~~ 😈