### PR TITLE
Add ExecuteResult component

### DIFF
--- a/packages/outputs/__tests__/output-spec.js
+++ b/packages/outputs/__tests__/output-spec.js
@@ -1,7 +1,13 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 
-import { Output, StreamText, KernelOutputError, DisplayData } from "../src";
+import {
+  Output,
+  StreamText,
+  KernelOutputError,
+  DisplayData,
+  ExecuteResult
+} from "../src";
 
 describe("Output", () => {
   it("handles stream data", () => {
@@ -64,5 +70,28 @@ describe("Output", () => {
     );
 
     expect(component.type()).toEqual(DisplayData);
+  });
+  it("handles an execute result message", () => {
+    const output = {
+      outputType: "pyout",
+      data: {
+        "text/plain": "42 is the answer to life, the universe, and everything."
+      }
+    };
+
+    const Plain = props => <pre>{props.data}</pre>;
+    Plain.defaultProps = {
+      mediaType: "text/plain"
+    };
+
+    const component = shallow(
+      <Output output={output}>
+        <ExecuteResult>
+          <Plain />
+        </ExecuteResult>
+      </Output>
+    );
+
+    expect(component.type()).toEqual(ExecuteResult);
   });
 });

--- a/packages/outputs/src/components/execute-result.js
+++ b/packages/outputs/src/components/execute-result.js
@@ -1,0 +1,53 @@
+// @flow strict
+import * as React from "react";
+
+import { RichMedia } from "./rich-media";
+
+import type { MediaBundle } from "@nteract/records";
+
+type Props = {
+  /**
+   * The literal type of output, used for routing with the `<Output />` element
+   */
+  outputType: "pyout",
+  /**
+   * Object of media type → data
+   *
+   * E.g.
+   *
+   * ```js
+   * {
+   *   "text/plain": "raw text",
+   * }
+   * ```
+   *
+   * See [Jupyter message spec](http://jupyter-client.readthedocs.io/en/stable/messaging.html)
+   * for more detail.
+   *
+   */
+  data: MediaBundle,
+  /**
+   * custom settings, typically keyed by media type
+   */
+  metadata: {},
+  /**
+   * React elements that accept mimebundle data, will get passed data[mimetype]
+   */
+  children: React.Node
+};
+
+export const ExecuteResult = (props: Props) => {
+  const { data, metadata, children } = props;
+
+  return (
+    <RichMedia data={data} metadata={metadata}>
+      {children}
+    </RichMedia>
+  );
+};
+
+ExecuteResult.defaultProps = {
+  outputType: "pyout",
+  data: {},
+  metadata: {}
+};

--- a/packages/outputs/src/components/execute-result.md
+++ b/packages/outputs/src/components/execute-result.md
@@ -1,0 +1,12 @@
+The `<ExecuteResult />` component will render execution outputs (SVGs, HTML, text, etc) in the front end.
+
+```jsx
+const Plain = props => <pre>{props.data}</pre>;
+Plain.defaultProps = {
+  mediaType: "text/plain"
+};
+
+<ExecuteResult data={{ "text/plain": "The answer to everything is 42." }}>
+  <Plain />
+</ExecuteResult>;
+```

--- a/packages/outputs/src/index.js
+++ b/packages/outputs/src/index.js
@@ -3,5 +3,6 @@ export { RichMedia } from "./components/rich-media";
 export { Output } from "./components/output";
 export { KernelOutputError } from "./components/kernel-output-error";
 export { DisplayData } from "./components/display-data";
+export { ExecuteResult } from "./components/execute-result";
 import StreamText from "./components/stream-text";
 export { StreamText };


### PR DESCRIPTION
Decided to duplicate the code from DisplayData instead of setting up some sort of inheritance structure to allow use to have more fine-grained control of the doc strings on the types in the future.