### PR TITLE
dont show kernel shutdown error when no kernel

### DIFF
--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -13,16 +13,19 @@ export function unload(store: Store<AppState, Action>) {
   const state = store.getState();
 
   state.core.entities.kernels.byRef.forEach((kernel, kernelRef) => {
+    // Skip if kernel unknown
+    if (!kernel || !kernel.type) {
+      return;
+    }
+
     if (kernel.type === "zeromq") {
       try {
         killKernelImmediately(kernel);
       } catch (e) {
         alert(`Trouble shutting down - ${e.message}`);
       }
-    } else {
-      alert(
-        "Need to implement a way to shutdown non-zeromq kernels on desktop"
-      );
+    } else if (kernel.type === "websocket") {
+      alert("Need to implement a way to shutdown websocket kernels on desktop");
     }
   });
 }


### PR DESCRIPTION
This doesn't solve our core problems around picking out the right kernel for users when theirs doesn't match what's available in a notebook. However this does make it so they don't get a misleading message about closing down kernels when there isn't one to begin with.

Closes #3277