### PR TITLE
Send kernel shutdown messages when closing desktop notebook windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ packages/*/yarn.lock
 packages/styles/src/index.js
 
 styleguide
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ This progressive webpack build will keep rebuilding as you modify the source
 code. When you open a new notebook, you'll get the fresh, up-to-date copy of
 the notebook app.
 
+#### Logging
+
+`console.log` statements in the main Electron process are piped to stdout.
+`console.log` statements in the Electron renderer process go to the
+regular Dev Tools console (accessible from the View menu). Set
+ELECTRON_ENABLE_LOGGING=1 to pipe renderer `console.log` to the launching
+terminal as well. This is useful for debugging crashes and notebook closing
+behaviors.
+
 ### Hacking on `play`
 
 Run:

--- a/applications/desktop/__tests__/renderer/epics/close-notebook-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/close-notebook-spec.js
@@ -1,0 +1,283 @@
+/* @flow strict */
+
+import * as actions from "../../../src/notebook/actions";
+
+import {
+  makeDesktopNotebookRecord,
+  DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
+  DESKTOP_NOTEBOOK_CLOSING_STARTED,
+  DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+} from "../../../src/notebook/state.js";
+
+import { closeNotebookEpic } from "../../../src/notebook/epics/close-notebook";
+
+import {
+  actions as coreActions,
+  actionTypes as coreActionTypes,
+  createContentRef,
+  makeDocumentRecord,
+  makeNotebookContentRecord,
+  state as stateModule
+} from "@nteract/core";
+
+import * as Immutable from "immutable";
+
+import { Observable } from "rxjs/Observable";
+import { of } from "rxjs/observable/of";
+import { toArray, catchError, map } from "rxjs/operators";
+
+import { ActionsObservable, combineEpics, ofType } from "redux-observable";
+
+import { ipcRenderer as ipc } from "../../../__mocks__/electron";
+
+import { TestScheduler } from "rxjs/testing/TestScheduler";
+
+const buildScheduler = () =>
+  new TestScheduler((actual, expected) => expect(actual).toEqual(expected));
+
+const buildStore = (dirty: boolean = false) => {
+  return {
+    dispatch: jest.fn(),
+    getState: () => ({
+      core: {
+        entities: {
+          contents: {
+            byRef: Immutable.Map({
+              contentRef1: makeNotebookContentRecord({
+                model: makeDocumentRecord({
+                  notebook: "content",
+                  savedNotebook: dirty ? "content-MODIFIED" : "content"
+                })
+              })
+            })
+          },
+          kernels: {
+            byRef: Immutable.Map({
+              kernelRef1: stateModule.makeRemoteKernelRecord({
+                type: "zeromq"
+              }),
+              kernelRef2: stateModule.makeRemoteKernelRecord({
+                type: "not-zeromq"
+              })
+            })
+          }
+        }
+      }
+    })
+  };
+};
+
+describe("closeNotebookEpic", () => {
+  describe("when notebook is dirty, prompts user to abort", () => {
+    test("and allows continuing", async () => {
+      var registeredCallback;
+      ipc.once = (event, callback) => {
+        if (event == "show-message-box-response") registeredCallback = callback;
+      };
+      ipc.send = (event, data) => {
+        expect(event).toBe("show-message-box");
+        expect(data.message).toEqual(
+          "Unsaved data will be lost. Are you sure you want to quit?"
+        );
+
+        // "Yes"
+        registeredCallback("dummy-event", 0);
+      };
+
+      const store = buildStore(true);
+      const responses = await closeNotebookEpic(
+        ActionsObservable.of(
+          actions.closeNotebook({ contentRef: "contentRef1" })
+        ),
+        store
+      )
+        .pipe(toArray())
+        .toPromise();
+
+      expect(responses).toEqual([
+        coreActions.killKernel({ kernelRef: "kernelRef1", restarting: false }),
+        actions.closeNotebookProgress({
+          newState: DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+        })
+      ]);
+    });
+
+    test("and allows aborting, triggering IPC close-notebook-canceled for app-wide quit orchestration", async () => {
+      var registeredCallback;
+      ipc.once = (event, callback) => {
+        if (event == "show-message-box-response") registeredCallback = callback;
+      };
+      ipc.send = (event, data) => {
+        expect(event).toBe("show-message-box");
+        expect(data.message).toEqual(
+          "Unsaved data will be lost. Are you sure you want to quit?"
+        );
+
+        // Next expected message:
+        ipc.send = (event, data) => {
+          expect(event).toBe("close-notebook-canceled");
+        };
+
+        // "No"
+        registeredCallback("dummy-event", 1);
+      };
+
+      const store = buildStore(true);
+      const responses = await closeNotebookEpic(
+        ActionsObservable.of(
+          actions.closeNotebook({ contentRef: "contentRef1" })
+        ),
+        store
+      )
+        .pipe(toArray())
+        .toPromise();
+
+      // Closing state reset back to starting value
+      expect(responses).toEqual([
+        actions.closeNotebookProgress({
+          newState: DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED
+        })
+      ]);
+    });
+  });
+
+  describe("kill kernels", () => {
+    test("promptly continue when KILL_KERNEL is successful", async () => {
+      const store = buildStore(false);
+
+      const testScheduler = buildScheduler();
+
+      const inputActions = {
+        a: actions.closeNotebook({ contentRef: "contentRef1" }),
+        b: coreActions.killKernelSuccessful({ kernelRef: "kernelRef1" })
+      };
+
+      const outputActions = {
+        c: coreActions.killKernel({
+          kernelRef: "kernelRef1",
+          restarting: false
+        }),
+        d: actions.closeNotebookProgress({
+          newState: DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+        })
+      };
+
+      const inputMarbles = "a b";
+      const outputMarbles = "c d";
+
+      const inputAction$ = new ActionsObservable(
+        testScheduler.createHotObservable(inputMarbles, inputActions)
+      );
+      const outputAction$ = closeNotebookEpic(inputAction$, store);
+
+      testScheduler
+        .expectObservable(outputAction$)
+        .toBe(outputMarbles, outputActions);
+      testScheduler.flush();
+    });
+
+    test("promptly continue when KILL_KERNEL fails", async () => {
+      const store = buildStore(false);
+
+      const testScheduler = buildScheduler();
+
+      const inputActions = {
+        a: actions.closeNotebook({ contentRef: "contentRef1" }),
+        b: coreActions.killKernelFailed({
+          kernelRef: "kernelRef1",
+          error: new Error("barf")
+        })
+      };
+
+      const outputActions = {
+        c: coreActions.killKernel({
+          kernelRef: "kernelRef1",
+          restarting: false
+        }),
+        d: actions.closeNotebookProgress({
+          newState: DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+        })
+      };
+
+      const inputMarbles = "a b";
+      const outputMarbles = "c d";
+
+      const inputAction$ = new ActionsObservable(
+        testScheduler.createHotObservable(inputMarbles, inputActions)
+      );
+      const outputAction$ = closeNotebookEpic(inputAction$, store);
+
+      testScheduler
+        .expectObservable(outputAction$)
+        .toBe(outputMarbles, outputActions);
+      testScheduler.flush();
+    });
+
+    test("continue after a timeout period when no KILL_KERNEL result is received", async () => {
+      const store = buildStore(false);
+
+      const testScheduler = buildScheduler();
+
+      const inputActions = {
+        a: actions.closeNotebook({ contentRef: "contentRef1" })
+      };
+
+      const outputActions = {
+        c: coreActions.killKernel({
+          kernelRef: "kernelRef1",
+          restarting: false
+        }),
+        d: actions.closeNotebookProgress({
+          newState: DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+        })
+      };
+
+      // Unable to get TestScheduler to honor timeout() in the epic, even after
+      // trying the work-arounds specified in https://github.com/redux-observable/redux-observable/issues/180
+      // Let's wait for rsjs 6 and try again.
+      // In the meantime I've manually confirmed that the full desktop app correctly times out.
+      //      const inputMarbles =  "a" + "-".repeat(6000) + "";
+      //      const outputMarbles = "c" + "-".repeat(5000) + "d";
+
+      const inputMarbles = "a |"; // Must explicitly complete (`|`) our input observable; believe this is related to the timeout() issue
+      const outputMarbles = "c (d|)";
+
+      const inputAction$ = new ActionsObservable(
+        testScheduler.createHotObservable(inputMarbles, inputActions)
+      );
+      const outputAction$ = closeNotebookEpic(
+        inputAction$,
+        store,
+        testScheduler
+      );
+
+      testScheduler
+        .expectObservable(outputAction$)
+        .toBe(outputMarbles, outputActions);
+      testScheduler.flush();
+    });
+  });
+
+  test("update close progress state and trigger window.close", async () => {
+    window.close = jest.fn();
+
+    const store = buildStore(false);
+    const responses = await closeNotebookEpic(
+      ActionsObservable.of(
+        actions.closeNotebook({ contentRef: "contentRef1" })
+      ),
+      store
+    )
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responses).toEqual([
+      coreActions.killKernel({ kernelRef: "kernelRef1", restarting: false }),
+      actions.closeNotebookProgress({
+        newState: DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+      })
+    ]);
+
+    expect(window.close).toBeCalled();
+  });
+});

