### PR TITLE
set default theme to light for codemirror editor

### DIFF
--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -66,6 +66,7 @@ class CodeMirrorEditor extends React.Component<
   keyupEventsSubscriber: Subscription;
 
   static defaultProps = {
+    theme: "light",
     completion: false,
     tip: false,
     kernelStatus: "not connected",


### PR DESCRIPTION
Another (xref #3066) prop surfaced from using these components externally. Without a defaultProp for `theme`, flow types were harsh on users of the editor package.