### PR TITLE
cleanup output error test

### DIFF
--- a/packages/outputs/__tests__/output-spec.js
+++ b/packages/outputs/__tests__/output-spec.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import { Output, StreamText, JupyterError } from "../src";
+import { Output, StreamText, KernelOutputError } from "../src";
 
 describe("Output", () => {
   it("handles stream data", () => {
@@ -26,10 +26,10 @@ describe("Output", () => {
 
     const component = shallow(
       <Output output={output}>
-        <JupyterError />
+        <KernelOutputError />
       </Output>
     );
-    expect(component.type()).toEqual(JupyterError);
+    expect(component.type()).toEqual(KernelOutputError);
 
     const outputNoTraceback = {
       outputType: "error",
@@ -38,10 +38,10 @@ describe("Output", () => {
     };
 
     const component2 = shallow(
-      <Output output={output}>
-        <JupyterError />
+      <Output output={outputNoTraceback}>
+        <KernelOutputError />
       </Output>
     );
-    expect(component2.type()).toEqual(JupyterError);
+    expect(component2.type()).toEqual(KernelOutputError);
   });
 });

--- a/packages/outputs/src/components/jupyter-error.js
+++ b/packages/outputs/src/components/jupyter-error.js
@@ -9,16 +9,10 @@ export const JupyterError = (props: Props) => {
   const { ename, evalue, traceback } = props;
 
   if (!Array.isArray(traceback) || !traceback.length) {
-    return (
-      <Ansi className="nteract-display-area-traceback">{`${ename}: ${evalue}`}</Ansi>
-    );
+    return <Ansi>{`${ename}: ${evalue}`}</Ansi>;
   }
 
-  return (
-    <Ansi className="nteract-display-area-traceback">
-      {traceback.join("\n")}
-    </Ansi>
-  );
+  return <Ansi>{traceback.join("\n")}</Ansi>;
 };
 
 JupyterError.defaultProps = {

--- a/packages/outputs/src/components/jupyter-error.md
+++ b/packages/outputs/src/components/jupyter-error.md
@@ -1,9 +1,0 @@
-The `<JuptyerError />` component will render a Jupyter error with or without a traceback.
-
-```jsx
-<JupyterError ename="NameError" evalue="Yikes!" traceback={["Yikes, never heard of that one!"]} />
-```
-
-```jsx
-<JupyterError ename="NameError" evalue="Yikes!" />
-```

--- a/packages/outputs/src/components/kernel-output-error.js
+++ b/packages/outputs/src/components/kernel-output-error.js
@@ -5,7 +5,7 @@ import Ansi from "ansi-to-react";
 import type { ErrorOutput } from "@nteract/records";
 type Props = ErrorOutput;
 
-export const JupyterError = (props: Props) => {
+export const KernelOutputError = (props: Props) => {
   const { ename, evalue, traceback } = props;
 
   if (!Array.isArray(traceback) || !traceback.length) {
@@ -15,7 +15,7 @@ export const JupyterError = (props: Props) => {
   return <Ansi>{traceback.join("\n")}</Ansi>;
 };
 
-JupyterError.defaultProps = {
+KernelOutputError.defaultProps = {
   outputType: "error",
   ename: "",
   evalue: "",

--- a/packages/outputs/src/components/kernel-output-error.md
+++ b/packages/outputs/src/components/kernel-output-error.md
@@ -1,0 +1,9 @@
+The `<KernelOutputError />` component will render a Jupyter error with or without a traceback.
+
+```jsx
+<KernelOutputError ename="NameError" evalue="Yikes!" traceback={["Yikes, never heard of that one!"]} />
+```
+
+```jsx
+<KernelOutputError ename="NameError" evalue="Yikes!" />
+```

--- a/packages/outputs/src/components/output.md
+++ b/packages/outputs/src/components/output.md
@@ -16,7 +16,7 @@ const output = Object.freeze({
 ```
 
 ```jsx
-const { JupyterError } = require("./jupyter-error");
+const { KernelOutputError } = require("./kernel-output-error");
 
 const output = Object.freeze({
   outputType: "error",
@@ -26,7 +26,7 @@ const output = Object.freeze({
 });
 
 <Output output={output}>
-  <JupyterError />
+  <KernelOutputError />
 </Output>;
 
 ```

--- a/packages/outputs/src/index.js
+++ b/packages/outputs/src/index.js
@@ -1,6 +1,6 @@
 // @flow strict
 export { RichMedia } from "./components/rich-media";
 export { Output } from "./components/output";
-export { JupyterError } from "./components/jupyter-error";
+export { KernelOutputError } from "./components/kernel-output-error";
 import StreamText from "./components/stream-text";
 export { StreamText };


### PR DESCRIPTION
Following up on #3348 and #3347, this 
- renames `<JupyterError />` to `<KernelOutputError />` 
- uses the right output in the second test
- removes old className