### PR TITLE
Declare as stale after 300 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 180
+daysUntilStale: 300
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 31
 # Issues with these labels will never be considered stale


### PR DESCRIPTION
Giving us a little bit more wiggle room on stale issues.