### PR TITLE
[WIP] React 16+ compliant @nteract/mathjax API

### DIFF
--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -87,14 +87,15 @@ export default class App extends React.PureComponent<{}, null> {
       <Provider store={store}>
         <React.Fragment>
           <Styles>
-            <MathJax.Context input="tex">
+            {/* TODO: Provide MathJax here with mathjax-electron */}
+            <MathJax.Provider input="tex">
               <NotebookApp
                 // The desktop app always keeps the same contentRef in a browser window
                 contentRef={contentRef}
                 transforms={transforms}
                 displayOrder={displayOrder}
               />
-            </MathJax.Context>
+            </MathJax.Provider>
 
             <NotificationSystem
               ref={notificationSystem => {

--- a/packages/markdown/src/index.js
+++ b/packages/markdown/src/index.js
@@ -14,10 +14,7 @@ const inlineMath = (props: { value: string }) => (
   <MathJax.Node inline>{props.value}</MathJax.Node>
 );
 
-const MarkdownRender = (
-  props: ReactMarkdown.ReactMarkdownProps,
-  context: { MathJaxContext?: boolean }
-) => {
+const MarkdownRender = (props: ReactMarkdown.ReactMarkdownProps) => {
   const newProps = {
     // https://github.com/rexxars/react-markdown#options
     ...props,
@@ -30,23 +27,7 @@ const MarkdownRender = (
     }
   };
 
-  // Render a Context if one was not passed as a parent
-  if (!context.MathJaxContext) {
-    return (
-      <MathJax.Context input="tex">
-        <ReactMarkdown {...newProps} />
-      </MathJax.Context>
-    );
-  }
-
   return <ReactMarkdown {...newProps} />;
-};
-
-MarkdownRender.contextTypes = {
-  // Opt in to updates to the MathJax object even though
-  // Not explicitly used
-  MathJax: PropTypes.object,
-  MathJaxContext: PropTypes.bool
 };
 
 export default MarkdownRender;

--- a/packages/mathjax/examples.md
+++ b/packages/mathjax/examples.md
@@ -13,3 +13,11 @@ const tex = String.raw`f(x) = \int_{-\infty}^\infty
   </p>
 </MathJax.Provider>;
 ```
+
+What happens if you use a consumer and have no provider???
+
+```jsx
+var MathJax = require(".");
+
+<MathJax.Node>a = b</MathJax.Node>;
+```

--- a/packages/mathjax/examples.md
+++ b/packages/mathjax/examples.md
@@ -5,11 +5,11 @@ const tex = String.raw`f(x) = \int_{-\infty}^\infty
     \hat f(\xi)\,e^{2 \pi i \xi x}
     \,d\xi`;
 
-<MathJax.Context>
+<MathJax.Provider>
   <p>
     This is an inline math formula: <MathJax.Node inline>a = b</MathJax.Node>
     <span> and a block one:</span>
     <MathJax.Node>{tex}</MathJax.Node>
   </p>
-</MathJax.Context>;
+</MathJax.Provider>;
 ```

--- a/packages/mathjax/src/context.js
+++ b/packages/mathjax/src/context.js
@@ -1,150 +1,28 @@
-// @flow strict
-/* global MathJax */
-
+/* @flow strict */
 import * as React from "react";
-import PropTypes from "prop-types";
-import loadScript from "./load-script";
 
-// MathJax expected to be a global and may be undefined
-declare var MathJax: ?{
+export type MathJaxObject = {
   Hub: {
+    getJaxFor: HTMLElement => void,
     Config: (options: *) => void,
     Register: {
       StartupHook: (str: string, cb: () => void) => void,
       MessageHook: (string, cb: (msg: string) => void) => void
     },
+    Reprocess: (HTMLElement, cb: *) => *,
+    Queue: (*) => void,
     processSectionDelay: number
   }
 };
 
-declare type onLoad = () => void;
-type Props = {
-  src: ?string,
-  children: React.Node,
-  didFinishTypeset: ?() => void,
-  // Provide a way to override how we load MathJax and callback to the onLoad
-  // For Hydrogen, for instance we can set
-  //
-  //  loader={(onLoad) => loadMathJax(document, onLoad)}
-  //
-  onLoad: ?onLoad,
-  loader: ?(cb: onLoad) => void,
-  input: "ascii" | "tex",
-  delay: number,
-  options: ?*,
-  loading: React.Node,
-  noGate: boolean,
-  onError: (err: Error) => void
+export type MathJaxContextValue = {
+  MathJax: ?MathJaxObject,
+  input: "tex" | "ascii"
 };
 
-type State = {
-  loaded: boolean
-};
+const MathJaxContext: React.Context<MathJaxContextValue> = React.createContext({
+  MathJax: null,
+  input: "tex"
+});
 
-/**
- * Context for loading MathJax
- */
-class Context extends React.Component<Props, State> {
-  static defaultProps = {
-    src:
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML",
-    input: "tex",
-    didFinishTypeset: null,
-    loader: null,
-    delay: 0,
-    options: {},
-    loading: null,
-    noGate: false,
-    onLoad: null,
-    onError: (err: Error) => {
-      console.error(err);
-    }
-  };
-
-  constructor(props: Props) {
-    super(props);
-    this.state = { loaded: false };
-  }
-
-  getChildContext() {
-    return {
-      // Here we see if MathJax is defined globally by running a typeof on a
-      // potentially not set value then explicitly setting the MathJax context
-      // to undefined.
-      MathJax: typeof MathJax === "undefined" ? undefined : MathJax,
-      input: this.props.input,
-      MathJaxContext: true
-    };
-  }
-
-  componentDidMount() {
-    const src = this.props.src;
-
-    if (src == null) {
-      return this.onLoad();
-    }
-
-    if (!this.props.loader) {
-      loadScript(src, this.onLoad);
-    } else {
-      this.props.loader(this.onLoad);
-    }
-  }
-
-  onLoad = () => {
-    if (!MathJax || !MathJax.Hub) {
-      this.props.onError(
-        new Error("MathJax not really loaded even though onLoad called")
-      );
-      return;
-    }
-
-    const options = this.props.options;
-
-    MathJax.Hub.Config(options);
-
-    MathJax.Hub.Register.StartupHook("End", () => {
-      if (!MathJax) {
-        this.props.onError(
-          new Error("MathJax became undefined in the middle of processing")
-        );
-        return;
-      }
-      MathJax.Hub.processSectionDelay = this.props.delay;
-
-      if (this.props.didFinishTypeset) {
-        this.props.didFinishTypeset();
-      }
-    });
-
-    MathJax.Hub.Register.MessageHook("Math Processing Error", message => {
-      if (this.props.onError) {
-        this.props.onError(new Error(message));
-      }
-    });
-
-    if (this.props.onLoad) {
-      this.props.onLoad();
-    }
-
-    this.setState({
-      loaded: true
-    });
-  };
-
-  render() {
-    if (!this.state.loaded && !this.props.noGate) {
-      return this.props.loading;
-    }
-
-    return this.props.children;
-  }
-}
-
-Context.childContextTypes = {
-  MathJax: PropTypes.object,
-  input: PropTypes.string,
-  MathJaxContext: PropTypes.bool
-};
-
-export default Context;
+export default MathJaxContext;

--- a/packages/mathjax/src/context.js
+++ b/packages/mathjax/src/context.js
@@ -17,12 +17,15 @@ export type MathJaxObject = {
 
 export type MathJaxContextValue = {
   MathJax: ?MathJaxObject,
-  input: "tex" | "ascii"
+  input: "tex" | "ascii",
+  // Allow detecting if there's a <Provider> above a <Consumer>
+  hasProviderAbove: ?boolean
 };
 
 const MathJaxContext: React.Context<MathJaxContextValue> = React.createContext({
   MathJax: null,
-  input: "tex"
+  input: "tex",
+  hasProviderAbove: null
 });
 
 export default MathJaxContext;

--- a/packages/mathjax/src/index.js
+++ b/packages/mathjax/src/index.js
@@ -2,6 +2,7 @@
 
 import Node from "./node";
 import Context from "./context";
+import Provider from "./provider";
 
-export { Node, Context };
-export default { Node, Context };
+export { Node, Provider, Context };
+export default { Node, Provider, Context };

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -86,7 +86,7 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
 
     if (!MathJax || !MathJax.Hub) {
       throw Error(
-        "Could not find MathJax while attempting typeset! It's likely the MathJax script hasn't been loaded or MathJax.Context is not in the hierarchy"
+        "Could not find MathJax while attempting typeset! It's likely the MathJax script hasn't been loaded or MathJax.Context is not in the hierarchy."
       );
     }
 
@@ -98,10 +98,9 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
 
     if (forceUpdate || !this.script) {
       this.setScriptText(text);
-    }
-    // As an invariant of above, this shouldn't occur
-    if (!this.script) {
-      return;
+      if (!this.script) {
+        return;
+      }
     }
 
     MathJax.Hub.Queue(MathJax.Hub.Reprocess(this.script, this.props.onRender));
@@ -149,7 +148,7 @@ class MathJaxNode extends React.PureComponent<Props, null> {
     return (
       <MathJaxContext.Consumer>
         {({ MathJax, input, hasProviderAbove }: MathJaxContextValue) => {
-          // If no provider in the above tree, create our own
+          // If there is no <Provider /> in the above tree, create our own
           if (!hasProviderAbove) {
             return (
               <Provider>

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -12,6 +12,8 @@ import MathJaxContext, {
   type MathJaxContextValue
 } from "./context";
 
+import Provider from "./provider";
+
 type Props = {
   inline: boolean,
   children: string,
@@ -21,11 +23,6 @@ type Props = {
 class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
   script: ?HTMLScriptElement;
   nodeRef: React.ElementRef<*>;
-
-  static defaultProps = {
-    inline: false,
-    onRender: null
-  };
 
   constructor(props: Props & MathJaxContextValue) {
     super(props);
@@ -143,16 +140,38 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
 }
 
 class MathJaxNode extends React.PureComponent<Props, null> {
+  static defaultProps = {
+    inline: false,
+    onRender: null
+  };
+
   render() {
     return (
       <MathJaxContext.Consumer>
-        {({ MathJax, input }: MathJaxContextValue) => {
+        {({ MathJax, input, hasProviderAbove }: MathJaxContextValue) => {
+          // If no provider in the above tree, create our own
+          if (!hasProviderAbove) {
+            return (
+              <Provider>
+                <MathJaxNode {...this.props} />
+              </Provider>
+            );
+          }
+
           if (!MathJax) {
             return null;
           }
 
           return (
-            <MathJaxNode_ {...this.props} input={input} MathJax={MathJax} />
+            <MathJaxNode_
+              inline={this.props.inline}
+              onRender={this.props.onRender}
+              input={input}
+              MathJax={MathJax}
+              hasProviderAbove={hasProviderAbove}
+            >
+              {this.props.children}
+            </MathJaxNode_>
           );
         }}
       </MathJaxContext.Consumer>

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -7,13 +7,18 @@ const types = {
   tex: "tex"
 };
 
+import MathJaxContext, {
+  type MathJaxObject,
+  type MathJaxContextValue
+} from "./context";
+
 type Props = {
   inline: boolean,
   children: string,
   onRender: ?Function
 };
 
-class Node extends React.Component<Props, *> {
+class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
   script: ?HTMLScriptElement;
   nodeRef: React.ElementRef<*>;
 
@@ -22,7 +27,7 @@ class Node extends React.Component<Props, *> {
     onRender: null
   };
 
-  constructor(props: Props) {
+  constructor(props: Props & MathJaxContextValue) {
     super(props);
 
     this.nodeRef = React.createRef();
@@ -40,21 +45,11 @@ class Node extends React.Component<Props, *> {
   /**
    * Update the jax, force update if the display mode changed
    */
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props & MathJaxContextValue) {
     const forceUpdate =
       prevProps.inline !== this.props.inline ||
       prevProps.children !== this.props.children;
     this.typeset(forceUpdate);
-  }
-
-  /**
-   * Prevent update when the source has not changed
-   */
-  shouldComponentUpdate(nextProps: Props, nextState: *, nextContext: *) {
-    return (
-      nextProps.children !== this.props.children ||
-      nextProps.inline !== this.props.inline
-    );
   }
 
   /**
@@ -68,7 +63,11 @@ class Node extends React.Component<Props, *> {
    * Clear the jax
    */
   clear() {
-    const MathJax = this.context.MathJax;
+    const MathJax = this.props.MathJax;
+
+    if (!MathJax) {
+      return;
+    }
 
     if (!this.script) {
       return;
@@ -86,9 +85,9 @@ class Node extends React.Component<Props, *> {
    * @param { Boolean } forceUpdate
    */
   typeset(forceUpdate: boolean = false) {
-    const { MathJax } = this.context;
+    const { MathJax } = this.props;
 
-    if (!MathJax) {
+    if (!MathJax || !MathJax.Hub) {
       throw Error(
         "Could not find MathJax while attempting typeset! It's likely the MathJax script hasn't been loaded or MathJax.Context is not in the hierarchy"
       );
@@ -103,6 +102,10 @@ class Node extends React.Component<Props, *> {
     if (forceUpdate || !this.script) {
       this.setScriptText(text);
     }
+    // As an invariant of above, this shouldn't occur
+    if (!this.script) {
+      return;
+    }
 
     MathJax.Hub.Queue(MathJax.Hub.Reprocess(this.script, this.props.onRender));
   }
@@ -113,7 +116,7 @@ class Node extends React.Component<Props, *> {
    */
   setScriptText(text: *) {
     const inline = this.props.inline;
-    const type = types[this.context.input];
+    const type = types[this.props.input];
     if (!this.script) {
       this.script = document.createElement("script");
       this.script.type = `math/${type}; ${inline ? "" : "mode=display"}`;
@@ -139,8 +142,22 @@ class Node extends React.Component<Props, *> {
   }
 }
 
-Node.contextTypes = {
-  MathJax: PropTypes.object,
-  input: PropTypes.string
-};
-export default Node;
+class MathJaxNode extends React.PureComponent<Props, null> {
+  render() {
+    return (
+      <MathJaxContext.Consumer>
+        {({ MathJax, input }: MathJaxContextValue) => {
+          if (!MathJax) {
+            return null;
+          }
+
+          return (
+            <MathJaxNode_ {...this.props} input={input} MathJax={MathJax} />
+          );
+        }}
+      </MathJaxContext.Consumer>
+    );
+  }
+}
+
+export default MathJaxNode;

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -4,7 +4,10 @@
 import * as React from "react";
 import loadScript from "./load-script";
 
-import MathJaxContext, { type MathJaxObject } from "./context.js";
+import MathJaxContext, {
+  type MathJaxObject,
+  type MathJaxContextValue
+} from "./context.js";
 
 // MathJax expected to be a global and may be undefined
 declare var MathJax: ?MathJaxObject;
@@ -29,10 +32,7 @@ type Props = {
   onError: (err: Error) => void
 };
 
-type State = {
-  MathJax: ?MathJaxObject,
-  input: "ascii" | "tex"
-};
+type State = MathJaxContextValue;
 
 /**
  * MathJax Provider
@@ -60,7 +60,8 @@ class Provider extends React.Component<Props, State> {
     this.state = {
       MathJax: undefined,
       // TODO: Ensure state gets updated when the input prop changes
-      input: this.props.input
+      input: this.props.input,
+      hasProviderAbove: true
     };
   }
 

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -1,0 +1,131 @@
+// @flow strict
+/* global MathJax */
+
+import * as React from "react";
+import loadScript from "./load-script";
+
+import MathJaxContext, { type MathJaxObject } from "./context.js";
+
+// MathJax expected to be a global and may be undefined
+declare var MathJax: ?MathJaxObject;
+
+declare type onLoad = () => void;
+type Props = {
+  src: ?string,
+  children: React.Node,
+  didFinishTypeset: ?() => void,
+  // Provide a way to override how we load MathJax and callback to the onLoad
+  // For Hydrogen, for instance we can set
+  //
+  //  loader={(onLoad) => loadMathJax(document, onLoad)}
+  //
+  onLoad: ?onLoad,
+  loader: ?(cb: onLoad) => void,
+  input: "ascii" | "tex",
+  delay: number,
+  options: ?*,
+  loading: React.Node,
+  noGate: boolean,
+  onError: (err: Error) => void
+};
+
+type State = {
+  MathJax: ?MathJaxObject,
+  input: "ascii" | "tex"
+};
+
+/**
+ * MathJax Provider
+ */
+class Provider extends React.Component<Props, State> {
+  static defaultProps = {
+    src:
+      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML",
+    input: "tex",
+    didFinishTypeset: null,
+    loader: null,
+    delay: 0,
+    options: {},
+    loading: null,
+    noGate: false,
+    onLoad: null,
+    onError: (err: Error) => {
+      console.error(err);
+    }
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      MathJax: undefined,
+      // TODO: Ensure state gets updated when the input prop changes
+      input: this.props.input
+    };
+  }
+
+  componentDidMount() {
+    const src = this.props.src;
+
+    if (src == null) {
+      return this.onLoad();
+    }
+
+    if (!this.props.loader) {
+      loadScript(src, this.onLoad);
+    } else {
+      this.props.loader(this.onLoad);
+    }
+  }
+
+  onLoad = () => {
+    if (!MathJax || !MathJax.Hub) {
+      this.props.onError(
+        new Error("MathJax not really loaded even though onLoad called")
+      );
+      return;
+    }
+
+    const options = this.props.options;
+
+    MathJax.Hub.Config(options);
+
+    MathJax.Hub.Register.StartupHook("End", () => {
+      if (!MathJax) {
+        this.props.onError(
+          new Error("MathJax became undefined in the middle of processing")
+        );
+        return;
+      }
+      MathJax.Hub.processSectionDelay = this.props.delay;
+
+      if (this.props.didFinishTypeset) {
+        this.props.didFinishTypeset();
+      }
+    });
+
+    MathJax.Hub.Register.MessageHook("Math Processing Error", message => {
+      if (this.props.onError) {
+        this.props.onError(new Error(message));
+      }
+    });
+
+    if (this.props.onLoad) {
+      this.props.onLoad();
+    }
+
+    this.setState({
+      MathJax
+    });
+  };
+
+  render() {
+    return (
+      <MathJaxContext.Provider value={this.state}>
+        {this.props.children}
+      </MathJaxContext.Provider>
+    );
+  }
+}
+
+export default Provider;

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -87,7 +87,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
     const cellMap = notebook.get("cellMap");
 
     return (
-      <MathJax.Context>
+      <MathJax.Provider>
         <div className="notebook-preview">
           <Cells>
             {cellOrder.map(cellID => {
@@ -197,7 +197,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
           }
         `}</style>
         </div>
-      </MathJax.Context>
+      </MathJax.Provider>
     );
   }
 }

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -8,32 +8,10 @@ type Props = {
   data: string
 };
 
