### PR TITLE
Add eslint-plugin-react-perf to .eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,9 @@
     "react/display-name": 0,
     "react/no-unescaped-entities": 0,
     "react/no-deprecated": 1,
-    "no-unused-vars": 2
+    "no-unused-vars": 2,
+    "react-perf/jsx-no-new-object-as-prop": "warn",
+    "react-perf/jsx-no-new-array-as-prop": "warn"
   },
   "settings": {
     "react": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,10 +3,11 @@
     "prettier",
     "prettier/flowtype",
     "plugin:react/recommended",
-    "plugin:jsx-a11y/recommended"
+    "plugin:jsx-a11y/recommended",
+    "plugin:react-perf/recommended"
   ],
   "parser": "babel-eslint",
-  "plugins": ["prettier", "flowtype", "react", "jsx-a11y"],
+  "plugins": ["prettier", "flowtype", "react", "jsx-a11y", "react-perf"],
   "env": {
     "browser": true,
     "node": true,

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-perf": "^2.0.9",
     "flow-bin": "^0.81.0",
     "flow-copy-source": "^2.0.0",
     "husky": "^1.0.0",


### PR DESCRIPTION
- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

Adds the `eslint-plugin-react-perf` to `.eslint`

When running `yarn lint`, you'll now see errors like these:
```
applications\play\components\Main.js
161:21  error  prop value should not be an Object created in render()  react-perf/jsx-no-new-object-as-prop
  177:19  error  prop value should not be an Array created in render()   react-perf/jsx-no-new-array-as-prop
  212:22  error  prop value should not be an Object created in render()  react-perf/jsx-no-new-object-as-prop
  233:21  error  prop value should not be an Array created in render()   react-perf/jsx-no-new-array-as-prop
```

Issue: https://github.com/nteract/nteract/issues/3440