### PR TITLE
Activate eslint-react plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
     "react/prop-types": 0,
     "react/display-name": 0,
     "react/no-unescaped-entities": 0,
-    "react/no-deprecated": 1
+    "react/no-deprecated": 1,
+    "no-unused-vars": 1
   },
   "settings": {
     "react": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,12 @@
 {
-  "extends": ["prettier", "prettier/flowtype", "plugin:jsx-a11y/recommended"],
+  "extends": [
+    "prettier",
+    "prettier/flowtype",
+    "plugin:react/recommended",
+    "plugin:jsx-a11y/recommended"
+  ],
   "parser": "babel-eslint",
-  "plugins": ["prettier", "flowtype", "jsx-a11y"],
+  "plugins": ["prettier", "flowtype", "react", "jsx-a11y"],
   "env": {
     "browser": true,
     "node": true,
@@ -10,6 +15,16 @@
   "rules": {
     "jsx-a11y/no-onchange": 0,
     "jsx-a11y/anchor-has-content": 0,
-    "jsx-a11y/heading-has-content": 0
+    "jsx-a11y/heading-has-content": 0,
+    "react/prop-types": 0,
+    "react/display-name": 0,
+    "react/no-unescaped-entities": 0,
+    "react/no-deprecated": 1
+  },
+  "settings": {
+    "react": {
+      "version": "16.3.2",
+      "flowVersion": "0.81"
+    }
   }
 }

--- a/applications/commuter/components/contents/zeppelin.js
+++ b/applications/commuter/components/contents/zeppelin.js
@@ -66,7 +66,9 @@ const HokeyTable = props => (
       <tbody>
         {props.rows.map((row, idx) => (
           <tr key={idx}>
-            {row.map((item, colIdx) => <td key={colIdx}>{item}</td>)}
+            {row.map((item, colIdx) => (
+              <td key={colIdx}>{item}</td>
+            ))}
           </tr>
         ))}
       </tbody>
@@ -122,13 +124,17 @@ const DSVTable = (props: { data: Array<Object> }) => {
       <table>
         <thead>
           <tr>
-            {columnNames.map((column, idx) => <th key={idx}>{column}</th>)}
+            {columnNames.map((column, idx) => (
+              <th key={idx}>{column}</th>
+            ))}
           </tr>
         </thead>
         <tbody>
           {rows.map((row, idx) => (
             <tr key={idx}>
-              {columnNames.map((k, colIdx) => <td key={colIdx}>{row[k]}</td>)}
+              {columnNames.map((k, colIdx) => (
+                <td key={colIdx}>{row[k]}</td>
+              ))}
             </tr>
           ))}
         </tbody>
@@ -142,7 +148,11 @@ const UnsupportedResult = props => (
     <h1>UNSUPPORTED ZEPPELIN RESULT</h1>
     <p>
       Post an issue to{" "}
-      <a href="https://github.com/nteract/commuter/issues/new" target="_blank">
+      <a
+        href="https://github.com/nteract/commuter/issues/new"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
         commuter
       </a>{" "}
       to let us know about it
@@ -284,7 +294,9 @@ const ZeppelinView = (props: ZeppelinViewProps) => {
   return (
     <div style={{ paddingLeft: "10px" }}>
       <h1>{props.notebook.name}</h1>
-      {props.notebook.paragraphs.map(p => <Paragraph key={p.id} {...p} />)}
+      {props.notebook.paragraphs.map(p => (
+        <Paragraph key={p.id} {...p} />
+      ))}
     </div>
   );
 };

--- a/applications/desktop/__tests__/renderer/epics/close-notebook-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/close-notebook-spec.js
@@ -3,9 +3,7 @@
 import * as actions from "../../../src/notebook/actions";
 
 import {
-  makeDesktopNotebookRecord,
   DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
-  DESKTOP_NOTEBOOK_CLOSING_STARTED,
   DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
 } from "../../../src/notebook/state.js";
 
@@ -13,8 +11,6 @@ import { closeNotebookEpic } from "../../../src/notebook/epics/close-notebook";
 
 import {
   actions as coreActions,
-  actionTypes as coreActionTypes,
-  createContentRef,
   makeDocumentRecord,
   makeNotebookContentRecord,
   state as stateModule
@@ -22,11 +18,8 @@ import {
 
 import * as Immutable from "immutable";
 
-import { Observable } from "rxjs/Observable";
-import { of } from "rxjs/observable/of";
-import { toArray, catchError, map } from "rxjs/operators";
-
-import { ActionsObservable, combineEpics, ofType } from "redux-observable";
+import { toArray } from "rxjs/operators";
+import { ActionsObservable } from "redux-observable";
 
 import { ipcRenderer as ipc } from "../../../__mocks__/electron";
 
@@ -114,7 +107,7 @@ describe("closeNotebookEpic", () => {
         );
 
         // Next expected message:
-        ipc.send = (event, data) => {
+        ipc.send = event => {
           expect(event).toBe("close-notebook-canceled");
         };
 

--- a/applications/desktop/__tests__/renderer/epics/index-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/index-spec.js
@@ -14,14 +14,14 @@ describe("epics", () => {
 
 describe("retryAndEmitError", () => {
   test("returns the source observable, emitting an error action first", () => {
-    console.error = jest.fn(err => {});
+    console.error = jest.fn();
 
     const source = {
       pipe: jest.fn()
     };
 
     const err = new Error("Oh no!");
-    const newSource = retryAndEmitError(err, source);
+    retryAndEmitError(err, source);
 
     expect(console.error).toHaveBeenCalledWith(err);
 

--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -3,15 +3,12 @@ import { ActionsObservable } from "redux-observable";
 import { actions, actionTypes, makeStateRecord } from "@nteract/core";
 
 import {
-  acquireKernelInfo,
-  watchExecutionStateEpic,
   launchKernelObservable,
   launchKernelEpic,
   launchKernelByNameEpic
 } from "../../../src/notebook/epics/zeromq-kernels";
 
-import { of } from "rxjs/observable/of";
-import { toArray, catchError } from "rxjs/operators";
+import { toArray } from "rxjs/operators";
 
 describe("launchKernelObservable", () => {
   test("returns an observable", () => {
@@ -22,7 +19,6 @@ describe("launchKernelObservable", () => {
 
 describe("launchKernelEpic", () => {
   test("throws an error if given a bad action", async function() {
-    const actionBuffer = [];
     const action$ = ActionsObservable.of(
       {
         type: actionTypes.LAUNCH_KERNEL,
@@ -60,7 +56,6 @@ describe("launchKernelEpic", () => {
   });
 
   test("calls launchKernelObservable if given the correct action", async function() {
-    const actionBuffer = [];
     const action$ = ActionsObservable.of(
       actions.launchKernel({
         kernelSpec: { spec: "hokey", name: "woohoo" },

--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -2,13 +2,10 @@ import { ActionsObservable } from "redux-observable";
 
 import { monocellNotebook, toJS } from "@nteract/commutable";
 
-import { dummyCommutable, dummy } from "@nteract/core/dummy";
+import { dummyCommutable } from "@nteract/core/dummy";
 
 import {
-  load,
-  newNotebook,
   extractNewKernel,
-  convertRawNotebook,
   fetchContentEpic,
   newNotebookEpic
 } from "../../../src/notebook/epics/loading";

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -1,18 +1,13 @@
 jest.mock("fs");
 import { ActionsObservable } from "redux-observable";
 
-import {
-  actions,
-  createContentRef,
-  makeNotebookContentRecord
-} from "@nteract/core";
+import { actions, makeNotebookContentRecord } from "@nteract/core";
 
 import * as Immutable from "immutable";
 
 import { saveEpic, saveAsEpic } from "../../../src/notebook/epics/saving";
 
-import { of } from "rxjs/observable/of";
-import { catchError, toArray } from "rxjs/operators";
+import { toArray } from "rxjs/operators";
 
 describe("saveEpic", () => {
   test("saves the file using the notebook in the state tree", async function() {

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -1,7 +1,7 @@
 import { webFrame, ipcRenderer as ipc } from "electron";
 jest.mock("fs");
 import * as menu from "../../src/notebook/menu";
-import { selectors, actions, actionTypes } from "@nteract/core";
+import { actions, actionTypes } from "@nteract/core";
 
 import * as Immutable from "immutable";
 
@@ -719,7 +719,6 @@ describe("exportPDF", () => {
 
 describe("storeToPDF", () => {
   test("triggers notification when not saved", () => {
-    const config = { noFilename: true };
     const props = {
       contentRef: "123"
     };

--- a/applications/desktop/__tests__/renderer/native-window-spec.js
+++ b/applications/desktop/__tests__/renderer/native-window-spec.js
@@ -1,7 +1,6 @@
 import Immutable from "immutable";
 import { remote } from "electron";
 
-import { from } from "rxjs/observable/from";
 import { of } from "rxjs/observable/of";
 
 import * as nativeWindow from "../../src/notebook/native-window";
@@ -52,10 +51,6 @@ describe("createTitleFeed", () => {
     const kernelRef = stateModule.createKernelRef();
     const contentRef = stateModule.createContentRef();
 
-    const notebook = new Immutable.Map().setIn(
-      ["metadata", "kernelspec", "display_name"],
-      "python3000"
-    );
     const state = {
       core: stateModule.makeStateRecord({
         kernelRef,

--- a/applications/desktop/babel.config.js
+++ b/applications/desktop/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = function(api) {
-  const env = api.env();
+  const env = api.env(); // eslint-disable-line no-unused-vars
 
   const config = {
     presets: ["@babel/preset-env", "@babel/preset-react", "@babel/preset-flow"],

--- a/applications/desktop/src/main/cli.js
+++ b/applications/desktop/src/main/cli.js
@@ -9,6 +9,7 @@ import { writeFileObservable, createSymlinkObservable } from "fs-observable";
 
 // Overwrite the type for `process` to match Electron's process
 // https://electronjs.org/docs/api/process
+// eslint-disable-next-line no-unused-vars
 declare var ElectronProcess: typeof process & {
   resourcesPath: string
 };

--- a/applications/desktop/src/main/index.js
+++ b/applications/desktop/src/main/index.js
@@ -229,7 +229,7 @@ windowAllClosed.pipe(skipUntil(appAndKernelSpecsReady)).subscribe(() => {
   }
 });
 
-ipc.on("close-notebook-canceled", (event, k) => {
+ipc.on("close-notebook-canceled", () => {
   // User canceled, so interpret that as cancelling any in-flight app-wide quit
   store.dispatch(setQuittingState(QUITTING_STATE_NOT_STARTED));
 });

--- a/applications/desktop/src/main/launch.js
+++ b/applications/desktop/src/main/launch.js
@@ -1,7 +1,7 @@
 /* @flow strict */
 import * as path from "path";
 
-import { Menu, shell, BrowserWindow, dialog } from "electron";
+import { Menu, shell, BrowserWindow } from "electron";
 
 import { loadFullMenu } from "./menu";
 

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -9,6 +9,7 @@ import { manifest } from "@nteract/examples";
 
 // Overwrite the type for `process` to match Electron's process
 // https://electronjs.org/docs/api/process
+// eslint-disable-next-line no-unused-vars
 declare var ElectronProcess: typeof process & {
   resourcesPath: string
 };
@@ -627,17 +628,6 @@ export function loadTrayMenu(store: * = global.store) {
   //      "core" state -- it's a main process side model in the electron app
   const state = store.getState();
   const kernelSpecs = state.get("kernelSpecs") ? state.get("kernelSpecs") : {};
-
-  function generateSubMenu(kernel) {
-    return {
-      label: kernel.spec.display_name,
-      click: createSender("menu:new-kernel", kernel)
-    };
-  }
-
-  const kernelMenuItems = sortBy(kernelSpecs, "spec.display_name").map(
-    generateSubMenu
-  );
 
   const newNotebookItems = sortBy(kernelSpecs, "spec.display_name").map(
     kernel => ({

--- a/applications/desktop/src/notebook/epics/close-notebook.js
+++ b/applications/desktop/src/notebook/epics/close-notebook.js
@@ -7,9 +7,7 @@ import * as actions from "../actions";
 import * as actionTypes from "../actionTypes";
 
 import {
-  makeDesktopNotebookRecord,
   DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
-  DESKTOP_NOTEBOOK_CLOSING_STARTED,
   DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
 } from "../state.js";
 
@@ -30,8 +28,6 @@ import {
   concatMap,
   exhaustMap,
   filter,
-  map,
-  switchMap,
   take,
   tap,
   timeout
@@ -39,7 +35,7 @@ import {
 
 import { ActionsObservable, ofType } from "redux-observable";
 
-import { remote, ipcRenderer as ipc } from "electron";
+import { ipcRenderer as ipc } from "electron";
 
 export const closeNotebookEpic = (action$: ActionsObservable<*>, store: *) =>
   action$.pipe(
@@ -110,7 +106,7 @@ export const closeNotebookEpic = (action$: ActionsObservable<*>, store: *) =>
             console.log(JSON.stringify(r)); // To see these in terminal, set ELECTRON_ENABLE_LOGGING=1. Could also start more explicitly routing them to main process stdout.
           }
         }),
-        concatMap(_ =>
+        concatMap(() =>
           // We don't need the results. Further, allowing the Array<Action> to flow through error middleware crashed
           // node.js for me, with "Error: async hook stack has become corrupted (actual: 1528, expected: 0)".
           // Seemed related to the error middleware not expecting an Array (returning result[0] avoids the crash as

--- a/applications/desktop/src/notebook/epics/config.js
+++ b/applications/desktop/src/notebook/epics/config.js
@@ -1,9 +1,9 @@
 /* @flow strict */
 import { remote } from "electron";
 
-import { selectors, actions, actionTypes } from "@nteract/core";
+import { actions, actionTypes } from "@nteract/core";
 import { readFileObservable, writeFileObservable } from "fs-observable";
-import { mapTo, mergeMap, map, switchMap, filter } from "rxjs/operators";
+import { mapTo, mergeMap, map, switchMap } from "rxjs/operators";
 import { ofType } from "redux-observable";
 
 import type { ActionsObservable } from "redux-observable";

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -5,15 +5,13 @@ import { selectors, actions, actionTypes } from "@nteract/core";
 
 const path = require("path");
 
-import type { Observer } from "rxjs/Observer";
 import type { ActionsObservable } from "redux-observable";
 
-import { Observable } from "rxjs/Observable";
 import { of } from "rxjs/observable/of";
 
 import { empty } from "rxjs/observable/empty";
 
-import { mergeMap, map, catchError } from "rxjs/operators";
+import { mergeMap, catchError } from "rxjs/operators";
 import { ofType } from "redux-observable";
 
 import { ajax } from "rxjs/observable/dom/ajax";
@@ -178,7 +176,7 @@ export const publishEpic = (action$: ActionsObservable<*>, store: *) => {
         catchError(err => {
           // Turn the response headers into an object
           var arr = err.xhr.getAllResponseHeaders().split("\r\n");
-          var headers = arr.reduce(function(acc, current, i) {
+          var headers = arr.reduce(function(acc, current) {
             var parts = current.split(": ");
             acc[parts[0]] = parts[1];
             return acc;

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -6,27 +6,14 @@ import * as fs from "fs";
 import { of } from "rxjs/observable/of";
 import { forkJoin } from "rxjs/observable/forkJoin";
 import { empty } from "rxjs/observable/empty";
-import {
-  map,
-  tap,
-  mergeMap,
-  switchMap,
-  catchError,
-  timeout
-} from "rxjs/operators";
+import { map, tap, switchMap, catchError, timeout } from "rxjs/operators";
 
 import { ActionsObservable, ofType } from "redux-observable";
 
 import { readFileObservable, statObservable } from "fs-observable";
 
-import * as Immutable from "immutable";
-import {
-  monocellNotebook,
-  fromJS,
-  parseNotebook,
-  toJS
-} from "@nteract/commutable";
-import type { Notebook, ImmutableNotebook } from "@nteract/commutable";
+import { monocellNotebook, toJS } from "@nteract/commutable";
+import type { ImmutableNotebook } from "@nteract/commutable";
 
 import { actionTypes, actions, selectors } from "@nteract/core";
 
@@ -61,7 +48,8 @@ function createContentsResponse(
   const parsedFilePath = path.parse(filePath);
 
   const name = parsedFilePath.base;
-  const writable = Boolean(fs.constants.W_OK & stat.mode);
+  // TODO: Check if this is unnecessary or should be used
+  // const writable = Boolean(fs.constants.W_OK & stat.mode);
   const created = stat.birthtime;
   const last_modified = stat.mtime;
 
@@ -205,8 +193,7 @@ export const newNotebookEpic = (action$: ActionsObservable<*>) =>
     map((action: actionTypes.NewNotebook) => {
       const {
         payload: {
-          kernelSpec: { name, spec },
-          kernelRef
+          kernelSpec: { name, spec }
         }
       } = action;
 

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -10,7 +10,7 @@ import { actionTypes, selectors, actions } from "@nteract/core";
 import { toJS, stringifyNotebook } from "@nteract/commutable";
 
 import { of } from "rxjs/observable/of";
-import { tap, mergeMap, catchError, map } from "rxjs/operators";
+import { mergeMap, catchError, map } from "rxjs/operators";
 
 import type { Store } from "redux";
 

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -1,32 +1,24 @@
 /* @flow strict */
-import { unlinkObservable } from "fs-observable";
 
 import type { ChildProcess } from "child_process";
 
 import { Observable } from "rxjs/Observable";
 import { of } from "rxjs/observable/of";
-import { from } from "rxjs/observable/from";
 import { empty } from "rxjs/observable/empty";
-import { fromEvent } from "rxjs/observable/fromEvent";
 import { merge } from "rxjs/observable/merge";
 
 import { sample } from "lodash";
 
-import * as fs from "fs";
-
 import {
   filter,
   map,
-  mapTo,
   tap,
   mergeMap,
   catchError,
-  pluck,
   switchMap,
   concatMap,
   timeout,
-  first,
-  concat
+  first
 } from "rxjs/operators";
 
 import { launchSpec } from "spawnteract";
@@ -44,16 +36,10 @@ import type {
   KernelspecInfo,
   KernelRef,
   ContentRef,
-  LocalKernelProps,
-  LocalKernelRecord
+  LocalKernelProps
 } from "@nteract/core";
 
-import {
-  createMessage,
-  childOf,
-  ofMessageType,
-  shutdownRequest
-} from "@nteract/messaging";
+import { childOf, ofMessageType, shutdownRequest } from "@nteract/messaging";
 
 /**
  * Instantiate a connection to a new kernel.
@@ -411,7 +397,7 @@ export const killKernelEpic = (action$: *, store: *): Observable<Action> =>
     })
   );
 
-export function watchSpawn(action$: *, store: *) {
+export function watchSpawn(action$: *) {
   return action$.pipe(
     ofType(actionTypes.LAUNCH_KERNEL_SUCCESSFUL),
     switchMap((action: actionTypes.NewKernelAction) => {

--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -2,12 +2,9 @@
 
 import type { Store } from "redux";
 
-import { is } from "immutable";
 import { selectors } from "@nteract/core";
 
-import type { AppState, KernelRef, ContentRef } from "@nteract/core";
-
-import { ipcMain as ipc } from "electron";
+import type { ContentRef } from "@nteract/core";
 
 import * as actions from "./actions";
 
@@ -17,12 +14,9 @@ import {
   DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
 } from "./state.js";
 
-const urljoin = require("url-join");
-
 export function beforeUnload(
   contentRef: ContentRef,
-  store: Store<DesktopNotebookAppState, Action>,
-  e: *
+  store: Store<DesktopNotebookAppState, Action>
 ) {
   const state = store.getState();
   const model = selectors.model(state, { contentRef });

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -4,7 +4,6 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 import { ipcRenderer as ipc, remote } from "electron";
 import { Provider } from "react-redux";
-import type { Store } from "redux";
 
 // Load the nteract fonts
 require("./fonts");
@@ -29,7 +28,7 @@ import {
   makeEntitiesRecord
 } from "@nteract/core";
 
-import type { AppState, ContentRef, ContentRecord } from "@nteract/core";
+import type { ContentRef, ContentRecord } from "@nteract/core";
 
 import NotebookApp from "@nteract/notebook-app-component";
 

--- a/applications/desktop/src/notebook/middlewares.js
+++ b/applications/desktop/src/notebook/middlewares.js
@@ -8,10 +8,6 @@ import epics from "./epics/index.js";
 
 const rootEpic = combineEpics(...epics);
 
-type Action = {
-  type: string
-};
-
 const middlewares = [
   createEpicMiddleware(rootEpic),
   coreMiddlewares.errorMiddleware

--- a/applications/desktop/src/notebook/native-window.js
+++ b/applications/desktop/src/notebook/native-window.js
@@ -1,6 +1,5 @@
 /* @flow */
 import { remote } from "electron";
-import { is } from "immutable";
 
 import path from "path";
 
@@ -18,7 +17,6 @@ import {
   distinctUntilChanged,
   debounceTime,
   switchMap,
-  filter,
   mergeMap,
   share
 } from "rxjs/operators";
@@ -91,7 +89,7 @@ export function createTitleFeed(contentRef: ContentRef, state$: *) {
     mergeMap(content => {
       if (content && content.type === "notebook") {
         // FIXME COME BACK TO HERE, we need to strip off the kernelRef
-        const kernelRef = content.model.kernelRef;
+        // const kernelRef = content.model.kernelRef;
         return of(content.model.kernelRef);
       } else {
         return empty();

--- a/applications/desktop/src/notebook/reducers.js
+++ b/applications/desktop/src/notebook/reducers.js
@@ -2,10 +2,7 @@
 
 import * as actionTypes from "./actionTypes";
 
-import type {
-  DesktopNotebookRecord,
-  DesktopNotebookClosingState
-} from "./state";
+import type { DesktopNotebookRecord } from "./state";
 import {
   makeDesktopNotebookRecord,
   DESKTOP_NOTEBOOK_CLOSING_STARTED

--- a/applications/desktop/webpack.prod.js
+++ b/applications/desktop/webpack.prod.js
@@ -1,4 +1,3 @@
-const webpack = require("webpack");
 const merge = require("webpack-merge");
 
 const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");

--- a/applications/play/components/consoles.js
+++ b/applications/play/components/consoles.js
@@ -5,7 +5,12 @@ class BinderLogo extends React.Component<*, *> {
   render() {
     return (
       <React.Fragment>
-        <a className="anchor" href="https://mybinder.org" target="_blank">
+        <a
+          className="anchor"
+          href="https://mybinder.org"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
           <img
             src="https://mybinder.org/static/logo.svg?v=f9f0d927b67cc9dc99d788c822ca21c0"
             alt="binder logo"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^3.0.0",
-    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react": "^7.11.1",
     "flow-bin": "^0.81.0",
     "flow-copy-source": "^2.0.0",
     "husky": "^1.0.0",

--- a/packages/octicons/src/index.js
+++ b/packages/octicons/src/index.js
@@ -123,7 +123,6 @@ export const PulseOcticon = (props: any) => (
       fillRule="evenodd"
       d="M11.5 8L8.8 5.4 6.6 8.5 5.5 1.6 2.38 8H0v2h3.6l.9-1.8.9 5.4L9 8.5l1.6 1.5H14V8z"
     />
-    />
   </SVGWrapper>
 );
 

--- a/packages/timeago/src/index.js
+++ b/packages/timeago/src/index.js
@@ -72,7 +72,7 @@ export const YEAR = DAY * 365;
 
 export default class TimeAgo extends React.Component<Props, void> {
   static displayName = "TimeAgo";
-  static defaultProps = {
+  static defaultProps: DefaultProps = {
     live: true,
     component: "time",
     minPeriod: 0,

--- a/packages/transform-dataresource/src/PalettePicker.js
+++ b/packages/transform-dataresource/src/PalettePicker.js
@@ -1,7 +1,6 @@
 /* @flow */
 import * as React from "react";
-import { join } from "path";
-import { BlockPicker, ChromePicker } from "react-color";
+import { ChromePicker } from "react-color";
 import paletteStyle from "./css/palette-picker";
 
 type Props = {

--- a/packages/transform-dataresource/src/ParallelCoordinatesController.js
+++ b/packages/transform-dataresource/src/ParallelCoordinatesController.js
@@ -108,7 +108,7 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
   };
 
   render(): ?React$Element<any> {
-    const { options, data, schema } = this.props;
+    const { options, data } = this.props;
 
     const { primaryKey, metrics, chart, colors } = options;
     const { dim1 } = chart;

--- a/packages/transform-dataresource/src/VizControls.js
+++ b/packages/transform-dataresource/src/VizControls.js
@@ -234,6 +234,7 @@ export default ({
               {availableAreaTypes.map(d => (
                 <button
                   className={`button-text ${areaType === d.type && "selected"}`}
+                  key={d.type}
                   onClick={() => setAreaType(d.type)}
                 >
                   {d.label}

--- a/packages/transform-dataresource/src/charts/bar.js
+++ b/packages/transform-dataresource/src/charts/bar.js
@@ -12,14 +12,8 @@ export const semioticBarChart = (
   schema: Object,
   options: Object
 ) => {
-  const {
-    selectedMetrics,
-    selectedDimensions,
-    chart,
-    colors,
-    setColor
-  } = options;
-  const { dim1, dim2, metric1, metric3 } = chart;
+  const { selectedDimensions, chart, colors, setColor } = options;
+  const { dim1, metric1, metric3 } = chart;
 
   const oAccessor =
     selectedDimensions.length === 0

--- a/packages/transform-dataresource/src/charts/grid.js
+++ b/packages/transform-dataresource/src/charts/grid.js
@@ -8,7 +8,7 @@ export const DataResourceTransformGrid = ({
   data: { data, schema },
   height
 }) => {
-  const tableColumns = schema.fields.map((f, i) => ({
+  const tableColumns = schema.fields.map(f => ({
     Header: f.name,
     accessor: f.name,
     fixed: schema.primaryKey.indexOf(f.name) !== -1 && "left"

--- a/packages/transform-dataresource/src/charts/line.js
+++ b/packages/transform-dataresource/src/charts/line.js
@@ -19,7 +19,6 @@ export const semioticLineChart = (
     selectedMetrics,
     lineType,
     metrics,
-    dimensions,
     primaryKey,
     colors
   } = options;

--- a/packages/transform-dataresource/src/charts/xyplot.js
+++ b/packages/transform-dataresource/src/charts/xyplot.js
@@ -110,24 +110,26 @@ export const semioticScatterplot = (
         >
           ID, {metric1}, {metric2}
         </h3>
-        {d.binItems.map(d => (
-          <p
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              margin: "5px"
-            }}
-          >
-            {dimensions
-              .map(
-                dim =>
-                  (d[dim.name].toString && d[dim.name].toString()) ||
-                  d[dim.name]
-              )
-              .join(",")}
-            , {d[metric1]}, {d[metric2]}
-          </p>
-        ))}
+        {d.binItems.map(d => {
+          const id = dimensions
+            .map(
+              dim =>
+                (d[dim.name].toString && d[dim.name].toString()) || d[dim.name]
+            )
+            .join(",");
+          return (
+            <p
+              key={id}
+              style={{
+                fontSize: "12px",
+                textTransform: "uppercase",
+                margin: "5px"
+              }}
+            >
+              {id}, {d[metric1]}, {d[metric2]}
+            </p>
+          );
+        })}
       </TooltipContent>
     );
   };

--- a/packages/transform-dataresource/src/icons.js
+++ b/packages/transform-dataresource/src/icons.js
@@ -1,12 +1,5 @@
 import * as React from "react";
 import { SVGWrapper } from "@nteract/octicons";
-import {
-  XYFrame,
-  OrdinalFrame,
-  ResponsiveOrdinalFrame,
-  ResponsiveXYFrame,
-  ResponsiveNetworkFrame
-} from "semiotic";
 
 export const BoxplotIcon = (props: any) => (
   <SVGWrapper width={16} height={16} viewBox="0 0 16 16" outerProps={props}>

--- a/packages/transform-vdom/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/transform-vdom/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VDOM Transform is cool 1`] = `
+<div
+  style={
+    Object {
+      "color": "DeepPink",
+    }
+  }
+>
+  <h1>
+    Wahoo
+  </h1>
+  <h1 />
+  <img
+    height="100px"
+    src="about:blank"
+    width="100px"
+  />
+</div>
+`;

--- a/packages/transform-vdom/__tests__/index.test.js
+++ b/packages/transform-vdom/__tests__/index.test.js
@@ -20,4 +20,6 @@ test("VDOM Transform is cool", () => {
       }}
     />
   );
+
+  expect(component.toJSON()).toMatchSnapshot();
 });

--- a/packages/transforms/__tests__/latex-spec.js
+++ b/packages/transforms/__tests__/latex-spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-import renderer from "react-test-renderer";
 
 import { shallow } from "enzyme";
 import toJson from "enzyme-to-json";

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -35,7 +35,6 @@
     "@nteract/transform-vdom": "^2.2.3",
     "ansi-to-react": "^3.3.3",
     "babel-runtime": "^6.26.0",
-    "prop-types": "^15.6.1",
     "react-json-tree": "^0.11.0"
   },
   "peerDependencies": {

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -1,6 +1,5 @@
 /* @flow */
 import React from "react";
-import PropTypes from "prop-types";
 
 import MathJax from "@nteract/mathjax";
 

--- a/packages/webpack-configurator/index.js
+++ b/packages/webpack-configurator/index.js
@@ -3,8 +3,6 @@
 // Since this has to be loaded at the stage of use by webpack and won't be
 // transpiled, all flow in this file uses the "comment style".
 
-const path = require("path");
-
 /*::
 opaque type Aliases = {[string]: string }
 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5458,7 +5458,7 @@ eslint-plugin-prettier@^3.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@^7.7.0:
+eslint-plugin-react@^7.11.1:
   version "7.11.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
   integrity sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==


### PR DESCRIPTION
I noticed we have a lot of unused variables and imports. Configuring configuring the ESLINT React plugin allows us to add the `no-unused-vars` ESLINT rule without complaining on React imports for JSX.

I added the `no-unused-vars` rule as a warning so we can start reducing the amount of unused variables and imports.