### PR TITLE
Changed applications/jupyter-extension/README.md to support python < 3.6

### DIFF
--- a/applications/jupyter-extension/README.md
+++ b/applications/jupyter-extension/README.md
@@ -34,7 +34,7 @@ npm install -g lerna
 
 For more details see the instructions in the [base README](../../README.md#set-the-monorepo-up-in-dev-mode)
 
-### 2. Install/enable `nteract_on_jupyter` (Python 3.6 or greater)
+### 2. Install/enable `nteract_on_jupyter` (Supporting Python 3.X)
 
 Install the python package locally from the `nteract/applications/jupyter-extension/` directory (you should see a `setup.py` here).
 


### PR DESCRIPTION
Summary: Changed applications/jupyter-extension/README.md

This PR corresponds with #3289 , which supports python < 3.6.
I have tested on python 2.7.13 but didn't work. So wrote `Python 3.X`

Thank you!

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

