### PR TITLE
disable building desktop on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,11 +55,3 @@ jobs:
           name: Build Jupyter Extension
           command: npx lerna run build:asap --scope nteract-on-jupyter
           no_output_timeout: 30m
-      - run:
-          name: Build Desktop
-          command: npx lerna run dist --scope nteract
-          no_output_timeout: 30m
-
-      - store_artifacts:
-          path: applications/desktop/dist
-          destination: desktop-app


### PR DESCRIPTION
Not sure what's causing the issue, but this build takes a good while and is currently blocking things.

I'm going to switch desktop builds to be done nightly and not affect day-to-day development.
