### PR TITLE
switch commuter readme to using yarn

### DIFF
--- a/applications/commuter/README.md
+++ b/applications/commuter/README.md
@@ -80,8 +80,8 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 
 1. `git clone git@github.com:nteract/nteract.git`
 1. `cd nteract`
-1. `npm i`
-1. `npm run app:commuter`
+1. `yarn`
+1. `yarn app:commuter`
 1. open `http://localhost:4000`
 
 ## Tests


### PR DESCRIPTION
As noted in #3292, these docs were listing `npm i` instead of `yarn`.