### PR TITLE
Display data

### DIFF
--- a/packages/outputs/src/components/display-data.js
+++ b/packages/outputs/src/components/display-data.js
@@ -3,8 +3,38 @@ import * as React from "react";
 
 import { RichMedia } from "./rich-media";
 
-import type { DisplayDataProps } from "@nteract/records";
-type Props = DisplayDataProps;
+import type { MediaBundle } from "@nteract/records";
+
+type Props = {
+  /**
+   * The literal type of output, used for routing with the `<Output />` element
+   */
+  outputType: "display_data",
+  /**
+   * Object of media type → data
+   *
+   * E.g.
+   *
+   * ```js
+   * {
+   *   "text/plain": "raw text",
+   * }
+   * ```
+   *
+   * See [Jupyter message spec](http://jupyter-client.readthedocs.io/en/stable/messaging.html#display-data)
+   * for more detail.
+   *
+   */
+  data: MediaBundle,
+  /**
+   * custom settings, typically keyed by media type
+   */
+  metadata: {},
+  /**
+   * React elements that accept mimebundle data, will get passed data[mimetype]
+   */
+  children: React.Node
+};
 
 export const DisplayData = (props: Props) => {
   const { data, metadata, children } = props;

--- a/packages/outputs/src/components/display-data.md
+++ b/packages/outputs/src/components/display-data.md
@@ -7,5 +7,7 @@ Plain.defaultProps = {
   mediaType: "text/plain"
 };
 
-<DisplayData data={ { "text/plain": "Cheese is the best food." } } ><Plain/></DisplayData>
+<DisplayData data={{ "text/plain": "Jackfruit is the best food." }}>
+  <Plain />
+</DisplayData>;
 ```

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -28,13 +28,6 @@ export type DisplayDataOutput = {
   metadata: {}
 };
 
-export type DisplayDataProps = {
-  outputType: DisplayDataType,
-  data: common.MediaBundle,
-  metadata: {},
-  children: React.Node
-};
-
 // On disk
 export type NbformatDisplayDataOutput = {
   output_type: DisplayDataType,

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -3,8 +3,7 @@ import type { JupyterMessage } from "@nteract/messaging";
 
 import type {
   NbformatDisplayDataOutput,
-  DisplayDataOutput,
-  DisplayDataProps
+  DisplayDataOutput
 } from "./display-data";
 import type { NbformatStreamOutput, StreamOutput } from "./stream";
 import type { NbformatErrorOutput, ErrorOutput } from "./error";
@@ -39,8 +38,7 @@ export type {
   StreamOutput,
   ErrorOutput,
   ExecuteResultOutput,
-  DisplayDataOutput,
-  DisplayDataProps
+  DisplayDataOutput
 };
 
 /**


### PR DESCRIPTION
Props weren't being shown nicely when imported from `@nteract/records`. This switches over to defining it locally.

Old:

<img width="992" alt="screen shot 2018-09-23 at 11 30 11 am" src="https://user-images.githubusercontent.com/836375/45929756-224d0180-bf24-11e8-82c9-cf01f5b7fd0a.png">

New:

<img width="992" alt="screen shot 2018-09-23 at 11 30 02 am" src="https://user-images.githubusercontent.com/836375/45929759-29740f80-bf24-11e8-9358-d72ee64276a0.png">
