### PR TITLE
Add shortcut for tips to user guide and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Now, run `jupyter nteract` and you're running nteract on jupyter!
 
 We're still hard at work on the playground. Here's a sneak peek to explore: https://play.nteract.io
 
+### User Guide
+
+For the user guide, please check [USER_GUIDE.md](https://github.com/nteract/nteract/blob/master/USER_GUIDE.md)
+
 ---
 
 ## Contributors
@@ -101,7 +105,7 @@ To keep up-to-date with changes to the root nteract/nteract branch:
 
 5. Set the root as a remote: `git remote add upstream https://github.com/nteract/nteract.git`
 
-When changes are made, they can then be pulled from the master branch:
+When changes are made to the root nteract/nteract, they can then be pulled from the root and merged to your master branch:
 
 6. `git pull upstream master`
 7. `yarn clean`

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -29,7 +29,7 @@ There are several ways to open a notebook in nteract:
     ⮑  Open
 ```
 
-_Keyboard shortcut ⌘O on macOS and Ctrl-O on Windows/Linux_
+Keyboard shortcut `⌘ O` on macOS and `Ctrl O` on Windows/Linux
 
 * Double-click a notebook file :tada: **_Note: currently this works only in macOS_**
 
@@ -39,56 +39,56 @@ _Keyboard shortcut ⌘O on macOS and Ctrl-O on Windows/Linux_
 
 A notebook can be saved in the following ways:
 
-```
-  File
-    ⮑  Save
-```
+* _Save_:
+    ```
+      File
+        ⮑  Save
+    ```
 
-_Keyboard shortcut: ⌘S on macOS and Ctrl-S on Windows/Linux_
+    Keyboard shortcut: `⌘ S` on macOS and `Ctrl S` on Windows/Linux
 
-```
-  File
-    ⮑  Save As
-```
+* _Save As_:
+  ```
+    File
+      ⮑  Save As
+  ```
 
-_Keyboard shortcut: ⇧⌘S on macOS and Shift-Ctrl-S on Windows/Linux_
+  Keyboard shortcut: `Shift ⌘ S` on macOS and `Shift Ctrl S` on Windows/Linux
 
 ## Notebook Cells
 
 ### Adding a Cell
 
-#### Code Cells
+* Code Cells:
+    A code cell can be created by accessing the menu,
 
-A code cell can be created by accessing the menu,
+    ```
+      Edit
+        ⮑  New Code Cell
+    ```
 
-```
-  Edit
-    ⮑  New Code Cell
-```
+    Keyboard shortcut: `Shift ⌘ N` on macOS or `Shift Ctrl N` on Windows/Linux
 
-_Keyboard shortcut: Shift ⌘N on macOS or Shift Ctrl-N on Windows/Linux_
+    A code cell can also be created by clicking <> on the cell hover menu.
 
-A code cell can also be created by clicking <> on the cell hover menu.
+* Text Cells
+    A text cell can be created by accessing the menu,
 
-#### Text Cells
+    ```
+      Edit
+        ⮑  New Text Cell
+    ```
 
-A text cell can be created by accessing the menu,
+    Keyboard shortcut: `Shift ⌘ M` on macOS or `Shift Ctrl M` on Windows/Linux
 
-```
-  Edit
-    ⮑  New Text Cell
-```
+    A text cell can also be created by clicking **M** on the cell hover menu.
 
-_Keyboard shortcut: Shift ⌘M on macOS or Shift Ctrl-M on Windows/Linux_
-
-A text cell can also be created by clicking **M** on the cell hover menu.
-
-Text cells support the [commonmark spec](http://commonmark.org/) along with
-inline mathematics, block mathematics, and tables.
+    Text cells support the [commonmark spec](http://commonmark.org/) along with
+    inline mathematics, block mathematics, and tables.
 
 ### Running a Cell
 
-A cell can be run from the keyboard by pressing _Shift ⏎_ or by selecting the ▶︎ button from the cell toolbar.
+A cell can be run from the keyboard by pressing `Shift ⏎` or by selecting the ▶︎ button from the cell toolbar.
 
 **_N.B. To run all cells at once, access the menu:_**
 
@@ -101,7 +101,13 @@ A cell can be run from the keyboard by pressing _Shift ⏎_ or by selecting the 
 
 A cell can be moved anywhere in the notebook by clicking and dragging to desired position.
 
+### Other Cell Shortcuts
+
+* Copy Cell: `Shift ⌘ C` on macOS or `Shift Ctrl C` on Windows/Linux
+* Paste Cell: `Shift ⌘ V` on macOS or `Shift Ctrl V` on Windows/Linux
+* Cut Cell: `Shift ⌘ X` on macOS or `Shift Ctrl X` on Windows/Linux
+
 ## Autocompletion
 
-* Autocomplete Suggestions: _Ctrl_ + _Space_
-* Documentation/Tips Expansion: _Ctrl_ + _._(on Windows/Linux) or _⌘_ + _._ (on MacOS)
+* Autocomplete Suggestions: `Ctrl Space`
+* Documentation/Tips Expansion: `Ctrl Period(.)` (on Windows/Linux) or `⌘ Period(.)` (on MacOS)

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,8 +14,8 @@ A new notebook can be created by accessing the menu,
 
 ```
   File
-    -->  New
-          -->  <Language Kernel> (e.g. Python 3, R, Julia etc.)
+    ⮑  New
+         ⮑  <Language Kernel> (e.g. Python 3, R, Julia etc.)
 ```
 
 ### Opening a Notebook
@@ -26,7 +26,7 @@ There are several ways to open a notebook in nteract:
 
 ```
   File
-    -->  Open
+    ⮑  Open
 ```
 
 _Keyboard shortcut ⌘O on macOS and Ctrl-O on Windows/Linux_
@@ -100,3 +100,8 @@ A cell can be run from the keyboard by pressing _Shift ⏎_ or by selecting the 
 ### Moving a Cell
 
 A cell can be moved anywhere in the notebook by clicking and dragging to desired position.
+
+## Autocompletion
+
+* Autocomplete Suggestions: _Ctrl_ + _Space_
+* Documentation/Tips Expansion: _Ctrl_ + _._(on Windows/Linux) or _⌘_ + _._ (on MacOS)


### PR DESCRIPTION
Added shortcut for Tips (Module Documentation) to `USER_GUIDE.md` and linked it to `README.md`. Also updated the separator for menu-options-hierarchy for the USER_GUIDE so that the same separator (⮑) is used everywhere

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)