### PR TITLE
Replace f-strings to fix compatibility with python < 3.6

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/nteractapp.py
@@ -14,7 +14,7 @@ from .utils import cmd_in_new_dir
 
 webpack_port = 8357
 
-webpack_hot = {"address": f'http://localhost:{webpack_port}/',
+webpack_hot = {"address": 'http://localhost:{webpack_port}/'.format(webpack_port=webpack_port),
                "command": ["yarn", "workspace", "nteract-on-jupyter",
                            "run", "hot", "--port", str(webpack_port)]}
 nteract_flags = dict(flags)
@@ -74,7 +74,7 @@ class NteractApp(NotebookApp):
                     pass
                 else:
                     raise Exception(
-                        f"Webpack dev server exited - return code {exit_code}")
+                        "Webpack dev server exited - return code {exit_code}".format(exit_code=exit_code))
 
                 # Now wait for webpack to have the initial bundle mostly ready
                 time.sleep(5)


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

When trying out nteract in my python 3.4 env, I've noticed that `nteractapp.py` uses f-strings (Literal String Interpolation), which is a python 3.6 feature (and hence it crashed on start for me). I've replaced the two instances in the file with `.format` and managed to get it to work.
I've done a text search for `f'` and `f"` over the whole codebase and it seems like this is the only file where this is used.