### PR TITLE
Invite contributors to dream team by default

### DIFF
--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,0 +1,2 @@
+# Add new contributors to dream-team by default
+team: dream-team


### PR DESCRIPTION
Our auto-inviter invites people yet grants them no ability, as evidenced in https://github.com/nteract/hydrogen/pull/1365. 😆 

Now we're enabling people with this change!