### PR TITLE
[Issue-3134] Replace references to NPM with Yarn in Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ in the nteract world? Here's a quick rundown!
    feature that you want to add.
 6. Confirm that unit tests and linting still pass successfully with:
    
-       npm run test
+       yarn test
    
    If tests fail, don't hesitate to ask for help.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ When changes are made to the root nteract/nteract, they can then be pulled from 
 6. `git pull upstream master`
 7. `yarn clean`
 8. `yarn install`
+7. yarn install
 
 #### Windows Caveats
 
@@ -135,7 +136,7 @@ specific package, use this command, replacing `packageName` with the package you
 want to hack on:
 
 ```
-$(npm bin)/lerna run build --scope packageName
+$(yarn bin)/lerna run build --scope packageName
 ```
 
 ### Hacking on the Desktop application
@@ -147,7 +148,7 @@ yarn app:desktop
 ```
 
 As you make changes, you will have to close the entire app (CMD-q on macOS or
-CNTL-c at the terminal) and then run `npm run app:desktop` again to see the
+CNTL-c at the terminal) and then run `yarn run app:desktop` again to see the
 changes.
 
 #### Progressive Webpack build (automatic)
@@ -200,7 +201,7 @@ rebuild those using [the instructions for building specific packages](#building-
 > I want to debug redux actions and state changes.
 
 * Enable [redux-logger](https://github.com/evgenyrodionov/redux-logger) by
-  spawning the application with `npm run spawn:debug`.
+  spawning the application with `yarn run spawn:debug`.
 
 > I keep getting a pop-up asking: *Do you want the application "nteract Helper.app" to accept
   incoming network connections?* while developing or using a custom build of

--- a/README.md
+++ b/README.md
@@ -131,11 +131,17 @@ to do this.
 
 In some cases you'll want to modify an individual base package (i.e. commutable
 or transforms) and not rebuild all of the other packages. To target a build of a
-specific package, use this command, replacing `packageName` with the package you
+specific package, use this command, replacing `packageName` with the fully qualified name of the package you
 want to hack on:
 
 ```
-$(yarn bin)/lerna run build --scope packageName
+yarn build:only packageName
+```
+
+For example, to hack on the `transforms` package, use
+
+```
+yarn build:only @nteract/transforms
 ```
 
 ### Hacking on the Desktop application

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To get started developing, [set up the nteract monorepo](#set-the-monorepo-up-in
 
 #### Set the monorepo up in dev mode
 
-Requires [Node.js and npm 3+](https://docs.npmjs.com/getting-started/installing-node#installing-npm-from-the-nodejs-site).
+Requires [Node.js](https://docs.npmjs.com/getting-started/installing-node) and [yarn](https://yarnpkg.com/lang/en/docs/install/).
 
 1. Fork this repo
 2. Clone your fork or this repo `git clone https://github.com/nteract/nteract`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ When changes are made to the root nteract/nteract, they can then be pulled from 
 6. `git pull upstream master`
 7. `yarn clean`
 8. `yarn install`
-7. yarn install
 
 #### Windows Caveats
 
@@ -148,7 +147,7 @@ yarn app:desktop
 ```
 
 As you make changes, you will have to close the entire app (CMD-q on macOS or
-CNTL-c at the terminal) and then run `yarn run app:desktop` again to see the
+CNTL-c at the terminal) and then run `yarn app:desktop` again to see the
 changes.
 
 #### Progressive Webpack build (automatic)
@@ -201,7 +200,7 @@ rebuild those using [the instructions for building specific packages](#building-
 > I want to debug redux actions and state changes.
 
 * Enable [redux-logger](https://github.com/evgenyrodionov/redux-logger) by
-  spawning the application with `yarn run spawn:debug`.
+  spawning the application with `yarn spawn:debug`.
 
 > I keep getting a pop-up asking: *Do you want the application "nteract Helper.app" to accept
   incoming network connections?* while developing or using a custom build of

--- a/applications/commuter/README.md
+++ b/applications/commuter/README.md
@@ -28,8 +28,12 @@ Try **commuter** today and take your notebooks wherever you need them.
 
 ## Installation
 
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
 ```
