### PR TITLE
Allow Nteract on Jupyter to build on Firefox >= 31

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/.babelrc
+++ b/applications/jupyter-extension/nteract_on_jupyter/.babelrc
@@ -1,5 +1,9 @@
 {
-  "presets": ["env", "react"],
+  "presets": [["env", {
+      "targets": {
+        "browsers": ["last 2 versions", "firefox >= 31"]
+      }
+    }], "react"],
   "plugins": [
     "react-hot-loader/babel",
     "transform-flow-strip-types",


### PR DESCRIPTION
showing how to build on old browsers live from jupytercon, on my phone
