### PR TITLE
Disable ReactTableFixedColumns til prefixed uniqid

### DIFF
--- a/packages/transform-dataresource/src/charts/grid.js
+++ b/packages/transform-dataresource/src/charts/grid.js
@@ -16,7 +16,7 @@ export const DataResourceTransformGrid = ({
 
   return (
     <div style={{ width: "calc(100vw - 150px)" }}>
-      <ReactTableFixedColumns
+      <ReactTable
         data={data}
         columns={tableColumns}
         style={{


### PR DESCRIPTION
Stuck with using regular `react-table` until https://github.com/GuillaumeJasmin/react-table-hoc-fixed-columns/pull/12 is merged.

because sometimes uniqid will generate an invalid selector (leading digit). This ends up
being deterministic per machine because they're using the mac address of the system
as part of the hash.
