### PR TITLE
Report kernel "launching" properly - Take two.

### DIFF
--- a/packages/core/__tests__/reducers/core/entities/kernels.js
+++ b/packages/core/__tests__/reducers/core/entities/kernels.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { makeKernelsRecord } from "../../../../src/state/entities/kernels";
+import { kernels } from "../../../../src/reducers/core/entities/kernels";
+import { actions } from "@nteract/core";
+describe("LAUNCH_KERNEL reducers", () => {
+  test("set launching state", () => {
+    const originalState = makeKernelsRecord();
+    const action = actions.launchKernel({
+      kernelSpec: "kernelSpec",
+      kernelType: "unknown",
+      cwd: ".",
+      kernelRef: "kernelRef",
+      selectNextKernel: false,
+      contentRef: "contentRef"
+    });
+    const state = kernels(originalState, action);
+    expect(state.byRef.get("kernelRef").type).toBe("unknown");
+    expect(state.byRef.get("kernelRef").status).toBe("launching");
+  });
+});

--- a/packages/core/src/reducers/core/entities/kernels.js
+++ b/packages/core/src/reducers/core/entities/kernels.js
@@ -1,5 +1,6 @@
 // @flow
 import {
+  makeKernelNotStartedRecord,
   makeLocalKernelRecord,
   makeRemoteKernelRecord,
   makeKernelsRecord
@@ -45,8 +46,23 @@ const byRef = (
     case actionTypes.RESTART_KERNEL:
       return state.setIn([action.payload.kernelRef, "status"], "restarting");
     case actionTypes.LAUNCH_KERNEL:
+      const launchAction = (action: actionTypes.LaunchKernelAction);
+      return state.set(
+        launchAction.payload.kernelRef,
+        makeKernelNotStartedRecord({
+          status: "launching",
+          kernelSpecName: launchAction.payload.kernelSpec.name
+        })
+      );
     case actionTypes.LAUNCH_KERNEL_BY_NAME:
-      return state.setIn([action.payload.kernelRef, "status"], "launching");
+      const launchByNameAction = (action: actionTypes.LaunchKernelByNameAction);
+      return state.set(
+        launchByNameAction.payload.kernelRef,
+        makeKernelNotStartedRecord({
+          status: "launching",
+          kernelSpecName: launchByNameAction.payload.kernelSpecName
+        })
+      );
     case actionTypes.CHANGE_KERNEL_BY_NAME:
       return state.setIn([action.payload.oldKernelRef, "status"], "changing");
     case actionTypes.SET_KERNEL_INFO:

--- a/packages/core/src/state/entities/kernels.js
+++ b/packages/core/src/state/entities/kernels.js
@@ -8,6 +8,35 @@ import { Subject } from "rxjs/Subject";
 import type { KernelInfo } from "./kernel-info";
 export type { KernelInfo };
 
+// See #3427. This represents the kernel early in the launch process.
+// With a bit more work we could probably drop this and just use either
+// Local or RemoteKernelProps as our initial representation of the kernel,
+// deriving local-vs-remote from known sources of truth about kernels.
+export type KernelNotStartedProps = {
+  kernelSpecName: ?string,
+  status: ?string,
+  // The following properties are not known immediately at the start of
+  // launch; they are just included to keep Flow happy and minimize the
+  // impact of this likely-to-be-deleted type.
+  type: "unknown",
+  cwd: ".",
+  channels: rxjs$Subject<*>,
+  info: ?KernelInfo
+};
+
+export type KernelNotStartedRecord = Immutable.RecordOf<KernelNotStartedProps>;
+
+export const makeKernelNotStartedRecord: Immutable.RecordFactory<
+  KernelNotStartedProps
+> = Immutable.Record({
+  kernelSpecName: null,
+  status: null,
+  type: "unknown",
+  cwd: ".",
+  channels: new Subject(),
+  info: null
+});
+
 export type LocalKernelProps = {
   kernelSpecName: ?string,
   info: ?KernelInfo,
@@ -78,7 +107,10 @@ export const makeRemoteKernelRecord: Immutable.RecordFactory<
 
 export type RemoteKernelRecord = Immutable.RecordOf<RemoteKernelProps>;
 
-export type KernelRecord = LocalKernelRecord | RemoteKernelRecord;
+export type KernelRecord =
+  | KernelNotStartedRecord
+  | LocalKernelRecord
+  | RemoteKernelRecord;
 
 export type KernelsRecordProps = {
   byRef: Immutable.Map<KernelRef, KernelRecord>


### PR DESCRIPTION
Previously, reducers in kernel.js reacted to LAUNCH_KERNEL/LAUNCH_KERNEL_BY_NAME by populating kernels.byRef[newKernelRefUUID] with a Map({state: "launching"}). Later, when more complete kernel info is available (LAUNCH_KERNEL_SUCCESSFUL), the Map was replaced with either a LocalKernelRecord or a RemoteKernelRecord. Reading Maps and Records isn't symmetrical and so this creates issues like #3417.

The fix applied here is to create a special type to model the kernel at this early launch point.

See also #3427 which explores an alternate approach of requiring the specification of local vs remote kernel type before dispatching any launch action.