### PR TITLE
create Output Picker that defers to a child element

### DIFF
--- a/packages/outputs/package.json
+++ b/packages/outputs/package.json
@@ -15,10 +15,10 @@
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "dependencies": {
-    "@babel/runtime-corejs2": "^7.0.0",
-    "babel-runtime": "^6.26.0",
-    "immer": "^1.5.0",
-    "lodash": "^4.17.4"
+    "@babel/runtime-corejs2": "^7.0.0"
+  },
+  "devDependencies": {
+    "@nteract/records": "^0.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/outputs/src/components/output.js
+++ b/packages/outputs/src/components/output.js
@@ -1,0 +1,62 @@
+// @flow strict
+
+import * as React from "react";
+
+// We might only need this as a devDependency as it is only here for flow
+import type OutputType from "@nteract/records";
+
+type Props = {
+  /**
+   * React elements that accept Output
+   */
+  children: React.Node,
+  /**
+   * The raw output, as expected from @nteract/records
+   */
+  output: OutputType
+};
+
+type State = {};
+
+export class Output extends React.Component<Props, State> {
+  static defaultProps = {
+    output: null
+  };
+
+  render() {
+    // We must pick only one child to render
+    let chosenOne = null;
+
+    if (this.props.output == null) {
+      return null;
+    }
+
+    const outputType = this.props.output.outputType;
+
+    // Find the first child element that matches something in this.props.data
+    React.Children.forEach(this.props.children, child => {
+      if (chosenOne) {
+        // Already have a selection
+        return;
+      }
+      if (
+        child.props &&
+        child.props.outputType &&
+        child.props.outputType === outputType
+      ) {
+        chosenOne = child;
+        return;
+      }
+    });
+
+    // If we didn't find a match, render nothing
+    if (chosenOne === null) {
+      return null;
+    }
+
+    // Render the output component that handles this output type
+    return React.cloneElement(chosenOne, {
+      output: this.props.output
+    });
+  }
+}

--- a/packages/outputs/src/components/output.md
+++ b/packages/outputs/src/components/output.md
@@ -1,0 +1,99 @@
+The `<Output />` element is a glorified Switch statement for picking what to render an output with.
+
+```jsx
+// Until we create <Stream />
+const StreamText = props => (
+  <pre
+    style={{
+      backgroundColor: props.output.name === "stderr" ? "#f9e0db" : "#e0f9db"
+    }}
+  >
+    {props.output.text}
+  </pre>
+);
+
+StreamText.defaultProps = {
+  outputType: "stream"
+};
+
+const output = Object.freeze({
+  outputType: "stream",
+  text: "Hello World\nHow are you?",
+  name: "stdout"
+});
+
+<Output output={output}>
+  <StreamText />
+</Output>;
+```
+
+```jsx
+const { RichMedia } = require("./rich-media");
+
+const StreamText = props => (
+  <pre
+    style={{
+      backgroundColor: props.output.name === "stderr" ? "#f9e0db" : "#e0f9db"
+    }}
+  >
+    {props.output.text}
+  </pre>
+);
+
+StreamText.defaultProps = {
+  outputType: "stream"
+};
+
+// Some "rich" handlers for Media
+const Plain = props => <marquee>{props.data}</marquee>;
+Plain.defaultProps = {
+  mediaType: "text/plain"
+};
+
+const HTML = props => <div dangerouslySetInnerHTML={{ __html: props.data }} />;
+HTML.defaultProps = {
+  mediaType: "text/html"
+};
+
+const DisplayData = props => (
+  <RichMedia data={props.output.data} metadata={props.output.metadata}>
+    {props.children}
+  </RichMedia>
+);
+
+DisplayData.defaultProps = {
+  outputType: "display_data"
+};
+
+const outputs = [
+  {
+    outputType: "stream",
+    text: "Hello World\nHow are you?",
+    name: "stdout"
+  },
+  {
+    outputType: "display_data",
+    data: {
+      "text/plain": "O____O"
+    },
+    metadata: {}
+  },
+  {
+    outputType: "stream",
+    text: "Pretty good I would say",
+    name: "stdout"
+  }
+];
+
+<div>
+  {outputs.map(output => (
+    <Output output={output}>
+      <StreamText />
+      <DisplayData>
+        <Plain />
+        <HTML />
+      </DisplayData>
+    </Output>
+  ))}
+</div>;
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -6799,7 +6799,7 @@ is-root@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz#07b6c233bc394cd9d02ba15c966bd6660d6342d5"
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -8774,9 +8774,16 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.1.2, node-fetch@^1.0.1, node-fetch@^2.0.0, node-fetch@^2.1.2:
+node-fetch@2.1.2, node-fetch@^2.0.0, node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"


### PR DESCRIPTION
@ivanov and I experimented with a new API for rendering outputs
that lets you provide what you want to use for rendering `execute_result`,
`display_data`, `stream`, etc.

Here's the API outline:

```jsx
import { Output, DisplayData, ExecuteResult, StreamText } from "@nteract/outputs";

// Outputs from a cell!
const outputs = [
  {
    outputType: "stream",
    text: "Hello World\nHow are you?",
    name: "stdout"
  },
  {
    outputType: "display_data",
    data: {
      "text/plain": "O____O"
    },
    metadata: {}
  },
  {
    outputType: "stream",
    text: "Pretty good I would say",
    name: "stdout"
  }
];

// Render the outputs
<div>
  {outputs.map(output => (
    <Output output={output}>
      <StreamText />
      <DisplayData>
        <Plain />
        <HTML />
      </DisplayData>
      <ExecuteResult>
        <Plain />
        <HTML />
      </ExecuteResult>
    </Output>
  ))}
</div>;
```

The main motivation here is to make an API that allows doing configuration by composition, so that we can pass things like `onMetadataChange` to a media component without having to refactor several other components. With `@nteract/display-area`, this was a regular problem requiring a lot of "prop-drilling" to pass a prop through N components.

We'll want to follow this PR up with elements for each of the Jupyter output types. I wrote
hokey ones in the docs here to get this started.

All that being said, this may be ok to bring in as is since it's not integrated into the overall app!

----

To hack on this, you should:

* Grab this branch
* Run:

```
yarn
yarn docs
```

* Open http://127.0.0.1:6060/#!/Output

-----

Next steps I see:

* [ ] Write our "official" output components that would handle all the output types just like what we previously handled in `packages/display-area/src/output.js`
  * [ ] `<ExecuteResult>`
  * [ ] `<DisplayData>`
  * [ ] `<Traceback />` (or call it `<JupyterError />`
  * [ ] `<Stream />`
* [ ] Write a jest test for this component. Seems pretty simple! Not too many edge cases to knock out.
* [ ] Re-write (?) the "transforms" components with the new `<Media />` names

Some of these might be ok as separate steps.

-----

Hey look @BenRussert & @alexandercbooth, we're using the output record types here. 😄 

cc @emeeks 