### PR TITLE
Fixes desktop reload feature, which I broke in f89e94c89.

### DIFF
--- a/applications/desktop/src/main/index.js
+++ b/applications/desktop/src/main/index.js
@@ -99,6 +99,14 @@ ipc.on("open-notebook", (event, filename) => {
   launch(resolve(filename));
 });
 
+ipc.on("reload", (event) => { // Based on https://github.com/electron/electron/blob/b50f86ef43b17f90c295349d8ca93751ad9045a6/lib/browser/rpc-server.js#L411-L418
+  const window = event.sender.getOwnerBrowserWindow();
+  if (window) {
+    window.reload();
+  }
+  event.returnValue = null
+});
+
 ipc.on("show-message-box", (event, arg) => {
   const response = dialog.showMessageBox(arg);
   event.sender.send("show-message-box-response", response);

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -1,5 +1,5 @@
 /* @flow strict */
-import { dialog, app, shell, Menu, BrowserWindow } from "electron";
+import { dialog, app, shell, Menu, BrowserWindow, ipcRenderer as ipc } from "electron";
 import * as path from "path";
 import { sortBy } from "lodash";
 import { launch, launchNewNotebook } from "./launch";
@@ -461,11 +461,7 @@ export function loadFullMenu(store: * = global.store) {
         label: "Reload",
         enabled: BrowserWindow.getAllWindows().length > 0,
         accelerator: "CmdOrCtrl+R",
-        click: (item, focusedWindow) => {
-          if (focusedWindow) {
-            focusedWindow.reload();
-          }
-        }
+        click: createSender("reload")
       },
       {
         label: "Toggle Full Screen",

--- a/applications/desktop/src/notebook/actionTypes.js
+++ b/applications/desktop/src/notebook/actionTypes.js
@@ -8,7 +8,8 @@ export const CLOSE_NOTEBOOK = "DESKTOP/CLOSE_NOTEBOOK";
 export type CloseNotebook = {
   type: "DESKTOP/CLOSE_NOTEBOOK",
   payload: {
-    contentRef: ContentRef
+    contentRef: ContentRef,
+    reloading: boolean
   }
 };
 

--- a/applications/desktop/src/notebook/actions.js
+++ b/applications/desktop/src/notebook/actions.js
@@ -7,7 +7,8 @@ import type { ContentRef } from "@nteract/core";
 import type { DesktopNotebookClosingState } from "./state";
 
 export function closeNotebook(payload: {
-  contentRef: ContentRef
+  contentRef: ContentRef,
+  reloading: boolean
 }): actionTypes.CloseNotebook {
   return {
     type: actionTypes.CLOSE_NOTEBOOK,

--- a/applications/desktop/src/notebook/epics/close-notebook.js
+++ b/applications/desktop/src/notebook/epics/close-notebook.js
@@ -129,8 +129,14 @@ export const closeNotebookEpic = (action$: ActionsObservable<*>, store: *) =>
       );
 
       const initiateClose = Observable.create(observer => {
-        console.log("Kernel shutdown complete; closing notebook window...");
-        window.close();
+        if (action.payload.reloading) {
+          console.log("Kernel shutdown complete; reloading notebook window...");
+          ipc.send("reload");
+        } else {
+          console.log("Kernel shutdown complete; closing notebook window...");
+          window.close();
+        }
+
         observer.complete();
       });
 


### PR DESCRIPTION
The closeNotebookEpic initiated in the renderer's onbeforeunload was being fired for reload as well, and was hard-coded to finish the workflow by asking the main process to close the window.

The simplest way I found to distinguish between a close and a reload was to wire a custom "reload" message, to be sent from the Reload menu/shortcut in the main process to the
renderer. This controls how the closeNotebookEpic will finish up, messaging back to the main process asking it to either close or reload the window.

I considered renaming the whole epic to couple it less tightly to close and acknowledge that it handles reload, but there are a lot of types/constants around and it doesn't seem worth the effort.

A failed attempt, recorded for posterity:
I initially tried to distinguish between close and reload cases purely within the renderer. By some readings of the docs the close event should fire only on closes, and the beforeunload even should fire in both close and reload, making it possible to distinguish between the two. Unfortunately it seems that close events wired from within the renderer do not actually work.
