### PR TITLE
Clusterbar sometimes

### DIFF
--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -39,7 +39,7 @@
     "react-color": "^2.14.1",
     "react-hot-loader": "^4.1.2",
     "react-virtualized": "9.20.1",
-    "semiotic": "^1.13.1",
+    "semiotic": "^1.13.2",
     "tv4": "^1.3.0"
   }
 }

--- a/packages/transform-dataresource/src/charts/bar.js
+++ b/packages/transform-dataresource/src/charts/bar.js
@@ -92,8 +92,17 @@ export const semioticBarChart = (
     }
   }
 
+  //replace with incoming cardinality when df.describe metadata is implemented
+  const cardinality =
+    (selectedDimensions.length > 0 &&
+      !(selectedDimensions.length === 1 && dim1 === selectedDimensions[0]) &&
+      sortedData
+        .map(d => d[dim1])
+        .reduce((p, c) => (p.indexOf(c) === -1 ? [...p, c] : p), []).length) ||
+    0;
+
   const barSettings = {
-    type: "bar",
+    type: cardinality > 4 ? "clusterbar" : "bar",
     data: sortedData,
     oAccessor,
     rAccessor,


### PR DESCRIPTION
Simple heuristics to choose cluster bar when cardinality is high.
Also update Semiotic so the tooltip works right

Beyond that, the only thing Zeppelin has is a pie chart, which we can implement at some point if there's public desire, and then a bunch of UI bits like dragging and dropping and other things, so this was focused on chart parity and the only thing missing from that perspective were grouped bar charts.
