### PR TITLE
match version of styled-jsx with that of next

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -151,7 +151,7 @@
     "shell-env": "^2.0.0",
     "spawn-rx": "^2.0.12",
     "spawnteract": "^5.0.0",
-    "styled-jsx": "^2.2.6",
+    "styled-jsx": "^3.0.3-canary.0",
     "uuid": "^3.1.0",
     "webfontloader": "^1.6.28",
     "webpack": "^4.17.2",

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -51,7 +51,7 @@
     "redux-observable": "^0.19.0",
     "rx-jupyter": "^3.2.1",
     "rxjs": "^5.5.6",
-    "styled-jsx": "^2.2.6",
+    "styled-jsx": "^3.0.3-canary.0",
     "url-join": "^4.0.0",
     "webfontloader": "^1.6.28",
     "webpack": "^4.17.2"

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "spawn-rx": "^2.0.12",
     "spawnteract": "^5.0.0",
     "style-loader": "^0.23.0",
-    "styled-jsx": "^2.2.6",
+    "styled-jsx": "^3.0.3-canary.0",
     "tv4": "^1.3.0",
     "unified": "^7.0.0",
     "unist-builder": "^1.0.2",

--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "react-hot-loader": "^4.1.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "peerDependencies": {
     "react": "^16.3.2",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -37,7 +37,7 @@
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/logos/package.json
+++ b/packages/logos/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -39,7 +39,7 @@
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-render/package.json
+++ b/packages/notebook-render/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "author": "Benjamin Abel <dev.abel@laposte.net>",
   "license": "BSD-3-Clause"

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.2",
-    "styled-jsx": "^2.2.6"
+    "styled-jsx": "^3.0.3-canary.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,7 +1490,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@6.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1, babel-runtime@^6.9.2:
+babel-runtime@6.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -10809,10 +10809,6 @@ source-map@0.5.7, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
 source-map@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
@@ -10822,6 +10818,10 @@ source-map@^0.4.4:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -11207,7 +11207,7 @@ style-loader@^0.23.0:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
-styled-jsx@3.0.3-canary.0:
+styled-jsx@3.0.3-canary.0, styled-jsx@^3.0.3-canary.0:
   version "3.0.3-canary.0"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.0.3-canary.0.tgz#91b5e2cabf5a66dc2d205ff1e806eae3126e08d6"
   dependencies:
@@ -11220,26 +11220,9 @@ styled-jsx@3.0.3-canary.0:
     stylis "3.5.3"
     stylis-rule-sheet "0.0.10"
 
-styled-jsx@^2.2.6:
-  version "2.2.7"
-  resolved "https://registry.npmjs.org/styled-jsx/-/styled-jsx-2.2.7.tgz#0ada82e2e4b8b59e38508a8e57258fd1f70e204a"
-  dependencies:
-    babel-plugin-syntax-jsx "6.18.0"
-    babel-runtime "6.26.0"
-    babel-types "6.26.0"
-    convert-source-map "1.5.1"
-    source-map "0.6.1"
-    string-hash "1.1.3"
-    stylis "3.5.1"
-    stylis-rule-sheet "0.0.10"
-
 stylis-rule-sheet@0.0.10:
   version "0.0.10"
   resolved "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-
-stylis@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.npmjs.org/stylis/-/stylis-3.5.1.tgz#fd341d59f57f9aeb412bc14c9d8a8670b438e03b"
 
 stylis@3.5.3:
   version "3.5.3"


### PR DESCRIPTION
Something I probably could have done in the babel PR that I didn't think of was to upgrade our styled-jsx to match that of next.js. I look forward to when these aren't on their canary versions.