### PR TITLE
bump engine requirement to match eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "yargs": "^12.0.0"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=8.10.0"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
On one of my systems I noticed that I was not matching eslint's required engine level. `yarn` exits with a semi-helpful error message that I continually ignored and wondered why my setup wasn't complete. By updating this at a higher level, `yarn` will bomb out much earlier and with a better message.