-type Context = {
-  MathJax?: Object,
-  MathJaxContext?: boolean
-};
-
-export const LaTeXDisplay = (props: Props, context: Context) => {
-  // If there's a MathJaxContext as a parent, rely on it being
-  // available for the individual MathJax.Node
-  if (context && context.MathJaxContext) {
-    return <MathJax.Node>{props.data}</MathJax.Node>;
-  }
-
-  return (
-    <MathJax.Context input="tex">
-      <MathJax.Node>{props.data}</MathJax.Node>
-    </MathJax.Context>
-  );
+export const LaTeXDisplay = (props: Props) => {
+  return <MathJax.Node>{props.data}</MathJax.Node>;
 };
 
 LaTeXDisplay.MIMETYPE = "text/latex";
-
-LaTeXDisplay.contextTypes = {
-  // Opt in to updates to the MathJax object even though
-  // Not explicitly used
-  MathJax: PropTypes.object,
-  MathJaxContext: PropTypes.bool
-};
 
 export default LaTeXDisplay;


### PR DESCRIPTION
This switches us over to the new React 16 API for our mathjax components.

```jsx
var MathJax = require("@nteract/mathjax");

const tex = String.raw`f(x) = \int_{-\infty}^\infty
    \hat f(\xi)\,e^{2 \pi i \xi x}
    \,d\xi`;

<MathJax.Provider>
  <p>
    This is an inline math formula: <MathJax.Node inline>a = b</MathJax.Node>
    <span> and a block one:</span>
    <MathJax.Node>{tex}</MathJax.Node>
  </p>
</MathJax.Provider>;
```

What's left to do:

* [ ] Include tests
* [x] Update documentation
* [ ] Adapt all uses in the monorepo
* [ ] Clean up all TODOs left behind