### PR TITLE
Report kernel "launching" properly.

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -59,6 +59,7 @@ describe("launchKernelEpic", () => {
     const action$ = ActionsObservable.of(
       actions.launchKernel({
         kernelSpec: { spec: "hokey", name: "woohoo" },
+        kernelType: "zeromq",
         contentRef: "abc",
         cwd: "~",
         selectNextKernel: true,
@@ -119,6 +120,7 @@ describe("launchKernelByNameEpic", () => {
     const action$ = ActionsObservable.of(
       actions.launchKernelByName({
         kernelSpecName: "python3",
+        kernelType: "zeromq",
         cwd: "~"
       })
     );

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -508,6 +508,7 @@ describe("dispatchNewKernel", () => {
       type: actionTypes.LAUNCH_KERNEL,
       payload: {
         kernelSpec: { spec: "hokey" },
+        kernelType: "zeromq",
         cwd: process.cwd(),
         selectNextKernel: true,
         kernelRef: expect.any(String),

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -174,6 +174,7 @@ export const launchKernelWhenNotebookSetEpic = (
 
       return actions.launchKernelByName({
         kernelSpecName,
+        kernelType: "zeromq",
         cwd,
         kernelRef: action.payload.kernelRef,
         selectNextKernel: true,

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -174,6 +174,7 @@ export const launchKernelByNameEpic = (
           of(
             actions.launchKernel({
               kernelSpec: specs[action.payload.kernelSpecName],
+              kernelType: "zeromq",
               cwd: action.payload.cwd,
               kernelRef: action.payload.kernelRef,
               selectNextKernel: action.payload.selectNextKernel,

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -156,6 +156,7 @@ export function promptUserAboutNewKernel(
           store.dispatch(
             actions.launchKernelByName({
               kernelSpecName: kernel.kernelSpecName,
+              kernelType: kernel.type,
               cwd,
               selectNextKernel: true,
               kernelRef,
@@ -215,6 +216,7 @@ export function dispatchNewKernel(
   store.dispatch(
     actions.launchKernel({
       kernelSpec,
+      kernelType: "zeromq",
       cwd,
       selectNextKernel: true,
       kernelRef,

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -127,11 +127,16 @@ describe("setExecutionState", () => {
 describe("launchKernel", () => {
   test("creates a LAUNCH_KERNEL action", () => {
     expect(
-      actions.launchKernel({ kernelSpec: { spec: "hokey" }, cwd: "." })
+      actions.launchKernel({
+        kernelSpec: { spec: "hokey" },
+        kernelType: "zeromq",
+        cwd: "."
+      })
     ).toEqual({
       type: actionTypes.LAUNCH_KERNEL,
       payload: {
         kernelSpec: { spec: "hokey" },
+        kernelType: "zeromq",
         cwd: "."
       }
     });
@@ -141,11 +146,16 @@ describe("launchKernel", () => {
 describe("launchKernelByName", () => {
   test("creates a LAUNCH_KERNEL_BY_NAME action", () => {
     expect(
-      actions.launchKernelByName({ kernelSpecName: "python2", cwd: "." })
+      actions.launchKernelByName({
+        kernelSpecName: "python2",
+        kernelType: "zeromq",
+        cwd: "."
+      })
     ).toEqual({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
       payload: {
         kernelSpecName: "python2",
+        kernelType: "zeromq",
         cwd: "."
       }
     });

--- a/packages/core/__tests__/epics/kernel-lifecycle-spec.js
+++ b/packages/core/__tests__/epics/kernel-lifecycle-spec.js
@@ -231,6 +231,7 @@ describe("restartKernelEpic", () => {
       }),
       d: actions.launchKernelByName({
         kernelSpecName: null,
+        kernelType: "websocket",
         cwd: ".",
         kernelRef: newKernelRef,
         selectNextKernel: true,
@@ -312,6 +313,7 @@ describe("restartKernelEpic", () => {
       }),
       d: actions.launchKernelByName({
         kernelSpecName: null,
+        kernelType: "websocket",
         cwd: ".",
         kernelRef: newKernelRef,
         selectNextKernel: true,

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -55,6 +55,7 @@ describe("launchWebSocketKernelEpic", () => {
         contentRef,
         kernelRef,
         kernelSpecName: "fancy",
+        kernelType: "websocket",
         cwd: "/",
         selectNextKernel: true
       })

--- a/packages/core/__tests__/reducers/core/entities/kernels.js
+++ b/packages/core/__tests__/reducers/core/entities/kernels.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { makeKernelsRecord } from "../../../../src/state/entities/kernels";
+import { kernels } from "../../../../src/reducers/core/entities/kernels";
+import { actions } from "@nteract/core";
+
+describe("LAUNCH_KERNEL reducers", () => {
+  test("set launching state", () => {
+    const originalState = makeKernelsRecord();
+
+    const action = actions.launchKernel({
+      kernelSpec: "kernelSpec",
+      kernelType: "zeromq",
+      cwd: ".",
+      kernelRef: "kernelRef",
+      selectNextKernel: false,
+      contentRef: "contentRef"
+    });
+
+    const state = kernels(originalState, action);
+
+    expect(state.byRef.get("kernelRef").type).toBe("zeromq");
+    expect(state.byRef.get("kernelRef").status).toBe("launching");
+  });
+});

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -725,6 +725,7 @@ export type LaunchKernelAction = {
   type: "LAUNCH_KERNEL",
   payload: {
     kernelRef: KernelRef,
+    kernelType: string,
     kernelSpec: Object,
     cwd: string,
     selectNextKernel: boolean,
@@ -747,6 +748,7 @@ export type LaunchKernelByNameAction = {
   type: "LAUNCH_KERNEL_BY_NAME",
   payload: {
     kernelSpecName: string,
+    kernelType: string,
     cwd: string,
     kernelRef: KernelRef,
     selectNextKernel: boolean,

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -136,6 +136,7 @@ export function launchKernelSuccessful(payload: {
 
 export function launchKernel(payload: {
   kernelSpec: any,
+  kernelType: string, // See #3427
   cwd: string,
   kernelRef: KernelRef,
   selectNextKernel: boolean,
@@ -160,6 +161,7 @@ export function changeKernelByName(payload: {
 
 export function launchKernelByName(payload: {
   kernelSpecName: any,
+  kernelType: string, // See #3427
   cwd: string,
   kernelRef: KernelRef,
   selectNextKernel: boolean,

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -153,11 +153,13 @@ export const extractNewKernel = (
 };
 
 /**
- * NOTE: This function is _exactly_ the same as the desktop loading.js version
- *       with one strong exception -- extractNewKernel
+ * NOTE: This function is _highly similar_ to the desktop loading.js version
+ *       with two exceptions -- extractNewKernel and kernelType
  *       Can they be combined without incurring a penalty on the web app?
- *       The native functions used are `path.dirname`, `path.resolve`, and `process.cwd()`
- *       We could always inject those dependencies separately...
+ *       extractNewKernel - The native functions used are `path.dirname`, `path.resolve`, and `process.cwd()`
+ *                          We could always inject those dependencies separately...
+ *       kernelType - See #3427, this relates to the currently-unrepresentable state of "launching a kernel
+ *                    but we aren't sure if it's local or remote yet".
  */
 export const launchKernelWhenNotebookSetEpic = (
   action$: ActionsObservable<*>,
@@ -189,6 +191,7 @@ export const launchKernelWhenNotebookSetEpic = (
       return of(
         actions.launchKernelByName({
           kernelSpecName,
+          kernelType: "websocket",
           cwd,
           kernelRef: action.payload.kernelRef,
           selectNextKernel: true,
@@ -249,6 +252,7 @@ export const restartKernelEpic = (
 
       const relaunch = actions.launchKernelByName({
         kernelSpecName: oldKernel.kernelSpecName,
+        kernelType: oldKernel.type,
         cwd: oldKernel.cwd,
         kernelRef: newKernelRef,
         selectNextKernel: true,

--- a/packages/core/src/state/entities/kernels.js
+++ b/packages/core/src/state/entities/kernels.js
@@ -80,6 +80,20 @@ export type RemoteKernelRecord = Immutable.RecordOf<RemoteKernelProps>;
 
 export type KernelRecord = LocalKernelRecord | RemoteKernelRecord;
 
+export const makeKernelRecordForType = (
+  type: string,
+  props: any = {}
+): KernelRecord => {
+  switch (type) {
+    case "zeromq":
+      return makeLocalKernelRecord(props);
+    case "websocket":
+      return makeRemoteKernelRecord(props);
+    default:
+      throw new Error(`Unrecognized kernel type "${type}".`);
+  }
+};
+
 export type KernelsRecordProps = {
   byRef: Immutable.Map<KernelRef, KernelRecord>
 };

--- a/packages/notebook-app-component/src/status-bar.js
+++ b/packages/notebook-app-component/src/status-bar.js
@@ -90,7 +90,11 @@ const mapStateToProps = (
   if (kernelStatus === NOT_CONNECTED) {
     kernelSpecDisplayName = "no kernel";
   } else if (kernel != null && kernel.kernelSpecName != null) {
-    kernelSpecDisplayName = kernel.kernelSpecName;
+    if (kernel.kernelSpecName === undefined || kernel.kernelSpecName === null) {
+      kernelSpecDisplayName = " ";
+    } else {
+      kernelSpecDisplayName = kernel.kernelSpecName;
+    }
   } else if (content != null && content.type === "notebook") {
     kernelSpecDisplayName =
       selectors.notebook.displayName(content.model) || " ";


### PR DESCRIPTION
Currently, reducers in kernel.js react to LAUNCH_KERNEL/LAUNCH_KERNEL_BY_NAME actions by populating `kernels.byRef[newKernelRefUUID]` with a `Map({state: "launching"})`. Later, when more complete kernel info is available (LAUNCH_KERNEL_SUCCESSFUL), the `Map` is replaced with either a LocalKernelRecord or a RemoteKernelRecord. Reading Maps and Records isn't symmetrical and so this creates issues like #3417.

I find myself unfamiliar w/ all the different states kernels might be in, especially for the non-desktop applications. The big question I have is how early in the launch process can we identify the kernel as local vs. remote. If we can do it very early, then I would keep the Local and Remote types as they are, and just create the Records sooner. If we cannot determine local vs. remote very early, I’d recommend changing the Record types so that this early, uncertain, state can be represented cleanly in the store.

This PR assumes we can identify local vs remote early. I modified the LAUNCH_KERNEL actions to require Local vs Remote in their payload. If this feels directionally good, then I could use an assist w/ the TODO-annotated lines, figuring out if/how local-vs-remote can be decided in each case.