### PR TITLE
Wait until MathJax is configured before passing it to children

### DIFF
--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -28,8 +28,6 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
     super(props);
 
     this.nodeRef = React.createRef();
-
-    (this: any).typeset = this.typeset;
   }
 
   /**
@@ -137,7 +135,7 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
   }
 }
 
-class MathJaxNode extends React.PureComponent<Props, null> {
+class MathJaxNode extends React.Component<Props, null> {
   static defaultProps = {
     inline: false,
     onRender: null

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -84,8 +84,9 @@ class Provider extends React.Component<Props, State> {
     }
 
     const options = this.props.options;
-
-    MathJax.Hub.Config(options);
+    if (options != null && Object.keys(options).length > 0) {
+      MathJax.Hub.Config(options);
+    }
 
     MathJax.Hub.Register.StartupHook("End", () => {
       if (typeof MathJax === "undefined" || !MathJax) {
@@ -99,6 +100,10 @@ class Provider extends React.Component<Props, State> {
       if (this.props.didFinishTypeset) {
         this.props.didFinishTypeset();
       }
+
+      this.setState({
+        MathJax
+      });
     });
 
     MathJax.Hub.Register.MessageHook("Math Processing Error", message => {
@@ -110,10 +115,6 @@ class Provider extends React.Component<Props, State> {
     if (this.props.onLoad) {
       this.props.onLoad();
     }
-
-    this.setState({
-      MathJax
-    });
   };
 
   render() {

--- a/packages/mathjax/src/text.js
+++ b/packages/mathjax/src/text.js
@@ -45,7 +45,7 @@ class MathJaxText_ extends React.Component<Props & MathJaxContextValue, null> {
   }
 }
 
-class MathJaxText extends React.PureComponent<Props, null> {
+class MathJaxText extends React.Component<Props, null> {
   static defaultProps = {
     onRender: null
   };


### PR DESCRIPTION
Currently MathJax may error or won't render when opening an existing notebook containing math. This is due to MathJax beeing fully ready when passed down by the provider.

With this PR The Provider waits for MathJax before passing it down. Currently MathJax is only updated inside the Markdown Cells. For normal output this needs some more React wizardry.

## This PR
![pr2](https://user-images.githubusercontent.com/13285808/46839393-f18f1800-cdbd-11e8-9542-eaed650e4a00.gif)

## master
![master](https://user-images.githubusercontent.com/13285808/46839361-dc19ee00-cdbd-11e8-8097-9b50372e4bb5.gif)
