### PR TITLE
React 16+ compliant @nteract/mathjax API

### DIFF
--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -1,4 +1,5 @@
 /* @flow strict */
+import * as path from "path";
 import * as React from "react";
 import ReactDOM from "react-dom";
 import { ipcRenderer as ipc, remote } from "electron";
@@ -70,6 +71,15 @@ const store = configureStore({
 // Register for debugging
 window.store = store;
 
+const mathJaxPath = path.join(
+  "..",
+  "node_modules",
+  "mathjax-electron",
+  "resources",
+  "MathJax",
+  "MathJax.js?config=electron"
+);
+
 initNativeHandlers(contentRef, store);
 initMenuHandlers(contentRef, store);
 initGlobalHandlers(contentRef, store);
@@ -88,8 +98,7 @@ export default class App extends React.PureComponent<{}, null> {
       <Provider store={store}>
         <React.Fragment>
           <Styles>
-            {/* TODO: Provide MathJax here with mathjax-electron */}
-            <MathJax.Provider input="tex">
+            <MathJax.Provider src={mathJaxPath} input="tex">
               <NotebookApp
                 // The desktop app always keeps the same contentRef in a browser window
                 contentRef={contentRef}

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -88,14 +88,15 @@ export default class App extends React.PureComponent<{}, null> {
       <Provider store={store}>
         <React.Fragment>
           <Styles>
-            <MathJax.Context input="tex">
+            {/* TODO: Provide MathJax here with mathjax-electron */}
+            <MathJax.Provider input="tex">
               <NotebookApp
                 // The desktop app always keeps the same contentRef in a browser window
                 contentRef={contentRef}
                 transforms={transforms}
                 displayOrder={displayOrder}
               />
-            </MathJax.Context>
+            </MathJax.Provider>
 
             <NotificationSystem
               ref={notificationSystem => {

--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -27,7 +27,6 @@
     "@nteract/editor": "^7.3.5",
     "@nteract/logos": "^0.1.3",
     "@nteract/markdown": "^2.1.4",
-    "@nteract/mathjax": "^2.1.4",
     "@nteract/messaging": "^4.1.4",
     "@nteract/octicons": "^0.4.3",
     "@nteract/presentational-components": "^0.4.3",

--- a/packages/markdown/__tests__/__snapshots__/index-spec.js.snap
+++ b/packages/markdown/__tests__/__snapshots__/index-spec.js.snap
@@ -19,17 +19,202 @@ volume of paint to be added, with a constraint only on the relative change in
 height between texels.
 "
 >
-  <Context
-    delay={0}
-    didFinishTypeset={null}
-    input="tex"
-    loader={null}
-    loading={null}
-    noGate={false}
-    onError={[Function]}
-    onLoad={null}
-    options={Object {}}
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
-  />
+  <ReactMarkdown
+    astPlugins={Array []}
+    escapeHtml={false}
+    plugins={
+      Array [
+        [Function],
+      ]
+    }
+    rawSourcePos={false}
+    renderers={
+      Object {
+        "inlineMath": [Function],
+        "math": [Function],
+      }
+    }
+    skipHtml={false}
+    source="
+# Watching Paint Dry
+
+The composited _color_ of the **paint** must not change during drying. The
+optical blending function is used with this constraint to compensate for the new
+dry layer $C_{d}^{prime}$, when some volume $delta_{alpha}$ is removed from
+the wet layer.
+
+$$
+C_{d}^{prime} = \\\\frac{alpha}{}
+$$
+
+The dry layer of the canvas uses a relative height field to allow for unlimited
+volume of paint to be added, with a constraint only on the relative change in
+height between texels.
+"
+    sourcePos={false}
+    transformLinkUri={[Function]}
+  >
+    <div
+      key="root-1-1"
+    >
+      <Heading
+        key="heading-2-1"
+        level={1}
+      >
+        <h1>
+          Watching Paint Dry
+        </h1>
+      </Heading>
+      <p
+        key="paragraph-4-1"
+      >
+        The composited 
+        <em
+          key="emphasis-4-16"
+        >
+          color
+        </em>
+         of the 
+        <strong
+          key="strong-4-31"
+        >
+          paint
+        </strong>
+         must not change during drying. The
+optical blending function is used with this constraint to compensate for the new
+dry layer 
+        <inlineMath
+          data={
+            Object {
+              "hChildren": Array [
+                Object {
+                  "type": "text",
+                  "value": "C_{d}^{prime}",
+                },
+              ],
+              "hName": "span",
+              "hProperties": Object {
+                "className": "inlineMath",
+              },
+            }
+          }
+          key="inlineMath-6-11"
+          value="C_{d}^{prime}"
+        >
+          <MathJaxNode
+            inline={true}
+            onRender={null}
+          >
+            <Provider
+              delay={0}
+              didFinishTypeset={null}
+              input="tex"
+              loading={null}
+              noGate={false}
+              onError={[Function]}
+              onLoad={null}
+              options={Object {}}
+              src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+            >
+              <MathJaxNode
+                inline={true}
+                onRender={null}
+              />
+            </Provider>
+          </MathJaxNode>
+        </inlineMath>
+        , when some volume 
+        <inlineMath
+          data={
+            Object {
+              "hChildren": Array [
+                Object {
+                  "type": "text",
+                  "value": "delta_{alpha}",
+                },
+              ],
+              "hName": "span",
+              "hProperties": Object {
+                "className": "inlineMath",
+              },
+            }
+          }
+          key="inlineMath-6-45"
+          value="delta_{alpha}"
+        >
+          <MathJaxNode
+            inline={true}
+            onRender={null}
+          >
+            <Provider
+              delay={0}
+              didFinishTypeset={null}
+              input="tex"
+              loading={null}
+              noGate={false}
+              onError={[Function]}
+              onLoad={null}
+              options={Object {}}
+              src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+            >
+              <MathJaxNode
+                inline={true}
+                onRender={null}
+              />
+            </Provider>
+          </MathJaxNode>
+        </inlineMath>
+         is removed from
+the wet layer.
+      </p>
+      <math
+        data={
+          Object {
+            "hChildren": Array [
+              Object {
+                "type": "text",
+                "value": "C_{d}^{prime} = \\\\frac{alpha}{}",
+              },
+            ],
+            "hName": "div",
+            "hProperties": Object {
+              "className": "math",
+            },
+          }
+        }
+        key="math-9-1"
+        value="C_{d}^{prime} = \\\\frac{alpha}{}"
+      >
+        <MathJaxNode
+          inline={false}
+          onRender={null}
+        >
+          <Provider
+            delay={0}
+            didFinishTypeset={null}
+            input="tex"
+            loading={null}
+            noGate={false}
+            onError={[Function]}
+            onLoad={null}
+            options={Object {}}
+            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+          >
+            <MathJaxNode
+              inline={false}
+              onRender={null}
+            />
+          </Provider>
+        </MathJaxNode>
+      </math>
+      <p
+        key="paragraph-13-1"
+      >
+        The dry layer of the canvas uses a relative height field to allow for unlimited
+volume of paint to be added, with a constraint only on the relative change in
+height between texels.
+      </p>
+    </div>
+  </ReactMarkdown>
 </MarkdownRender>
 `;

--- a/packages/markdown/src/index.js
+++ b/packages/markdown/src/index.js
@@ -14,10 +14,7 @@ const inlineMath = (props: { value: string }) => (
   <MathJax.Node inline>{props.value}</MathJax.Node>
 );
 
-const MarkdownRender = (
-  props: ReactMarkdown.ReactMarkdownProps,
-  context: { MathJaxContext?: boolean }
-) => {
+const MarkdownRender = (props: ReactMarkdown.ReactMarkdownProps) => {
   const newProps = {
     // https://github.com/rexxars/react-markdown#options
     ...props,
@@ -30,23 +27,7 @@ const MarkdownRender = (
     }
   };
 
-  // Render a Context if one was not passed as a parent
-  if (!context.MathJaxContext) {
-    return (
-      <MathJax.Context input="tex">
-        <ReactMarkdown {...newProps} />
-      </MathJax.Context>
-    );
-  }
-
   return <ReactMarkdown {...newProps} />;
-};
-
-MarkdownRender.contextTypes = {
-  // Opt in to updates to the MathJax object even though
-  // Not explicitly used
-  MathJax: PropTypes.object,
-  MathJaxContext: PropTypes.bool
 };
 
 export default MarkdownRender;

--- a/packages/mathjax/__tests__/__snapshots__/index-spec.js.snap
+++ b/packages/mathjax/__tests__/__snapshots__/index-spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MathJax Node can be renderered without provider: nodejs 1`] = `
+exports[`MathJax Node can be renderered without provider 1`] = `
 <MathJaxNode
   inline={false}
   onRender={null}
@@ -24,7 +24,7 @@ exports[`MathJax Node can be renderered without provider: nodejs 1`] = `
 </MathJaxNode>
 `;
 
-exports[`MathJax Nodes use existing provider: nodejs 1`] = `
+exports[`MathJax Nodes use existing provider 1`] = `
 <Provider
   delay={0}
   didFinishTypeset={null}

--- a/packages/mathjax/__tests__/__snapshots__/index-spec.js.snap
+++ b/packages/mathjax/__tests__/__snapshots__/index-spec.js.snap
@@ -34,7 +34,7 @@ exports[`MathJax Nodes use existing provider 1`] = `
   onError={[Function]}
   onLoad={null}
   options={Object {}}
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+  src="script-src"
 >
   <MathJaxNode
     inline={false}

--- a/packages/mathjax/__tests__/__snapshots__/index-spec.js.snap
+++ b/packages/mathjax/__tests__/__snapshots__/index-spec.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MathJax Node can be renderered without provider: nodejs 1`] = `
+<MathJaxNode
+  inline={false}
+  onRender={null}
+>
+  <Provider
+    delay={0}
+    didFinishTypeset={null}
+    input="tex"
+    loading={null}
+    noGate={false}
+    onError={[Function]}
+    onLoad={null}
+    options={Object {}}
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+  >
+    <MathJaxNode
+      inline={false}
+      onRender={null}
+    />
+  </Provider>
+</MathJaxNode>
+`;
+
+exports[`MathJax Nodes use existing provider: nodejs 1`] = `
+<Provider
+  delay={0}
+  didFinishTypeset={null}
+  input="tex"
+  loading={null}
+  noGate={false}
+  onError={[Function]}
+  onLoad={null}
+  options={Object {}}
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+>
+  <MathJaxNode
+    inline={false}
+    onRender={null}
+  />
+  <MathJaxNode
+    inline={false}
+    onRender={null}
+  />
+</Provider>
+`;

--- a/packages/mathjax/__tests__/__snapshots__/load-script-spec.js.snap
+++ b/packages/mathjax/__tests__/__snapshots__/load-script-spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Load script 1`] = `<head />`;
+
+exports[`Load script 2`] = `
+<head>
+  <script
+    charset="utf8"
+    src="script-path"
+    type="text/javascript"
+  />
+</head>
+`;

--- a/packages/mathjax/__tests__/index-spec.js
+++ b/packages/mathjax/__tests__/index-spec.js
@@ -1,0 +1,27 @@
+// @flow
+
+import * as React from "react";
+import { Node, Provider } from "../src";
+import renderer from "react-test-renderer";
+
+import toJson from "enzyme-to-json";
+
+import Enzyme, { shallow, mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+describe("MathJax", () => {
+  test("Node can be renderered without provider", () => {
+    const wrapper = mount(<Node>x^2 + y = 3</Node>);
+    expect(toJson(wrapper)).toMatchSnapshot(name);
+  });
+
+  test("Nodes use existing provider", () => {
+    const wrapper = mount(
+      <Provider>
+        <Node>x^2 + y = 3</Node>
+        <Node>x^3 + y = 2</Node>
+      </Provider>
+    );
+    expect(toJson(wrapper)).toMatchSnapshot(name);
+  });
+});

--- a/packages/mathjax/__tests__/index-spec.js
+++ b/packages/mathjax/__tests__/index-spec.js
@@ -1,22 +1,31 @@
 import * as React from "react";
-import { Node, Provider } from "../src";
-
+import Enzyme, { mount } from "enzyme";
 import toJson from "enzyme-to-json";
 
-import Enzyme, { mount } from "enzyme";
+jest.mock("../src/load-script");
+import loadScript from "../src/load-script";
+import { Node, Provider } from "../src";
 
 describe("MathJax", () => {
   test("Node can be renderered without provider", () => {
     const wrapper = mount(<Node>x^2 + y = 3</Node>);
+    expect(loadScript).toHaveBeenLastCalledWith(
+      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML",
+      expect.any(Function)
+    );
     expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   test("Nodes use existing provider", () => {
     const wrapper = mount(
-      <Provider>
+      <Provider src="script-src">
         <Node>x^2 + y = 3</Node>
         <Node>x^3 + y = 2</Node>
       </Provider>
+    );
+    expect(loadScript).toHaveBeenLastCalledWith(
+      "script-src",
+      expect.any(Function)
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/packages/mathjax/__tests__/index-spec.js
+++ b/packages/mathjax/__tests__/index-spec.js
@@ -1,18 +1,14 @@
-// @flow
-
 import * as React from "react";
 import { Node, Provider } from "../src";
-import renderer from "react-test-renderer";
 
 import toJson from "enzyme-to-json";
 
-import Enzyme, { shallow, mount } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
+import Enzyme, { mount } from "enzyme";
 
 describe("MathJax", () => {
   test("Node can be renderered without provider", () => {
     const wrapper = mount(<Node>x^2 + y = 3</Node>);
-    expect(toJson(wrapper)).toMatchSnapshot(name);
+    expect(toJson(wrapper)).toMatchSnapshot();
   });
 
   test("Nodes use existing provider", () => {
@@ -22,6 +18,6 @@ describe("MathJax", () => {
         <Node>x^3 + y = 2</Node>
       </Provider>
     );
-    expect(toJson(wrapper)).toMatchSnapshot(name);
+    expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/packages/mathjax/__tests__/load-script-spec.js
+++ b/packages/mathjax/__tests__/load-script-spec.js
@@ -1,0 +1,7 @@
+import load from "../src/load-script";
+
+test("Load script", () => {
+  expect(document.head).toMatchSnapshot();
+  load("script-path");
+  expect(document.head).toMatchSnapshot();
+});

--- a/packages/mathjax/examples.md
+++ b/packages/mathjax/examples.md
@@ -1,3 +1,5 @@
+The MathJax component provides a way to both load MathJax on the page and render MathJax Nodes. Many people love ❤️ beautifully typeset mathematics, and these components are the way to provide it.
+
 ```jsx
 var MathJax = require(".");
 
@@ -14,7 +16,9 @@ const tex = String.raw`f(x) = \int_{-\infty}^\infty
 </MathJax.Provider>;
 ```
 
-What happens if you use a consumer and have no provider???
+The components are written in a React 16+ way to both load mathjax through a `<Provider />` and render individual MathJax nodes with `<MathJax.Node />`. React does the heavy lifting of knowing what changed and the `<MathJax.Node>` component triggers having MathJax do what it's good at -- typesetting mathematics!
+
+If you use `<MathJax.Node />` with no provider, a `<MathJax.Provider />` is created for you automatically.
 
 ```jsx
 var MathJax = require(".");

--- a/packages/mathjax/examples.md
+++ b/packages/mathjax/examples.md
@@ -5,11 +5,19 @@ const tex = String.raw`f(x) = \int_{-\infty}^\infty
     \hat f(\xi)\,e^{2 \pi i \xi x}
     \,d\xi`;
 
-<MathJax.Context>
+<MathJax.Provider>
   <p>
     This is an inline math formula: <MathJax.Node inline>a = b</MathJax.Node>
     <span> and a block one:</span>
     <MathJax.Node>{tex}</MathJax.Node>
   </p>
-</MathJax.Context>;
+</MathJax.Provider>;
+```
+
+What happens if you use a consumer and have no provider???
+
+```jsx
+var MathJax = require(".");
+
+<MathJax.Node>a = b</MathJax.Node>;
 ```

--- a/packages/mathjax/examples.md
+++ b/packages/mathjax/examples.md
@@ -16,7 +16,72 @@ const tex = String.raw`f(x) = \int_{-\infty}^\infty
 </MathJax.Provider>;
 ```
 
-The components are written in a React 16+ way to both load mathjax through a `<Provider />` and render individual MathJax nodes with `<MathJax.Node />`. React does the heavy lifting of knowing what changed and the `<MathJax.Node>` component triggers having MathJax do what it's good at -- typesetting mathematics!
+The components are written in a React 16+ way to both load mathjax through a `<Provider />` and render individual MathJax nodes with `<MathJax.Node />`. React does the heavy lifting of knowing what changed and the `<MathJax.Node>` component triggers having MathJax do what it's good at — _typesetting mathematics_!
+
+This semi-contrived example shows
+
+```jsx
+var MathJax = require(".");
+
+const verbs = ["do", "can", "should", "will"];
+
+class CleanUpdates extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      exponent: 1,
+      verb: "can"
+    };
+  }
+
+  componentDidMount() {
+    this.intervals = [
+      setInterval(() => {
+        this.setState(state => ({
+          exponent: (state.exponent + 1) % 10
+        }));
+      }, 3001), // Prime
+
+      setInterval(() => {
+        this.setState(state => ({
+          verb: verbs[Math.floor(Math.random() * verbs.length)]
+        }));
+      }, 557) // Also prime
+    ];
+  }
+
+  componentWillUnmount() {
+    this.intervals.map(id => clearInterval(id));
+  }
+
+  render() {
+    return (
+      <MathJax.Provider options={{ messageStyle: "none" }}>
+        <p>
+          We{" "}
+          <span
+            style={{
+              backgroundColor: "#7ee77e",
+              padding: "5px",
+              margin: "5px",
+              width: "42px",
+              display: "inline-block",
+              textAlign: "center"
+            }}
+          >
+            {this.state.verb}
+          </span>{" "}
+          update
+          <MathJax.Node inline>{"n^" + this.state.exponent}</MathJax.Node> pieces
+          of a paragraph without triggering a MathJax re-render.
+        </p>
+      </MathJax.Provider>
+    );
+  }
+}
+
+<CleanUpdates />;
+```
 
 If you use `<MathJax.Node />` with no provider, a `<MathJax.Provider />` is created for you automatically.
 

--- a/packages/mathjax/src/context.js
+++ b/packages/mathjax/src/context.js
@@ -1,150 +1,31 @@
-// @flow strict
-/* global MathJax */
-
+/* @flow strict */
 import * as React from "react";
-import PropTypes from "prop-types";
-import loadScript from "./load-script";
 
-// MathJax expected to be a global and may be undefined
-declare var MathJax: ?{
+export type MathJaxObject = {
   Hub: {
+    getJaxFor: HTMLElement => void,
     Config: (options: *) => void,
     Register: {
       StartupHook: (str: string, cb: () => void) => void,
       MessageHook: (string, cb: (msg: string) => void) => void
     },
+    Reprocess: (HTMLElement, cb: *) => *,
+    Queue: (*) => void,
     processSectionDelay: number
   }
 };
 
-declare type onLoad = () => void;
-type Props = {
-  src: ?string,
-  children: React.Node,
-  didFinishTypeset: ?() => void,
-  // Provide a way to override how we load MathJax and callback to the onLoad
-  // For Hydrogen, for instance we can set
-  //
-  //  loader={(onLoad) => loadMathJax(document, onLoad)}
-  //
-  onLoad: ?onLoad,
-  loader: ?(cb: onLoad) => void,
-  input: "ascii" | "tex",
-  delay: number,
-  options: ?*,
-  loading: React.Node,
-  noGate: boolean,
-  onError: (err: Error) => void
+export type MathJaxContextValue = {
+  MathJax: ?MathJaxObject,
+  input: "tex" | "ascii",
+  // Allow detecting if there's a <Provider> above a <Consumer>
+  hasProviderAbove: ?boolean
 };
 
-type State = {
-  loaded: boolean
-};
+const MathJaxContext: React.Context<MathJaxContextValue> = React.createContext({
+  MathJax: null,
+  input: "tex",
+  hasProviderAbove: null
+});
 
-/**
- * Context for loading MathJax
- */
-class Context extends React.Component<Props, State> {
-  static defaultProps = {
-    src:
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML",
-    input: "tex",
-    didFinishTypeset: null,
-    loader: null,
-    delay: 0,
-    options: {},
-    loading: null,
-    noGate: false,
-    onLoad: null,
-    onError: (err: Error) => {
-      console.error(err);
-    }
-  };
-
-  constructor(props: Props) {
-    super(props);
-    this.state = { loaded: false };
-  }
-
-  getChildContext() {
-    return {
-      // Here we see if MathJax is defined globally by running a typeof on a
-      // potentially not set value then explicitly setting the MathJax context
-      // to undefined.
-      MathJax: typeof MathJax === "undefined" ? undefined : MathJax,
-      input: this.props.input,
-      MathJaxContext: true
-    };
-  }
-
-  componentDidMount() {
-    const src = this.props.src;
-
-    if (src == null) {
-      return this.onLoad();
-    }
-
-    if (!this.props.loader) {
-      loadScript(src, this.onLoad);
-    } else {
-      this.props.loader(this.onLoad);
-    }
-  }
-
-  onLoad = () => {
-    if (!MathJax || !MathJax.Hub) {
-      this.props.onError(
-        new Error("MathJax not really loaded even though onLoad called")
-      );
-      return;
-    }
-
-    const options = this.props.options;
-
-    MathJax.Hub.Config(options);
-
-    MathJax.Hub.Register.StartupHook("End", () => {
-      if (!MathJax) {
-        this.props.onError(
-          new Error("MathJax became undefined in the middle of processing")
-        );
-        return;
-      }
-      MathJax.Hub.processSectionDelay = this.props.delay;
-
-      if (this.props.didFinishTypeset) {
-        this.props.didFinishTypeset();
-      }
-    });
-
-    MathJax.Hub.Register.MessageHook("Math Processing Error", message => {
-      if (this.props.onError) {
-        this.props.onError(new Error(message));
-      }
-    });
-
-    if (this.props.onLoad) {
-      this.props.onLoad();
-    }
-
-    this.setState({
-      loaded: true
-    });
-  };
-
-  render() {
-    if (!this.state.loaded && !this.props.noGate) {
-      return this.props.loading;
-    }
-
-    return this.props.children;
-  }
-}
-
-Context.childContextTypes = {
-  MathJax: PropTypes.object,
-  input: PropTypes.string,
-  MathJaxContext: PropTypes.bool
-};
-
-export default Context;
+export default MathJaxContext;

--- a/packages/mathjax/src/index.js
+++ b/packages/mathjax/src/index.js
@@ -2,6 +2,7 @@
 
 import Node from "./node";
 import Context from "./context";
+import Provider from "./provider";
 
-export { Node, Context };
-export default { Node, Context };
+export { Node, Provider, Context };
+export default { Node, Provider, Context };

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -98,10 +98,9 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
 
     if (forceUpdate || !this.script) {
       this.setScriptText(text);
-      if (!this.script) {
-        return;
-      }
     }
+
+    if (!this.script) return;
 
     MathJax.Hub.Queue(MathJax.Hub.Reprocess(this.script, this.props.onRender));
   }

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -7,22 +7,24 @@ const types = {
   tex: "tex"
 };
 
+import MathJaxContext, {
+  type MathJaxObject,
+  type MathJaxContextValue
+} from "./context";
+
+import Provider from "./provider";
+
 type Props = {
   inline: boolean,
   children: string,
   onRender: ?Function
 };
 
-class Node extends React.Component<Props, *> {
+class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
   script: ?HTMLScriptElement;
   nodeRef: React.ElementRef<*>;
 
-  static defaultProps = {
-    inline: false,
-    onRender: null
-  };
-
-  constructor(props: Props) {
+  constructor(props: Props & MathJaxContextValue) {
     super(props);
 
     this.nodeRef = React.createRef();
@@ -40,21 +42,11 @@ class Node extends React.Component<Props, *> {
   /**
    * Update the jax, force update if the display mode changed
    */
-  componentDidUpdate(prevProps: Props) {
+  componentDidUpdate(prevProps: Props & MathJaxContextValue) {
     const forceUpdate =
       prevProps.inline !== this.props.inline ||
       prevProps.children !== this.props.children;
     this.typeset(forceUpdate);
-  }
-
-  /**
-   * Prevent update when the source has not changed
-   */
-  shouldComponentUpdate(nextProps: Props, nextState: *, nextContext: *) {
-    return (
-      nextProps.children !== this.props.children ||
-      nextProps.inline !== this.props.inline
-    );
   }
 
   /**
@@ -68,7 +60,11 @@ class Node extends React.Component<Props, *> {
    * Clear the jax
    */
   clear() {
-    const MathJax = this.context.MathJax;
+    const MathJax = this.props.MathJax;
+
+    if (!MathJax) {
+      return;
+    }
 
     if (!this.script) {
       return;
@@ -86,11 +82,11 @@ class Node extends React.Component<Props, *> {
    * @param { Boolean } forceUpdate
    */
   typeset(forceUpdate: boolean = false) {
-    const { MathJax } = this.context;
+    const { MathJax } = this.props;
 
-    if (!MathJax) {
+    if (!MathJax || !MathJax.Hub) {
       throw Error(
-        "Could not find MathJax while attempting typeset! It's likely the MathJax script hasn't been loaded or MathJax.Context is not in the hierarchy"
+        "Could not find MathJax while attempting typeset! It's likely the MathJax script hasn't been loaded or MathJax.Context is not in the hierarchy."
       );
     }
 
@@ -102,6 +98,9 @@ class Node extends React.Component<Props, *> {
 
     if (forceUpdate || !this.script) {
       this.setScriptText(text);
+      if (!this.script) {
+        return;
+      }
     }
 
     MathJax.Hub.Queue(MathJax.Hub.Reprocess(this.script, this.props.onRender));
@@ -113,7 +112,7 @@ class Node extends React.Component<Props, *> {
    */
   setScriptText(text: *) {
     const inline = this.props.inline;
-    const type = types[this.context.input];
+    const type = types[this.props.input];
     if (!this.script) {
       this.script = document.createElement("script");
       this.script.type = `math/${type}; ${inline ? "" : "mode=display"}`;
@@ -139,8 +138,44 @@ class Node extends React.Component<Props, *> {
   }
 }
 
-Node.contextTypes = {
-  MathJax: PropTypes.object,
-  input: PropTypes.string
-};
-export default Node;
+class MathJaxNode extends React.PureComponent<Props, null> {
+  static defaultProps = {
+    inline: false,
+    onRender: null
+  };
+
+  render() {
+    return (
+      <MathJaxContext.Consumer>
+        {({ MathJax, input, hasProviderAbove }: MathJaxContextValue) => {
+          // If there is no <Provider /> in the above tree, create our own
+          if (!hasProviderAbove) {
+            return (
+              <Provider>
+                <MathJaxNode {...this.props} />
+              </Provider>
+            );
+          }
+
+          if (!MathJax) {
+            return null;
+          }
+
+          return (
+            <MathJaxNode_
+              inline={this.props.inline}
+              onRender={this.props.onRender}
+              input={input}
+              MathJax={MathJax}
+              hasProviderAbove={hasProviderAbove}
+            >
+              {this.props.children}
+            </MathJaxNode_>
+          );
+        }}
+      </MathJaxContext.Consumer>
+    );
+  }
+}
+
+export default MathJaxNode;

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -63,8 +63,10 @@ class Provider extends React.Component<Props, State> {
     if (src == null) {
       return this.onLoad();
     }
-
-    loadScript(src, this.onLoad);
+    if (typeof MathJax === "undefined" || !MathJax || !MathJax.Hub) {
+      return loadScript(src, this.onLoad);
+    }
+    this.onLoad();
   }
 
   onLoad = () => {

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -12,18 +12,11 @@ import MathJaxContext, {
 // MathJax expected to be a global and may be undefined
 declare var MathJax: ?MathJaxObject;
 
-declare type onLoad = () => void;
 type Props = {
   src: ?string,
   children: React.Node,
   didFinishTypeset: ?() => void,
-  // Provide a way to override how we load MathJax and callback to the onLoad
-  // For Hydrogen, for instance we can set
-  //
-  //  loader={(onLoad) => loadMathJax(document, onLoad)}
-  //
-  onLoad: ?onLoad,
-  loader: ?(cb: onLoad) => void,
+  onLoad: ?() => void,
   input: "ascii" | "tex",
   delay: number,
   options: ?*,
@@ -43,7 +36,6 @@ class Provider extends React.Component<Props, State> {
       "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML",
     input: "tex",
     didFinishTypeset: null,
-    loader: null,
     delay: 0,
     options: {},
     loading: null,
@@ -72,11 +64,7 @@ class Provider extends React.Component<Props, State> {
       return this.onLoad();
     }
 
-    if (!this.props.loader) {
-      loadScript(src, this.onLoad);
-    } else {
-      this.props.loader(this.onLoad);
-    }
+    loadScript(src, this.onLoad);
   }
 
   onLoad = () => {

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -1,0 +1,132 @@
+// @flow strict
+/* global MathJax */
+
+import * as React from "react";
+import loadScript from "./load-script";
+
+import MathJaxContext, {
+  type MathJaxObject,
+  type MathJaxContextValue
+} from "./context.js";
+
+// MathJax expected to be a global and may be undefined
+declare var MathJax: ?MathJaxObject;
+
+declare type onLoad = () => void;
+type Props = {
+  src: ?string,
+  children: React.Node,
+  didFinishTypeset: ?() => void,
+  // Provide a way to override how we load MathJax and callback to the onLoad
+  // For Hydrogen, for instance we can set
+  //
+  //  loader={(onLoad) => loadMathJax(document, onLoad)}
+  //
+  onLoad: ?onLoad,
+  loader: ?(cb: onLoad) => void,
+  input: "ascii" | "tex",
+  delay: number,
+  options: ?*,
+  loading: React.Node,
+  noGate: boolean,
+  onError: (err: Error) => void
+};
+
+type State = MathJaxContextValue;
+
+/**
+ * MathJax Provider
+ */
+class Provider extends React.Component<Props, State> {
+  static defaultProps = {
+    src:
+      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML",
+    input: "tex",
+    didFinishTypeset: null,
+    loader: null,
+    delay: 0,
+    options: {},
+    loading: null,
+    noGate: false,
+    onLoad: null,
+    onError: (err: Error) => {
+      console.error(err);
+    }
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      MathJax: undefined,
+      // TODO: Ensure state gets updated when the input prop changes
+      input: this.props.input,
+      hasProviderAbove: true
+    };
+  }
+
+  componentDidMount() {
+    const src = this.props.src;
+
+    if (src == null) {
+      return this.onLoad();
+    }
+
+    if (!this.props.loader) {
+      loadScript(src, this.onLoad);
+    } else {
+      this.props.loader(this.onLoad);
+    }
+  }
+
+  onLoad = () => {
+    if (!MathJax || !MathJax.Hub) {
+      this.props.onError(
+        new Error("MathJax not really loaded even though onLoad called")
+      );
+      return;
+    }
+
+    const options = this.props.options;
+
+    MathJax.Hub.Config(options);
+
+    MathJax.Hub.Register.StartupHook("End", () => {
+      if (!MathJax) {
+        this.props.onError(
+          new Error("MathJax became undefined in the middle of processing")
+        );
+        return;
+      }
+      MathJax.Hub.processSectionDelay = this.props.delay;
+
+      if (this.props.didFinishTypeset) {
+        this.props.didFinishTypeset();
+      }
+    });
+
+    MathJax.Hub.Register.MessageHook("Math Processing Error", message => {
+      if (this.props.onError) {
+        this.props.onError(new Error(message));
+      }
+    });
+
+    if (this.props.onLoad) {
+      this.props.onLoad();
+    }
+
+    this.setState({
+      MathJax
+    });
+  };
+
+  render() {
+    return (
+      <MathJaxContext.Provider value={this.state}>
+        {this.props.children}
+      </MathJaxContext.Provider>
+    );
+  }
+}
+
+export default Provider;

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -68,7 +68,7 @@ class Provider extends React.Component<Props, State> {
   }
 
   onLoad = () => {
-    if (!MathJax || !MathJax.Hub) {
+    if (typeof MathJax === "undefined" || !MathJax || !MathJax.Hub) {
       this.props.onError(
         new Error("MathJax not really loaded even though onLoad called")
       );
@@ -80,7 +80,7 @@ class Provider extends React.Component<Props, State> {
     MathJax.Hub.Config(options);
 
     MathJax.Hub.Register.StartupHook("End", () => {
-      if (!MathJax) {
+      if (typeof MathJax === "undefined" || !MathJax) {
         this.props.onError(
           new Error("MathJax became undefined in the middle of processing")
         );

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -51,10 +51,16 @@ class Provider extends React.Component<Props, State> {
 
     this.state = {
       MathJax: undefined,
-      // TODO: Ensure state gets updated when the input prop changes
       input: this.props.input,
       hasProviderAbove: true
     };
+  }
+
+  static getDerivedStateFromProps(props: Props, state: State) {
+    if (state.input !== props.input) {
+      return { ...state, input: props.input };
+    }
+    return null;
   }
 
   componentDidMount() {

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -27,7 +27,6 @@
     "@nteract/dropdown-menu": "^0.5.5",
     "@nteract/editor": "^7.3.5",
     "@nteract/markdown": "^2.1.4",
-    "@nteract/mathjax": "^2.1.4",
     "@nteract/messaging": "^4.1.4",
     "@nteract/octicons": "^0.4.3",
     "@nteract/presentational-components": "^0.4.3",

--- a/packages/notebook-app-component/src/notebook-app.js
+++ b/packages/notebook-app-component/src/notebook-app.js
@@ -28,7 +28,6 @@ import { DragDropContext as dragDropContext } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 import { connect } from "react-redux";
 
-import MathJax from "@nteract/mathjax";
 import { RichestMime, Output } from "@nteract/display-area";
 import {
   displayOrder as defaultDisplayOrder,

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -1,11 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Notebook accepts an Immutable.List of cells 1`] = `
-<Context
+<Provider
   delay={0}
   didFinishTypeset={null}
   input="tex"
-  loader={null}
   loading={null}
   noGate={false}
   onError={[Function]}
@@ -245,15 +244,14 @@ print('hey')
         
     </style>
   </div>
-</Context>
+</Provider>
 `;
 
 exports[`Notebook accepts an Object of cells 1`] = `
-<Context
+<Provider
   delay={0}
   didFinishTypeset={null}
   input="tex"
-  loader={null}
   loading={null}
   noGate={false}
   onError={[Function]}
@@ -493,5 +491,5 @@ print('hey')
         
     </style>
   </div>
-</Context>
+</Provider>
 `;

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -87,7 +87,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
     const cellMap = notebook.get("cellMap");
 
     return (
-      <MathJax.Context>
+      <MathJax.Provider>
         <div className="notebook-preview">
           <Cells>
             {cellOrder.map(cellID => {
@@ -197,7 +197,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
           }
         `}</style>
         </div>
-      </MathJax.Context>
+      </MathJax.Provider>
     );
   }
 }

--- a/packages/transforms/__tests__/__snapshots__/latex-spec.js.snap
+++ b/packages/transforms/__tests__/__snapshots__/latex-spec.js.snap
@@ -1,23 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LaTeXDisplay processes basic LaTeX 1`] = `
-<Context
-  delay={0}
-  didFinishTypeset={null}
-  input="tex"
-  loader={null}
-  loading={null}
-  noGate={false}
-  onError={[Function]}
-  onLoad={null}
-  options={Object {}}
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+<MathJaxNode
+  inline={false}
+  onRender={null}
 >
-  <Node
-    inline={false}
-    onRender={null}
-  >
-    x^2 + y = 3
-  </Node>
-</Context>
+  x^2 + y = 3
+</MathJaxNode>
 `;

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -8,32 +8,10 @@ type Props = {
   data: string
 };
 
-type Context = {
-  MathJax?: Object,
-  MathJaxContext?: boolean
-};
-
-export const LaTeXDisplay = (props: Props, context: Context) => {
-  // If there's a MathJaxContext as a parent, rely on it being
-  // available for the individual MathJax.Node
-  if (context && context.MathJaxContext) {
-    return <MathJax.Node>{props.data}</MathJax.Node>;
-  }
-
-  return (
-    <MathJax.Context input="tex">
-      <MathJax.Node>{props.data}</MathJax.Node>
-    </MathJax.Context>
-  );
+export const LaTeXDisplay = (props: Props) => {
+  return <MathJax.Node>{props.data}</MathJax.Node>;
 };
 
 LaTeXDisplay.MIMETYPE = "text/latex";
-
-LaTeXDisplay.contextTypes = {
-  // Opt in to updates to the MathJax object even though
-  // Not explicitly used
-  MathJax: PropTypes.object,
-  MathJaxContext: PropTypes.bool
-};
 
 export default LaTeXDisplay;


### PR DESCRIPTION
This switches us over to the new React 16 API for our mathjax components.

```jsx
var MathJax = require("@nteract/mathjax");

const tex = String.raw`f(x) = \int_{-\infty}^\infty
    \hat f(\xi)\,e^{2 \pi i \xi x}
    \,d\xi`;

<MathJax.Provider>
  <p>
    This is an inline math formula: <MathJax.Node inline>a = b</MathJax.Node>
    <span> and a block one:</span>
    <MathJax.Node>{tex}</MathJax.Node>
  </p>
</MathJax.Provider>;
```

What's left to do:

* [x] Include tests
* [x] Update documentation
* [x] Adapt all uses in the monorepo
* [x] Clean up all TODOs left behind