-yarn install @nteract/commuter -g
+npm install @nteract/commuter -g
+# OR
+yarn global add @nteract/commuter
 ```
 
 ## Usage

--- a/applications/commuter/README.md
+++ b/applications/commuter/README.md
@@ -29,7 +29,7 @@ Try **commuter** today and take your notebooks wherever you need them.
 ## Installation
 
 ```
-npm install @nteract/commuter -g
+yarn install @nteract/commuter -g
 ```
 
 ## Usage
@@ -86,9 +86,9 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 
 ## Tests
 
-1. `npm t`
+1. `yarn test`
 
 ## Deployment
 
-1. Install commuter cli `npm install @nteract/commuter`
+1. Install commuter cli `yarn install @nteract/commuter`
 1. `exec commuter` - the service is typically wrapped inside [daemontools](https://cr.yp.to/daemontools.html)

--- a/packages/ansi-to-react/README.md
+++ b/packages/ansi-to-react/README.md
@@ -2,8 +2,14 @@
 
 Convert ANSI Escape Codes to pretty text output for React.
 
-```
-yarn install --save ansi-to-react
+## Installation
+
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install --save ansi-to-react
+# OR
+yarn add ansi-to-react
 ```
 
 ## Usage

--- a/packages/ansi-to-react/README.md
+++ b/packages/ansi-to-react/README.md
@@ -3,7 +3,7 @@
 Convert ANSI Escape Codes to pretty text output for React.
 
 ```
-npm install --save ansi-to-react
+yarn install --save ansi-to-react
 ```
 
 ## Usage

--- a/packages/commutable/README.md
+++ b/packages/commutable/README.md
@@ -19,8 +19,12 @@ Credits to [Tom MacWright](http://www.macwright.org/2015/05/18/practical-undo.ht
 
 ## Installation
 
-```
-yarn install --save @nteract/commutable
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install --save @nteract/commutable
+# OR
+yarn add @nteract/commutable
 ```
 
 ## Docs

--- a/packages/commutable/README.md
+++ b/packages/commutable/README.md
@@ -20,10 +20,9 @@ Credits to [Tom MacWright](http://www.macwright.org/2015/05/18/practical-undo.ht
 ## Installation
 
 ```
-npm install --save @nteract/commutable
+yarn install --save @nteract/commutable
 ```
 
 ## Docs
 
 Check out our [docs](https://nteract.github.io/docs/commutable/) for getting started.
-

--- a/packages/display-area/README.md
+++ b/packages/display-area/README.md
@@ -3,8 +3,12 @@ Render Jupyter notebook outputs in a trim little React component.
 
 ## Installation
 
-```
-yarn install @nteract/display-area
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/display-area
+# OR
+yarn add @nteract/display-area
 ```
 
 ## Usage

--- a/packages/display-area/README.md
+++ b/packages/display-area/README.md
@@ -4,7 +4,7 @@ Render Jupyter notebook outputs in a trim little React component.
 ## Installation
 
 ```
-npm install @nteract/display-area
+yarn install @nteract/display-area
 ```
 
 ## Usage

--- a/packages/enchannel-zmq-backend/README.md
+++ b/packages/enchannel-zmq-backend/README.md
@@ -46,7 +46,13 @@ That's it. Functions for four channels; *simplicity in action*.
 
 Prerequisite: [Node.js and npm](https://docs.npmjs.com/getting-started/installing-node)
 
-`yarn install enchannel-zmq-backend`
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install enchannel-zmq-backend
+# OR
+yarn add enchannel-zmq-backend
+```
 
 ## Usage
 

--- a/packages/enchannel-zmq-backend/README.md
+++ b/packages/enchannel-zmq-backend/README.md
@@ -252,7 +252,7 @@ Then, fork and clone this repo:
 ```bash
 git clone https://github.com/nteract/enchannel-zmq-backend.git
 cd enchannel-zmq-backend
-yarn install
+yarn
 ```
 
 Develop! We welcome new and first time contributors.

