### PR TITLE
enforce the react hot loader plugin for commuter

### DIFF
--- a/applications/commuter/.babelrc
+++ b/applications/commuter/.babelrc
@@ -11,6 +11,7 @@
     "next/babel"
   ],
   "plugins": [
+    "react-hot-loader/babel",
     "transform-class-properties",
     "transform-flow-strip-types",
     "transform-object-rest-spread"


### PR DESCRIPTION
I missed this as part of #3081. I just happened to notice I never committed this part. 😞 