### PR TITLE
[Commuter-3233] Point to nteract instead of personal copy of commuter demo

### DIFF
--- a/applications/commuter/README.md
+++ b/applications/commuter/README.md
@@ -1,4 +1,4 @@
-[![Glitch Deployed](https://img.shields.io/badge/glitch-deployed-3652d3.svg)](https://hydrosquall-nteract-commuter-glitch-demo.glitch.me/view/)
+[![Glitch Deployed](https://img.shields.io/badge/glitch-deployed-3652d3.svg)](https://nteract-commuter-glitch-demo.glitch.me/view/)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 # com·mut·er
@@ -26,8 +26,9 @@ and convenience.
 
 Try **commuter** today and take your notebooks wherever you need them.
 
-- [Demo](https://hydrosquall-nteract-commuter-glitch-demo.glitch.me/view/)
-- [Remix Demo](https://glitch.com/edit/#!/remix/hydrosquall-nteract-commuter-glitch-demo)
+- [Demo](https://nteract-commuter-glitch-demo.glitch.me/view/)
+- [Remix Demo](https://glitch.com/edit/#!/remix/nteract-commuter-glitch-demo)
+- [Demo Source](https://github.com/nteract/commuter-on-glitch)
 
 ## Installation
 


### PR DESCRIPTION
This is a follow-up PR to address trailing comments on #3451, which replaces references to my github account's repository to `nteract` organization's copy of the `commuter` demo instance.

## Related links

- Commuter demo source: https://github.com/nteract/commuter-on-glitch
- Sibling PR: https://github.com/nteract/commuter-on-glitch/pull/1

cc @captainsafia 