### PR TITLE
Update nteractapp.py to use yarn workspaces

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -15,9 +15,8 @@ from .utils import cmd_in_new_dir
 webpack_port = 8357
 
 webpack_hot = {"address": f'http://localhost:{webpack_port}/',
-               "command": ["lerna", "run", "hot",
-                           "--scope", "nteract-on-jupyter",
-                           "--stream", "--", "--", "--port", str(webpack_port)]}
+               "command": ["yarn", "workspace", "nteract-on-jupyter",
+                           "run", "hot", "--port", str(webpack_port)]}
 nteract_flags = dict(flags)
 nteract_flags['dev'] = (
     {'NteractConfig': {'asset_url': webpack_hot['address']},


### PR DESCRIPTION
Updates nteractapp.py to use yarn workspaces instead of lerna to launch the nteract-on-jupyter webpack build.

@rgbkrk I believe this should unblock people developing on the jupyter extension for now. If you like, we can merge this PR now, and I can keep this branch alive as a place to make more commits related to updating docs/package scripts to reference yarn instead of npm.