### PR TITLE
Change errorMiddleWare to log/notify about more types of failure-related actions

### DIFF
--- a/packages/core/__tests__/middleware-spec.js
+++ b/packages/core/__tests__/middleware-spec.js
@@ -24,7 +24,7 @@ describe("The error middleware", () => {
       reducer: jest.fn()
     };
     const next = action => store.dispatch(action);
-    const action = { type: "ERROR", payload: "This is a payload", err: true };
+    const action = { type: "ERROR", payload: "This is a payload" };
 
     const fakeConsole = {
       error: msg => {}
@@ -62,13 +62,85 @@ describe("The error middleware", () => {
       reducer: jest.fn()
     };
     const next = action => store.dispatch(action);
-    const action = { type: "ERROR", payloa: "typo", err: true };
+    const action = { type: "ERROR", payloa: "typo" };
     const notification = store.getState().app.notificationSystem
       .addNotification;
     errorMiddleware(store, fakeConsole)(next)(action);
     expect(notification).toBeCalledWith({
       title: "ERROR",
       message: JSON.stringify(action, 2, 2),
+      dismissible: true,
+      position: "tr",
+      level: "error"
+    });
+    expect(store.reducer).toBeCalled();
+  });
+  test("treats an action w/ 'error: true' as an error", () => {
+    const store = {
+      getState() {
+        return this.state;
+      },
+      dispatch(action) {
+        return this.reducer(store, action);
+      },
+      state: {
+        app: {
+          get() {
+            return this.notificationSystem;
+          },
+          notificationSystem: { addNotification: jest.fn() }
+        }
+      },
+      reducer: jest.fn()
+    };
+    const next = action => store.dispatch(action);
+    const action = {
+      type: "BAD_STUFF_ACTION_TYPE",
+      payload: "This is a payload",
+      error: true
+    };
+    const notification = store.getState().app.notificationSystem
+      .addNotification;
+    errorMiddleware(store, fakeConsole)(next)(action);
+    expect(notification).toBeCalledWith({
+      title: "BAD_STUFF_ACTION_TYPE",
+      message: JSON.stringify("This is a payload", 2, 2),
+      dismissible: true,
+      position: "tr",
+      level: "error"
+    });
+    expect(store.reducer).toBeCalled();
+  });
+  test("stringifies a nested Error object sensibly", () => {
+    const store = {
+      getState() {
+        return this.state;
+      },
+      dispatch(action) {
+        return this.reducer(store, action);
+      },
+      state: {
+        app: {
+          get() {
+            return this.notificationSystem;
+          },
+          notificationSystem: { addNotification: jest.fn() }
+        }
+      },
+      reducer: jest.fn()
+    };
+    const next = action => store.dispatch(action);
+    const action = {
+      type: "BAD_STUFF_ACTION_TYPE",
+      payload: { error: new Error("JS ERROR") },
+      error: true
+    };
+    const notification = store.getState().app.notificationSystem
+      .addNotification;
+    errorMiddleware(store, fakeConsole)(next)(action);
+    expect(notification).toBeCalledWith({
+      title: "BAD_STUFF_ACTION_TYPE",
+      message: "JS ERROR",
       dismissible: true,
       position: "tr",
       level: "error"

--- a/packages/core/src/middlewares.js
+++ b/packages/core/src/middlewares.js
@@ -3,9 +3,11 @@
 // to divide up the desktop app and this core package
 
 import * as selectors from "./selectors";
+import { cloneDeep } from "lodash";
 
 type Action = {
   type: string,
+  error: ?boolean,
   payload: ?any
 };
 
@@ -16,13 +18,21 @@ export const errorMiddleware = (
   store: any,
   console: Console = global.console
 ) => (next: any) => (action: Action) => {
-  if (!action.type.includes("ERROR")) {
+  if (!(action.type.includes("ERROR") || action.error)) {
     return next(action);
   }
   console.error(action);
   let errorText;
+
   if ("payload" in action) {
-    errorText = JSON.stringify(action.payload, null, 2);
+    if (
+      action.payload instanceof Object &&
+      action.payload.error instanceof Error
+    ) {
+      errorText = action.payload.error.message;
+    } else {
+      errorText = JSON.stringify(action.payload, null, 2);
+    }
   } else {
     errorText = JSON.stringify(action, null, 2);
   }


### PR DESCRIPTION
Fixes #3369.

The following actions will now be logged to the console, and users will see notifications:
FETCH_CONTENT_FAILED
LAUNCH_KERNEL_FAILED
KILL_KERNEL_FAILED
INTERRUPT_KERNEL_FAILED
EXECUTE_FAILED
SAVE_FAILED
UPDATE_DISPLAY_FAILED
DELETE_CONNECTION_FILE_FAILED
SHUTDOWN_REPLY_TIMED_OUT
RESTART_KERNEL_FAILED
CORE/ERROR

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

