### PR TITLE
add HTML media component

### DIFF
--- a/packages/outputs/__tests__/media-spec.js
+++ b/packages/outputs/__tests__/media-spec.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { mount } from "enzyme";
+
+import * as Media from "../src/components/media";
+
+describe("HTML", () => {
+  it("renders direct HTML", () => {
+    const component = mount(<Media.HTML data={"<b>cats are best</b>"} />);
+    expect(component.html()).toEqual("<div><b>cats are best</b></div>");
+  });
+  it("correctly chooses to update with data changing", () => {
+    const wrapper = mount(<Media.HTML data={"<b>cats are best</b>"} />);
+
+    const component = wrapper.instance();
+    expect(
+      component.shouldComponentUpdate({ data: "<b>cats are best</b>" })
+    ).toBeFalsy();
+    expect(
+      component.shouldComponentUpdate({
+        data: "<b>squirrels are pretty great, too</b>"
+      })
+    ).toBeTruthy();
+  });
+  it("updates the underlying HTML when data changes", () => {
+    const wrapper = mount(<Media.HTML data={"<b>cats are best</b>"} />);
+    expect(wrapper.html()).toEqual("<div><b>cats are best</b></div>");
+
+    wrapper.setProps({ data: "<b>squirrels are pretty great, too</b>" });
+
+    expect(wrapper.html()).toEqual(
+      "<div><b>squirrels are pretty great, too</b></div>"
+    );
+  });
+});

--- a/packages/outputs/src/components/media/html.js
+++ b/packages/outputs/src/components/media/html.js
@@ -1,0 +1,65 @@
+// @flow strict
+import * as React from "react";
+
+type Props = {
+  data: string,
+  mediaType: string
+};
+
+// Note: createRange and Range must be polyfilled on older browsers with
+//       https://github.com/timdown/rangy
+export function createFragment(html: string): Node {
+  /**
+   * createFragment takes in an HTML string and outputs a DOM element that is
+   * treated as if it originated on the page "like normal".
+   * @type {Node} - https://developer.mozilla.org/en-US/docs/Web/API/Node
+   */
+  // Create a range to ensure that scripts are invoked from within the HTML
+  const range = document.createRange();
+  const fragment = range.createContextualFragment(html);
+  return fragment;
+}
+
+export class HTML extends React.Component<Props> {
+  el: ?HTMLElement;
+  static defaultProps = {
+    mediaType: "text/html",
+    data: null
+  };
+  componentDidMount(): void {
+    // clear out all DOM element children
+    // This matters on server side render otherwise we'll get both the `innerHTML`ed
+    // version + the fragment version right after each other
+    // In the desktop app (and successive loads with tools like commuter) this
+    // will be a no-op
+    if (!this.el) return;
+    while (this.el.firstChild) {
+      this.el.removeChild(this.el.firstChild);
+    }
+    // DOM element appended with a real DOM Node fragment
+    this.el.appendChild(createFragment(this.props.data));
+  }
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return nextProps.data !== this.props.data;
+  }
+  componentDidUpdate(): void {
+    if (!this.el) return;
+    // clear out all DOM element children
+    while (this.el.firstChild) {
+      this.el.removeChild(this.el.firstChild);
+    }
+    this.el.appendChild(createFragment(this.props.data));
+  }
+
+  render() {
+    return (
+      <div
+        dangerouslySetInnerHTML={{ __html: this.props.data }}
+        ref={el => {
+          this.el = el;
+        }}
+      />
+    );
+  }
+}

--- a/packages/outputs/src/components/media/index.js
+++ b/packages/outputs/src/components/media/index.js
@@ -1,0 +1,1 @@
+export { HTML } from "./html";

--- a/packages/outputs/src/components/rich-media.md
+++ b/packages/outputs/src/components/rich-media.md
@@ -1,4 +1,6 @@
 ```jsx
+const Media = require('./media')
+
 /**
  * First we'll create some simple components that take data and a mediaType for rendering
  */
@@ -7,18 +9,13 @@ Plain.defaultProps = {
   mediaType: "text/plain"
 };
 
-const HTML = props => <div dangerouslySetInnerHTML={{ __html: props.data }} />;
-HTML.defaultProps = {
-  mediaType: "text/html"
-};
-
 <RichMedia
   data={{
     "text/plain": "plain is sooooo basic",
     "text/html": "<p>I pick the <b>richest</b> to <i>render</i>!</p>"
   }}
 >
-  <HTML />
+  <Media.HTML />
   <Plain />
 </RichMedia>;
 ```
@@ -85,8 +82,10 @@ There are several different jupyter message types that include these objects:
 The `<RichMedia />` component accepts the whole media bundle from a kernel via the `data` prop and all the elements for rendering media types as `children`. The order of the children states their richness from highest to lowest.
 
 ```jsx static
+const Media = require('./media')
+
 <RichMedia data={{ "text/plain": "SparkContext ⚡️" }}>
-  <HTML />
+  <Media.HTML />
   <Plain />
 </RichMedia>
 ```
@@ -94,18 +93,15 @@ The `<RichMedia />` component accepts the whole media bundle from a kernel via t
 The `<RichMedia />` component will pass the appropriate data from the media bundle to the element that accepts the media type. In this case, `<Plain />` is picked as the richest since `text/plain` is the only available. `"SparkContext ⚡️"` is passed as `<Plain data="SparkContext ⚡️" />` to render the richest media.
 
 ```jsx
+const Media = require('./media')
+
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
   mediaType: "text/plain"
 };
 
-const HTML = props => <div dangerouslySetInnerHTML={{ __html: props.data }} />;
-HTML.defaultProps = {
-  mediaType: "text/html"
-};
-
 <RichMedia data={{ "text/plain": "SparkContext ⚡️" }}>
-  <HTML />
+  <Media.HTML />
   <Plain />
 </RichMedia>;
 ```
@@ -113,14 +109,11 @@ HTML.defaultProps = {
 Whereas this output has a richer HTML output:
 
 ```jsx
+const Media = require('./media')
+
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
   mediaType: "text/plain"
-};
-
-const HTML = props => <div dangerouslySetInnerHTML={{ __html: props.data }} />;
-HTML.defaultProps = {
-  mediaType: "text/html"
 };
 
 <RichMedia
@@ -129,7 +122,7 @@ HTML.defaultProps = {
     "text/html": "<b>HTML is so rich</b>"
   }}
 >
-  <HTML />
+  <Media.HTML />
   <Plain />
 </RichMedia>;
 ```
@@ -185,14 +178,11 @@ Plain.defaultProps = {
 Which means that you can customize outputs as props!
 
 ```jsx
+const Media = require('./media')
+
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
   mediaType: "text/plain"
-};
-
-const HTML = props => <div dangerouslySetInnerHTML={{ __html: props.data }} />;
-HTML.defaultProps = {
-  mediaType: "text/html"
 };
 
 // Pretend this is the data explorer :)
@@ -242,7 +232,7 @@ class Output extends React.Component {
           }}
         >
           <FancyTable color={this.state.color} />
-          <HTML />
+          <Media.HTML />
           <Plain />
         </RichMedia>
       </div>


### PR DESCRIPTION
Continuing with the output work, this kicks off bringing in the transforms by starting with HTML. At the moment, I have not yet included a `.md` for it alone, but used it in the `output.md` instead. 