--- a/packages/enchannel-zmq-backend/README.md
+++ b/packages/enchannel-zmq-backend/README.md
@@ -46,7 +46,7 @@ That's it. Functions for four channels; *simplicity in action*.
 
 Prerequisite: [Node.js and npm](https://docs.npmjs.com/getting-started/installing-node)
 
-`npm install enchannel-zmq-backend`
+`yarn install enchannel-zmq-backend`
 
 ## Usage
 
@@ -252,7 +252,7 @@ Then, fork and clone this repo:
 ```bash
 git clone https://github.com/nteract/enchannel-zmq-backend.git
 cd enchannel-zmq-backend
-npm install
+yarn install
 ```
 
 Develop! We welcome new and first time contributors.

--- a/packages/notebook-preview/README.md
+++ b/packages/notebook-preview/README.md
@@ -1,12 +1,19 @@
 # Notebook Preview
+
 Preview Jupyter notebooks in a small React component.
 
 ## Installation
-```
-yarn install --save @nteract/notebook-preview
+
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install --save @nteract/notebook-preview
+# OR
+yarn add @nteract/notebook-preview
 ```
 
 ## Usage
+
 ```jsx
 import NotebookPreview from "@nteract/notebook-preview";
 

--- a/packages/notebook-preview/README.md
+++ b/packages/notebook-preview/README.md
@@ -3,7 +3,7 @@ Preview Jupyter notebooks in a small React component.
 
 ## Installation
 ```
-npm install --save @nteract/notebook-preview
+yarn install --save @nteract/notebook-preview
 ```
 
 ## Usage

--- a/packages/rx-jupyter/README.md
+++ b/packages/rx-jupyter/README.md
@@ -35,7 +35,7 @@ To install `rx-jupyter` for development, do the following:
 ```
 git clone https://github.com/nteract/nteract.git
 cd nteract
-yarn install
+yarn
 # Note that rx-jupyter is in packages/rx-jupyter
 ```
 ## Testing

--- a/packages/rx-jupyter/README.md
+++ b/packages/rx-jupyter/README.md
@@ -35,12 +35,12 @@ To install `rx-jupyter` for development, do the following:
 ```
 git clone https://github.com/nteract/nteract.git
 cd nteract
-npm i
+yarn install
 # Note that rx-jupyter is in packages/rx-jupyter
 ```
 ## Testing
 
-Use `npm test` to run the test suite.
+Use `yarn test` to run the test suite.
 
 
 [Jupyter Server API]: http://jupyter-api.surge.sh/

--- a/packages/transform-geojson/README.md
+++ b/packages/transform-geojson/README.md
@@ -6,5 +6,5 @@ in `@nteract/transforms-full`.
 ## Installation
 
 ```
-npm install @nteract/transform-geojson
+yarn install @nteract/transform-geojson
 ```

--- a/packages/transform-geojson/README.md
+++ b/packages/transform-geojson/README.md
@@ -5,6 +5,10 @@ in `@nteract/transforms-full`.
 
 ## Installation
 
-```
-yarn install @nteract/transform-geojson
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/transform-geojson
+# OR
+yarn add @nteract/transform-geojson
 ```

--- a/packages/transform-model-debug/README.md
+++ b/packages/transform-model-debug/README.md
@@ -7,6 +7,10 @@ in `@nteract/transforms-full`.
 
 ## Installation
 
-```
-yarn install @nteract/transform-model-debug
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/transform-model-debug
+# OR
+yarn add @nteract/transform-model-debug
 ```

--- a/packages/transform-model-debug/README.md
+++ b/packages/transform-model-debug/README.md
@@ -8,5 +8,5 @@ in `@nteract/transforms-full`.
 ## Installation
 
 ```
-npm install @nteract/transform-model-debug
+yarn install @nteract/transform-model-debug
 ```

--- a/packages/transform-plotly/README.md
+++ b/packages/transform-plotly/README.md
@@ -5,6 +5,10 @@ in `@nteract/transforms-full`.
 
 ## Installation
 
-```
-yarn install @nteract/transform-plotly
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/transform-plotly
+# OR
+yarn add @nteract/transform-plotly
 ```

--- a/packages/transform-plotly/README.md
+++ b/packages/transform-plotly/README.md
@@ -6,5 +6,5 @@ in `@nteract/transforms-full`.
 ## Installation
 
 ```
-npm install @nteract/transform-plotly
+yarn install @nteract/transform-plotly
 ```

--- a/packages/transform-vdom/README.md
+++ b/packages/transform-vdom/README.md
@@ -5,8 +5,12 @@ Elements.
 
 ## Installation
 
-```
-yarn install --save @nteract/transform-vdom
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install --save @nteract/transform-vdom
+# OR
+yarn add @nteract/transform-vdom
 ```
 
 Note: This transform is included in `@nteract/transforms` so if you're using that

--- a/packages/transform-vdom/README.md
+++ b/packages/transform-vdom/README.md
@@ -6,7 +6,7 @@ Elements.
 ## Installation
 
 ```
-npm install --save @nteract/transform-vdom
+yarn install --save @nteract/transform-vdom
 ```
 
 Note: This transform is included in `@nteract/transforms` so if you're using that

--- a/packages/transform-vega/README.md
+++ b/packages/transform-vega/README.md
@@ -5,6 +5,10 @@ in `@nteract/transforms-full`.
 
 ## Installation
 
-```
-yarn install @nteract/transform-vega
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/transform-vega
+# OR
+yarn add @nteract/transform-vega
 ```

--- a/packages/transform-vega/README.md
+++ b/packages/transform-vega/README.md
@@ -6,5 +6,5 @@ in `@nteract/transforms-full`.
 ## Installation
 
 ```
-npm install @nteract/transform-vega
+yarn install @nteract/transform-vega
 ```

--- a/packages/transforms-full/README.md
+++ b/packages/transforms-full/README.md
@@ -14,8 +14,12 @@ release of the display area (:soon:).
 
 ## Installation
 
-```
-yarn install @nteract/transforms-full
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/transforms-full
+#OR
+yarn add @nteract/transforms-full
 ```
 
 Note: React is a peer dependencies you'll have to install yourself.

--- a/packages/transforms-full/README.md
+++ b/packages/transforms-full/README.md
@@ -15,7 +15,7 @@ release of the display area (:soon:).
 ## Installation
 
 ```
-npm install @nteract/transforms-full
+yarn install @nteract/transforms-full
 ```
 
 Note: React is a peer dependencies you'll have to install yourself.

--- a/packages/transforms/README.md
+++ b/packages/transforms/README.md
@@ -8,7 +8,7 @@ release of the display area (:soon:).
 ## Installation
 
 ```
-npm install @nteract/transforms
+yarn install @nteract/transforms
 ```
 
 Note: React is a peer dependencies you'll have to install yourself.

--- a/packages/transforms/README.md
+++ b/packages/transforms/README.md
@@ -7,8 +7,12 @@ release of the display area (:soon:).
 
 ## Installation
 
-```
-yarn install @nteract/transforms
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install @nteract/transforms
+# OR
+yarn add @nteract/transforms
 ```
 
 Note: React is a peer dependencies you'll have to install yourself.


### PR DESCRIPTION
## Overview
This is a PR to fulfill the request from #3134.

I went about this by doing a global search using Sublime for the following key phrases in all files with the `.md` suffix

- `npm install`
- `npm i` (npm install shorthand)
- `npm t` (npm test)
- `npm r` (npm run)

I believe this covers everything that would affect contributors. 

There were some different instructions used in the release/packaging documents, but I wasn't sure if we wanted to change those since the original issue only asked about changing `README.md` documents / it would require us to add Yarn to some of the CI pipelines. I left those out since I was already touching a large number of files.

These files in question which still include `npm install` references include `PACKAGING-NOTES.md` and the travis / circleci / appveyor CI yaml files.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

