### PR TITLE
target with :global only on nested selectors

### DIFF
--- a/packages/directory-listing/src/components/icon.js
+++ b/packages/directory-listing/src/components/icon.js
@@ -34,7 +34,7 @@ export class Icon extends React.Component<IconProps, null> {
       <td className="icon" style={{ color: this.props.color }}>
         {icon}
         <style jsx>{`
-          :global(.icon) {
+          .icon {
             padding-right: 2px;
             padding-left: 10px;
             width: 17px;

--- a/packages/directory-listing/src/components/name.js
+++ b/packages/directory-listing/src/components/name.js
@@ -22,11 +22,11 @@ export class Name extends React.Component<NameProps, null> {
             padding: 8px;
           }
 
-          :global(a) {
+          .name :global(a) {
             text-decoration: none;
           }
 
-          :global(a:hover) {
+          .name :global(a:hover) {
             text-decoration: underline;
             outline-width: 0;
           }


### PR DESCRIPTION
largely this is so that the jsx-whateverID gets attached to the start like documented in https://github.com/zeit/styled-jsx/tree/v2#how-it-works

cc @alexandercbooth 