### PR TITLE
move delete to the right of menu and run, put nonclickable bar inbetween

### DIFF
--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar-spec.js.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar-spec.js.snap
@@ -5,17 +5,17 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
   type="code"
 >
   <div
-    className="jsx-3251887977 cell-toolbar-mask"
+    className="jsx-4158988748 cell-toolbar-mask"
   >
     <div
-      className="jsx-3251887977 cell-toolbar"
+      className="jsx-4158988748 cell-toolbar"
     >
       <button
-        className="jsx-3251887977 executeButton"
+        className="jsx-4158988748 executeButton"
         title="execute cell"
       >
         <span
-          className="jsx-3251887977 octicon"
+          className="jsx-4158988748 octicon"
         >
           <TriangleRightOcticon>
             <SVGWrapper
@@ -64,11 +64,11 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
               onClick={[Function]}
             >
               <button
-                className="jsx-3251887977"
+                className="jsx-4158988748"
                 title="show additional actions"
               >
                 <span
-                  className="jsx-3251887977 octicon toggle-menu"
+                  className="jsx-4158988748 octicon toggle-menu"
                 >
                   <ChevronDownOcticon>
                     <SVGWrapper
@@ -117,16 +117,14 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
         </div>
       </DropdownMenu>
       <span
-        className="jsx-3251887977"
-      >
-         | 
-      </span>
+        className="jsx-4158988748 boundary"
+      />
       <button
-        className="jsx-3251887977 deleteButton"
+        className="jsx-4158988748 deleteButton"
         title="delete cell"
       >
         <span
-          className="jsx-3251887977 octicon"
+          className="jsx-4158988748 octicon"
         >
           <TrashOcticon>
             <SVGWrapper
@@ -164,13 +162,13 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
       </button>
     </div>
     <JSXStyle
-      css=".cell-toolbar.__jsx-style-dynamic-selector>div.__jsx-style-dynamic-selector{display:inline-block;}.cell-toolbar.__jsx-style-dynamic-selector{background-color:var(--theme-cell-toolbar-bg);opacity:0.4;-webkit-transition:opacity 0.4s;transition:opacity 0.4s;}.cell-toolbar.__jsx-style-dynamic-selector:hover{opacity:1;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector{display:inline-block;width:22px;height:20px;padding:0px 4px;text-align:center;border:none;outline:none;background:none;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector{font-size:15px;line-height:1;color:var(--theme-cell-toolbar-fg);}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector:hover{color:var(--theme-cell-toolbar-fg-hover);}.cell-toolbar-mask.__jsx-style-dynamic-selector{z-index:9999;display:none;position:absolute;top:0px;right:0px;height:34px;padding:0px 0px 0px 50px;}.octicon.__jsx-style-dynamic-selector{-webkit-transition:color 0.5s;transition:color 0.5s;}"
+      css=".cell-toolbar.__jsx-style-dynamic-selector>div.__jsx-style-dynamic-selector{display:inline-block;}.cell-toolbar.__jsx-style-dynamic-selector{background-color:var(--theme-cell-toolbar-bg);opacity:0.4;-webkit-transition:opacity 0.4s;transition:opacity 0.4s;}.cell-toolbar.__jsx-style-dynamic-selector:hover{opacity:1;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector{display:inline-block;width:22px;height:20px;padding:0px 4px;text-align:center;border:none;outline:none;background:none;}.cell-toolbar.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector{font-size:15px;line-height:1;color:var(--theme-cell-toolbar-fg);}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector:hover{color:var(--theme-cell-toolbar-fg-hover);}.cell-toolbar-mask.__jsx-style-dynamic-selector{z-index:9999;display:none;position:absolute;top:0px;right:0px;height:34px;padding:0px 0px 0px 50px;}.octicon.__jsx-style-dynamic-selector{-webkit-transition:color 0.5s;transition:color 0.5s;}.cell-toolbar.__jsx-style-dynamic-selector span.boundary.__jsx-style-dynamic-selector{display:inline-block;vertical-align:middle;margin:1px 10px 3px 10px;border-left:2.5px solid rgba(16,22,26,0.1);height:11px;}"
       dynamic={
         Array [
           "none",
         ]
       }
