### PR TITLE
Use examples package

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -108,7 +108,7 @@
     ]
   },
   "dependencies": {
-    "@nteract/examples": "^2.0.0",
+    "@nteract/examples": "3.0.0",
     "ijavascript": "^5.0.17",
     "jmp": "^1.0.0",
     "mathjax-electron": "^2.0.1",

--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -108,6 +108,7 @@
     ]
   },
   "dependencies": {
+    "@nteract/examples": "^2.0.0",
     "ijavascript": "^5.0.17",
     "jmp": "^1.0.0",
     "mathjax-electron": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,9 +130,9 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
-"@nteract/examples@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@nteract/examples/-/examples-2.0.0.tgz#d1f0c5bdcdcee69378c7efc790ebcf05d713b72a"
+"@nteract/examples@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nteract/examples/-/examples-3.0.0.tgz#08686a5305d528ff3625e048b48f6655b7c91c81"
 
 "@nteract/plotly@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4071,12 +4071,6 @@ encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -6375,7 +6369,7 @@ is-scoped@^1.0.0:
   dependencies:
     scoped-regex "^1.0.0"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -8332,16 +8326,9 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.1.2, node-fetch@^2.0.0, node-fetch@^2.1.2:
+node-fetch@2.1.2, node-fetch@^1.0.1, node-fetch@^2.0.0, node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,6 +130,10 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
 
+"@nteract/examples@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nteract/examples/-/examples-2.0.0.tgz#d1f0c5bdcdcee69378c7efc790ebcf05d713b72a"
+
 "@nteract/plotly@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@nteract/plotly/-/plotly-1.0.0.tgz#1ce454ab1baa67dc26e72ff5a917c2065eed9146"
@@ -4067,6 +4071,12 @@ encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -6365,7 +6375,7 @@ is-scoped@^1.0.0:
   dependencies:
     scoped-regex "^1.0.0"
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -8322,9 +8332,16 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.1.2, node-fetch@^1.0.1, node-fetch@^2.0.0, node-fetch@^2.1.2:
+node-fetch@2.1.2, node-fetch@^2.0.0, node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"


### PR DESCRIPTION
This switches us to using [`@nteract/examples`](https://github.com/nteract/examples) for generating our menus, making it easier to contribute new notebooks and for us to keep a manifest built all the time.

<img width="763" alt="screen shot 2018-08-28 at 4 22 29 pm" src="https://user-images.githubusercontent.com/836375/44756262-b15e2980-aade-11e8-8fd8-ba3d71ff0357.png">

Little bit of follow up work from collaborating with @josephofiowa at the JupyterCon Sprints! 🎉 

Supported in part by https://github.com/nteract/examples/pull/8. 😄 