### PR TITLE
Fix import

### DIFF
--- a/packages/jupyter-widgets/src/index.js
+++ b/packages/jupyter-widgets/src/index.js
@@ -1,31 +1,20 @@
 /* @flow */
-import type {
-  ContentRef,
-  AppState,
-  KernelRecord,
-  RemoteKernelProps,
-  LocalKernelProps
-} from "@nteract/core";
-
 import React from "react";
 // import { OuterShim } from "./outer-shim";
-import { actions, selectors } from "@nteract/core";
-import { connect } from "react-redux";
-
 
 type Props = {
   data: { model_id: string },
-  channels: rxjs$Subject<any>,
+  channels: rxjs$Subject<any>
 };
 
 /**
  * Component used to render a widget view.
- * 
+ *
  * Given a kernel and widget model id, this component will render a widget
  * view for the widget model. The widget view and widget models are isolated to
  * a cross domain iframe. Since they have access to the kernel, they are capable
  * of communicating directly with the kernel instance which makes them atypical.
- * 
+ *
  * Even though it may appear to be pure, since it doesn't have react state, this
  * component's iframe maintains it's own state in communication with the kernel.
  */
@@ -34,7 +23,7 @@ export class WidgetDisplay extends React.Component<Props, null> {
 
   // TODO: Uncomment this and related code in a follow-up PR.
   // The outer shim is responsable for managing the rendered cross domain
-  // iframe, communicating with it, and relaying information to and from the 
+  // iframe, communicating with it, and relaying information to and from the
   // kernel.
   // shim: OuterShim;
 
@@ -78,19 +67,21 @@ export class WidgetDisplay extends React.Component<Props, null> {
   render(): ?React$Element<any> {
     this.createOrUpdateShim();
 
-    return (<pre>
-      Jupyter-Widgets are not yet supported in nteract.
-      <div ref={this.container} /></pre>);
+    return (
+      <pre>
+        Jupyter-Widgets are not yet supported in nteract.
+        <div ref={this.container} />
+      </pre>
+    );
   }
 
-  /** 
+  /**
    * Creates or updates the existing shim to the current model id and kernel.
    */
   createOrUpdateShim() {
     // if (!this.shim) {
     //   this.shim = new OuterShim();
     // }
-
     // this.shim.setCommMsgsSubject(this.props.channels);
     // this.shim.setModelId(this.props.data.model_id);
   }

--- a/packages/transforms-full/src/index.js
+++ b/packages/transforms-full/src/index.js
@@ -12,7 +12,7 @@ import ModelDebug from "@nteract/transform-model-debug";
 import DataResourceTransform from "@nteract/transform-dataresource";
 
 import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
-import { WidgetDisplay } from "@nteract/transform-widgets";
+import { WidgetDisplay } from "@nteract/jupyter-widgets";
 
 import {
   standardTransforms,


### PR DESCRIPTION
Noticed desktop wasn't launching due to a name change of the widgets package.

```
    ERROR in /Users/kylek/code/src/github.com/nteract/nteract/packages/transforms-full/src/index.js
    Module not found: Error: Can't resolve '@nteract/transform-widgets' in '/Users/kylek/code/src/github.com/nteract/nteract/packages/transforms-full/src'
     @ /Users/kylek/code/src/github.com/nteract/nteract/packages/transforms-full/src/index.js 9:0-59 11:28-41
     @ ./src/notebook/index.js
```

This fixes up the import. I also deleted some unused imports.

Follow up to #3445 