### PR TITLE
add data explorer readme with dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Basics
 
 **nteract** is first and foremost a dynamic tool to give you flexibility when
-writing code, exploring data, and authoring text to share insights about the
+writing code, [exploring data](https://github.com/nteract/nteract/tree/master/packages/transform-dataresource), and authoring text to share insights about the
 data.
 
 **Edit code, write prose, and visualize.**

--- a/packages/transform-dataresource/README.md
+++ b/packages/transform-dataresource/README.md
@@ -1,0 +1,53 @@
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/nteract/examples/master?urlpath=%2Fnteract%2Fedit%2Fpython%2Fhappiness.ipynb)
+# nteract Data Explorer
+
+[Read](https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897) @emeeks's post on designing the data explorer.
+
+## Hacking on the nteract Data Explorer
+For expedited development, we recommend using the [Jupyter Extension](https://github.com/nteract/nteract/tree/master/applications/jupyter-extension) to contribute.
+
+_Note: the desktop app can be used instead, but you'll have to manually reload to see changes_
+
+## Installation
+
+### 1. Setup the monorepo
+Navigate to the base directory of the repo and install all dependencies
+```bash
+npm install
+```
+
+### 2. Setup Jupyter Extension
+___Note: this requires Python >= 3.6___
+
+First, install lerna globally
+```bash
+npm install -g lerna
+```
+Now, install the Python package
+```bash
+cd applications/jupyter-extension
+pip install -e .
+jupyter serverextension enable nteract_on_jupyter
+```
+
+### 3. Build JS assests and run a Jupyter server with hot reloading
+```bash
+jupyter nteract --dev
+```
+This will run two servers, a webpack server for live reloading javascript and html assets and a Jupyter server.
+
+Once the assets have been built, you won't need to refresh the page, but you may need to manually refresh the page if it loads before the assets are built.
+
+### 4. Initialize data explorer in the notebook
+In the notebook launched from step 3, run the following code in a cell before anything else :arrow_down:
+```python
+import pandas as pd
+pd.options.display.html.table_schema = True
+pd.options.display.max_rows = None
+```
+
+### Now you are ready to contribute :tada:
+
+
+


### PR DESCRIPTION
As discussed offline by @rgbkrk and @emeeks, we need some instructions to quickly get hacking on the data explorer. This adds a readme in `packages/transform-dataresource` with instructions to use Jupyter Extension.

For the purposes of the sprints or maybe just in general, I thought we ought to have some sort of direct link or mention of data explorer in the top level readme since folks might not think to look in  `transform-dataresouce`, so I added a link there, too.

Side note: data explorer is just plain ___awesome___ -- thanks @emeeks! 😄 