-      styleId="3927607621"
+      styleId="2414219362"
     />
   </div>
 </PureToolbar>
@@ -181,17 +179,17 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
   type="code"
 >
   <div
-    className="jsx-3251887977 cell-toolbar-mask"
+    className="jsx-4158988748 cell-toolbar-mask"
   >
     <div
-      className="jsx-3251887977 cell-toolbar"
+      className="jsx-4158988748 cell-toolbar"
     >
       <button
-        className="jsx-3251887977 executeButton"
+        className="jsx-4158988748 executeButton"
         title="execute cell"
       >
         <span
-          className="jsx-3251887977 octicon"
+          className="jsx-4158988748 octicon"
         >
           <TriangleRightOcticon>
             <SVGWrapper
@@ -240,11 +238,11 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
               onClick={[Function]}
             >
               <button
-                className="jsx-3251887977"
+                className="jsx-4158988748"
                 title="show additional actions"
               >
                 <span
-                  className="jsx-3251887977 octicon toggle-menu"
+                  className="jsx-4158988748 octicon toggle-menu"
                 >
                   <ChevronDownOcticon>
                     <SVGWrapper
@@ -298,84 +296,84 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
               >
                 <li
                   aria-selected="false"
-                  className="jsx-3251887977 clearOutput"
+                  className="jsx-4158988748 clearOutput"
                   key=".0"
                   onClick={[Function]}
                   role="option"
                   tabIndex="0"
                 >
                   <a
-                    className="jsx-3251887977"
+                    className="jsx-4158988748"
                   >
                     Clear Cell Output
                   </a>
                 </li>
                 <li
                   aria-selected="false"
-                  className="jsx-3251887977 inputVisibility"
+                  className="jsx-4158988748 inputVisibility"
                   key=".1"
                   onClick={[Function]}
                   role="option"
                   tabIndex="0"
                 >
                   <a
-                    className="jsx-3251887977"
+                    className="jsx-4158988748"
                   >
                     Toggle Input Visibility
                   </a>
                 </li>
                 <li
                   aria-selected="false"
-                  className="jsx-3251887977 outputVisibility"
+                  className="jsx-4158988748 outputVisibility"
                   key=".2"
                   onClick={[Function]}
                   role="option"
                   tabIndex="0"
                 >
                   <a
-                    className="jsx-3251887977"
+                    className="jsx-4158988748"
                   >
                     Toggle Output Visibility
                   </a>
                 </li>
                 <li
                   aria-selected="false"
-                  className="jsx-3251887977 outputExpanded"
+                  className="jsx-4158988748 outputExpanded"
                   key=".3"
                   onClick={[Function]}
                   role="option"
                   tabIndex="0"
                 >
                   <a
-                    className="jsx-3251887977"
+                    className="jsx-4158988748"
                   >
                     Toggle Expanded Output
                   </a>
                 </li>
                 <li
                   aria-selected="false"
-                  className="jsx-3251887977"
+                  className="jsx-4158988748"
                   key=".4"
                   onClick={[Function]}
                   role="option"
                   tabIndex="0"
                 >
                   <a
-                    className="jsx-3251887977"
+                    className="jsx-4158988748"
                   >
                     Toggle Parameter Cell
                   </a>
                 </li>
                 <li
                   aria-selected="false"
-                  className="jsx-3251887977 changeType"
+                  className="jsx-4158988748 changeType"
                   key=".5"
                   onClick={[Function]}
                   role="option"
                   tabIndex="0"
                 >
                   <a
