### PR TITLE
Debounce code completion requests.

### DIFF
--- a/packages/editor/__tests__/complete-spec.js
+++ b/packages/editor/__tests__/complete-spec.js
@@ -1,3 +1,7 @@
+import { Subject } from "rxjs/Subject";
+
+import { createMessage } from "@nteract/messaging";
+
 const complete = require("../src/jupyter/complete");
 
 describe("completionRequest", () => {
@@ -20,5 +24,47 @@ describe("pick", () => {
 
     complete.pick(null, handle);
     expect(handle.pick).toBeCalled();
+  });
+});
+
+describe("codeCompleteObservable", () => {
+  it("handles code completion", done => {
+    const sent = new Subject();
+    const received = new Subject();
+    const mockSocket = Subject.create(sent, received);
+    const channels = mockSocket;
+
+    const cm = {
+      getCursor: () => ({ line: 2 }),
+      getValue: () => "\n\nimport thi",
+      indexFromPos: () => 12,
+      posFromIndex: x => ({ ch: x, line: 3 })
+    };
+
+    const message = createMessage("complete_request");
+    const observable = complete.codeCompleteObservable(channels, cm, message);
+
+    // Craft the response to their message
+    const response = createMessage("complete_reply");
+    response.content = {
+      matches: ["import this"],
+      cursor_start: 9,
+      cursor_end: 10
+    }; // Likely hokey values
+    response.parent_header = Object.assign({}, message.header);
+
+    // Listen on the Observable
+    observable.subscribe(
+      msg => {
+        expect(msg.from).toEqual({ line: 3, ch: 9 });
+        expect(msg.list[0].text).toEqual("import this");
+        expect(msg.to).toEqual({ ch: 10, line: 3 });
+      },
+      err => {
+        throw err;
+      },
+      done
+    );
+    received.next(response);
   });
 });

--- a/packages/editor/__tests__/editor-spec.js
+++ b/packages/editor/__tests__/editor-spec.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Subject } from "rxjs/Subject";
 
+import { empty } from "rxjs/observable/empty";
+
 import { mount } from "enzyme";
 
 import { createMessage } from "@nteract/messaging";
@@ -9,14 +11,11 @@ import Editor from "../src/";
 const complete = require("../src/jupyter/complete");
 const tooltip = require("../src/jupyter/tooltip");
 
