### PR TITLE
trim naming boilerplate in records

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "moduleNameMapper": {
       "^@nteract/styles$": "<rootDir>/packages/styles/lib",
       "^@nteract/core/dummy$": "<rootDir>/packages/core/src/dummy",
-      "^@nteract/(.*)$": "<rootDir>/packages/$1/src",
+      "^@nteract/([^/]*)$": "<rootDir>/packages/$1/src",
       "^(ansi-to-react|enchannel-zmq-backend|fs-observable|rx-binder|rx-jupyter)$": "<rootDir>/packages/$1/src",
       "\\.css$": "<rootDir>/scripts/noop-module.js"
     },

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,5 +1,6 @@
 // @flow
 import * as nteractRecords from "@nteract/records";
+import { displayData } from "@nteract/records";
 
 describe("stream output", () => {
   test("can be converted from nbformat", () => {
@@ -42,7 +43,7 @@ describe("stream output", () => {
 describe("display_data output", () => {
   test("can be converted from nbformat", () => {
     expect(
-      nteractRecords.outputFromNbformat({
+      displayData.fromNbformat({
         output_type: "display_data",
         data: {
           "text/plain": [
@@ -57,7 +58,7 @@ describe("display_data output", () => {
         metadata: { "application/json": { expanded: true } }
       })
     ).toEqual(
-      nteractRecords.makeDisplayDataOutputRecord({
+      displayData({
         outputType: "display_data",
         data: {
           "text/plain": "mind\ntime\nspace\nreality\npower\nsoul"
@@ -71,7 +72,7 @@ describe("display_data output", () => {
 
   test("can be converted from jupyter messages", () => {
     expect(
-      nteractRecords.displayDataRecordFromMessage({
+      displayData.fromJupyterMessage({
         header: {
           msg_type: "display_data"
         },
@@ -81,7 +82,7 @@ describe("display_data output", () => {
         }
       })
     ).toEqual(
-      nteractRecords.makeDisplayDataOutputRecord({
+      displayData({
         outputType: "display_data",
         data: { "text/plain": "another\nDoug" },
         metadata: { "application/json": { expanded: true } }

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as nteractRecords from "@nteract/records";
 
 import { streamOutput } from "@nteract/records/src/outputs/stream";

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -3,6 +3,7 @@ import * as nteractRecords from "@nteract/records";
 
 import { streamOutput } from "@nteract/records/src/outputs/stream";
 import { displayData } from "@nteract/records/src/outputs/display-data";
+import { errorOutput } from "@nteract/records/src/outputs/error";
 
 describe("stream output", () => {
   test("can be converted from nbformat", () => {
@@ -157,8 +158,7 @@ describe("error output", () => {
         traceback: ["sweet", "rabbit"]
       })
     ).toEqual(
-      nteractRecords.makeErrorOutputRecord({
-        output_type: "error",
+      errorOutput({
         ename: "Thor",
         evalue: "Pirate Angel",
         traceback: ["sweet", "rabbit"]
@@ -168,7 +168,7 @@ describe("error output", () => {
 
   test("can be converted from jupyter messages", () => {
     expect(
-      nteractRecords.errorRecordFromMessage({
+      errorOutput.fromJupyterMessage({
         header: {
           msg_type: "error"
         },
@@ -179,8 +179,7 @@ describe("error output", () => {
         }
       })
     ).toEqual(
-      nteractRecords.makeErrorOutputRecord({
-        outputType: "error",
+      errorOutput({
         ename: "cats",
         evalue: "good",
         traceback: ["squirrel"]

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,17 +1,19 @@
 // @flow
 import * as nteractRecords from "@nteract/records";
-import { displayData } from "@nteract/records";
+
+import { streamOutput } from "@nteract/records/src/outputs/stream";
+import { displayData } from "@nteract/records/src/outputs/display-data";
 
 describe("stream output", () => {
   test("can be converted from nbformat", () => {
     expect(
-      nteractRecords.outputFromNbformat({
+      streamOutput.fromNbformat({
         output_type: "stream",
         name: "stdout",
         text: ["sup\n", "yall"]
       })
     ).toEqual(
-      nteractRecords.makeStreamOutputRecord({
+      streamOutput({
         outputType: "stream",
         name: "stdout",
         text: "sup\nyall"
@@ -21,7 +23,7 @@ describe("stream output", () => {
 
   test("can be converted from jupyter messages", () => {
     expect(
-      nteractRecords.streamRecordFromMessage({
+      streamOutput.fromJupyterMessage({
         header: {
           msg_type: "stream"
         },
@@ -31,7 +33,7 @@ describe("stream output", () => {
         }
       })
     ).toEqual(
-      nteractRecords.makeStreamOutputRecord({
+      streamOutput({
         outputType: "stream",
         name: "stdout",
         text: "it is love we must hold on to\nnever easy but we try"

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,6 +1,7 @@
 // @flow strict
 import * as nteractRecords from "@nteract/records";
 
+import { executeResult } from "@nteract/records/src/outputs/execute-result";
 import { streamOutput } from "@nteract/records/src/outputs/stream";
 import { displayData } from "@nteract/records/src/outputs/display-data";
 import { errorOutput } from "@nteract/records/src/outputs/error";
@@ -114,8 +115,7 @@ describe("execute_result output", () => {
         metadata: { "application/json": { expanded: true } }
       })
     ).toEqual(
-      nteractRecords.makeExecuteResultOutputRecord({
-        outputType: "execute_result",
+      executeResult({
         executionCount: 7,
         data: {
           "text/plain": "xandar\nnidavellir\nterra"
@@ -129,7 +129,7 @@ describe("execute_result output", () => {
 
   test("can be converted from jupyter messages", () => {
     expect(
-      nteractRecords.executeResultRecordFromMessage({
+      executeResult.fromJupyterMessage({
         header: {
           msg_type: "execute_result"
         },
@@ -139,8 +139,7 @@ describe("execute_result output", () => {
         }
       })
     ).toEqual(
-      nteractRecords.makeExecuteResultOutputRecord({
-        outputType: "execute_result",
+      executeResult({
         data: { anotherDay: "anotherDoug" },
         metadata: { "application/json": { expanded: false } }
       })

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -89,6 +89,14 @@ describe("display_data output", () => {
       })
     );
   });
+
+  test("has default values", () => {
+    expect(displayData()).toEqual({
+      outputType: "display_data",
+      data: {},
+      metadata: {}
+    });
+  });
 });
 
 describe("execute_result output", () => {

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -15,6 +15,7 @@
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "babel-runtime": "^6.26.0",
     "immer": "^1.5.0"
   },

--- a/packages/records/src/cells/code-cell.js
+++ b/packages/records/src/cells/code-cell.js
@@ -3,7 +3,9 @@ import produce from "immer";
 import { outputFromNbformat } from "../outputs";
 
 import type { MultilineString } from "../common";
-import type { OutputType, NbformatOutput, ExecutionCount } from "../outputs";
+import type { OutputType, NbformatOutput } from "../outputs";
+
+import type { ExecutionCount } from "../outputs/execute-result";
 
 export type CodeCellType = "code";
 export const CODECELL = "code";

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import { deepFreeze } from "./freeze";
 
 // Straight from nbformat
@@ -17,21 +17,21 @@ export type OnDiskMimebundle = {
   "image/gif"?: MultilineString,
   "image/svg+xml"?: MultilineString,
   "text/vnd.plotly.v1+html"?: MultilineString,
-  "application/vdom.v1+json"?: Object,
-  "application/vnd.dataresource+json"?: Object,
+  "application/vdom.v1+json"?: {},
+  "application/vnd.dataresource+json"?: {},
 
   "text/vnd.plotly.v1+html"?: MultilineString,
-  "application/vnd.plotly.v1+json"?: Object,
-  "application/geo+json"?: Object,
+  "application/vnd.plotly.v1+json"?: {},
+  "application/geo+json"?: {},
 
-  "application/x-nteract-model-debug+json"?: Object,
+  "application/x-nteract-model-debug+json"?: {},
 
-  "application/vnd.vega.v2+json"?: Object,
-  "application/vnd.vega.v3+json"?: Object,
-  "application/vnd.vegalite.v1+json"?: Object,
-  "application/vnd.vegalite.v2+json"?: Object,
+  "application/vnd.vega.v2+json"?: {},
+  "application/vnd.vega.v3+json"?: {},
+  "application/vnd.vegalite.v1+json"?: {},
+  "application/vnd.vegalite.v2+json"?: {},
 
-  [key: string]: string | Array<string> | Object
+  [key: string]: string | Array<string> | {}
 };
 
 // Enumerating over all the possible
@@ -54,22 +54,22 @@ export type MimeBundle = {
   //   * A string, which would be deserialized
   //   * An array, which would have to be assumed to be a multiline string
   //
-  "application/json"?: Object,
+  "application/json"?: {},
 
-  "application/vdom.v1+json"?: Object,
-  "application/vnd.dataresource+json"?: Object,
+  "application/vdom.v1+json"?: {},
+  "application/vnd.dataresource+json"?: {},
 
   "text/vnd.plotly.v1+html"?: string,
-  "application/vnd.plotly.v1+json"?: Object,
-  "application/geo+json"?: Object,
+  "application/vnd.plotly.v1+json"?: {},
+  "application/geo+json"?: {},
 
-  "application/x-nteract-model-debug+json"?: Object,
+  "application/x-nteract-model-debug+json"?: {},
 
-  "application/vnd.vega.v2+json"?: Object,
-  "application/vnd.vega.v3+json"?: Object,
-  "application/vnd.vegalite.v1+json"?: Object,
-  "application/vnd.vegalite.v2+json"?: Object,
-  [key: string]: string | Array<string> | Object // all others
+  "application/vnd.vega.v2+json"?: {},
+  "application/vnd.vega.v3+json"?: {},
+  "application/vnd.vegalite.v1+json"?: {},
+  "application/vnd.vegalite.v2+json"?: {},
+  [key: string]: string | Array<string> | {} // all others
 };
 
 /**

--- a/packages/records/src/common.js
+++ b/packages/records/src/common.js
@@ -1,4 +1,5 @@
 // @flow
+import { deepFreeze } from "./freeze";
 
 // Straight from nbformat
 export type MultilineString = string | Array<string>;
@@ -55,7 +56,6 @@ export type MimeBundle = {
   //
   "application/json"?: Object,
 
-  // TODO: These can all be more fully typed
   "application/vdom.v1+json"?: Object,
   "application/vnd.dataresource+json"?: Object,
 
@@ -132,8 +132,7 @@ export function createImmutableMimeBundle(
       bundle[key] = demultiline(mimeBundle[key]);
     } else {
       // we now know it's an Object of some kind
-      // TODO: DeepFreeze the mimebundle object for @nteract/records
-      bundle[key] = Object.freeze(mimeBundle[key]);
+      bundle[key] = deepFreeze(mimeBundle[key]);
     }
   }
 

--- a/packages/records/src/freeze.js
+++ b/packages/records/src/freeze.js
@@ -1,0 +1,21 @@
+/* @flow strict */
+
+export function deepFreeze(object: *) {
+  if (typeof object === "string") {
+    return Object.freeze(object);
+  }
+
+  // Retrieve the property names defined on object
+  // $FlowFixMe: It's ok to getOwnPropertyNames on an Array in this case
+  var propNames = Object.getOwnPropertyNames(object);
+
+  // Freeze properties before freezing self
+  for (let name of propNames) {
+    let value = object[name];
+
+    object[name] =
+      value && typeof value === "object" ? deepFreeze(value) : value;
+  }
+
+  return Object.freeze(object);
+}

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -45,9 +45,10 @@ type DisplayDataMessage = {
   }
 };
 
-export function displayData(
-  displayDataOutput?: DisplayDataOutput
-): DisplayDataOutput {
+export function displayData(displayDataOutput?: {
+  data?: common.MimeBundle,
+  metadata?: {}
+}): DisplayDataOutput {
   const defaultDisplayData = {
     outputType: DISPLAYDATA,
     data: {},

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import produce from "immer";
 import * as common from "../common";
@@ -23,14 +23,14 @@ export const DISPLAYDATA = "display_data";
 export type DisplayDataOutput = {
   outputType: DisplayDataType,
   data: common.MimeBundle,
-  metadata: Object
+  metadata: {}
 };
 
 // On disk
 export type NbformatDisplayDataOutput = {
   output_type: DisplayDataType,
   data: common.OnDiskMimebundle,
-  metadata: Object
+  metadata: {}
 };
 
 type DisplayDataMessage = {
@@ -39,40 +39,44 @@ type DisplayDataMessage = {
   },
   content: {
     data: common.MimeBundle,
-    metadata: Object
+    metadata: {}
   }
 };
 
-export function makeDisplayDataOutputRecord(
+export function displayData(
   displayDataOutput: DisplayDataOutput
 ): DisplayDataOutput {
-  const defaultDisplayDataRecord = {
+  const defaultDisplayData = {
     outputType: DISPLAYDATA,
     data: {},
     metadata: {}
   };
 
-  return produce(defaultDisplayDataRecord, draft => {
+  return produce(defaultDisplayData, draft => {
     return Object.assign(draft, displayDataOutput);
   });
 }
 
-export function displayDataRecordFromNbformat(
+displayData.type = "display_data";
+
+displayData.fromNbformat = function fromNbformat(
   s: NbformatDisplayDataOutput
 ): DisplayDataOutput {
-  return makeDisplayDataOutputRecord({
+  return displayData({
     outputType: s.output_type,
     data: common.createImmutableMimeBundle(s.data),
     metadata: s.metadata
   });
-}
+};
 
-export function displayDataRecordFromMessage(
+displayData.fromJupyterMessage = function displayDataRecordFromMessage(
   msg: DisplayDataMessage
 ): DisplayDataOutput {
-  return makeDisplayDataOutputRecord({
+  return displayData({
     outputType: DISPLAYDATA,
+    // The data field in a display data output type on the message spec is the same as we need
+    // We could do additional checking here though
     data: msg.content.data,
     metadata: msg.content.metadata
   });
-}
+};

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -44,7 +44,7 @@ type DisplayDataMessage = {
 };
 
 export function displayData(
-  displayDataOutput: DisplayDataOutput
+  displayDataOutput?: DisplayDataOutput
 ): DisplayDataOutput {
   const defaultDisplayData = {
     outputType: DISPLAYDATA,

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -2,6 +2,7 @@
 
 import produce from "immer";
 import * as common from "../common";
+
 /**
  * Let this declare the way for well typed records for outputs
  *
@@ -9,15 +10,16 @@ import * as common from "../common";
  *
  *   - Declare the in-memory type
  *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
- *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
- *   - Write a way to go from nbformat to these records
- *   - Write a way to go from message spec to these records
+ *   - Declare the message type (matching http://jupyter-client.readthedocs.io/en/stable/messaging.html)
+ *   - Write a way to go from nbformat to our in-memory version
+ *   - Write a way to go from message spec to our in-memory version
  *
  */
 
 type DisplayDataType = "display_data";
 
 export const DISPLAYDATA = "display_data";
+export const outputType = DISPLAYDATA;
 
 // In-memory version
 export type DisplayDataOutput = {

--- a/packages/records/src/outputs/error.js
+++ b/packages/records/src/outputs/error.js
@@ -10,9 +10,9 @@ import * as common from "../common";
  *
  *   - Declare the in-memory type
  *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
- *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
- *   - Write a way to go from nbformat to these records
- *   - Write a way to go from message spec to these records
+ *   - Declare the message type (matching http://jupyter-client.readthedocs.io/en/stable/messaging.html)
+ *   - Write a way to go from nbformat to our in-memory version
+ *   - Write a way to go from message spec to our in-memory version
  *
  */
 

--- a/packages/records/src/outputs/error.js
+++ b/packages/records/src/outputs/error.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-import produce from "immer";
 import * as common from "../common";
 
 /**

--- a/packages/records/src/outputs/error.js
+++ b/packages/records/src/outputs/error.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import produce from "immer";
 import * as common from "../common";

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -10,9 +10,9 @@ import * as common from "../common";
  *
  *   - Declare the in-memory type
  *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
- *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
- *   - Write a way to go from nbformat to these records
- *   - Write a way to go from message spec to these records
+ *   - Declare the message type (matching http://jupyter-client.readthedocs.io/en/stable/messaging.html)
+ *   - Write a way to go from nbformat to our in-memory version
+ *   - Write a way to go from message spec to our in-memory version
  *
  */
 

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -22,7 +22,7 @@ export type ExecutionCount = ?number;
 export const EXECUTE_RESULT = "execute_result";
 
 // In-memory version
-export type ExecuteResultOutput = {
+export type ExecuteResult = {
   outputType: ExecuteResultType,
   executionCount: ExecutionCount,
   data: common.MimeBundle,
@@ -30,7 +30,7 @@ export type ExecuteResultOutput = {
 };
 
 // On disk
-export type NbformatExecuteResultOutput = {
+export type NbformatExecuteResult = {
   output_type: ExecuteResultType,
   execution_count: ExecutionCount,
   data: common.OnDiskMimebundle,
@@ -48,38 +48,40 @@ type ExecuteResultMessage = {
   }
 };
 
-export function makeExecuteResultOutputRecord(
-  executeResultOutput: ExecuteResultOutput
-): ExecuteResultOutput {
-  const defaultExecuteResultOutput = {
+export function executeResult(executeResultOutput?: {
+  executionCount?: ExecutionCount,
+  data?: common.MimeBundle,
+  metadata?: {}
+}): ExecuteResult {
+  const defaultExecuteResult = {
     outputType: EXECUTE_RESULT,
     executionCount: undefined,
     data: {},
     metadata: {}
   };
-  return produce(defaultExecuteResultOutput, draft => {
+  return produce(defaultExecuteResult, draft => {
     return Object.assign(draft, executeResultOutput);
   });
 }
 
-export function executeResultRecordFromNbformat(
-  s: NbformatExecuteResultOutput
-): ExecuteResultOutput {
-  return makeExecuteResultOutputRecord({
-    outputType: s.output_type,
+executeResult.type = EXECUTE_RESULT;
+
+executeResult.fromNbformat = function fromNbformat(
+  s: NbformatExecuteResult
+): ExecuteResult {
+  return executeResult({
     executionCount: s.execution_count,
     data: common.createImmutableMimeBundle(s.data),
     metadata: s.metadata
   });
-}
+};
 
-export function executeResultRecordFromMessage(
+executeResult.fromJupyterMessage = function fromJupyterMessage(
   msg: ExecuteResultMessage
-): ExecuteResultOutput {
-  return makeExecuteResultOutputRecord({
-    outputType: EXECUTE_RESULT,
+): ExecuteResult {
+  return executeResult({
     executionCount: msg.content.execution_count,
     data: msg.content.data,
     metadata: msg.content.metadata
   });
-}
+};

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import produce from "immer";
 import * as common from "../common";
@@ -26,7 +26,7 @@ export type ExecuteResultOutput = {
   outputType: ExecuteResultType,
   executionCount: ExecutionCount,
   data: common.MimeBundle,
-  metadata: Object
+  metadata: {}
 };
 
 // On disk
@@ -34,7 +34,7 @@ export type NbformatExecuteResultOutput = {
   output_type: ExecuteResultType,
   execution_count: ExecutionCount,
   data: common.OnDiskMimebundle,
-  metadata: Object
+  metadata: {}
 };
 
 type ExecuteResultMessage = {
@@ -44,7 +44,7 @@ type ExecuteResultMessage = {
   content: {
     execution_count: number,
     data: common.MimeBundle,
-    metadata: Object
+    metadata: {}
   }
 };
 

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -48,11 +48,13 @@ type ExecuteResultMessage = {
   }
 };
 
-export function executeResult(executeResultOutput?: {
-  executionCount?: ExecutionCount,
-  data?: common.MimeBundle,
-  metadata?: {}
-}): ExecuteResult {
+export function executeResult(
+  executeResultOutput?: $ReadOnly<{
+    executionCount?: ExecutionCount,
+    data?: common.MimeBundle,
+    metadata?: {}
+  }>
+): ExecuteResult {
   const defaultExecuteResult = {
     outputType: EXECUTE_RESULT,
     executionCount: undefined,

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -1,12 +1,20 @@
-// @flow
+// @flow strict
 
 import type { JupyterMessage } from "@nteract/messaging";
 
 import * as stream from "./stream";
-import * as displayData from "./display-data";
+import * as dd from "./display-data";
+
+import type {
+  NbformatDisplayDataOutput,
+  DisplayDataOutput
+} from "./display-data";
+
 import * as executeResult from "./execute-result";
 import * as error from "./error";
 import * as unrecognized from "./unrecognized";
+
+import { displayData } from "./display-data";
 
 export * from "./stream";
 export * from "./display-data";
@@ -15,12 +23,12 @@ export * from "./error";
 
 export type NbformatOutput =
   | stream.NbformatStreamOutput
-  | displayData.NbformatDisplayDataOutput
+  | NbformatDisplayDataOutput
   | executeResult.NbformatExecuteResultOutput
   | error.NbformatErrorOutput;
 export type OutputType =
   | stream.StreamOutput
-  | displayData.DisplayDataOutput
+  | DisplayDataOutput
   | executeResult.ExecuteResultOutput
   | error.ErrorOutput;
 
@@ -31,8 +39,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputType {
   switch (output.output_type) {
     case stream.STREAM:
       return stream.streamRecordFromNbformat(output);
-    case displayData.DISPLAYDATA:
-      return displayData.displayDataRecordFromNbformat(output);
+    case displayData.type:
+      return displayData.fromNbformat(output);
     case executeResult.EXECUTE_RESULT:
       return executeResult.executeResultRecordFromNbformat(output);
     case error.ERROR:
@@ -51,7 +59,7 @@ export function outputFromMessage(msg: JupyterMessage<*, *>): OutputType {
   switch (msg_type) {
     case stream.STREAM:
       return stream.streamRecordFromMessage(msg);
-    case displayData.DISPLAYDATA:
+    case displayData.type:
       return displayData.displayDataRecordFromMessage(msg);
     case executeResult.EXECUTE_RESULT:
       return executeResult.executeResultRecordFromMessage(msg);

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -9,26 +9,26 @@ import type {
 import type { NbformatStreamOutput, StreamOutput } from "./stream";
 import type { NbformatErrorOutput, ErrorOutput } from "./error";
 import type { NbformatExecuteResult, ExecuteResult } from "./execute-result";
+import type { UnrecognizedOutput } from "./unrecognized";
 
-import * as unrecognized from "./unrecognized";
-
+import { unrecognized } from "./unrecognized";
 import { displayData } from "./display-data";
 import { streamOutput } from "./stream";
 import { errorOutput } from "./error";
 import { executeResult } from "./execute-result";
-
-export * from "./execute-result";
 
 export type NbformatOutput =
   | NbformatStreamOutput
   | NbformatDisplayDataOutput
   | NbformatExecuteResult
   | NbformatErrorOutput;
+
 export type OutputType =
   | StreamOutput
   | DisplayDataOutput
   | ExecuteResult
-  | ErrorOutput;
+  | ErrorOutput
+  | UnrecognizedOutput;
 
 /**
  * Turn any output that was in nbformat into a record
@@ -44,8 +44,7 @@ export function outputFromNbformat(output: NbformatOutput): OutputType {
     case errorOutput.type:
       return errorOutput.fromNbformat(output);
     default:
-      // TODO: Properly type unrecognized output messages
-      return unrecognized.unrecognizedRecordFromNbformat();
+      return unrecognized.fromNbformat(output);
   }
 }
 
@@ -64,6 +63,6 @@ export function outputFromMessage(msg: JupyterMessage<*, *>): OutputType {
     case errorOutput.type:
       return errorOutput.fromJupyterMessage(msg);
     default:
-      return unrecognized.makeUnrecognizedOutputRecord();
+      return unrecognized.fromJupyterMessage(msg);
   }
 }

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -2,32 +2,30 @@
 
 import type { JupyterMessage } from "@nteract/messaging";
 
-import * as stream from "./stream";
-import * as dd from "./display-data";
-
 import type {
   NbformatDisplayDataOutput,
   DisplayDataOutput
 } from "./display-data";
+
+import type { NbformatStreamOutput, StreamOutput } from "./stream";
 
 import * as executeResult from "./execute-result";
 import * as error from "./error";
 import * as unrecognized from "./unrecognized";
 
 import { displayData } from "./display-data";
+import { streamOutput } from "./stream";
 
-export * from "./stream";
-export * from "./display-data";
 export * from "./execute-result";
 export * from "./error";
 
 export type NbformatOutput =
-  | stream.NbformatStreamOutput
+  | NbformatStreamOutput
   | NbformatDisplayDataOutput
   | executeResult.NbformatExecuteResultOutput
   | error.NbformatErrorOutput;
 export type OutputType =
-  | stream.StreamOutput
+  | StreamOutput
   | DisplayDataOutput
   | executeResult.ExecuteResultOutput
   | error.ErrorOutput;
@@ -37,8 +35,8 @@ export type OutputType =
  */
 export function outputFromNbformat(output: NbformatOutput): OutputType {
   switch (output.output_type) {
-    case stream.STREAM:
-      return stream.streamRecordFromNbformat(output);
+    case streamOutput.type:
+      return streamOutput.fromNbformat(output);
     case displayData.type:
       return displayData.fromNbformat(output);
     case executeResult.EXECUTE_RESULT:
@@ -57,8 +55,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputType {
 export function outputFromMessage(msg: JupyterMessage<*, *>): OutputType {
   const msg_type = msg.header.msg_type;
   switch (msg_type) {
-    case stream.STREAM:
-      return stream.streamRecordFromMessage(msg);
+    case streamOutput.type:
+      return streamOutput.streamRecordFromMessage(msg);
     case displayData.type:
       return displayData.displayDataRecordFromMessage(msg);
     case executeResult.EXECUTE_RESULT:

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -6,28 +6,28 @@ import type {
   NbformatDisplayDataOutput,
   DisplayDataOutput
 } from "./display-data";
-
 import type { NbformatStreamOutput, StreamOutput } from "./stream";
 import type { NbformatErrorOutput, ErrorOutput } from "./error";
+import type { NbformatExecuteResult, ExecuteResult } from "./execute-result";
 
-import * as executeResult from "./execute-result";
 import * as unrecognized from "./unrecognized";
 
 import { displayData } from "./display-data";
 import { streamOutput } from "./stream";
 import { errorOutput } from "./error";
+import { executeResult } from "./execute-result";
 
 export * from "./execute-result";
 
 export type NbformatOutput =
   | NbformatStreamOutput
   | NbformatDisplayDataOutput
-  | executeResult.NbformatExecuteResultOutput
+  | NbformatExecuteResult
   | NbformatErrorOutput;
 export type OutputType =
   | StreamOutput
   | DisplayDataOutput
-  | executeResult.ExecuteResultOutput
+  | ExecuteResult
   | ErrorOutput;
 
 /**
@@ -39,8 +39,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputType {
       return streamOutput.fromNbformat(output);
     case displayData.type:
       return displayData.fromNbformat(output);
-    case executeResult.EXECUTE_RESULT:
-      return executeResult.executeResultRecordFromNbformat(output);
+    case executeResult.type:
+      return executeResult.fromNbformat(output);
     case errorOutput.type:
       return errorOutput.fromNbformat(output);
     default:
@@ -59,8 +59,8 @@ export function outputFromMessage(msg: JupyterMessage<*, *>): OutputType {
       return streamOutput.fromJupyterMessage(msg);
     case displayData.type:
       return displayData.fromJupyterMessage(msg);
-    case executeResult.EXECUTE_RESULT:
-      return executeResult.executeResultRecordFromMessage(msg);
+    case executeResult.type:
+      return executeResult.fromJupyterMessage(msg);
     case errorOutput.type:
       return errorOutput.fromJupyterMessage(msg);
     default:

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -49,7 +49,7 @@ export function outputFromNbformat(output: NbformatOutput): OutputType {
 }
 
 /**
- * Turn any output that was in JupyterMessage into a record
+ * Turn any output from a JupyterMessage into a record
  */
 export function outputFromMessage(msg: JupyterMessage<*, *>): OutputType {
   const msg_type = msg.header.msg_type;

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -8,27 +8,27 @@ import type {
 } from "./display-data";
 
 import type { NbformatStreamOutput, StreamOutput } from "./stream";
+import type { NbformatErrorOutput, ErrorOutput } from "./error";
 
 import * as executeResult from "./execute-result";
-import * as error from "./error";
 import * as unrecognized from "./unrecognized";
 
 import { displayData } from "./display-data";
 import { streamOutput } from "./stream";
+import { errorOutput } from "./error";
 
 export * from "./execute-result";
-export * from "./error";
 
 export type NbformatOutput =
   | NbformatStreamOutput
   | NbformatDisplayDataOutput
   | executeResult.NbformatExecuteResultOutput
-  | error.NbformatErrorOutput;
+  | NbformatErrorOutput;
 export type OutputType =
   | StreamOutput
   | DisplayDataOutput
   | executeResult.ExecuteResultOutput
-  | error.ErrorOutput;
+  | ErrorOutput;
 
 /**
  * Turn any output that was in nbformat into a record
@@ -41,8 +41,8 @@ export function outputFromNbformat(output: NbformatOutput): OutputType {
       return displayData.fromNbformat(output);
     case executeResult.EXECUTE_RESULT:
       return executeResult.executeResultRecordFromNbformat(output);
-    case error.ERROR:
-      return error.errorRecordFromNbformat(output);
+    case errorOutput.type:
+      return errorOutput.fromNbformat(output);
     default:
       // TODO: Properly type unrecognized output messages
       return unrecognized.unrecognizedRecordFromNbformat();
@@ -56,13 +56,13 @@ export function outputFromMessage(msg: JupyterMessage<*, *>): OutputType {
   const msg_type = msg.header.msg_type;
   switch (msg_type) {
     case streamOutput.type:
-      return streamOutput.streamRecordFromMessage(msg);
+      return streamOutput.fromJupyterMessage(msg);
     case displayData.type:
-      return displayData.displayDataRecordFromMessage(msg);
+      return displayData.fromJupyterMessage(msg);
     case executeResult.EXECUTE_RESULT:
       return executeResult.executeResultRecordFromMessage(msg);
-    case error.ERROR:
-      return error.errorRecordFromMessage(msg);
+    case errorOutput.type:
+      return errorOutput.fromJupyterMessage(msg);
     default:
       return unrecognized.makeUnrecognizedOutputRecord();
   }

--- a/packages/records/src/outputs/stream.js
+++ b/packages/records/src/outputs/stream.js
@@ -10,9 +10,9 @@ import * as common from "../common";
  *
  *   - Declare the in-memory type
  *   - Declare the nbformat type (exactly matching nbformat.v4.schema.json)
- *   - Create a "record maker", which we _don't_ export, followed by the real `makeXRecord` function that enforces set values
- *   - Write a way to go from nbformat to these records
- *   - Write a way to go from message spec to these records
+ *   - Declare the message type (matching http://jupyter-client.readthedocs.io/en/stable/messaging.html)
+ *   - Write a way to go from nbformat to our in-memory version
+ *   - Write a way to go from message spec to our in-memory version
  *
  */
 

--- a/packages/records/src/outputs/stream.js
+++ b/packages/records/src/outputs/stream.js
@@ -48,11 +48,12 @@ type StreamMessage = {
   }
 };
 
-export function streamOutput(s: {
-  outputType?: StreamType,
-  name?: StreamName,
-  text?: string
-}): StreamOutput {
+export function streamOutput(
+  s: $ReadOnly<{
+    name?: StreamName,
+    text?: string
+  }>
+): StreamOutput {
   return Object.freeze(
     Object.assign({}, { outputType: STREAM, name: STDOUT, text: "" }, s)
   );
@@ -64,7 +65,6 @@ streamOutput.fromNbformat = function fromNbformat(
   s: NbformatStreamOutput
 ): StreamOutput {
   return streamOutput({
-    outputType: STREAM,
     name: s.name,
     text: common.demultiline(s.text)
   });
@@ -74,7 +74,6 @@ streamOutput.fromJupyterMessage = function fromJupyterMessage(
   msg: StreamMessage
 ): StreamOutput {
   return streamOutput({
-    outputType: STREAM,
     name: msg.content.name,
     text: msg.content.text
   });

--- a/packages/records/src/outputs/stream.js
+++ b/packages/records/src/outputs/stream.js
@@ -48,31 +48,34 @@ type StreamMessage = {
   }
 };
 
-export const makeStreamOutputRecord: Function = (streamOutput: Object) => {
-  const defaultStreamOutput = {
-    outputType: STREAM,
-    name: STDOUT,
-    text: ""
-  };
-  return produce(defaultStreamOutput, draft =>
-    Object.assign(draft, streamOutput)
+export function streamOutput(s: {
+  outputType?: StreamType,
+  name?: StreamName,
+  text?: string
+}): StreamOutput {
+  return Object.freeze(
+    Object.assign({}, { outputType: STREAM, name: STDOUT, text: "" }, s)
   );
-};
+}
 
-export function streamRecordFromNbformat(
+streamOutput.type = STREAM;
+
+streamOutput.fromNbformat = function fromNbformat(
   s: NbformatStreamOutput
 ): StreamOutput {
-  return makeStreamOutputRecord({
-    outputType: s.output_type,
+  return streamOutput({
+    outputType: STREAM,
     name: s.name,
     text: common.demultiline(s.text)
   });
-}
+};
 
-export function streamRecordFromMessage(msg: StreamMessage): StreamOutput {
-  return makeStreamOutputRecord({
+streamOutput.fromJupyterMessage = function fromJupyterMessage(
+  msg: StreamMessage
+): StreamOutput {
+  return streamOutput({
     outputType: STREAM,
     name: msg.content.name,
     text: msg.content.text
   });
-}
+};

--- a/packages/records/src/outputs/stream.js
+++ b/packages/records/src/outputs/stream.js
@@ -1,6 +1,5 @@
 // @flow strict
 
-import produce from "immer";
 import * as common from "../common";
 
 /**

--- a/packages/records/src/outputs/stream.js
+++ b/packages/records/src/outputs/stream.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 
 import produce from "immer";
 import * as common from "../common";

--- a/packages/records/src/outputs/unrecognized.js
+++ b/packages/records/src/outputs/unrecognized.js
@@ -4,21 +4,28 @@
 // frontends are able to have a known fallback when an output type isn't known.
 
 // In-memory version
-export type UnrecognizedOutput = any;
+export type UnrecognizedOutput = {
+  outputType: "unrecognized"
+};
 
 // On disk
 export type NbformatUnrecognizedOutput = {
   output_type: string // Technically, not one of "execute_result", "display_data", "stream", or "error"
 };
 
-export function makeUnrecognizedOutputRecord(): UnrecognizedOutput {
-  const defaultUnrecognizedOutput = {
-    outputType: "unrecognized"
-  };
+const UNRECOGNIZED = "unrecognized";
 
-  return defaultUnrecognizedOutput;
+export function unrecognized(raw: any) {
+  return Object.freeze({
+    outputType: "unrecognized",
+    raw
+  });
 }
 
-export function unrecognizedRecordFromNbformat(): UnrecognizedOutput {
-  return makeUnrecognizedOutputRecord();
-}
+unrecognized.fromNbformat = function fromNbformat(a: any) {
+  return unrecognized(a);
+};
+
+unrecognized.fromJupyterMessage = function fromJupyterMessage(a: any) {
+  return unrecognized(a);
+};

--- a/packages/records/src/outputs/unrecognized.js
+++ b/packages/records/src/outputs/unrecognized.js
@@ -5,7 +5,8 @@
 
 // In-memory version
 export type UnrecognizedOutput = {
-  outputType: "unrecognized"
+  outputType: "unrecognized",
+  raw: any
 };
 
 // On disk


### PR DESCRIPTION
This takes a new approach to setting up our base little types. To create a `displayData` record you:

```js
import { displayData } from "@nteract/records"

const dd = displayData()
```

converting from notebook format looks like:

```js
import { displayData } from "@nteract/records"

const dd = displayData.fromNbformat({
  output_type: "display_data",
  data: {
    "text/plain": [
      "mind\n",
      "time\n",
      "space\n",
      "reality\n",
      "power\n",
      "soul"
    ]
  },
  metadata: { "application/json": { expanded: true } }
});
```

similarly, there's `displayData.fromJupyterMessage`.

----

Posting this to see what folks think of the interface.