### PR TITLE
Include missing deps

### DIFF
--- a/applications/commuter/package.json
+++ b/applications/commuter/package.json
@@ -63,6 +63,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
+    "react-hot-loader": "^4.1.2",
     "s3-proxy": "^1.1.0",
     "util": "^0.10.3",
     "webpack": "3.12.0",

--- a/packages/directory-listing/package.json
+++ b/packages/directory-listing/package.json
@@ -19,7 +19,8 @@
     },
     "dependencies": {
         "@nteract/timeago": "^3.5.0",
-        "@nteract/octicons": "^0.3.0"
+        "@nteract/octicons": "^0.3.0",
+        "react-hot-loader": "^4.1.2"
     },
     "peerDependencies": {
       "react": "^16.3.2"

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -24,11 +24,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
+  "dependencies": {
     "react-hot-loader": "^4.1.2",
     "styled-jsx": "^2.2.6"
+  },
+  "peerDependencies": {
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"


### PR DESCRIPTION
Commuter coudln't be deployed in production uses because of missing `react-hot-loader`. 