### PR TITLE
Add rimraf as a devDependency to packages that use it.

### DIFF
--- a/packages/ansi-to-react/package.json
+++ b/packages/ansi-to-react/package.json
@@ -30,5 +30,8 @@
   "peerDependencies": {
     "react": "^16.3.2",
     "react-dom": "^16.3.2"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
   }
 }

--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -30,5 +30,8 @@
     "babel-runtime": "^6.26.0",
     "immutable": "^4.0.0-rc.9",
     "uuid": "^3.1.0"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
   }
 }

--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -45,6 +45,9 @@
     "react": "^16.3.2",
     "styled-jsx": "^3.0.3-canary.0"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,9 @@
     "url-join": "^4.0.0",
     "uuid": "^3.1.0"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9"
   },

--- a/packages/directory-listing/package.json
+++ b/packages/directory-listing/package.json
@@ -21,6 +21,9 @@
     "@nteract/timeago": "^3.6.3",
     "react-hot-loader": "^4.1.2"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "peerDependencies": {
     "react": "^16.3.2"
   },

--- a/packages/display-area/package.json
+++ b/packages/display-area/package.json
@@ -23,6 +23,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/transforms": "^4.4.4",

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -24,6 +24,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@babel/runtime-corejs2": "^7.0.0",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -34,6 +34,9 @@
     "lodash": "^4.17.4",
     "rxjs": "^5.5.6"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
     "react": "^16.3.2",

--- a/packages/enchannel-zmq-backend/package.json
+++ b/packages/enchannel-zmq-backend/package.json
@@ -21,6 +21,9 @@
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/fs-observable/package.json
+++ b/packages/fs-observable/package.json
@@ -29,6 +29,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "mkdirp": "^0.5.1"

--- a/packages/gatsby-transformer-ipynb/package.json
+++ b/packages/gatsby-transformer-ipynb/package.json
@@ -23,6 +23,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/notebook-render": "^2.0.1",

--- a/packages/host-cache/package.json
+++ b/packages/host-cache/package.json
@@ -30,6 +30,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/iron-icons/package.json
+++ b/packages/iron-icons/package.json
@@ -14,6 +14,9 @@
     "build:lib:watch": "npm run build:lib -- --watch",
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/logos/package.json
+++ b/packages/logos/package.json
@@ -24,6 +24,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -24,6 +24,9 @@
   ],
   "author": "Trevor Lyon <github.com/tlyon3>",
   "license": "BSD-3-Clause",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/mathjax": "^2.1.4",

--- a/packages/mathjax/package.json
+++ b/packages/mathjax/package.json
@@ -23,6 +23,9 @@
   ],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -15,6 +15,9 @@
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/messaging",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -25,6 +25,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/display-area": "^4.4.5",

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -18,6 +18,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/commutable": "^4.1.3",

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -18,6 +18,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/commutable": "^4.1.3",

--- a/packages/notebook-render/package.json
+++ b/packages/notebook-render/package.json
@@ -18,6 +18,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/commutable": "^4.1.3",

--- a/packages/octicons/package.json
+++ b/packages/octicons/package.json
@@ -14,6 +14,9 @@
     "build:lib:watch": "npm run build:lib -- --watch",
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/outputs/package.json
+++ b/packages/outputs/package.json
@@ -14,6 +14,9 @@
     "build:lib:watch": "npm run build:lib -- --watch",
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "ansi-to-react": "^3.3.3"

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -14,6 +14,9 @@
     "build:lib:watch": "npm run build:lib -- --watch",
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -14,6 +14,9 @@
     "build:lib:watch": "npm run build:lib -- --watch",
     "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/rx-binder/package.json
+++ b/packages/rx-binder/package.json
@@ -24,6 +24,9 @@
     "notebook",
     "nteract"
   ],
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -25,6 +25,9 @@
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -21,6 +21,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/timeago/package.json
+++ b/packages/timeago/package.json
@@ -38,6 +38,9 @@
   "peerDependencies": {
     "react": "^16.3.2"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -28,6 +28,9 @@
     "profiles"
   ],
   "license": "BSD-3-Clause",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "@babel/runtime-corejs2": "^7.0.0",

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -20,6 +20,9 @@
     "babel-runtime": "^6.26.0",
     "leaflet": "^1.0.3"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "peerDependencies": {
     "react": "^16.3.2"
   },

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -19,6 +19,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -19,6 +19,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/plotly": "^1.0.0",

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -19,6 +19,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -19,6 +19,9 @@
     "access": "public"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/transform-vega",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/vega-embed2": "^2.1.3",

--- a/packages/transforms-full/package.json
+++ b/packages/transforms-full/package.json
@@ -32,6 +32,9 @@
   "peerDependencies": {
     "react": "^16.3.2"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/transform-dataresource": "^4.3.5",

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -28,6 +28,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/markdown": "^2.1.4",

--- a/packages/vega-embed2/package.json
+++ b/packages/vega-embed2/package.json
@@ -19,6 +19,9 @@
     "access": "public"
   },
   "repository": "https://github.com/nteract/nteract/tree/master/packages/vega-embed2",
+  "devDependencies": {
+    "rimraf": "^2.6.2"
+  },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0",


### PR DESCRIPTION
Problem:
Users cannot develop individual packages outside of the context of the monorepo without rimraf installed globally because the package.json files do not accurately reflect dependencies required in the scripts.

Solution:
Add rimraf to all package.json files that reference it and do not currently have it defined.