### PR TITLE
[WIP] add appendOutput & typing from @nteract/records in reducer

### DIFF
--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -25,7 +25,7 @@ import type {
 
 import type { ExecuteRequest } from "@nteract/messaging";
 
-import type { Output } from "@nteract/commutable/src/v4";
+import type { OutputType } from "@nteract/records";
 
 export type ErrorAction<T: string> = {
   type: T,
@@ -202,7 +202,7 @@ export type AppendOutput = {
   type: "APPEND_OUTPUT",
   payload: {
     id: CellID,
-    output: Output,
+    output: OutputType,
     contentRef: ContentRef
   }
 };

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -24,7 +24,7 @@ import type {
   MimeBundle
 } from "@nteract/commutable/src/types";
 
-import type { Output } from "@nteract/commutable/src/v4";
+import type { OutputType } from "@nteract/records";
 
 import { createExecuteRequest } from "@nteract/messaging";
 import type { HostRecordProps } from "./state/entities/hosts";
@@ -864,7 +864,7 @@ export function commMessageAction(message: any) {
 
 export function appendOutput(payload: {
   id: CellID,
-  output: Output,
+  output: OutputType,
   contentRef: ContentRef
 }): actionTypes.AppendOutput {
   return {

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -8,8 +8,6 @@ import * as actionTypes from "../../../../actionTypes";
 import * as Immutable from "immutable";
 
 import { appendOutput as appendOutputRecord } from "@nteract/records";
-import type { NbformatOutput } from "@nteract/records";
-type Immouts = Immutable.List<NbformatOutput>;
 
 import type {
   ImmutableCell,
@@ -210,7 +208,7 @@ function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
   ) {
     return state.updateIn(
       ["notebook", "cellMap", cellID, "outputs"],
-      (outputs: ImmutableOutputs): ImmutableOutputs =>
+      (outputs: ImmutableOutputs): mixed =>
         Immutable.fromJS(appendOutputRecord(outputs.toJS(), output))
     );
   }

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -7,6 +7,10 @@ import * as actionTypes from "../../../../actionTypes";
 
 import * as Immutable from "immutable";
 
+import { appendOutput as appendOutputRecord } from "@nteract/records";
+import type { NbformatOutput } from "@nteract/records";
+type Immouts = Immutable.List<NbformatOutput>;
+
 import type {
   ImmutableCell,
   ImmutableCellMap,
@@ -207,7 +211,7 @@ function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
     return state.updateIn(
       ["notebook", "cellMap", cellID, "outputs"],
       (outputs: ImmutableOutputs): ImmutableOutputs =>
-        reduceOutputs(outputs, output)
+        Immutable.fromJS(appendOutputRecord(outputs.toJS(), output))
     );
   }
 

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -268,7 +268,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
       <Cell
         _hovered={false}
         isSelected={false}
-        key="14"
+        key="15"
       >
         <div
           className="jsx-2513275823 content-margin"
@@ -288,7 +288,7 @@ exports[`Notebook accepts an Object of cells 1`] = `
       <Cell
         _hovered={false}
         isSelected={false}
-        key="15"
+        key="16"
       >
         <PapermillView
           status={null}

--- a/packages/notebook-render/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-render/__tests__/__snapshots__/index.test.js.snap
@@ -261,7 +261,7 @@ exports[`Test NotebokRender snapshots accepts an Object of cells 1`] = `
     <Cell
       _hovered={false}
       isSelected={false}
-      key="14"
+      key="15"
     >
       <div
         className="jsx-2299737332 content-margin"
@@ -301,7 +301,7 @@ exports[`Test NotebokRender snapshots accepts an Object of cells 1`] = `
     <Cell
       _hovered={false}
       isSelected={false}
-      key="15"
+      key="16"
     >
       <Input
         hidden={false}

--- a/packages/records/__tests__/appendOutput-spec.js
+++ b/packages/records/__tests__/appendOutput-spec.js
@@ -1,5 +1,5 @@
 // @flow strict
-import appendOutput from "../src/outputs/append-output";
+import { appendOutput } from "../src/outputs/append-output";
 import { mutate } from "../src/outputs/append-output";
 
 describe("appendOutput", () => {

--- a/packages/records/src/outputs/append-output.js
+++ b/packages/records/src/outputs/append-output.js
@@ -74,6 +74,4 @@ function appendText(text: string, streamText: string): string {
   return text;
 }
 
-const appendOutput = produce(mutate.appendOutput);
-
-export default appendOutput;
+export const appendOutput = produce(mutate.appendOutput);


### PR DESCRIPTION
Continuing with our previous work, this begins to integrate some of the records work. In particular, this brings in the appendOutput function and typings for use within our reducers.

Also changes `appendOutput()` to a named export.

Still need to fix flow later, 😔. 

This W is very much IP and really just a starting point to continue the momentum 🙃. 