### PR TITLE
Add menu items and shortcuts for cell actions

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -64,10 +64,9 @@ A notebook can be saved in the following ways:
 
     ```
       Edit
-        ⮑  New Code Cell
+        ⮑  Insert Code Cell Above
+        ⮑  Insert Code Cell Below
     ```
-
-    Keyboard shortcut: `Shift ⌘ N` on macOS or `Shift Ctrl N` on Windows/Linux
 
     A code cell can also be created by clicking <> on the cell hover menu.
 
@@ -78,8 +77,6 @@ A notebook can be saved in the following ways:
       Edit
         ⮑  New Text Cell
     ```
-
-    Keyboard shortcut: `Shift ⌘ M` on macOS or `Shift Ctrl M` on Windows/Linux
 
     A text cell can also be created by clicking **M** on the cell hover menu.
 
@@ -101,13 +98,20 @@ A cell can be run from the keyboard by pressing `Shift ⏎` or by selecting the 
 
 A cell can be moved anywhere in the notebook by clicking and dragging to desired position.
 
-### Other Cell Shortcuts
+### Cell Shortcuts
 
-* Copy Cell: `Shift ⌘ C` on macOS or `Shift Ctrl C` on Windows/Linux
-* Paste Cell: `Shift ⌘ V` on macOS or `Shift Ctrl V` on Windows/Linux
-* Cut Cell: `Shift ⌘ X` on macOS or `Shift Ctrl X` on Windows/Linux
+Command | macOS | Windows/Linux
+---|---|---
+Insert Cell Above | `Shift ⌘ A` | `Shift Ctrl A`
+Insert Cell Below | `Shift ⌘ B` | `Shift Ctrl B`
+Delete Cell | `Shift ⌘ D` | `Shift Ctrl D`
+Change Cell Type to Markdown | `Shift ⌘ M` | `Shift Ctrl M`
+Change Cell Type to Code | `Shift ⌘ Y` | `Shift Ctrl Y`
+Copy Cell | `Shift ⌘ C` | `Shift Ctrl C`
+Paste Cell | `Shift ⌘ V` | `Shift Ctrl V`
+Cut Cell | `Shift ⌘ X` | `Shift Ctrl X`
 
-## Autocompletion
+## General Shortcuts
 
 * Autocomplete Suggestions: `Ctrl Space`
 * Documentation/Tips Expansion: `Ctrl Period(.)` (on Windows/Linux) or `⌘ Period(.)` (on MacOS)

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -18,7 +18,6 @@ describe("dispatchCreateCellAbove", () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       actions.createCellBefore({
         cellType: "code",
-        source: "",
         contentRef: props.contentRef
       })
     );
@@ -647,7 +646,9 @@ describe("initMenuHandlers", () => {
       "menu:unhide-all",
       "menu:save",
       "menu:save-as",
-      "menu:new-code-cell",
+      "menu:new-text-cell-below",
+      "menu:new-code-cell-above",
+      "menu:new-code-cell-below",
       "menu:copy-cell",
       "menu:cut-cell",
       "menu:paste-cell",

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -5,7 +5,27 @@ import { selectors, actions, actionTypes } from "@nteract/core";
 
 import * as Immutable from "immutable";
 
-describe("dispatchCreateCellAfter", () => {
+describe("dispatchCreateCellAbove", () => {
+  test("dispatches a CREATE_CELL_BEFORE with code action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCreateCellAbove(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.createCellBefore({
+        cellType: "code",
+        source: "",
+        contentRef: props.contentRef
+      })
+    );
+  });
+});
+
+describe("dispatchCreateCellBelow", () => {
   test("dispatches a CREATE_CELL_AFTER with code action", () => {
     const store = {
       dispatch: jest.fn()
@@ -14,7 +34,7 @@ describe("dispatchCreateCellAfter", () => {
       contentRef: "123"
     };
 
-    menu.dispatchCreateCellAfter(props, store);
+    menu.dispatchCreateCellBelow(props, store);
     expect(store.dispatch).toHaveBeenCalledWith(
       actions.createCellAfter({
         cellType: "code",
@@ -25,7 +45,7 @@ describe("dispatchCreateCellAfter", () => {
   });
 });
 
-describe("dispatchCreateTextCellAfter", () => {
+describe("dispatchCreateTextCellBelow", () => {
   test("dispatches a CREATE_CELL_AFTER with markdown action", () => {
     const store = {
       dispatch: jest.fn()
@@ -34,12 +54,68 @@ describe("dispatchCreateTextCellAfter", () => {
       contentRef: "123"
     };
 
-    menu.dispatchCreateTextCellAfter(props, store);
+    menu.dispatchCreateTextCellBelow(props, store);
     expect(store.dispatch).toHaveBeenCalledWith(
       actions.createCellAfter({
         cellType: "markdown",
         source: "",
         contentRef: "123"
+      })
+    );
+  });
+});
+
+describe("dispatchDeleteCell", () => {
+  test("dispatches a REMOVE_CELL on currently active cell", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchDeleteCell(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.removeCell({
+        contentRef: props.contentRef
+      })
+    );
+  });
+});
+
+describe("dispatchChangeCellToCode", () => {
+  test("dispatches a CHANGE_CELL_TYPE with code action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchChangeCellToCode(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.changeCellType({
+        to: "code",
+        contentRef: props.contentRef
+      })
+    );
+  });
+});
+
+describe("dispatchChangeCellToText", () => {
+  test("dispatches a CHANGE_CELL_TYPE with code action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchChangeCellToText(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.changeCellType({
+        to: "markdown",
+        contentRef: props.contentRef
       })
     );
   });

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -366,16 +366,24 @@ export function loadFullMenu(store: * = global.store) {
         type: "separator"
       },
       {
-        label: "New Code Cell",
+        label: "Insert Code Cell Above",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+N",
-        click: createSender("menu:new-code-cell")
+        accelerator: "CmdOrCtrl+Shift+A",
+        click: createSender("menu:new-code-cell-above")
       },
       {
-        label: "New Text Cell",
+        label: "Insert Code Cell Below",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+M",
-        click: createSender("menu:new-text-cell")
+        accelerator: "CmdOrCtrl+Shift+B",
+        click: createSender("menu:new-code-cell-below")
+      },
+      {
+        label: "Insert Text Cell Below",
+        enabled: BrowserWindow.getAllWindows().length > 0,
+        click: createSender("menu:new-text-cell-below")
+      },
+      {
+        type: "separator"
       },
       {
         label: "Copy Cell",
@@ -394,6 +402,12 @@ export function loadFullMenu(store: * = global.store) {
         enabled: BrowserWindow.getAllWindows().length > 0,
         accelerator: "CmdOrCtrl+Shift+V",
         click: createSender("menu:paste-cell")
+      },
+      {
+        label: "Delete Cell",
+        enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: "CmdOrCtrl+Shift+D",
+        click: createSender("menu:delete-cell")
       }
     ]
   };
@@ -401,6 +415,21 @@ export function loadFullMenu(store: * = global.store) {
   const cell = {
     label: "Cell",
     submenu: [
+      {
+        label: "Change Cell Type to Code",
+        enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: "CmdOrCtrl+Shift+Y",
+        click: createSender("menu:change-cell-to-code")
+      },
+      {
+        label: "Change Cell Type to Text",
+        enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: "CmdOrCtrl+Shift+M",
+        click: createSender("menu:change-cell-to-text")
+      },
+      {
+        type: "separator"
+      },
       {
         label: "Run All",
         enabled: BrowserWindow.getAllWindows().length > 0,

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -455,7 +455,7 @@ export function dispatchCreateTextCellBelow(
 
 export function dispatchChangeCellToCode(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
     actions.changeCellType({
@@ -467,7 +467,7 @@ export function dispatchChangeCellToCode(
 
 export function dispatchChangeCellToText(
   ownProps: { contentRef: ContentRef },
-  store: Store<AppState, *>
+  store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
     actions.changeCellType({

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -412,7 +412,6 @@ export function dispatchDeleteCell(
   ownProps: { contentRef: ContentRef },
   store: Store<DesktopNotebookAppState, *>
 ) {
-  console.log(store);
   store.dispatch(actions.removeCell({ contentRef: ownProps.contentRef }));
 }
 

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -408,7 +408,27 @@ export function dispatchPasteCell(
   store.dispatch(actions.pasteCell(ownProps));
 }
 
-export function dispatchCreateCellAfter(
+export function dispatchDeleteCell(
+  ownProps: { contentRef: ContentRef },
+  store: Store<DesktopNotebookAppState, *>
+) {
+  console.log(store);
+  store.dispatch(actions.removeCell({ contentRef: ownProps.contentRef }));
+}
+
+export function dispatchCreateCellAbove(
+  ownProps: { contentRef: ContentRef },
+  store: Store<DesktopNotebookAppState, *>
+) {
+  store.dispatch(
+    actions.createCellBefore({
+      cellType: "code",
+      contentRef: ownProps.contentRef
+    })
+  );
+}
+
+export function dispatchCreateCellBelow(
   ownProps: { contentRef: ContentRef },
   store: Store<DesktopNotebookAppState, *>
 ) {
@@ -421,7 +441,7 @@ export function dispatchCreateCellAfter(
   );
 }
 
-export function dispatchCreateTextCellAfter(
+export function dispatchCreateTextCellBelow(
   ownProps: { contentRef: ContentRef },
   store: Store<DesktopNotebookAppState, *>
 ) {
@@ -429,6 +449,30 @@ export function dispatchCreateTextCellAfter(
     actions.createCellAfter({
       cellType: "markdown",
       source: "",
+      contentRef: ownProps.contentRef
+    })
+  );
+}
+
+export function dispatchChangeCellToCode(
+  ownProps: { contentRef: ContentRef },
+  store: Store<AppState, *>
+) {
+  store.dispatch(
+    actions.changeCellType({
+      to: "code",
+      contentRef: ownProps.contentRef
+    })
+  );
+}
+
+export function dispatchChangeCellToText(
+  ownProps: { contentRef: ContentRef },
+  store: Store<AppState, *>
+) {
+  store.dispatch(
+    actions.changeCellType({
+      to: "markdown",
       contentRef: ownProps.contentRef
     })
   );
@@ -622,14 +666,30 @@ export function initMenuHandlers(
   ipc.on("menu:unhide-all", dispatchUnhideAll.bind(null, opts, store));
   ipc.on("menu:save", throttle(dispatchSave.bind(null, opts, store), 2000));
   ipc.on("menu:save-as", dispatchSaveAs.bind(null, opts, store));
-  ipc.on("menu:new-code-cell", dispatchCreateCellAfter.bind(null, opts, store));
   ipc.on(
-    "menu:new-text-cell",
-    dispatchCreateTextCellAfter.bind(null, opts, store)
+    "menu:new-text-cell-below",
+    dispatchCreateTextCellBelow.bind(null, opts, store)
+  );
+  ipc.on(
+    "menu:new-code-cell-above",
+    dispatchCreateCellAbove.bind(null, opts, store)
+  );
+  ipc.on(
+    "menu:new-code-cell-below",
+    dispatchCreateCellBelow.bind(null, opts, store)
   );
   ipc.on("menu:copy-cell", dispatchCopyCell.bind(null, opts, store));
   ipc.on("menu:cut-cell", dispatchCutCell.bind(null, opts, store));
   ipc.on("menu:paste-cell", dispatchPasteCell.bind(null, opts, store));
+  ipc.on("menu:delete-cell", dispatchDeleteCell.bind(null, opts, store));
+  ipc.on(
+    "menu:change-cell-to-code",
+    dispatchChangeCellToCode.bind(null, opts, store)
+  );
+  ipc.on(
+    "menu:change-cell-to-text",
+    dispatchChangeCellToText.bind(null, opts, store)
+  );
   ipc.on("menu:kill-kernel", dispatchKillKernel.bind(null, opts, store));
   ipc.on(
     "menu:interrupt-kernel",

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -162,7 +162,7 @@ export const REMOVE_CELL = "REMOVE_CELL";
 export type RemoveCell = {
   type: "REMOVE_CELL",
   payload: {
-    id: CellID,
+    id?: CellID,
     contentRef: ContentRef
   }
 };
@@ -535,7 +535,7 @@ export const CHANGE_CELL_TYPE = "CHANGE_CELL_TYPE";
 export type ChangeCellType = {
   type: "CHANGE_CELL_TYPE",
   payload: {
-    id: CellID,
+    id?: CellID,
     to: CellType,
     contentRef: ContentRef
   }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -245,7 +245,7 @@ export function moveCell(payload: {
 }
 
 export function removeCell(payload: {
-  id: string,
+  id?: string,
   contentRef: ContentRef
 }): actionTypes.RemoveCell {
   return {

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -583,7 +583,7 @@ export function pasteCell(payload: {
 }
 
 export function changeCellType(payload: {
-  id: CellID,
+  id?: CellID,
   to: CellType,
   contentRef: ContentRef
 }): actionTypes.ChangeCellType {

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -410,7 +410,7 @@ function removeCellFromState(
   state: NotebookModel,
   action: actionTypes.RemoveCell
 ) {
-  const { id } = action.payload;
+  const id = action.payload.id ? action.payload.id : state.cellFocused;
   return cleanCellTransient(
     state.update("notebook", (notebook: ImmutableNotebook) =>
       removeCell(notebook, id)

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -411,6 +411,9 @@ function removeCellFromState(
   action: actionTypes.RemoveCell
 ) {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
+  if (!id) {
+    return state;
+  }
   return cleanCellTransient(
     state.update("notebook", (notebook: ImmutableNotebook) =>
       removeCell(notebook, id)

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.2":
+"@babel/core@^7.0.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.2.tgz#f8d2a9ceb6832887329a7b60f9d035791400ba4e"
   integrity sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,7 +68,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.0.0":
+"@babel/core@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.2.tgz#f8d2a9ceb6832887329a7b60f9d035791400ba4e"
   integrity sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==


### PR DESCRIPTION
Added menu options for 
* Delete cell (`CmdorCtrl Shift D`)
* Change cell type to md/code (`CmdorCtrl Shift M/Y`)
* Insert cell above (`CmdorCtrl Shift A`)
* Insert cell below (`CmdorCtrl Shift B`)

Choice of shortcuts: For similarity to jupyter-notebook. Also had to remove shortcut for inserting a text cell below as the same shortcut was to be used for changing cell type to Markdown

Updated `USER_GUIDE.md` with a table of cell shortcuts