-                    className="jsx-3251887977"
+                    className="jsx-4158988748"
                   >
                     Convert to Markdown Cell
                   </a>
@@ -394,16 +392,14 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
         </div>
       </DropdownMenu>
       <span
-        className="jsx-3251887977"
-      >
-         | 
-      </span>
+        className="jsx-4158988748 boundary"
+      />
       <button
-        className="jsx-3251887977 deleteButton"
+        className="jsx-4158988748 deleteButton"
         title="delete cell"
       >
         <span
-          className="jsx-3251887977 octicon"
+          className="jsx-4158988748 octicon"
         >
           <TrashOcticon>
             <SVGWrapper
@@ -441,13 +437,13 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
       </button>
     </div>
     <JSXStyle
-      css=".cell-toolbar.__jsx-style-dynamic-selector>div.__jsx-style-dynamic-selector{display:inline-block;}.cell-toolbar.__jsx-style-dynamic-selector{background-color:var(--theme-cell-toolbar-bg);opacity:0.4;-webkit-transition:opacity 0.4s;transition:opacity 0.4s;}.cell-toolbar.__jsx-style-dynamic-selector:hover{opacity:1;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector{display:inline-block;width:22px;height:20px;padding:0px 4px;text-align:center;border:none;outline:none;background:none;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector{font-size:15px;line-height:1;color:var(--theme-cell-toolbar-fg);}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector:hover{color:var(--theme-cell-toolbar-fg-hover);}.cell-toolbar-mask.__jsx-style-dynamic-selector{z-index:9999;display:none;position:absolute;top:0px;right:0px;height:34px;padding:0px 0px 0px 50px;}.octicon.__jsx-style-dynamic-selector{-webkit-transition:color 0.5s;transition:color 0.5s;}"
+      css=".cell-toolbar.__jsx-style-dynamic-selector>div.__jsx-style-dynamic-selector{display:inline-block;}.cell-toolbar.__jsx-style-dynamic-selector{background-color:var(--theme-cell-toolbar-bg);opacity:0.4;-webkit-transition:opacity 0.4s;transition:opacity 0.4s;}.cell-toolbar.__jsx-style-dynamic-selector:hover{opacity:1;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector{display:inline-block;width:22px;height:20px;padding:0px 4px;text-align:center;border:none;outline:none;background:none;}.cell-toolbar.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector{font-size:15px;line-height:1;color:var(--theme-cell-toolbar-fg);}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector:hover{color:var(--theme-cell-toolbar-fg-hover);}.cell-toolbar-mask.__jsx-style-dynamic-selector{z-index:9999;display:none;position:absolute;top:0px;right:0px;height:34px;padding:0px 0px 0px 50px;}.octicon.__jsx-style-dynamic-selector{-webkit-transition:color 0.5s;transition:color 0.5s;}.cell-toolbar.__jsx-style-dynamic-selector span.boundary.__jsx-style-dynamic-selector{display:inline-block;vertical-align:middle;margin:1px 10px 3px 10px;border-left:2.5px solid rgba(16,22,26,0.1);height:11px;}"
       dynamic={
         Array [
           "none",
         ]
       }
-      styleId="3927607621"
+      styleId="2414219362"
     />
   </div>
 </PureToolbar>

--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar-spec.js.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar-spec.js.snap
@@ -51,47 +51,6 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
           </TriangleRightOcticon>
         </span>
       </button>
-      <button
-        className="jsx-3251887977 deleteButton"
-        title="delete cell"
-      >
-        <span
-          className="jsx-3251887977 octicon"
-        >
-          <TrashOcticon>
-            <SVGWrapper
-              height={16}
-              outerProps={Object {}}
-              viewBox="0 0 12 16"
-              width={12}
-            >
-              <span>
-                <svg
-                  height={16}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fill": "currentColor",
-                      "verticalAlign": "text-bottom",
-                    }
-                  }
-                  viewBox="0 0 12 16"
-                  width={12}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <title>
-                    Delete Cell
-                  </title>
-                  <path
-                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </SVGWrapper>
-          </TrashOcticon>
-        </span>
-      </button>
       <DropdownMenu>
         <div
           className="jsx-3444321073 dropdown"
