### PR TITLE
Use markdown parser to escape math delimiters in text/latex

### DIFF
--- a/packages/transforms/__tests__/__snapshots__/latex-spec.js.snap
+++ b/packages/transforms/__tests__/__snapshots__/latex-spec.js.snap
@@ -1,10 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LaTeXDisplay processes basic LaTeX 1`] = `
-<MathJaxNode
-  inline={false}
-  onRender={null}
+<LaTeXDisplay
+  data="Pseudo LaTeX $x^2 + y = 3$"
 >
-  x^2 + y = 3
-</MathJaxNode>
+  <MarkdownRender
+    allowedTypes={Array []}
+    source="Pseudo LaTeX $x^2 + y = 3$"
+    unwrapDisallowed={true}
+  >
+    <ReactMarkdown
+      allowedTypes={Array []}
+      astPlugins={Array []}
+      escapeHtml={false}
+      plugins={
+        Array [
+          [Function],
+        ]
+      }
+      rawSourcePos={false}
+      renderers={
+        Object {
+          "inlineMath": [Function],
+          "math": [Function],
+        }
+      }
+      skipHtml={false}
+      source="Pseudo LaTeX $x^2 + y = 3$"
+      sourcePos={false}
+      transformLinkUri={[Function]}
+      unwrapDisallowed={true}
+    >
+      <div
+        key="root-1-1"
+      >
+        Pseudo LaTeX 
+        <inlineMath
+          data={
+            Object {
+              "hChildren": Array [
+                Object {
+                  "type": "text",
+                  "value": "x^2 + y = 3",
+                },
+              ],
+              "hName": "span",
+              "hProperties": Object {
+                "className": "inlineMath",
+              },
+            }
+          }
+          key="inlineMath-1-14"
+          value="x^2 + y = 3"
+        >
+          <MathJaxNode
+            inline={true}
+            onRender={null}
+          >
+            <Provider
+              delay={0}
+              didFinishTypeset={null}
+              input="tex"
+              loading={null}
+              noGate={false}
+              onError={[Function]}
+              onLoad={null}
+              options={Object {}}
+              src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+            >
+              <MathJaxNode
+                inline={true}
+                onRender={null}
+              />
+            </Provider>
+          </MathJaxNode>
+        </inlineMath>
+      </div>
+    </ReactMarkdown>
+  </MarkdownRender>
+</LaTeXDisplay>
 `;

--- a/packages/transforms/__tests__/latex-spec.js
+++ b/packages/transforms/__tests__/latex-spec.js
@@ -1,14 +1,14 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import toJson from "enzyme-to-json";
 
 import LaTeXDisplay from "../src/latex";
 
 describe("LaTeXDisplay", () => {
   it("processes basic LaTeX", () => {
-    const wrapper = shallow(<LaTeXDisplay data={"x^2 + y = 3"} />);
+    const wrapper = mount(<LaTeXDisplay data={"Pseudo LaTeX $x^2 + y = 3$"} />);
 
     expect(toJson(wrapper)).toMatchSnapshot();
   });

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -35,7 +35,6 @@
     "@nteract/transform-vdom": "^2.2.3",
     "ansi-to-react": "^3.3.3",
     "babel-runtime": "^6.26.0",
-    "prop-types": "^15.6.1",
     "react-json-tree": "^0.11.0"
   },
   "peerDependencies": {

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -1,17 +1,18 @@
 /* @flow */
 import React from "react";
-import PropTypes from "prop-types";
 
-import MathJax from "@nteract/mathjax";
+import Markdown from "@nteract/markdown";
+import MarkdownDisplay from "./markdown";
 
-type Props = {
-  data: string
-};
+export class LaTeXDisplay extends MarkdownDisplay {
+  static MIMETYPE = "text/latex";
 
-export const LaTeXDisplay = (props: Props) => {
-  return <MathJax.Node>{props.data}</MathJax.Node>;
-};
-
-LaTeXDisplay.MIMETYPE = "text/latex";
+  render(): ?React$Element<any> {
+    // Only parse math types using the markdown parser
+    return (
+      <Markdown allowedTypes={[]} unwrapDisallowed source={this.props.data} />
+    );
+  }
+}
 
 export default LaTeXDisplay;


### PR DESCRIPTION
Fixes https://github.com/nteract/nteract/pull/3384#issuecomment-428729447

## This PR
<img width="832" alt="bildschirmfoto 2018-10-11 um 00 02 44" src="https://user-images.githubusercontent.com/13285808/46768721-9be93b80-cce9-11e8-8a1e-63cc578e3902.png">

## v0.11.9
<img width="832" alt="bildschirmfoto 2018-10-11 um 00 02 47" src="https://user-images.githubusercontent.com/13285808/46768723-9c81d200-cce9-11e8-9c36-f337df4c5c18.png">

## Jupyter Notebook
<img width="832" alt="bildschirmfoto 2018-10-11 um 00 10 36" src="https://user-images.githubusercontent.com/13285808/46768862-1e71fb00-ccea-11e8-96e9-3a4c0024c77c.png">

