### PR TITLE
[WIP] set optimizeForSpeed to true to showcase issue

### DIFF
--- a/applications/commuter/.babelrc
+++ b/applications/commuter/.babelrc
@@ -8,7 +8,12 @@
         }
       }
     ],
-    "next/babel"
+    [
+      "next/babel",
+      {
+        "styled-jsx": { "optimizeForSpeed": true }
+      }
+    ]
   ],
   "plugins": [
     "react-hot-loader/babel",


### PR DESCRIPTION
This PR is up merely to show an issue we're currently having with `styled-jsx`. If you run `npm run app:commuter` on this branch, open your devtools, and navigate between pages with the directory listing, you'll see the following warnings in the console:

<img width="1016" alt="screen shot 2018-08-08 at 12 14 20 pm" src="https://user-images.githubusercontent.com/836375/43859118-9d7f52b6-9b04-11e8-9080-75b29d00c669.png">

Navigate again and the whole page will break down with errors:

<img width="1016" alt="screen shot 2018-08-08 at 12 15 08 pm" src="https://user-images.githubusercontent.com/836375/43859144-b4aebde6-9b04-11e8-9141-cb83e5fb19cb.png">

In summary, it looks like Chrome is rejecting stylesheets that are being added (saying they're invalid) and then later styled-jsx appears to be trying to remove styles that are not there (due to never getting added properly).

This is styled-jsx 2.2.6 and affects both next 5 and next 6.