@@ -157,6 +116,52 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
           />
         </div>
       </DropdownMenu>
+      <span
+        className="jsx-3251887977"
+      >
+         | 
+      </span>
+      <button
+        className="jsx-3251887977 deleteButton"
+        title="delete cell"
+      >
+        <span
+          className="jsx-3251887977 octicon"
+        >
+          <TrashOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 12 16"
+              width={12}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
+                    }
+                  }
+                  viewBox="0 0 12 16"
+                  width={12}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title>
+                    Delete Cell
+                  </title>
+                  <path
+                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </TrashOcticon>
+        </span>
+      </button>
     </div>
     <JSXStyle
       css=".cell-toolbar.__jsx-style-dynamic-selector>div.__jsx-style-dynamic-selector{display:inline-block;}.cell-toolbar.__jsx-style-dynamic-selector{background-color:var(--theme-cell-toolbar-bg);opacity:0.4;-webkit-transition:opacity 0.4s;transition:opacity 0.4s;}.cell-toolbar.__jsx-style-dynamic-selector:hover{opacity:1;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector{display:inline-block;width:22px;height:20px;padding:0px 4px;text-align:center;border:none;outline:none;background:none;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector{font-size:15px;line-height:1;color:var(--theme-cell-toolbar-fg);}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector:hover{color:var(--theme-cell-toolbar-fg-hover);}.cell-toolbar-mask.__jsx-style-dynamic-selector{z-index:9999;display:none;position:absolute;top:0px;right:0px;height:34px;padding:0px 0px 0px 50px;}.octicon.__jsx-style-dynamic-selector{-webkit-transition:color 0.5s;transition:color 0.5s;}"
@@ -220,47 +225,6 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
               </span>
             </SVGWrapper>
           </TriangleRightOcticon>
-        </span>
-      </button>
-      <button
-        className="jsx-3251887977 deleteButton"
-        title="delete cell"
-      >
-        <span
-          className="jsx-3251887977 octicon"
-        >
-          <TrashOcticon>
-            <SVGWrapper
-              height={16}
-              outerProps={Object {}}
-              viewBox="0 0 12 16"
-              width={12}
-            >
-              <span>
-                <svg
-                  height={16}
-                  style={
-                    Object {
-                      "display": "inline-block",
-                      "fill": "currentColor",
-                      "verticalAlign": "text-bottom",
-                    }
-                  }
-                  viewBox="0 0 12 16"
-                  width={12}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <title>
-                    Delete Cell
-                  </title>
-                  <path
-                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
-                    fillRule="evenodd"
-                  />
-                </svg>
-              </span>
-            </SVGWrapper>
-          </TrashOcticon>
         </span>
       </button>
       <DropdownMenu>
@@ -429,6 +393,52 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
           />
         </div>
       </DropdownMenu>
