### PR TITLE
[Commuter-3233]: Link to Working Commuter Demo on Glitch.me

### DIFF
--- a/applications/commuter/README.md
+++ b/applications/commuter/README.md
@@ -1,4 +1,4 @@
-[![▲ Now Deployed](https://img.shields.io/badge/%E2%96%B2%20now-deployed-777777.svg)](https://commuter-now-otvkncbefl.now.sh/view/)
+[![Glitch Deployed](https://img.shields.io/badge/glitch-deployed-3652d3.svg)](https://hydrosquall-nteract-commuter-glitch-demo.glitch.me/view/)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 # com·mut·er
@@ -25,6 +25,9 @@ and convenience.
 ![commuter](https://cloud.githubusercontent.com/assets/836375/23089382/e330effa-f53c-11e6-85d0-7561ccdbe163.gif)
 
 Try **commuter** today and take your notebooks wherever you need them.
+
+- [Demo](https://hydrosquall-nteract-commuter-glitch-demo.glitch.me/view/)
+- [Remix Demo](https://glitch.com/edit/#!/remix/hydrosquall-nteract-commuter-glitch-demo)
 
 ## Installation
 


### PR DESCRIPTION
# Summary

I set up an instance of commuter on `glitch.me` to fix #3233, which replaces a deprecated `now.sh` deployment.

- Source code: https://github.com/hydrosquall/nteract-commuter-glitch-demo
- Demo link: https://hydrosquall-nteract-commuter-glitch-demo.glitch.me/view/

I also changed the color of the deployment badge to be closer to Glitch's palette than now.sh's.

## Possible Concerns

1. Can we prevent the demo code from getting out of sync with this repository?

I wanted to use this repository directly instead of making a new one, but there didn't seem to be a way to stop Glitch from installing all the other applications, since it jumps right to the `package.json` in the project root, which is the desktop app.

The jupyter `binder` project (an application for sharing runnable collections jupyter notebooks) works around problems like this (demo code possibly interfering with actual app code) by letting you specify a `".binder"` folder to tell sites like `mybinder.org` what commands to run when installing things, but I don't think Glitch has something similar. It just jumps straight to the first `npm install` and `npm start` it can find.

I feel OK about having the demo frozen in time with a working set of code, but can envision a situation where alternatives might be preferable.

2. Should this demo code live under the nteract org instead of under my personal github account?

I don't mind changing it to nteract if it's preferable, but I don't mind hosting it on my account.