-describe("Editor", () => {
-  it.skip("reaches out for code completion", done => {
-    const sent = new Subject();
-    const received = new Subject();
+jest.useFakeTimers();
 
-    const mockSocket = Subject.create(sent, received);
-
-    const channels = mockSocket;
+describe("editor.completions CodeMirror callback", () => {
+  it("eventually calls complete.codeComplete", () => {
+    const channels = {};
 
     const editorWrapper = mount(<Editor completion channels={channels} />);
 
@@ -29,16 +28,98 @@ describe("Editor", () => {
       indexFromPos: () => 90001
     };
 
-    complete.codeComplete = jest.fn().mockImplementation(chan => chan.shell);
+    complete.codeComplete = jest.fn().mockImplementation(() => empty());
 
-    sent.subscribe(msg => {
-      expect(msg.content.code).toBe("MY VALUE");
-      expect(complete.codeComplete).lastCalledWith(channels, cm);
-      done();
-    });
     editor.completions(cm, () => {});
+
+    jest.runAllTimers();
+
+    expect(complete.codeComplete).toBeCalledWith(channels, cm);
   });
-  it("doesn't try for code completion when not set", () => {
+  it("collapses multiple calls into one via debouncing", () => {
+    const channels = {};
+
+    const editorWrapper = mount(<Editor completion channels={channels} />);
+
+    expect(editorWrapper).not.toBeNull();
+
+    const editor = editorWrapper.instance();
+    const cm = {
+      getCursor: () => ({ line: 12 }),
+      getValue: () => "MY VALUE",
+      indexFromPos: () => 90001
+    };
+
+    complete.codeComplete = jest.fn().mockImplementation(() => empty());
+
+    for (var i = 0; i < 3; i++ ) {
+      editor.completions(cm, () => {});
+    }
+
+    jest.runAllTimers();
+
+    expect(complete.codeComplete.mock.calls.length).toBe(1);
+    expect(complete.codeComplete).toBeCalledWith(channels, cm);
+  });
+  it("can opt out of debouncing my mutating debounceNextCompletionRequest", () => {
+    const channels = {};
+
+    const editorWrapper = mount(<Editor completion channels={channels} />);
+
+    expect(editorWrapper).not.toBeNull();
+
+    const editor = editorWrapper.instance();
+    const cm = {
+      getCursor: () => ({ line: 12 }),
+      getValue: () => "MY VALUE",
+      indexFromPos: () => 90001
+    };
+
+    complete.codeComplete = jest.fn().mockImplementation(() => empty());
+
+    for (var i = 0; i < 3; i++ ) {
+      editor.debounceNextCompletionRequest = false;
+      editor.completions(cm, () => {});
+      expect(editor.debounceNextCompletionRequest).toBe(true);
+    }
+
+    jest.runAllTimers();
+
+    expect(complete.codeComplete.mock.calls.length).toBe(3);
+    expect(complete.codeComplete).toBeCalledWith(channels, cm);
+  });
+  it("debounceNextCompletionRequest discards queued debounced events", () => {
+    const channels = {};
+
+    const editorWrapper = mount(<Editor completion channels={channels} />);
+
+    expect(editorWrapper).not.toBeNull();
+
+    const editor = editorWrapper.instance();
+    const cm = {
+      getCursor: () => ({ line: 12 }),
+      getValue: () => "MY VALUE",
+      indexFromPos: () => 90001
+    };
+
+    complete.codeComplete = jest.fn().mockImplementation(() => empty());
+
+    // By themselves, these would be debounced. If we aren't careful they will emerge after our
+    // non-debounced call, creating duplicate requests.
+    editor.completions(cm, () => {});
+    editor.completions(cm, () => {});
+    editor.completions(cm, () => {});
+
+    editor.debounceNextCompletionRequest = false;
+    editor.completions(cm, () => {});
+    expect(editor.debounceNextCompletionRequest).toBe(true);
+
+    jest.runAllTimers();
+
+    expect(complete.codeComplete.mock.calls.length).toBe(1);
+    expect(complete.codeComplete).toBeCalledWith(channels, cm);
+  });
+  it("doesn't call complete.codeComplete when completion property is unset", () => {
     const sent = new Subject();
     const received = new Subject();
 
@@ -59,6 +140,9 @@ describe("Editor", () => {
     editor.completions(cm, callback);
     expect(callback).not.toHaveBeenCalled();
   });
+});
+
+describe("Editor", () => {
   it("handles cursor blinkery changes", () => {
     const editorWrapper = mount(<Editor options={{ cursorBlinkRate: 530 }} />);
     const instance = editorWrapper.instance();
@@ -66,48 +150,6 @@ describe("Editor", () => {
     expect(cm.options.cursorBlinkRate).toBe(530);
     editorWrapper.setProps({ options: { cursorBlinkRate: 0 } });
     expect(cm.options.cursorBlinkRate).toBe(0);
-  });
-});
-
-describe("complete", () => {
-  it("handles code completion", done => {
-    const sent = new Subject();
-    const received = new Subject();
-    const mockSocket = Subject.create(sent, received);
-    const channels = mockSocket;
-
-    const cm = {
-      getCursor: () => ({ line: 2 }),
-      getValue: () => "\n\nimport thi",
-      indexFromPos: () => 12,
-      posFromIndex: x => ({ ch: x, line: 3 })
-    };
-
-    const message = createMessage("complete_request");
-    const observable = complete.codeCompleteObservable(channels, cm, message);
-
-    // Craft the response to their message
-    const response = createMessage("complete_reply");
-    response.content = {
-      matches: ["import this"],
-      cursor_start: 9,
-      cursor_end: 10
-    }; // Likely hokey values
-    response.parent_header = Object.assign({}, message.header);
-
-    // Listen on the Observable
-    observable.subscribe(
-      msg => {
-        expect(msg.from).toEqual({ line: 3, ch: 9 });
-        expect(msg.list[0].text).toEqual("import this");
-        expect(msg.to).toEqual({ ch: 10, line: 3 });
-      },
-      err => {
-        throw err;
-      },
-      done
-    );
-    received.next(response);
   });
 });
 

--- a/packages/editor/src/jupyter/complete.js
+++ b/packages/editor/src/jupyter/complete.js
@@ -112,8 +112,8 @@ export function codeCompleteObservable(
     pluck("content"),
     first(),
     map(expand_completions(editor)),
-    timeout(2000)
-  ); // 2s
+    timeout(15000) // Large timeout for slower languages; this is just here to make sure we eventually clean up resources
+  );
 
   // On subscription, send the message
   return Observable.create(observer => {


### PR DESCRIPTION
Related to #3314.

Previously we'd fire off a code completion request to the kernel for almost every keystroke. Some kernels don't currently handle this well. I don't have a view across other kernels, but I know that Almond (Scala) currently queues up these requests and lacks the ability to cancel a request-in-process when a new one arrives.

We can mitigate this partially by debouncing. To be clear, this is not a comprehensive solution. I cannot imagine our aggressive completion attempts working seamlessly for users without a kernel that can prioritize newer requests. But debouncing can make the problem much less pronounced
by reducing the flood of requests that occur while one types quickly.

This PR hard-codes a debounceTime interval of 150ms, such that it should have relatively unnoticeable impact to other kernels. If this proves problematic, I can imagine making this configuration driven, or language driven, or kernel-metadata driven.

Lower-level details:
- Explicit invocation of completion via Ctrl+Space circumvents debouncing since it is unambiguously the right time to go get completions.
- I've made it so that typing a period initiates a completion. It seemed odd to me that many alphanumeric keystrokes would initiate one, but not this.
- Keystrokes and Ctrl+Space will now initiate completion regardless of kernelStatus. Previous code attempted to only initiate non-Ctrl+Space strokes when idle, but had a bug in it where it only checked against the status at mount() time. The feedback I'm getting from my users is that completion behaves inconsistently, so rather than have this subtle dependency that can lead to confusion I'd rather we shoot these requests over to the kernel and let it get to them when it can.
- There are some code gymnastics around dealing w/ CodeMirror completions() callback. I tried to find less obtuse ways to interact w/ CodeMirror but came up empty.
- I reorganized and renamed some tests that seems slightly off. Found two editor tests skip()'d, so rejiggered them to run again, and let me test the new functionality. Things still feel a little janky here, VERY narrow unit testing that method A calls methods B; I can't quite justify the split between the editor itself and ./jupyter/complete.js, which is the particular boundary being tested here. Open to feedback, but mostly think I've made things marginally better, and not worse.
- Given my lack of RxJS experience, slightly worried about memory leaks
  around Subject and manual subscription; so please look from that angle.