--- a/applications/desktop/src/main/actions.js
+++ b/applications/desktop/src/main/actions.js
@@ -1,8 +1,17 @@
 // @flow strict
 
+import type { QuittingState } from "./reducers.js";
+
 export function setKernelSpecs(kernelSpecs: KernelSpecs) {
   return {
     type: "SET_KERNELSPECS",
     kernelSpecs: kernelSpecs
+  };
+}
+
+export function setQuittingState(newState: QuittingState) {
+  return {
+    type: "SET_QUITTING_STATE",
+    newState: newState
   };
 }

--- a/applications/desktop/src/main/launch.js
+++ b/applications/desktop/src/main/launch.js
@@ -1,7 +1,7 @@
 /* @flow strict */
 import * as path from "path";
 
-import { Menu, shell, BrowserWindow, dialog, ipcMain as ipc } from "electron";
+import { Menu, shell, BrowserWindow, dialog } from "electron";
 
 import { loadFullMenu } from "./menu";
 
@@ -44,18 +44,6 @@ export function launch(filename: ?string) {
   });
   const index = path.join(__dirname, "..", "static", "index.html");
   win.loadURL(`file://${index}`);
-
-  win.webContents.on("will-prevent-unload", e => {
-    const response = dialog.showMessageBox({
-      type: "question",
-      buttons: ["Yes", "No"],
-      title: "Confirm",
-      message: "Unsaved data will be lost. Are you sure you want to quit?"
-    });
-    if (response == 0) {
-      e.preventDefault();
-    }
-  });
 
   win.webContents.on("did-finish-load", () => {
     const menu = loadFullMenu();

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -1,12 +1,5 @@
 /* @flow strict */
-import {
-  dialog,
-  app,
-  shell,
-  Menu,
-  ipcMain as ipc,
-  BrowserWindow
-} from "electron";
+import { dialog, app, shell, Menu, BrowserWindow } from "electron";
 import * as path from "path";
 import { sortBy } from "lodash";
 import { launch, launchNewNotebook } from "./launch";

--- a/applications/desktop/src/main/reducers.js
+++ b/applications/desktop/src/main/reducers.js
@@ -4,24 +4,44 @@ import { Map } from "immutable";
 
 type MainState = Map<string, *>;
 
+export opaque type QuittingState =
+  | "Not Started" // Not currently orchestrating a quit
+  | "Quitting"; // In the process of closing notebooks in preparation to quit
+export const QUITTING_STATE_NOT_STARTED: QuittingState = "Not Started";
+export const QUITTING_STATE_QUITTING: QuittingState = "Quitting";
+
 type SetKernelSpecsAction = {
   type: "SET_KERNELSPECS",
   kernelSpecs: KernelSpecs
+};
+
+type SetQuittingStateAction = {
+  type: "SET_QUITTING_STATE",
+  newState: QuittingState
 };
 
 function setKernelSpecs(state: MainState, action: SetKernelSpecsAction) {
   return state.set("kernelSpecs", action.kernelSpecs);
 }
 
-type MainAction = SetKernelSpecsAction;
+function setQuittingState(state: MainState, action: SetQuittingStateAction) {
+  return state.set("quittingState", action.newState);
+}
+
+type MainAction = SetKernelSpecsAction | SetQuittingStateAction;
 
 export default function handleApp(
-  state: MainState = Map({ kernelSpecs: {} }),
+  state: MainState = Map({
+    kernelSpecs: {},
+    quittingState: QUITTING_STATE_NOT_STARTED
+  }),
   action: MainAction
 ) {
   switch (action.type) {
     case "SET_KERNELSPECS":
       return setKernelSpecs(state, action);
+    case "SET_QUITTING_STATE":
+      return setQuittingState(state, action);
     default:
       return state;
   }

--- a/applications/desktop/src/notebook/actionTypes.js
+++ b/applications/desktop/src/notebook/actionTypes.js
@@ -1,0 +1,21 @@
+// @flow strict
+
+import type { ContentRef } from "@nteract/core";
+
+import type { DesktopNotebookClosingState } from "./state";
+
+export const CLOSE_NOTEBOOK = "DESKTOP/CLOSE_NOTEBOOK";
+export type CloseNotebook = {
+  type: "DESKTOP/CLOSE_NOTEBOOK",
+  payload: {
+    contentRef: ContentRef
+  }
+};
+
+export const CLOSE_NOTEBOOK_PROGRESS = "DESKTOP/CLOSE_NOTEBOOK_PROGRESS";
+export type CloseNotebookProgress = {
+  type: "DESKTOP/CLOSE_NOTEBOOK_PROGRESS",
+  payload: {
+    newState: DesktopNotebookClosingState
+  }
+};

--- a/applications/desktop/src/notebook/actions.js
+++ b/applications/desktop/src/notebook/actions.js
@@ -1,0 +1,25 @@
+// @flow strict
+
+import * as actionTypes from "./actionTypes";
+
+import type { ContentRef } from "@nteract/core";
+
+import type { DesktopNotebookClosingState } from "./state";
+
+export function closeNotebook(payload: {
+  contentRef: ContentRef
+}): actionTypes.CloseNotebook {
+  return {
+    type: actionTypes.CLOSE_NOTEBOOK,
+    payload
+  };
+}
+
+export function closeNotebookProgress(payload: {
+  newState: DesktopNotebookClosingState
+}): actionTypes.CloseNotebookProgress {
+  return {
+    type: actionTypes.CLOSE_NOTEBOOK_PROGRESS,
+    payload
+  };
+}

--- a/applications/desktop/src/notebook/epics/close-notebook.js
+++ b/applications/desktop/src/notebook/epics/close-notebook.js
@@ -1,0 +1,164 @@
+// Flow goes crazy when this file is typed, raising errors throughout the project.
+// I believe it's related to the intersection type of DesktopNotebookAppState.
+// Lots of open bugs around intersection types, and they're used inside Immutable.js too, so layers upon layers.
+// https://github.com/facebook/flow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+intersect
+
+import * as actions from "../actions";
+import * as actionTypes from "../actionTypes";
+
+import {
+  makeDesktopNotebookRecord,
+  DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
+  DESKTOP_NOTEBOOK_CLOSING_STARTED,
+  DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+} from "../state.js";
+
+import {
+  actionTypes as coreActionTypes,
+  actions as coreActions,
+  selectors
+} from "@nteract/core";
+
+import { Observable } from "rxjs/Observable";
+import { empty } from "rxjs/observable/empty";
+import { of } from "rxjs/observable/of";
+import { zip } from "rxjs/observable/zip";
+import { concat } from "rxjs/observable/concat";
+
+import {
+  catchError,
+  concatMap,
+  exhaustMap,
+  filter,
+  map,
+  switchMap,
+  take,
+  tap,
+  timeout
+} from "rxjs/operators";
+
+import { ActionsObservable, ofType } from "redux-observable";
+
+import { remote, ipcRenderer as ipc } from "electron";
+
+export const closeNotebookEpic = (action$: ActionsObservable<*>, store: *) =>
+  action$.pipe(
+    ofType(actionTypes.CLOSE_NOTEBOOK),
+    exhaustMap((action: actionTypes.CloseNotebook) => {
+      const contentRef = action.payload.contentRef;
+      const state = store.getState();
+      const model = selectors.model(state, { contentRef });
+
+      var dirtyPromptObservable: Observable<boolean>;
+      if (selectors.notebook.isDirty(model)) {
+        dirtyPromptObservable = Observable.create(observer => {
+          const promptDialog = {
+            type: "question",
+            buttons: ["Yes", "No"],
+            title: "Confirm",
+            message: "Unsaved data will be lost. Are you sure you want to quit?"
+          };
+          ipc.once("show-message-box-response", (event, arg) => {
+            observer.next(arg === 0);
+            observer.complete();
+          });
+          ipc.send("show-message-box", promptDialog);
+        });
+      } else {
+        dirtyPromptObservable = of(true);
+      }
+
+      const killKernelActions = [];
+      const killKernelAwaits = [];
+      state.core.entities.kernels.byRef.forEach((kernel, kernelRef) => {
+        // Skip if kernel unknown
+        if (!kernel || !kernel.type) {
+          return;
+        }
+
+        if (kernel.type === "zeromq") {
+          killKernelActions.push(
+            coreActions.killKernel({
+              restarting: false,
+              kernelRef: kernelRef
+            })
+          );
+
+          killKernelAwaits.push(
+            action$.pipe(
+              ofType(
+                coreActionTypes.KILL_KERNEL_SUCCESSFUL,
+                coreActionTypes.KILL_KERNEL_FAILED
+              ),
+              filter(action => action.payload.kernelRef === kernelRef),
+              take(1)
+            )
+          );
+        } else if (kernel.type === "websocket") {
+          console.log(
+            "Need to implement a way to shutdown websocket kernels on desktop"
+          );
+        }
+      });
+
+      const killKernels = of(...killKernelActions);
+
+      const awaitKillKernelResults = zip(...killKernelAwaits).pipe(
+        timeout(1000 * 5), // This should be at least as long as the timeout used to wait for kernel to reply to shutdown msgs
+        tap(result => {
+          for (let r of result) {
+            console.log(JSON.stringify(r)); // To see these in terminal, set ELECTRON_ENABLE_LOGGING=1. Could also start more explicitly routing them to main process stdout.
+          }
+        }),
+        concatMap(_ =>
+          // We don't need the results. Further, allowing the Array<Action> to flow through error middleware crashed
+          // node.js for me, with "Error: async hook stack has become corrupted (actual: 1528, expected: 0)".
+          // Seemed related to the error middleware not expecting an Array (returning result[0] avoids the crash as
+          // well).
+          empty()
+        ),
+        catchError((error: Error) => {
+          console.log(
+            "One or more kernels failed to shutdown properly in the allocated time."
+          );
+          console.log(error.message);
+          return empty(); // Just carry on with closing.
+        })
+      );
+
+      const updateClosingState = of(
+        actions.closeNotebookProgress({
+          newState: DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE // This is what allows the window to unload
+        })
+      );
+
+      const initiateClose = Observable.create(observer => {
+        console.log("Kernel shutdown complete; closing notebook window...");
+        window.close();
+        observer.complete();
+      });
+
+      return dirtyPromptObservable.pipe(
+        concatMap((proceed: boolean) => {
+          if (!proceed) {
+            // Cancel any full-app shutdown in flight
+            ipc.send("close-notebook-canceled");
+
+            // Reset notebook state to allow another attempt later
+            return of(
+              actions.closeNotebookProgress({
+                newState: DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED
+              })
+            );
+          }
+
+          return concat(
+            killKernels,
+            awaitKillKernelResults,
+            updateClosingState,
+            initiateClose
+          );
+        })
+      );
+    })
+  );

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -28,6 +28,8 @@ import {
   saveConfigOnChangeEpic
 } from "./config";
 
+import { closeNotebookEpic } from "./close-notebook";
+
 export function retryAndEmitError(err: Error, source: ActionsObservable<*>) {
   console.error(err);
   return source.pipe(startWith({ type: "ERROR", payload: err, error: true }));
@@ -58,7 +60,8 @@ const epics: Array<Epic<*, *, *, *>> = [
   killKernelEpic,
   loadConfigEpic,
   saveConfigEpic,
-  saveConfigOnChangeEpic
+  saveConfigOnChangeEpic,
+  closeNotebookEpic
 ].map(wrapEpic);
 
 export default epics;

--- a/applications/desktop/src/notebook/epics/kernels.md
+++ b/applications/desktop/src/notebook/epics/kernels.md
@@ -130,9 +130,7 @@ Right now we use kernelspecs in two places:
 * Launching kernels in the notebook window (renderer process)
 
 For native kernels, we could be shutting them down in the main thread instead of
-the browser windows which would make cleanup more consistent. We're stuck with
-a synchronous response on window close - kernels have to close immediately and
-they may not actually be able to.
+the browser windows which would make cleanup more consistent.
 
 We could be pushing the connection config across the inter process boundary for
 `native-jupyter`, `default-python`, and `conda` when the user selects them from

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 import { ipcRenderer as ipc, remote } from "electron";
 import { Provider } from "react-redux";
+import type { Store } from "redux";
 
 // Load the nteract fonts
 require("./fonts");
@@ -27,7 +28,7 @@ import {
   makeEntitiesRecord
 } from "@nteract/core";
 
-import type { ContentRef, ContentRecord } from "@nteract/core";
+import type { AppState, ContentRef, ContentRecord } from "@nteract/core";
 
 import NotebookApp from "@nteract/notebook-app-component";
 
@@ -36,6 +37,7 @@ import { displayOrder, transforms } from "@nteract/transforms-full";
 import { initMenuHandlers } from "./menu";
 import { initNativeHandlers } from "./native-window";
 import { initGlobalHandlers } from "./global-events";
+import { makeDesktopNotebookRecord } from "./state.js";
 
 import * as Immutable from "immutable";
 
@@ -61,7 +63,8 @@ const store = configureStore({
         byRef: initialRefs
       })
     })
-  })
+  }),
+  desktopNotebook: makeDesktopNotebookRecord()
 });
 
 // Register for debugging

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -18,6 +18,8 @@ import type { AppState, ContentRef, KernelRef } from "@nteract/core";
 
 import type { Store } from "redux";
 
