### PR TITLE
create <TooltipContent /> as component

### DIFF
--- a/packages/transform-dataresource/src/ParallelCoordinatesController.js
+++ b/packages/transform-dataresource/src/ParallelCoordinatesController.js
@@ -7,6 +7,8 @@ import HTMLLegend from "./HTMLLegend";
 import { numeralFormatting } from "./utilities";
 import buttonGroupStyle from "./css/button-group";
 
+import TooltipContent from "./tooltip-content";
+
 type State = {
   filterMode: boolean,
   data: Array<Object>,
@@ -247,7 +249,7 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
           }
           pieceHoverAnnotation={!filterMode}
           tooltipContent={d => (
-            <div className="tooltip-content">
+            <TooltipContent>
               <h3>{primaryKey.map(key => d[key]).join(", ")}</h3>
               {d[dim1] && (
                 <h3 style={{ color: colorHash[d[dim1]] }}>
@@ -257,7 +259,7 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
               <p>
                 {d.metric}: {d.rawvalue}
               </p>
-            </div>
+            </TooltipContent>
           )}
           canvasPieces={true}
           canvasConnectors={true}

--- a/packages/transform-dataresource/src/charts/bar.js
+++ b/packages/transform-dataresource/src/charts/bar.js
@@ -1,6 +1,8 @@
 /* @flow */
 import * as React from "react";
 
+import TooltipContent from "../tooltip-content";
+
 import { sortByOrdinalRange } from "./shared";
 import HTMLLegend from "../HTMLLegend";
 import { numeralFormatting } from "../utilities";
@@ -72,7 +74,7 @@ export const semioticBarChart = (
       additionalSettings.pieceHoverAnnotation = true;
       additionalSettings.tooltipContent = d => {
         return (
-          <div className="tooltip-content">
+          <TooltipContent>
             {dim1 && dim1 !== "none" && <p>{d[dim1]}</p>}
             <p>
               {typeof oAccessor === "function" ? oAccessor(d) : d[oAccessor]}
@@ -86,7 +88,7 @@ export const semioticBarChart = (
                   {metric3}: {d[metric3]}
                 </p>
               )}
-          </div>
+          </TooltipContent>
         );
       };
     }
@@ -123,7 +125,7 @@ export const semioticBarChart = (
     },
     tooltipContent: (d: Object) => {
       return (
-        <div className="tooltip-content">
+        <TooltipContent>
           <p>
             {typeof oAccessor === "function"
               ? oAccessor(d.pieces[0])
@@ -140,7 +142,7 @@ export const semioticBarChart = (
                 {d.pieces.map(p => p[metric3]).reduce((p, c) => p + c, 0)}
               </p>
             )}
-        </div>
+        </TooltipContent>
       );
     },
     baseMarkProps: { forceUpdate: true },

--- a/packages/transform-dataresource/src/charts/hierarchical.js
+++ b/packages/transform-dataresource/src/charts/hierarchical.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { nest } from "d3-collection";
 import { scaleLinear } from "d3-scale";
+import TooltipContent from "../tooltip-content";
 
 const parentPath = (d, pathArray) => {
   if (d.parent) {
@@ -27,7 +28,9 @@ const hierarchicalTooltip = (d, primaryKey, metric) => {
   } else {
     content.push(
       <p key="leaf-label">
-        {pathString}->{primaryKey.map(p => d[p]).join(", ")}
+        {pathString}
+        ->
+        {primaryKey.map(p => d[p]).join(", ")}
       </p>
     );
     content.push(
@@ -120,9 +123,9 @@ export const semioticHierarchicalChart = (
     hoverAnnotation: true,
     tooltipContent: (d: Object) => {
       return (
-        <div className="tooltip-content">
+        <TooltipContent>
           {hierarchicalTooltip(d, primaryKey, metric1)}
-        </div>
+        </TooltipContent>
       );
     }
   };

--- a/packages/transform-dataresource/src/charts/line.js
+++ b/packages/transform-dataresource/src/charts/line.js
@@ -1,6 +1,8 @@
 /* @flow */
 import * as React from "react";
 
+import TooltipContent from "../tooltip-content";
+
 import { curveMonotone } from "d3-shape";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { numeralFormatting } from "../utilities";
@@ -119,7 +121,7 @@ export const semioticLineChart = (
     },
     tooltipContent: (d: Object) => {
       return (
-        <div className="tooltip-content">
+        <TooltipContent>
           <p>{d.parentLine && d.parentLine.label}</p>
           <p>{(d.value && d.value.toLocaleString()) || d.value}</p>
           <p>
@@ -132,7 +134,7 @@ export const semioticLineChart = (
                 d.originalData[k]}
             </p>
           ))}
-        </div>
+        </TooltipContent>
       );
     }
   };

--- a/packages/transform-dataresource/src/charts/network.js
+++ b/packages/transform-dataresource/src/charts/network.js
@@ -1,6 +1,8 @@
 /* @flow */
 import * as React from "react";
 
+import TooltipContent from "../tooltip-content";
+
 export const semioticNetwork = (
   data: Array<Object>,
   schema: Object,
@@ -70,11 +72,11 @@ export const semioticNetwork = (
     hoverAnnotation: true,
     tooltipContent: (d: Object) => {
       return (
-        <div className="tooltip-content">
+        <TooltipContent>
           <h3>{d.id}</h3>
           <p>Links: {d.degree}</p>
           {d.value && <p>Value: {d.value}</p>}
-        </div>
+        </TooltipContent>
       );
     },
     margin: { left: 100, right: 100, top: 10, bottom: 10 }

--- a/packages/transform-dataresource/src/charts/summary.js
+++ b/packages/transform-dataresource/src/charts/summary.js
@@ -4,6 +4,8 @@ import HTMLLegend from "../HTMLLegend";
 import { numeralFormatting } from "../utilities";
 import { scaleLinear } from "d3-scale";
 
+import TooltipContent from "../tooltip-content";
+
 const fontScale = scaleLinear()
   .domain([8, 25])
   .range([14, 8])
@@ -82,7 +84,7 @@ export const semioticSummaryChart = (
     baseMarkProps: { forceUpdate: true },
     pieceHoverAnnotation: summaryType === "violin",
     tooltipContent: (d: Object) => (
-      <div className="tooltip-content">
+      <TooltipContent>
         <h3>{primaryKey.map(p => d[p]).join(", ")}</h3>
         <p>
           {dim1}: {d[dim1]}
@@ -90,7 +92,7 @@ export const semioticSummaryChart = (
         <p>
           {rAccessor}: {d[rAccessor]}
         </p>
-      </div>
+      </TooltipContent>
     ),
     ...additionalSettings
   };

--- a/packages/transform-dataresource/src/charts/xyplot.js
+++ b/packages/transform-dataresource/src/charts/xyplot.js
@@ -6,6 +6,8 @@ import { scaleLinear, scaleThreshold } from "d3-scale";
 import { numeralFormatting } from "../utilities";
 import HTMLLegend from "../HTMLLegend";
 
+import TooltipContent from "../tooltip-content";
+
 const steps = ["none", "#FBEEEC", "#f3c8c2", "#e39787", "#ce6751", "#b3331d"];
 const thresholds = scaleThreshold()
   .domain([0.01, 0.2, 0.4, 0.6, 0.8])
@@ -71,7 +73,7 @@ export const semioticScatterplot = (
   );
 
   const pointTooltip = (d: Object) => (
-    <div className="tooltip-content">
+    <TooltipContent>
       <h3>{primaryKey.map(p => d[p]).join(", ")}</h3>
       {dimensions.map(dim => (
         <p key={`tooltip-dim-${dim.name}`}>
@@ -91,13 +93,13 @@ export const semioticScatterplot = (
             {metric3}: {d[metric3]}
           </p>
         )}
-    </div>
+    </TooltipContent>
   );
 
   const areaTooltip = (d: Object) => {
     if (d.binItems.length === 0) return null;
     return (
-      <div className="tooltip-content">
+      <TooltipContent>
         <h3
           style={{
             fontSize: "14px",
@@ -126,7 +128,7 @@ export const semioticScatterplot = (
             , {d[metric1]}, {d[metric2]}
           </p>
         ))}
-      </div>
+      </TooltipContent>
     );
   };
 

--- a/packages/transform-dataresource/src/css/semiotic.js
+++ b/packages/transform-dataresource/src/css/semiotic.js
@@ -1,38 +1,6 @@
 import css from "styled-jsx/css";
 
 export default css`
-  :global(.tooltip-content) {
-    color: black;
-    padding: 10px;
-    z-index: 999999;
-    min-width: 120px;
-    background: white;
-    border: 1px solid #888;
-    border-radius: 5px;
-    position: relative;
-    transform: translate(calc(-50% + 7px), calc(0% + 9px));
-  }
-  :global(.tooltip-content:before) {
-    border-left: inherit;
-    border-top: inherit;
-    top: -8px;
-    left: calc(50% - 15px);
-    background: inherit;
-    content: "";
-    padding: 0px;
-    transform: rotate(45deg);
-    width: 15px;
-    height: 15px;
-    position: absolute;
-    z-index: 99;
-  }
-  :global(.tooltip-content h3) {
-    margin: 0 0 10px;
-  }
-  :global(.tooltip-content p) {
-    font-size: 14px;
-  }
-
   :global(.tick > path) {
     stroke: lightgray;
   }

--- a/packages/transform-dataresource/src/tooltip-content.js
+++ b/packages/transform-dataresource/src/tooltip-content.js
@@ -1,0 +1,44 @@
+// @flow
+
+import * as React from "react";
+
+const TooltipContent = (props: { children: React.Node }) => (
+  <React.Fragment>
+    <div className="tooltip-content">{props.children}</div>
+    <style jsx>{`
+      .tooltip-content {
+        color: black;
+        padding: 10px;
+        z-index: 999999;
+        min-width: 120px;
+        background: white;
+        border: 1px solid #888;
+        border-radius: 5px;
+        position: relative;
+        transform: translate(calc(-50% + 7px), calc(0% + 9px));
+      }
+      .tooltip-content:before {
+        border-left: inherit;
+        border-top: inherit;
+        top: -8px;
+        left: calc(50% - 15px);
+        background: inherit;
+        content: "";
+        padding: 0px;
+        transform: rotate(45deg);
+        width: 15px;
+        height: 15px;
+        position: absolute;
+        z-index: 99;
+      }
+      .tooltip-content :global(h3) {
+        margin: 0 0 10px;
+      }
+      .tooltip-content :global(p) {
+        font-size: 14px;
+      }
+    `}</style>
+  </React.Fragment>
+);
+
+export default TooltipContent;


### PR DESCRIPTION
This extracts the `.tooltip-content` styles into a single wrapper component you can use like this:

```jsx
import TooltipContent from "./tooltip-content";

...

<TooltipContent>
  <h1>15</h1>
  <p>Country: Guatemala</p>
<TooltipContent>
```

cc @binx @emeeks 