### PR TITLE
show text for unknowns instead of download link

### DIFF
--- a/applications/commuter/backend/content-providers/local/fs.js
+++ b/applications/commuter/backend/content-providers/local/fs.js
@@ -219,7 +219,23 @@ function getFile(
         if (err) {
           reject(err);
         }
-        resolve(Object.assign({}, file, { content: data.toString() }));
+        let str = data.toString("utf-8");
+        let format = file.format;
+        for (let i = 0; i < str.length; ++i) {
+          if (str.charCodeAt(i) === 65533) {
+            // 65533 is the magic number for unknown character
+            // We will not send the content, as the interface
+            // currently doesn't render it.  But this is a bad
+            // contract.
+            //
+            // We denote the format as null rather than some strange format since we need to
+            // stay spec compliant with jupyter
+            format = null;
+            str = "";
+            break;
+          }
+        }
+        resolve(Object.assign({}, file, { content: str, format: format }));
       }
     );
   });

--- a/applications/commuter/components/contents/index.js
+++ b/applications/commuter/components/contents/index.js
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import NotebookPreview from "@nteract/notebook-preview";
 import Markdown from "@nteract/markdown";
-import { Styles } from "@nteract/presentational-components";
+import { Styles, Source } from "@nteract/presentational-components";
 
 import DirectoryListing from "./directory-listing";
 
@@ -70,6 +70,13 @@ class File extends React.Component<*> {
       case "markdown":
       case "rmd":
         return <Markdown source={this.props.entry.content} />;
+      case "js":
+        return (
+          <Source language="javascript">{this.props.entry.content}</Source>
+        );
+      case "py":
+      case "pyx":
+        return <Source language="python">{this.props.entry.content}</Source>;
       case "gif":
       case "jpeg":
       case "jpg":
@@ -81,6 +88,11 @@ class File extends React.Component<*> {
           />
         );
       default:
+        if (this.props.entry.format === "text") {
+          return (
+            <Source language="text/plain">{this.props.entry.content}</Source>
+          );
+        }
         return <a href={`/files/${this.props.pathname}`}>Download raw file</a>;
     }
   }


### PR DESCRIPTION
@charsmith put in some detection for unknown filetypes to show a plaintext view when text and nothing when a binary blob.
