### PR TITLE
add error output component

### DIFF
--- a/packages/outputs/src/components/jupyter-error.js
+++ b/packages/outputs/src/components/jupyter-error.js
@@ -1,0 +1,29 @@
+// @flow strict
+import * as React from "react";
+import Ansi from "ansi-to-react";
+
+import type { ErrorOutput } from "@nteract/records";
+type Props = ErrorOutput;
+
+export const JupyterError = (props: Props) => {
+  const { ename, evalue, traceback } = props;
+
+  if (!Array.isArray(traceback) || !traceback.length) {
+    return (
+      <Ansi className="nteract-display-area-traceback">{`${ename}: ${evalue}`}</Ansi>
+    );
+  }
+
+  return (
+    <Ansi className="nteract-display-area-traceback">
+      {traceback.join("\n")}
+    </Ansi>
+  );
+};
+
+JupyterError.defaultProps = {
+  outputType: "error",
+  ename: "",
+  evalue: "",
+  traceback: []
+};

--- a/packages/outputs/src/components/jupyter-error.md
+++ b/packages/outputs/src/components/jupyter-error.md
@@ -1,0 +1,9 @@
+The `<JuptyerError />` component will render a Jupyter error with or without a traceback.
+
+```jsx
+<JupyterError ename="NameError" evalue="Yikes!" traceback={["Yikes, never heard of that one!"]} />
+```
+
+```jsx
+<JupyterError ename="NameError" evalue="Yikes!" />
+```

--- a/packages/outputs/src/components/output.md
+++ b/packages/outputs/src/components/output.md
@@ -16,6 +16,22 @@ const output = Object.freeze({
 ```
 
 ```jsx
+const { JupyterError } = require("./jupyter-error");
+
+const output = Object.freeze({
+  outputType: "error",
+  ename: "NameError",
+  evalue: "Yikes!",
+  traceback: ["Yikes, never heard of that one!"]
+});
+
+<Output output={output}>
+  <JupyterError />
+</Output>;
+
+```
+
+```jsx
 const { RichMedia } = require("./rich-media");
 
 const StreamText = require("./stream-text").default;


### PR DESCRIPTION
Towards #3342, this adds the `<JuptyerError />` component.

I went with JupyterError since it sounds more clear, but I'm OK with Traceback if folks would rather it be that.