+import type { DesktopNotebookAppState } from "./state.js";
+
 export function cwdKernelFallback() {
   // HACK: If we see they're at /, we assume that was the OS launching the Application
   //       from a launcher (launchctl on macOS)
@@ -29,7 +31,7 @@ export function cwdKernelFallback() {
 
 export function dispatchSaveAs(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   evt: Event,
   filepath: string
 ) {
@@ -80,7 +82,7 @@ export function showSaveAsDialog(): Promise<string> {
 
 export function triggerWindowRefresh(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   filepath: string
 ) {
   if (!filepath) {
@@ -92,7 +94,7 @@ export function triggerWindowRefresh(
 
 export function dispatchRestartKernel(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   outputHandling: actionTypes.RestartKernelOutputHandling
 ) {
   const state = store.getState();
@@ -114,7 +116,7 @@ export function dispatchRestartKernel(
 
 export function promptUserAboutNewKernel(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   filepath: string
 ): Promise<*> {
   return new Promise(resolve => {
@@ -169,7 +171,7 @@ export function promptUserAboutNewKernel(
 
 export function triggerSaveAs(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   showSaveAsDialog().then(filepath => {
     if (filepath) {
@@ -181,7 +183,7 @@ export function triggerSaveAs(
 
 export function dispatchSave(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   const state = store.getState();
 
@@ -196,7 +198,7 @@ export function dispatchSave(
 
 export function dispatchNewKernel(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   evt: Event,
   kernelSpec: KernelSpec
 ) {
@@ -223,7 +225,7 @@ export function dispatchNewKernel(
 
 export function dispatchPublishGist(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   event: Event
 ) {
   const state = store.getState();
@@ -285,28 +287,28 @@ export function dispatchPublishGist(
 
 export function dispatchRunAllBelow(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.executeAllCellsBelow(ownProps));
 }
 
 export function dispatchRunAll(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.executeAllCells(ownProps));
 }
 
 export function dispatchClearAll(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.clearAllOutputs(ownProps));
 }
 
 export function dispatchUnhideAll(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
     actions.unhideAll({
@@ -319,7 +321,7 @@ export function dispatchUnhideAll(
 
 export function dispatchKillKernel(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   const state = store.getState();
   const kernelRef = selectors.kernelRefByContentRef(state, ownProps);
@@ -333,7 +335,7 @@ export function dispatchKillKernel(
 
 export function dispatchInterruptKernel(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   const state = store.getState();
 
@@ -369,7 +371,7 @@ export function dispatchZoomReset() {
 
 export function dispatchSetTheme(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   evt: Event,
   theme: string
 ) {
@@ -378,7 +380,7 @@ export function dispatchSetTheme(
 
 export function dispatchSetCursorBlink(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   evt: Event,
   value: *
 ) {
@@ -387,28 +389,28 @@ export function dispatchSetCursorBlink(
 
 export function dispatchCopyCell(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.copyCell({ contentRef: ownProps.contentRef }));
 }
 
 export function dispatchCutCell(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.cutCell({ contentRef: ownProps.contentRef }));
 }
 
 export function dispatchPasteCell(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.pasteCell(ownProps));
 }
 
 export function dispatchCreateCellAfter(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
     actions.createCellAfter({
@@ -421,7 +423,7 @@ export function dispatchCreateCellAfter(
 
 export function dispatchCreateTextCellAfter(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
     actions.createCellAfter({
@@ -434,7 +436,7 @@ export function dispatchCreateTextCellAfter(
 
 export function dispatchLoad(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   event: Event,
   filepath: string
 ) {
@@ -453,7 +455,7 @@ export function dispatchLoad(
 
 export function dispatchNewNotebook(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   event: Event,
   kernelSpec: KernelSpec
 ) {
@@ -484,7 +486,7 @@ export function dispatchNewNotebook(
  */
 export function exportPDF(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>,
+  store: Store<DesktopNotebookAppState, *>,
   basepath: string,
   notificationSystem: *
 ): void {
@@ -553,7 +555,7 @@ export function exportPDF(
 
 export function triggerSaveAsPDF(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   showSaveAsDialog()
     .then(filepath => {
@@ -568,7 +570,7 @@ export function triggerSaveAsPDF(
 
 export function storeToPDF(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   const state = store.getState();
   const notebookName = selectors.filepath(state, ownProps);
@@ -599,14 +601,14 @@ export function storeToPDF(
 
 export function dispatchLoadConfig(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(actions.loadConfig());
 }
 
 export function initMenuHandlers(
   contentRef: ContentRef,
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   const opts = {
     contentRef

--- a/applications/desktop/src/notebook/reducers.js
+++ b/applications/desktop/src/notebook/reducers.js
@@ -1,0 +1,28 @@
+/* @flow strict */
+
+import * as actionTypes from "./actionTypes";
+
+import type {
+  DesktopNotebookRecord,
+  DesktopNotebookClosingState
+} from "./state";
+import {
+  makeDesktopNotebookRecord,
+  DESKTOP_NOTEBOOK_CLOSING_STARTED
+} from "./state";
+
+export function handleDesktopNotebook(
+  state: DesktopNotebookRecord = makeDesktopNotebookRecord(),
+  action: actionTypes.CloseNotebook | actionTypes.CloseNotebookProgress
+) {
+  switch (action.type) {
+    case actionTypes.CLOSE_NOTEBOOK:
+      return state.set("closingState", DESKTOP_NOTEBOOK_CLOSING_STARTED);
+
+    case actionTypes.CLOSE_NOTEBOOK_PROGRESS:
+      return state.set("closingState", action.payload.newState);
+
+    default:
+      return state;
+  }
+}

--- a/applications/desktop/src/notebook/state.js
+++ b/applications/desktop/src/notebook/state.js
@@ -1,0 +1,33 @@
+/* @flow strict */
+
+import * as Immutable from "immutable";
+
+import type { AppState } from "@nteract/core";
+
+export opaque type DesktopNotebookClosingState =
+  | "Not Started" // Attempts to close BrowserWindow will initiate closeNotebookEpic and the window will be left open
+  | "Started" // Attempts to close BrowserWindow will be ignored
+  | "Ready to Close"; // The BrowserWindow will be allowed to close
+
+export const DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED: DesktopNotebookClosingState =
+  "Not Started";
+export const DESKTOP_NOTEBOOK_CLOSING_STARTED: DesktopNotebookClosingState =
+  "Started";
+export const DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE: DesktopNotebookClosingState =
+  "Ready to Close";
+
+export type DesktopNotebookProps = {
+  closingState: DesktopNotebookClosingState
+};
+
+export type DesktopNotebookRecord = Immutable.RecordOf<DesktopNotebookProps>;
+
+export const makeDesktopNotebookRecord: Immutable.RecordFactory<
+  DesktopNotebookProps
+> = Immutable.Record({
+  closingState: DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED
+});
+
+export type DesktopNotebookAppState = AppState & {
+  desktopNotebook: DesktopNotebookRecord
+};

--- a/applications/desktop/src/notebook/store.js
+++ b/applications/desktop/src/notebook/store.js
@@ -4,16 +4,18 @@ import { createStore, applyMiddleware, combineReducers } from "redux";
 import middlewares from "./middlewares";
 
 import { reducers } from "@nteract/core";
-import type { AppState } from "@nteract/core";
+import type { DesktopNotebookAppState } from "./state.js";
+import { handleDesktopNotebook } from "./reducers.js";
 
 const rootReducer = combineReducers({
   app: reducers.app,
   comms: reducers.comms,
   config: reducers.config,
-  core: reducers.core
+  core: reducers.core,
+  desktopNotebook: handleDesktopNotebook
 });
 
-export default function configureStore(initialState: AppState) {
+export default function configureStore(initialState: DesktopNotebookAppState) {
   return createStore(
     rootReducer,
     initialState,

--- a/applications/play/redux/actions.js
+++ b/applications/play/redux/actions.js
@@ -156,6 +156,8 @@ export const killKernel = (payload: {
   type: actionTypes.KILL_KERNEL,
   payload
 });
+
+// NB: This appears unused. In core there's KILL_KERNEL_SUCCESSFUL, but it deals in KernelRefs rather than serverId/kernelName.
 export const killKernelFulfilled = (payload: {
   serverId: string,
   kernelName: string

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -252,6 +252,7 @@ export const interruptKernelEpic = (action$: *, store: *) =>
     })
   );
 
+// NB: This epic kills the *current* kernel. ZMQ killKernelEpic kills a *specified* kernel.
 export const killKernelEpic = (action$: *, store: *) =>
   // TODO: Use the sessions API for this
   action$.pipe(


### PR DESCRIPTION
This adds a closeNotebookEpic which orchestrates all aspects of closing
a notebook window, including prompting about unsaved changes and
shutting down kernels properly (using the shutdown msg before resorting
to a SIGKILL).

TODO:
- [x] Test manual, interactive use, on Windows
- [x] macOS Ctrl + Q closes all windows but doesn't quit app
- [x] Update existing unit tests if necessary
- [x] Add new tests
