### PR TITLE
Fix inconsistent names for functions and actions/types

### DIFF
--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -6,7 +6,7 @@ import { actions, actionTypes } from "@nteract/core";
 import * as Immutable from "immutable";
 
 describe("dispatchCreateCellAbove", () => {
-  test("dispatches a CREATE_CELL_BEFORE with code action", () => {
+  test("dispatches a CREATE_CELL_ABOVE with code action", () => {
     const store = {
       dispatch: jest.fn()
     };
@@ -16,7 +16,7 @@ describe("dispatchCreateCellAbove", () => {
 
     menu.dispatchCreateCellAbove(props, store);
     expect(store.dispatch).toHaveBeenCalledWith(
-      actions.createCellBefore({
+      actions.createCellAbove({
         cellType: "code",
         contentRef: props.contentRef
       })
@@ -25,7 +25,7 @@ describe("dispatchCreateCellAbove", () => {
 });
 
 describe("dispatchCreateCellBelow", () => {
-  test("dispatches a CREATE_CELL_AFTER with code action", () => {
+  test("dispatches a CREATE_CELL_BELOW with code action", () => {
     const store = {
       dispatch: jest.fn()
     };
@@ -35,7 +35,7 @@ describe("dispatchCreateCellBelow", () => {
 
     menu.dispatchCreateCellBelow(props, store);
     expect(store.dispatch).toHaveBeenCalledWith(
-      actions.createCellAfter({
+      actions.createCellBelow({
         cellType: "code",
         source: "",
         contentRef: props.contentRef
@@ -45,7 +45,7 @@ describe("dispatchCreateCellBelow", () => {
 });
 
 describe("dispatchCreateTextCellBelow", () => {
-  test("dispatches a CREATE_CELL_AFTER with markdown action", () => {
+  test("dispatches a CREATE_CELL_BELOW with markdown action", () => {
     const store = {
       dispatch: jest.fn()
     };
@@ -55,7 +55,7 @@ describe("dispatchCreateTextCellBelow", () => {
 
     menu.dispatchCreateTextCellBelow(props, store);
     expect(store.dispatch).toHaveBeenCalledWith(
-      actions.createCellAfter({
+      actions.createCellBelow({
         cellType: "markdown",
         source: "",
         contentRef: "123"

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -64,6 +64,65 @@ describe("dispatchCreateTextCellBelow", () => {
   });
 });
 
+describe("dispatchCreateCellBefore", () => {
+  test("WARNING: DEPRECATED. Use createCellAbove() instead. dispatches a CREATE_CELL_BEFORE with code action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCreateCellBefore(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.createCellBefore({
+        cellType: "code",
+        contentRef: props.contentRef
+      })
+    );
+  });
+});
+
+describe("dispatchCreateCellAfter", () => {
+  test("WARNING: DEPRECATED. Use createCellBelow() instead. dispatches a CREATE_CELL_AFTER with code action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCreateCellAfter(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.createCellAfter({
+        cellType: "code",
+        source: "",
+        contentRef: props.contentRef
+      })
+    );
+  });
+});
+
+describe("dispatchCreateTextCellAfter", () => {
+  test("WARNING:DEPRECATED. dispatches a CREATE_CELL_AFTER with markdown action", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchCreateTextCellAfter(props, store);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      actions.createCellAfter({
+        cellType: "markdown",
+        source: "",
+        contentRef: "123"
+      })
+    );
+  });
+});
+
 describe("dispatchDeleteCell", () => {
   test("dispatches a REMOVE_CELL on currently active cell", () => {
     const store = {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -453,6 +453,47 @@ export function dispatchCreateTextCellBelow(
   );
 }
 
+export function dispatchCreateCellBefore(
+  ownProps: { contentRef: ContentRef },
+  store: Store<DesktopNotebookAppState, *>
+) {
+  console.log("DEPRECATION WARNING: This function is being deprecated. Please use createCellAbove() instead");
+  store.dispatch(
+    actions.createCellBefore({
+      cellType: "code",
+      contentRef: ownProps.contentRef
+    })
+  );
+}
+
+export function dispatchCreateCellAfter(
+  ownProps: { contentRef: ContentRef },
+  store: Store<DesktopNotebookAppState, *>
+) {
+  console.log("DEPRECATION WARNING: This function is being deprecated. Please use createCellBelow() instead");
+  store.dispatch(
+    actions.createCellAfter({
+      cellType: "code",
+      source: "",
+      contentRef: ownProps.contentRef
+    })
+  );
+}
+
+export function dispatchCreateTextCellAfter(
+  ownProps: { contentRef: ContentRef },
+  store: Store<DesktopNotebookAppState, *>
+) {
+  console.log("DEPRECATION WARNING: This function is being deprecated. Please use createTextCellBelow() instead");
+  store.dispatch(
+    actions.createCellAfter({
+      cellType: "markdown",
+      source: "",
+      contentRef: ownProps.contentRef
+    })
+  );
+}
+
 export function dispatchChangeCellToCode(
   ownProps: { contentRef: ContentRef },
   store: Store<DesktopNotebookAppState, *>

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -420,7 +420,7 @@ export function dispatchCreateCellAbove(
   store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
-    actions.createCellBefore({
+    actions.createCellAbove({
       cellType: "code",
       contentRef: ownProps.contentRef
     })
@@ -432,7 +432,7 @@ export function dispatchCreateCellBelow(
   store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
-    actions.createCellAfter({
+    actions.createCellBelow({
       cellType: "code",
       source: "",
       contentRef: ownProps.contentRef
@@ -445,7 +445,7 @@ export function dispatchCreateTextCellBelow(
   store: Store<DesktopNotebookAppState, *>
 ) {
   store.dispatch(
-    actions.createCellAfter({
+    actions.createCellBelow({
       cellType: "markdown",
       source: "",
       contentRef: ownProps.contentRef

--- a/packages/connected-components/__tests__/notebook-menu-spec.js
+++ b/packages/connected-components/__tests__/notebook-menu-spec.js
@@ -39,7 +39,7 @@ describe("PureNotebookMenu ", () => {
         cutCell: jest.fn(),
         copyCell: jest.fn(),
         pasteCell: jest.fn(),
-        createCellAfter: jest.fn(),
+        createCellBelow: jest.fn(),
         changeCellType: jest.fn(),
         setTheme: jest.fn(),
         saveNotebook: jest.fn(),
@@ -146,23 +146,23 @@ describe("PureNotebookMenu ", () => {
       const createMarkdownCellItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.CREATE_MARKDOWN_CELL })
         .first();
-      expect(props.createCellAfter).not.toHaveBeenCalled();
+      expect(props.createCellBelow).not.toHaveBeenCalled();
       createMarkdownCellItem.simulate("click");
-      expect(props.createCellAfter).toHaveBeenCalledTimes(1);
-      expect(props.createCellAfter).toHaveBeenCalledWith({
+      expect(props.createCellBelow).toHaveBeenCalledTimes(1);
+      expect(props.createCellBelow).toHaveBeenCalledWith({
         cellType: "markdown",
         contentRef: props.currentContentRef,
         source: ""
       });
 
-      props.createCellAfter.mockClear();
+      props.createCellBelow.mockClear();
       const createCodeCellItem = wrapper
         .find({ eventKey: MENU_ITEM_ACTIONS.CREATE_CODE_CELL })
         .first();
-      expect(props.createCellAfter).not.toHaveBeenCalled();
+      expect(props.createCellBelow).not.toHaveBeenCalled();
       createCodeCellItem.simulate("click");
-      expect(props.createCellAfter).toHaveBeenCalledTimes(1);
-      expect(props.createCellAfter).toHaveBeenCalledWith({
+      expect(props.createCellBelow).toHaveBeenCalledTimes(1);
+      expect(props.createCellBelow).toHaveBeenCalledWith({
         cellType: "code",
         contentRef: props.currentContentRef,
         source: ""

--- a/packages/connected-components/src/notebook-menu/index.js
+++ b/packages/connected-components/src/notebook-menu/index.js
@@ -40,7 +40,7 @@ type Props = {
   copyCell: ?(payload: *) => void,
   notebook: Immutable.Map<string, *>,
   pasteCell: ?(payload: *) => void,
-  createCellAfter: ?(payload: *) => void,
+  createCellBelow: ?(payload: *) => void,
   changeCellType: ?(payload: *) => void,
   setTheme: ?(theme: ?string) => void,
   openAboutModal: ?() => void,
@@ -77,7 +77,7 @@ class PureNotebookMenu extends React.Component<Props, State> {
     cutCell: null,
     copyCell: null,
     pasteCell: null,
-    createCellAfter: null,
+    createCellBelow: null,
     setCellTypeCode: null,
     setCellTypeMarkdown: null,
     setTheme: null,
@@ -98,7 +98,7 @@ class PureNotebookMenu extends React.Component<Props, State> {
       changeKernelByName,
       currentKernelRef,
       copyCell,
-      createCellAfter,
+      createCellBelow,
       cutCell,
       executeAllCells,
       executeAllCellsBelow,
@@ -143,8 +143,8 @@ class PureNotebookMenu extends React.Component<Props, State> {
         }
         break;
       case MENU_ITEM_ACTIONS.CREATE_CODE_CELL:
-        if (createCellAfter) {
-          createCellAfter({
+        if (createCellBelow) {
+          createCellBelow({
             cellType: "code",
             source: "",
             contentRef: currentContentRef
@@ -152,8 +152,8 @@ class PureNotebookMenu extends React.Component<Props, State> {
         }
         break;
       case MENU_ITEM_ACTIONS.CREATE_MARKDOWN_CELL:
-        if (createCellAfter) {
-          createCellAfter({
+        if (createCellBelow) {
+          createCellBelow({
             cellType: "markdown",
             source: "",
             contentRef: currentContentRef
@@ -485,7 +485,7 @@ const mapDispatchToProps = dispatch => ({
   cutCell: (payload: *) => dispatch(actions.cutCell(payload)),
   copyCell: (payload: *) => dispatch(actions.copyCell(payload)),
   pasteCell: (payload: *) => dispatch(actions.pasteCell(payload)),
-  createCellAfter: (payload: *) => dispatch(actions.createCellAfter(payload)),
+  createCellBelow: (payload: *) => dispatch(actions.createCellBelow(payload)),
   changeCellType: (payload: *) => dispatch(actions.changeCellType(payload)),
   setTheme: theme => dispatch(actions.setTheme(theme)),
   openAboutModal: () =>

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -307,24 +307,24 @@ describe("focusNextCellEditor", () => {
   });
 });
 
-describe("createCellAfter", () => {
-  test("creates a CREATE_CELL_AFTER action with provided source string", () => {
+describe("createCellBelow", () => {
+  test("creates a CREATE_CELL_BELOW action with provided source string", () => {
     const cellType = "code";
     const id = "1234";
     const source = 'print("woo")';
-    expect(actions.createCellAfter({ cellType, id, source })).toEqual({
-      type: actionTypes.CREATE_CELL_AFTER,
+    expect(actions.createCellBelow({ cellType, id, source })).toEqual({
+      type: actionTypes.CREATE_CELL_BELOW,
       payload: { source, cellType, id }
     });
   });
 });
 
-describe("createCellBefore", () => {
-  test("creates a CREATE_CELL_BEFORE action", () => {
+describe("createCellAbove", () => {
+  test("creates a CREATE_CELL_ABOVE action", () => {
     expect(
-      actions.createCellBefore({ cellType: "markdown", id: "1234" })
+      actions.createCellAbove({ cellType: "markdown", id: "1234" })
     ).toEqual({
-      type: actionTypes.CREATE_CELL_BEFORE,
+      type: actionTypes.CREATE_CELL_ABOVE,
       payload: {
         cellType: "markdown",
         id: "1234"

--- a/packages/core/__tests__/actions-spec.js
+++ b/packages/core/__tests__/actions-spec.js
@@ -333,6 +333,32 @@ describe("createCellAbove", () => {
   });
 });
 
+describe("createCellAfter", () => {
+  test("WARNING:DEPRECATED. Use createCellBelow() instead. creates a CREATE_CELL_AFTER action with provided source string", () => {
+    const cellType = "code";
+    const id = "1234";
+    const source = 'print("woo")';
+    expect(actions.createCellAfter({ cellType, id, source })).toEqual({
+      type: actionTypes.CREATE_CELL_AFTER,
+      payload: { source, cellType, id }
+    });
+  });
+});
+
+describe("createCellBefore", () => {
+  test("WARNING:DEPRECATED. USE createCellAbove() instead. creates a CREATE_CELL_BEFORE action", () => {
+    expect(
+      actions.createCellBefore({ cellType: "markdown", id: "1234" })
+    ).toEqual({
+      type: actionTypes.CREATE_CELL_BEFORE,
+      payload: {
+        cellType: "markdown",
+        id: "1234"
+      }
+    });
+  });
+});
+
 describe("createCellAppend", () => {
   test("creates a CREATE_CELL_APPEND action", () => {
     expect(actions.createCellAppend({ cellType: "markdown" })).toEqual({

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -353,7 +353,7 @@ describe("moveCell", () => {
   test("should move a cell above another when asked", () => {
     const originalState = reducers(
       initialDocument.set("notebook", dummyCommutable),
-      actions.createCellAfter({
+      actions.createCellBelow({
         id: dummyCommutable.get("cellOrder").first(),
         cellType: "markdown",
         source: "# Woo\n*Yay*"
@@ -437,13 +437,13 @@ describe("clearOutputs", () => {
   });
 });
 
-describe("createCellAfter", () => {
+describe("createCellBelow", () => {
   test("creates a brand new cell after the given id", () => {
     const originalState = monocellDocument;
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
     const state = reducers(
       originalState,
-      actions.createCellAfter({ cellType: "markdown", id })
+      actions.createCellBelow({ cellType: "markdown", id })
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
     const cellID = state.getIn(["notebook", "cellOrder"]).last();
@@ -452,13 +452,13 @@ describe("createCellAfter", () => {
   });
 });
 
-describe("createCellBefore", () => {
+describe("createCellAbove", () => {
   test("creates a new cell before the given id", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
     const state = reducers(
       originalState,
-      actions.createCellBefore({ cellType: "markdown", id })
+      actions.createCellAbove({ cellType: "markdown", id })
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
     expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(id);

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -465,6 +465,34 @@ describe("createCellAbove", () => {
   });
 });
 
+describe("createCellAfter", () => {
+  test("WARNING:DEPRECATED. Use createCellBelow() instead. Creates a brand new cell after the given id", () => {
+    const originalState = monocellDocument;
+    const id = originalState.getIn(["notebook", "cellOrder"]).last();
+    const state = reducers(
+      originalState,
+      actions.createCellAfter({ cellType: "markdown", id })
+    );
+    expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
+    const cellID = state.getIn(["notebook", "cellOrder"]).last();
+    const cell = state.getIn(["notebook", "cellMap", cellID]);
+    expect(cell.get("cell_type")).toBe("markdown");
+  });
+});
+
+describe("createCellBefore", () => {
+  test("WARNING:DEPRECATED. sue createCellAbove() instead. Creates a new cell before the given id", () => {
+    const originalState = initialDocument.set("notebook", dummyCommutable);
+    const id = originalState.getIn(["notebook", "cellOrder"]).last();
+    const state = reducers(
+      originalState,
+      actions.createCellBefore({ cellType: "markdown", id })
+    );
+    expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
+    expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(id);
+  });
+});
+
 describe("newCellAppend", () => {
   test("appends a new code cell at the end", () => {
     const originalState = initialDocument.set("notebook", dummyCommutable);

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -167,9 +167,9 @@ export type RemoveCell = {
   }
 };
 
-export const CREATE_CELL_AFTER = "CREATE_CELL_AFTER";
-export type CreateCellAfter = {
-  type: "CREATE_CELL_AFTER",
+export const CREATE_CELL_BELOW = "CREATE_CELL_BELOW";
+export type createCellBelow = {
+  type: "CREATE_CELL_BELOW",
   payload: {
     id?: CellID,
     cellType: CellType,
@@ -178,9 +178,9 @@ export type CreateCellAfter = {
   }
 };
 
-export const CREATE_CELL_BEFORE = "CREATE_CELL_BEFORE";
-export type CreateCellBefore = {
-  type: "CREATE_CELL_BEFORE",
+export const CREATE_CELL_ABOVE = "CREATE_CELL_ABOVE";
+export type createCellAbove = {
+  type: "CREATE_CELL_ABOVE",
   payload: {
     cellType: CellType,
     id?: CellID,

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -168,7 +168,7 @@ export type RemoveCell = {
 };
 
 export const CREATE_CELL_BELOW = "CREATE_CELL_BELOW";
-export type createCellBelow = {
+export type CreateCellBelow = {
   type: "CREATE_CELL_BELOW",
   payload: {
     id?: CellID,
@@ -179,8 +179,31 @@ export type createCellBelow = {
 };
 
 export const CREATE_CELL_ABOVE = "CREATE_CELL_ABOVE";
-export type createCellAbove = {
+export type CreateCellAbove = {
   type: "CREATE_CELL_ABOVE",
+  payload: {
+    cellType: CellType,
+    id?: CellID,
+    contentRef: ContentRef
+  }
+};
+
+// DEPRECATION WARNING: This action type is being deprecated. Please use CREATE_CELL_BELOW instead
+export const CREATE_CELL_AFTER = "CREATE_CELL_AFTER";
+export type CreateCellAfter = {
+  type: "CREATE_CELL_AFTER",
+  payload: {
+    id?: CellID,
+    cellType: CellType,
+    source: string,
+    contentRef: ContentRef
+  }
+};
+
+// DEPRECATION WARNING: This action type is being deprecated. Please use CREATE_CELL_ABOVE instead
+export const CREATE_CELL_BEFORE = "CREATE_CELL_BEFORE";
+export type CreateCellBefore = {
+  type: "CREATE_CELL_BEFORE",
   payload: {
     cellType: CellType,
     id?: CellID,

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -254,7 +254,7 @@ export function createCellBelow(payload: {
   cellType: CellType,
   source: string,
   contentRef: ContentRef
-}): actionTypes.createCellBelow {
+}): actionTypes.CreateCellBelow {
   return {
     type: actionTypes.CREATE_CELL_BELOW,
     payload
@@ -265,9 +265,34 @@ export function createCellAbove(payload: {
   cellType: CellType,
   id?: string,
   contentRef: ContentRef
-}): actionTypes.createCellAbove {
+}): actionTypes.CreateCellAbove {
   return {
     type: actionTypes.CREATE_CELL_ABOVE,
+    payload
+  };
+}
+
+// Deprecation Warning: createCellAfter() is being deprecated. Please use createCellBelow() instead
+export function createCellAfter(payload: {
+  id?: CellID,
+  cellType: CellType,
+  source: string,
+  contentRef: ContentRef
+}): actionTypes.CreateCellAfter {
+  return {
+    type: actionTypes.CREATE_CELL_AFTER,
+    payload
+  };
+}
+
+// Deprecation Warning: createCellBefore is deprecated. Please use createCellAbove() instead
+export function createCellBefore(payload: {
+  cellType: CellType,
+  id?: string,
+  contentRef: ContentRef
+}): actionTypes.CreateCellBefore {
+  return {
+    type: actionTypes.CREATE_CELL_BEFORE,
     payload
   };
 }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -249,25 +249,25 @@ export function removeCell(payload: {
   };
 }
 
-export function createCellAfter(payload: {
+export function createCellBelow(payload: {
   id?: CellID,
   cellType: CellType,
   source: string,
   contentRef: ContentRef
-}): actionTypes.CreateCellAfter {
+}): actionTypes.createCellBelow {
   return {
-    type: actionTypes.CREATE_CELL_AFTER,
+    type: actionTypes.CREATE_CELL_BELOW,
     payload
   };
 }
 
-export function createCellBefore(payload: {
+export function createCellAbove(payload: {
   cellType: CellType,
   id?: string,
   contentRef: ContentRef
-}): actionTypes.CreateCellBefore {
+}): actionTypes.createCellAbove {
   return {
-    type: actionTypes.CREATE_CELL_BEFORE,
+    type: actionTypes.CREATE_CELL_ABOVE,
     payload
   };
 }

--- a/packages/core/src/reducers/core/entities/contents/index.js
+++ b/packages/core/src/reducers/core/entities/contents/index.js
@@ -177,8 +177,8 @@ const byRef = (state = Immutable.Map(), action) => {
     case actionTypes.SET_IN_CELL:
     case actionTypes.MOVE_CELL:
     case actionTypes.REMOVE_CELL:
-    case actionTypes.CREATE_CELL_AFTER:
-    case actionTypes.CREATE_CELL_BEFORE:
+    case actionTypes.CREATE_CELL_BELOW:
+    case actionTypes.CREATE_CELL_ABOVE:
     case actionTypes.CREATE_CELL_APPEND:
     case actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY:
     case actionTypes.TOGGLE_CELL_INPUT_VISIBILITY:

--- a/packages/core/src/reducers/core/entities/contents/index.js
+++ b/packages/core/src/reducers/core/entities/contents/index.js
@@ -179,6 +179,8 @@ const byRef = (state = Immutable.Map(), action) => {
     case actionTypes.REMOVE_CELL:
     case actionTypes.CREATE_CELL_BELOW:
     case actionTypes.CREATE_CELL_ABOVE:
+    case actionTypes.CREATE_CELL_AFTER:   // DEPRECATION WARNING: This action type is being deprecated. Please use CREATE_CELL_BELOW instead
+    case actionTypes.CREATE_CELL_BEFORE:  // DEPRECATION WARNING: This action type is being deprecated. Please use CREATE_CELL_ABOVE instead
     case actionTypes.CREATE_CELL_APPEND:
     case actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY:
     case actionTypes.TOGGLE_CELL_INPUT_VISIBILITY:

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -418,7 +418,7 @@ function removeCellFromState(
 
 function createCellBelow(
   state: NotebookModel,
-  action: actionTypes.createCellBelow
+  action: actionTypes.CreateCellBelow
 ) {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
@@ -436,8 +436,50 @@ function createCellBelow(
 
 function createCellAbove(
   state: NotebookModel,
-  action: actionTypes.createCellAbove
+  action: actionTypes.CreateCellAbove
 ) {
+  const id = action.payload.id ? action.payload.id : state.cellFocused;
+  if (!id) {
+    return state;
+  }
+
+  const { cellType } = action.payload;
+  const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  const cellID = uuid();
+  return state.update("notebook", (notebook: ImmutableNotebook) => {
+    const cellOrder: ImmutableCellOrder = notebook.get(
+      "cellOrder",
+      Immutable.List()
+    );
+    const index = cellOrder.indexOf(id);
+    return insertCellAt(notebook, cell, cellID, index);
+  });
+}
+
+function createCellAfter(
+  state: NotebookModel,
+  action: actionTypes.CreateCellAfter
+) {
+  console.log("DEPRECATION WARNING: This function is being deprecated. Please use createCellBelow() instead");
+  const id = action.payload.id ? action.payload.id : state.cellFocused;
+  if (!id) {
+    return state;
+  }
+
+  const { cellType, source } = action.payload;
+  const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  const cellID = uuid();
+  return state.update("notebook", (notebook: ImmutableNotebook) => {
+    const index = notebook.get("cellOrder", Immutable.List()).indexOf(id) + 1;
+    return insertCellAt(notebook, cell.set("source", source), cellID, index);
+  });
+}
+
+function createCellBefore(
+  state: NotebookModel,
+  action: actionTypes.CreateCellBefore
+) {
+  console.log("DEPRECATION WARNING: This function is being deprecated. Please use createCellAbove() instead");
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -737,6 +779,7 @@ function toggleOutputExpansion(
   );
 }
 
+// DEPRECATION WARNING: Below, the following action types are being deprecated: createCellAfter and createCellBefore
 type DocumentAction =
   | actionTypes.ToggleTagInCell
   | actionTypes.FocusPreviousCellEditor
@@ -750,8 +793,10 @@ type DocumentAction =
   | actionTypes.UpdateDisplay
   | actionTypes.MoveCell
   | actionTypes.RemoveCell
-  | actionTypes.createCellBelow
-  | actionTypes.createCellAbove
+  | actionTypes.CreateCellBelow
+  | actionTypes.CreateCellAbove
+  | actionTypes.CreateCellAfter
+  | actionTypes.CreateCellBefore
   | actionTypes.CreateCellAppend
   | actionTypes.ToggleCellOutputVisibility
   | actionTypes.ToggleCellInputVisibility
@@ -818,6 +863,12 @@ export function notebook(
       return createCellBelow(state, action);
     case actionTypes.CREATE_CELL_ABOVE:
       return createCellAbove(state, action);
+    case actionTypes.CREATE_CELL_AFTER:
+      console.log('DEPRECATION WARNING: This action type is being deprecated. Please use CREATE_CELL_BELOW instead');
+      return createCellAfter(state, action);
+    case actionTypes.CREATE_CELL_BEFORE:
+      console.log('DEPRECATION WARNING: This action type is being deprecated. Please use CREATE_CELL_ABOVE instead');
+      return createCellBefore(state, action);
     case actionTypes.CREATE_CELL_APPEND:
       return createCellAppend(state, action);
     case actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY:

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -416,9 +416,9 @@ function removeCellFromState(
   );
 }
 
-function createCellAfter(
+function createCellBelow(
   state: NotebookModel,
-  action: actionTypes.CreateCellAfter
+  action: actionTypes.createCellBelow
 ) {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
@@ -434,9 +434,9 @@ function createCellAfter(
   });
 }
 
-function createCellBefore(
+function createCellAbove(
   state: NotebookModel,
-  action: actionTypes.CreateCellBefore
+  action: actionTypes.createCellAbove
 ) {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
@@ -494,8 +494,8 @@ function acceptPayloadMessage(
       // FIXME: This is a weird pattern. We're basically faking a dispatch here
       // inside a reducer and then appending to the result. I think that both of
       // these reducers should just handle the original action.
-      return createCellAfter(state, {
-        type: actionTypes.CREATE_CELL_AFTER,
+      return createCellBelow(state, {
+        type: actionTypes.CREATE_CELL_BELOW,
         // $FlowFixMe: Switch this over to creating a cell after without having to take an action
         payload: {
           cellType: "code",
@@ -750,8 +750,8 @@ type DocumentAction =
   | actionTypes.UpdateDisplay
   | actionTypes.MoveCell
   | actionTypes.RemoveCell
-  | actionTypes.CreateCellAfter
-  | actionTypes.CreateCellBefore
+  | actionTypes.createCellBelow
+  | actionTypes.createCellAbove
   | actionTypes.CreateCellAppend
   | actionTypes.ToggleCellOutputVisibility
   | actionTypes.ToggleCellInputVisibility
@@ -814,10 +814,10 @@ export function notebook(
       return moveCell(state, action);
     case actionTypes.REMOVE_CELL:
       return removeCellFromState(state, action);
-    case actionTypes.CREATE_CELL_AFTER:
-      return createCellAfter(state, action);
-    case actionTypes.CREATE_CELL_BEFORE:
-      return createCellBefore(state, action);
+    case actionTypes.CREATE_CELL_BELOW:
+      return createCellBelow(state, action);
+    case actionTypes.CREATE_CELL_ABOVE:
+      return createCellAbove(state, action);
     case actionTypes.CREATE_CELL_APPEND:
       return createCellAppend(state, action);
     case actionTypes.TOGGLE_CELL_OUTPUT_VISIBILITY:

--- a/packages/notebook-app-component/__tests__/cell-creator-spec.js
+++ b/packages/notebook-app-component/__tests__/cell-creator-spec.js
@@ -72,7 +72,7 @@ describe("CellCreatorProvider", () => {
       const dispatch = action => {
         expect(action.payload.id).toBe("test");
         expect(action.payload.cellType).toBe("markdown");
-        expect(action.type).toBe(actionTypes.CREATE_CELL_AFTER);
+        expect(action.type).toBe(actionTypes.CREATE_CELL_BELOW);
         resolve();
       };
       store.dispatch = dispatch;
@@ -97,7 +97,7 @@ describe("CellCreatorProvider", () => {
       const dispatch = action => {
         expect(action.payload.id).toBe("test");
         expect(action.payload.cellType).toBe("code");
-        expect(action.type).toBe(actionTypes.CREATE_CELL_AFTER);
+        expect(action.type).toBe(actionTypes.CREATE_CELL_BELOW);
         resolve();
       };
       store.dispatch = dispatch;
@@ -122,7 +122,7 @@ describe("CellCreatorProvider", () => {
       const dispatch = action => {
         expect(action.payload.id).toBe("test");
         expect(action.payload.cellType).toBe("code");
-        expect(action.type).toBe(actionTypes.CREATE_CELL_BEFORE);
+        expect(action.type).toBe(actionTypes.CREATE_CELL_ABOVE);
         resolve();
       };
       store.dispatch = dispatch;

--- a/packages/notebook-app-component/src/cell-creator.js
+++ b/packages/notebook-app-component/src/cell-creator.js
@@ -13,8 +13,8 @@ type Props = {
 type ConnectedProps = {
   above: boolean,
   createCellAppend: (payload: *) => void,
-  createCellBefore: (payload: *) => void,
-  createCellAfter: (payload: *) => void,
+  createCellAbove: (payload: *) => void,
+  createCellBelow: (payload: *) => void,
   id?: string,
   contentRef: ContentRef
 };
@@ -122,9 +122,9 @@ class CellCreator extends React.Component<ConnectedProps> {
   createCell = (type: "code" | "markdown"): void => {
     const {
       above,
-      createCellAfter,
+      createCellBelow,
       createCellAppend,
-      createCellBefore,
+      createCellAbove,
       id,
       contentRef
     } = this.props;
@@ -135,8 +135,8 @@ class CellCreator extends React.Component<ConnectedProps> {
     }
 
     above
-      ? createCellBefore({ cellType: type, id, contentRef })
-      : createCellAfter({ cellType: type, id, source: "", contentRef });
+      ? createCellAbove({ cellType: type, id, contentRef })
+      : createCellBelow({ cellType: type, id, source: "", contentRef });
   };
 
   render() {
@@ -148,8 +148,8 @@ class CellCreator extends React.Component<ConnectedProps> {
 
 const mapDispatchToProps = dispatch => ({
   createCellAppend: (payload: *) => dispatch(actions.createCellAppend(payload)),
-  createCellBefore: (payload: *) => dispatch(actions.createCellBefore(payload)),
-  createCellAfter: (payload: *) => dispatch(actions.createCellAfter(payload))
+  createCellAbove: (payload: *) => dispatch(actions.createCellAbove(payload)),
+  createCellBelow: (payload: *) => dispatch(actions.createCellBelow(payload))
 });
 
 // $FlowFixMe: react-redux typings


### PR DESCRIPTION
* Renamed functions and actions/types so that they are consistent with the Jupyter conventions
* Earlier: Cells were either to be created "before" or "after" the focused cell. However, the functions I added in the menu were in continutation with Jupyter conventions, which use "above" and "below"
* All "before"s changed to "above"
* All "after"s changed to "below"
