### PR TITLE
data-explorer: Fix type issue

### DIFF
--- a/packages/transform-dataresource/src/ParallelCoordinatesController.js
+++ b/packages/transform-dataresource/src/ParallelCoordinatesController.js
@@ -244,7 +244,7 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
             filterMode && {
               columnsBrush: true,
               during: this.brushing,
-              extent: this.state.columnExtent
+              extent: Object.keys(this.state.columnExtent)
             }
           }
           pieceHoverAnnotation={!filterMode}


### PR DESCRIPTION
- ResponsiveOrdinalFrame component expects array for `interaction.extent` prop