### PR TITLE
explicitly set the registry to npmjs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock = false
+registry = https://registry.npmjs.org/


### PR DESCRIPTION
Setting this so renovate doesn't try to sneak yarn's registry like in #3195 