+      <span
+        className="jsx-3251887977"
+      >
+         | 
+      </span>
+      <button
+        className="jsx-3251887977 deleteButton"
+        title="delete cell"
+      >
+        <span
+          className="jsx-3251887977 octicon"
+        >
+          <TrashOcticon>
+            <SVGWrapper
+              height={16}
+              outerProps={Object {}}
+              viewBox="0 0 12 16"
+              width={12}
+            >
+              <span>
+                <svg
+                  height={16}
+                  style={
+                    Object {
+                      "display": "inline-block",
+                      "fill": "currentColor",
+                      "verticalAlign": "text-bottom",
+                    }
+                  }
+                  viewBox="0 0 12 16"
+                  width={12}
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <title>
+                    Delete Cell
+                  </title>
+                  <path
+                    d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </span>
+            </SVGWrapper>
+          </TrashOcticon>
+        </span>
+      </button>
     </div>
     <JSXStyle
       css=".cell-toolbar.__jsx-style-dynamic-selector>div.__jsx-style-dynamic-selector{display:inline-block;}.cell-toolbar.__jsx-style-dynamic-selector{background-color:var(--theme-cell-toolbar-bg);opacity:0.4;-webkit-transition:opacity 0.4s;transition:opacity 0.4s;}.cell-toolbar.__jsx-style-dynamic-selector:hover{opacity:1;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector{display:inline-block;width:22px;height:20px;padding:0px 4px;text-align:center;border:none;outline:none;background:none;}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector{font-size:15px;line-height:1;color:var(--theme-cell-toolbar-fg);}.cell-toolbar.__jsx-style-dynamic-selector button.__jsx-style-dynamic-selector span.__jsx-style-dynamic-selector:hover{color:var(--theme-cell-toolbar-fg-hover);}.cell-toolbar-mask.__jsx-style-dynamic-selector{z-index:9999;display:none;position:absolute;top:0px;right:0px;height:34px;padding:0px 0px 0px 50px;}.octicon.__jsx-style-dynamic-selector{-webkit-transition:color 0.5s;transition:color 0.5s;}"

--- a/packages/notebook-app-component/src/toolbar.js
+++ b/packages/notebook-app-component/src/toolbar.js
@@ -61,15 +61,6 @@ export class PureToolbar extends React.Component<PureToolbarProps> {
               </span>
             </button>
           )}
-          <button
-            onClick={removeCell}
-            title="delete cell"
-            className="deleteButton"
-          >
-            <span className="octicon">
-              <TrashOcticon />
-            </span>
-          </button>
           <DropdownMenu>
             <DropdownTrigger>
               <button title="show additional actions">
@@ -149,6 +140,16 @@ export class PureToolbar extends React.Component<PureToolbarProps> {
               </DropdownContent>
             )}
           </DropdownMenu>
+          <span> | </span>
+          <button
+            onClick={removeCell}
+            title="delete cell"
+            className="deleteButton"
+          >
+            <span className="octicon">
+              <TrashOcticon />
+            </span>
+          </button>
         </div>
 
         <style jsx>{`

--- a/packages/notebook-app-component/src/toolbar.js
+++ b/packages/notebook-app-component/src/toolbar.js
@@ -140,7 +140,7 @@ export class PureToolbar extends React.Component<PureToolbarProps> {
               </DropdownContent>
             )}
           </DropdownMenu>
-          <span> | </span>
+          <span className="boundary" />
           <button
             onClick={removeCell}
             title="delete cell"
@@ -181,7 +181,7 @@ export class PureToolbar extends React.Component<PureToolbarProps> {
             background: none;
           }
 
-          .cell-toolbar button span {
+          .cell-toolbar span {
             font-size: 15px;
             line-height: 1;
             color: var(--theme-cell-toolbar-fg);
@@ -207,6 +207,14 @@ export class PureToolbar extends React.Component<PureToolbarProps> {
 
           .octicon {
             transition: color 0.5s;
+          }
+
+          .cell-toolbar span.boundary {
+            display: inline-block;
+            vertical-align: middle;
+            margin: 1px 10px 3px 10px;
+            border-left: 2.5px solid rgba(16, 22, 26, 0.1);
+            height: 11px;
           }
         `}</style>
       </div>


### PR DESCRIPTION
This fixes the issue where you can accidentally delete a notebook when trying to click either the run button or the menu, with delete sandwiched inbetween.

There isn't an iron icon that on it's own does this without modification (as far as I can tell) and it was easier to make it non-clickable to just include a span with " | ". I think it gets the quick fix out there.

![image](https://user-images.githubusercontent.com/2482408/43667571-66ba4d88-972d-11e8-8d64-eb1eac24035f.png)
