### PR TITLE
set jest to only use one worker on circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       # run tests!
       - run: yarn run test:lint
       - run: yarn run build:packages
-      - run: yarn run test
+      - run: yarn run test --maxWorkers 1
       - run: yarn run test:flow
 
       - run:


### PR DESCRIPTION
Every now and then we're running out of memory on CircleCI. Jest by default runs in parallel when we really only have one vCPU (even if Linux itself is reporting more). This sets the maxWorkers to 1. Another thing we might consider in the future is [splitting tests along with CircleCI parallelism](https://circleci.com/docs/2.0/parallelism-faster-jobs/).