### PR TITLE
Enforce order in our imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,14 @@
     "plugin:react-perf/recommended"
   ],
   "parser": "babel-eslint",
-  "plugins": ["prettier", "flowtype", "react", "jsx-a11y", "react-perf"],
+  "plugins": [
+    "prettier",
+    "flowtype",
+    "react",
+    "jsx-a11y",
+    "react-perf",
+    "import"
+  ],
   "env": {
     "browser": true,
     "node": true,
@@ -23,7 +30,10 @@
     "react/no-deprecated": 1,
     "no-unused-vars": 2,
     "react-perf/jsx-no-new-object-as-prop": "warn",
-    "react-perf/jsx-no-new-array-as-prop": "warn"
+    "react-perf/jsx-no-new-array-as-prop": "warn",
+    "import/order": ["error", { "newlines-between": "always" }],
+    "import/newline-after-import": "error",
+    "import/no-duplicates": "warn"
   },
   "settings": {
     "react": {

--- a/applications/commuter/__tests__/s3test.js
+++ b/applications/commuter/__tests__/s3test.js
@@ -1,7 +1,8 @@
 // @flow
-const s3Service = require("./../backend/content-providers/s3/s3");
 jest.mock("aws-sdk/clients/s3");
 const awsMock = require("aws-sdk/clients/s3");
+
+const s3Service = require("./../backend/content-providers/s3/s3");
 
 describe("Test S3 service", () => {
   test("getObject returns notebook content", done => {

--- a/applications/commuter/backend/content-providers/local/contents.js
+++ b/applications/commuter/backend/content-providers/local/contents.js
@@ -1,11 +1,11 @@
 // @flow
-const express = require("express");
-
-const fs = require("./fs");
+import type { $Request, $Response } from "express";
 
 import type { DiskProviderOptions } from "./fs";
 
-import type { $Request, $Response } from "express";
+const express = require("express");
+
+const fs = require("./fs");
 
 type ErrorResponse = {
   message: string

--- a/applications/commuter/backend/content-providers/local/files.js
+++ b/applications/commuter/backend/content-providers/local/files.js
@@ -1,13 +1,14 @@
 // @flow
-const express = require("express");
+import type { $Request, $Response } from "express";
+
+import type { DiskProviderOptions } from "./fs";
 
 const fs = require("fs");
 const path = require("path");
 
-const sanitizeFilePath = require("./fs").sanitizeFilePath;
-import type { DiskProviderOptions } from "./fs";
+const express = require("express");
 
-import type { $Request, $Response } from "express";
+const sanitizeFilePath = require("./fs").sanitizeFilePath;
 
 type ErrorResponse = {
   message: string

--- a/applications/commuter/backend/content-providers/local/fs.js
+++ b/applications/commuter/backend/content-providers/local/fs.js
@@ -4,8 +4,9 @@
  * Local storage provider for commuter
  */
 
-const fs = require("fs-extra");
 const path = require("path");
+
+const fs = require("fs-extra");
 
 export type DiskProviderOptions = {
   local: {

--- a/applications/commuter/backend/index.js
+++ b/applications/commuter/backend/index.js
@@ -1,7 +1,9 @@
 // @flow
-const createServer = require("./server"),
-  Log = require("log"),
-  log = new Log("info");
+const Log = require("log");
+
+const createServer = require("./server");
+
+const log = new Log("info");
 
 createServer()
   .then(server => {

--- a/applications/commuter/backend/resources/generateMapping.js
+++ b/applications/commuter/backend/resources/generateMapping.js
@@ -1,7 +1,8 @@
 // @flow
-const path = require("path"),
-  jsonfile = require("jsonfile"),
-  nbformatv4Schema = require("nbschema").v4;
+const path = require("path");
+
+const jsonfile = require("jsonfile");
+const nbformatv4Schema = require("nbschema").v4;
 
 const writeFile = schema =>
   jsonfile.writeFileSync(

--- a/applications/commuter/backend/routes/api/index.js
+++ b/applications/commuter/backend/routes/api/index.js
@@ -1,8 +1,9 @@
 // @flow
+import type { Middleware, $Request, $Response } from "express";
+
 const express = require("express");
 const bodyParser = require("body-parser");
 
-import type { Middleware, $Request, $Response } from "express";
 
 const defaultContentTypeMiddleware: Middleware = (
   req: $Request,

--- a/applications/commuter/backend/server.js
+++ b/applications/commuter/backend/server.js
@@ -2,15 +2,18 @@
 
 import type { $Request, $Response } from "express";
 
-const front = require("../frontend");
 
 const { parse } = require("url");
+const http = require("http");
 
 const express = require("express");
-const http = require("http");
 const morgan = require("morgan");
-const config = require("./config");
 const Log = require("log");
+
+const front = require("../frontend");
+
+const config = require("./config");
+
 const log = new Log("info");
 
 function createServer() {

--- a/applications/commuter/components/browse-header.js
+++ b/applications/commuter/components/browse-header.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from "react";
 import Router from "next/router";
-
 import NextLink from "next/link";
 import { trim } from "lodash";
 

--- a/applications/commuter/components/contents/directory-listing.js
+++ b/applications/commuter/components/contents/directory-listing.js
@@ -1,10 +1,6 @@
 // @flow
 import * as React from "react";
-
 import Link from "next/link";
-
-import { theme } from "../../theme";
-
 import { groupBy } from "lodash";
 import {
   Entry,
@@ -13,6 +9,8 @@ import {
   Name,
   LastSaved
 } from "@nteract/directory-listing";
+
+import { theme } from "../../theme";
 
 export type DirectoryListingProps = {
   contents: Array<JupyterApi$Content>,

--- a/applications/commuter/components/contents/index.js
+++ b/applications/commuter/components/contents/index.js
@@ -1,28 +1,28 @@
 // @flow
 import * as React from "react";
-
 import NotebookPreview from "@nteract/notebook-preview";
 import Markdown from "@nteract/markdown";
 import { Styles, Source } from "@nteract/presentational-components";
-
-import DirectoryListing from "./directory-listing";
-
-// HACK: Temporarily provide jquery for others to use...
-const jquery = require("jquery");
-global.jquery = jquery;
-global.$ = jquery;
-
 import {
   standardTransforms,
   standardDisplayOrder,
   registerTransform
 } from "@nteract/transforms";
-
+import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 // import DataResourceTransform from "@nteract/transform-dataresource";
 
-import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
-
 import { PlotlyNullTransform, PlotlyTransform } from "../../transforms";
+
+import DirectoryListing from "./directory-listing";
+import HTMLView from "./html";
+import JSONView from "./json";
+import CSVView from "./csv";
+
+const jquery = require("jquery");
+
+// HACK: Temporarily provide jquery for others to use...
+global.jquery = jquery;
+global.$ = jquery;
 
 // Order is important here. The last transform in the array will have order `0`.
 const { transforms, displayOrder } = [
@@ -37,10 +37,6 @@ const { transforms, displayOrder } = [
   transforms: standardTransforms,
   displayOrder: standardDisplayOrder
 });
-
-import HTMLView from "./html";
-import JSONView from "./json";
-import CSVView from "./csv";
 
 const suffixRegex = /(?:\.([^.]+))?$/;
 

--- a/applications/commuter/components/contents/json.js
+++ b/applications/commuter/components/contents/json.js
@@ -1,11 +1,9 @@
 // @flow
 import * as React from "react";
+import { JSONTransform } from "@nteract/transforms";
+import Immutable from "immutable";
 
 import ZeppelinView from "./zeppelin";
-
-import { JSONTransform } from "@nteract/transforms";
-
-import Immutable from "immutable";
 
 export default (props: *) => {
   const content = JSON.parse(props.entry.content);

--- a/applications/commuter/components/contents/zeppelin.js
+++ b/applications/commuter/components/contents/zeppelin.js
@@ -1,8 +1,6 @@
 // @flow
 import * as React from "react";
-
 import { HTMLTransform } from "@nteract/transforms";
-
 import { Source } from "@nteract/presentational-components";
 
 const d3 = Object.assign({}, require("d3-dsv"));

--- a/applications/commuter/frontend.js
+++ b/applications/commuter/frontend.js
@@ -1,6 +1,7 @@
 // Note: this module must remain compatible with the ECMAScript version of the
 // Server as it does _not_ get transpiled
 const next = require("next");
+
 const dev = process.env.NODE_ENV !== "production" && !process.env.NOW;
 
 function createNextApp() {

--- a/applications/commuter/next.config.js
+++ b/applications/commuter/next.config.js
@@ -1,5 +1,4 @@
 const configurator = require("@nteract/webpack-configurator");
-
 const webpack = require("webpack");
 
 function webpackConfig(_config, options) {

--- a/applications/commuter/pages/_document.js
+++ b/applications/commuter/pages/_document.js
@@ -1,9 +1,7 @@
 // @flow
 import * as React from "react";
 import Document, { Head, Main, NextScript } from "next/document";
-
 import flush from "styled-jsx/server";
-
 import PropTypes from "prop-types";
 
 class MyDocument extends Document {

--- a/applications/commuter/pages/discover.js
+++ b/applications/commuter/pages/discover.js
@@ -1,12 +1,10 @@
 // @flow
 import * as React from "react";
 import TimeAgo from "@nteract/timeago";
-
 import NextLink from "next/link";
 
 import Header from "../components/header";
 import Body from "../components/body";
-
 import { getJSON } from "../shims/ajax";
 
 const Authors = props => (

--- a/applications/commuter/pages/view.js
+++ b/applications/commuter/pages/view.js
@@ -2,11 +2,9 @@
 import * as React from "react";
 
 import { getJSON } from "../shims/ajax";
-
 import Header from "../components/header";
 import BrowseHeader from "../components/browse-header";
 import Body from "../components/body";
-
 import { Entry } from "../components/contents";
 
 type ServerConfig = {

--- a/applications/commuter/transforms/PlotlyTransform.js
+++ b/applications/commuter/transforms/PlotlyTransform.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as React from "react";
 import { cloneDeep } from "lodash";
+
 declare var Plotly: Object;
 type Props = {
   data: string | Object

--- a/applications/desktop/__tests__/renderer/epics/close-notebook-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/close-notebook-spec.js
@@ -1,13 +1,7 @@
 /* @flow strict */
 
-import * as actions from "../../../src/notebook/actions";
 
-import {
-  DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
-  DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
-} from "../../../src/notebook/state.js";
 
-import { closeNotebookEpic } from "../../../src/notebook/epics/close-notebook";
 
 import {
   actions as coreActions,
@@ -15,15 +9,18 @@ import {
   makeNotebookContentRecord,
   state as stateModule
 } from "@nteract/core";
-
 import * as Immutable from "immutable";
-
 import { toArray } from "rxjs/operators";
 import { ActionsObservable } from "redux-observable";
+import { TestScheduler } from "rxjs/testing";
 
 import { ipcRenderer as ipc } from "../../../__mocks__/electron";
-
-import { TestScheduler } from "rxjs/testing";
+import { closeNotebookEpic } from "../../../src/notebook/epics/close-notebook";
+import {
+  DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
+  DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+} from "../../../src/notebook/state.js";
+import * as actions from "../../../src/notebook/actions";
 
 const buildScheduler = () =>
   new TestScheduler((actual, expected) => expect(actual).toEqual(expected));

--- a/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch-spec.js
@@ -1,6 +1,6 @@
 import { ActionsObservable } from "redux-observable";
-
 import { actions, actionTypes, makeStateRecord } from "@nteract/core";
+import { toArray } from "rxjs/operators";
 
 import {
   launchKernelObservable,
@@ -8,7 +8,6 @@ import {
   launchKernelByNameEpic
 } from "../../../src/notebook/epics/zeromq-kernels";
 
-import { toArray } from "rxjs/operators";
 
 describe("launchKernelObservable", () => {
   test("returns an observable", () => {

--- a/applications/desktop/__tests__/renderer/epics/loading-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/loading-spec.js
@@ -1,18 +1,14 @@
 import { ActionsObservable } from "redux-observable";
-
 import { monocellNotebook, toJS } from "@nteract/commutable";
-
 import { dummyCommutable } from "@nteract/core/dummy";
+import { actionTypes } from "@nteract/core";
+import { toArray } from "rxjs/operators";
 
 import {
   extractNewKernel,
   fetchContentEpic,
   newNotebookEpic
 } from "../../../src/notebook/epics/loading";
-
-import { actionTypes } from "@nteract/core";
-
-import { toArray } from "rxjs/operators";
 
 const path = require("path");
 

--- a/applications/desktop/__tests__/renderer/epics/saving-spec.js
+++ b/applications/desktop/__tests__/renderer/epics/saving-spec.js
@@ -1,13 +1,11 @@
 jest.mock("fs");
 import { ActionsObservable } from "redux-observable";
-
 import { actions, makeNotebookContentRecord } from "@nteract/core";
-
 import * as Immutable from "immutable";
+import { toArray } from "rxjs/operators";
 
 import { saveEpic, saveAsEpic } from "../../../src/notebook/epics/saving";
 
-import { toArray } from "rxjs/operators";
 
 describe("saveEpic", () => {
   test("saves the file using the notebook in the state tree", async function() {

--- a/applications/desktop/__tests__/renderer/global-events-spec.js
+++ b/applications/desktop/__tests__/renderer/global-events-spec.js
@@ -1,10 +1,6 @@
 /* @flow */
 
-import { ipcRenderer as ipc } from "../../__mocks__/electron";
-
-import * as globalEvents from "../../src/notebook/global-events";
 import * as Immutable from "immutable";
-
 import {
   createContentRef,
   makeStateRecord,
@@ -14,13 +10,14 @@ import {
   makeDocumentRecord
 } from "@nteract/core";
 
+import { ipcRenderer as ipc } from "../../__mocks__/electron";
+import * as globalEvents from "../../src/notebook/global-events";
 import {
   makeDesktopNotebookRecord,
   DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
   DESKTOP_NOTEBOOK_CLOSING_STARTED,
   DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
 } from "../../src/notebook/state.js";
-
 import * as actions from "../../src/notebook/actions.js";
 
 const createStore = (

--- a/applications/desktop/__tests__/renderer/menu-spec.js
+++ b/applications/desktop/__tests__/renderer/menu-spec.js
@@ -1,9 +1,9 @@
-import { webFrame, ipcRenderer as ipc } from "electron";
 jest.mock("fs");
-import * as menu from "../../src/notebook/menu";
+import { webFrame, ipcRenderer as ipc } from "electron";
 import { actions, actionTypes } from "@nteract/core";
-
 import * as Immutable from "immutable";
+
+import * as menu from "../../src/notebook/menu";
 
 describe("dispatchCreateCellAbove", () => {
   test("dispatches a CREATE_CELL_ABOVE with code action", () => {

--- a/applications/desktop/__tests__/renderer/native-window-spec.js
+++ b/applications/desktop/__tests__/renderer/native-window-spec.js
@@ -1,10 +1,9 @@
 import Immutable from "immutable";
 import { remote } from "electron";
-
 import { of } from "rxjs";
+import { state as stateModule } from "@nteract/core";
 
 import * as nativeWindow from "../../src/notebook/native-window";
-import { state as stateModule } from "@nteract/core";
 
 const path = require("path");
 

--- a/applications/desktop/src/main/cli.js
+++ b/applications/desktop/src/main/cli.js
@@ -1,8 +1,8 @@
 /* @flow strict */
+import { join } from "path";
+
 import { catchError, mergeMap } from "rxjs/operators";
 import { merge } from "rxjs";
-
-import { join } from "path";
 import { dialog } from "electron";
 import { spawn } from "spawn-rx";
 import { writeFileObservable, createSymlinkObservable } from "fs-observable";

--- a/applications/desktop/src/main/index.js
+++ b/applications/desktop/src/main/index.js
@@ -1,4 +1,7 @@
 /* @flow strict */
+import { resolve, join } from "path";
+import { existsSync } from "fs";
+
 import {
   Menu,
   dialog,
@@ -7,9 +10,6 @@ import {
   BrowserWindow,
   Tray
 } from "electron";
-import { resolve, join } from "path";
-import { existsSync } from "fs";
-
 import { Subscriber, fromEvent, forkJoin, zip } from "rxjs";
 import {
   mergeMap,
@@ -19,7 +19,6 @@ import {
   catchError,
   first
 } from "rxjs/operators";
-
 import {
   mkdirpObservable,
   readFileObservable,
@@ -28,9 +27,7 @@ import {
 
 import { launch, launchNewNotebook } from "./launch";
 import { initAutoUpdater } from "./auto-updater.js";
-
 import { loadFullMenu, loadTrayMenu } from "./menu";
-
 import prepareEnv from "./prepare-env";
 import initializeKernelSpecs from "./kernel-specs";
 import { setKernelSpecs, setQuittingState } from "./actions";
@@ -38,19 +35,17 @@ import {
   QUITTING_STATE_NOT_STARTED,
   QUITTING_STATE_QUITTING
 } from "./reducers.js";
-
 import configureStore from "./store";
 
 const store = configureStore();
 // HACK: The main process store should not be stored in a global.
 global.store = store;
 
-const log = require("electron-log");
-
-const kernelspecs = require("kernelspecs");
-const jupyterPaths = require("jupyter-paths");
 const path = require("path");
 
+const log = require("electron-log");
+const kernelspecs = require("kernelspecs");
+const jupyterPaths = require("jupyter-paths");
 const yargs = require("yargs/yargs");
 
 type Arguments = {

--- a/applications/desktop/src/main/kernel-specs.js
+++ b/applications/desktop/src/main/kernel-specs.js
@@ -1,6 +1,7 @@
 /* @flow strict */
-import { ipcMain as ipc } from "electron";
 import { join } from "path";
+
+import { ipcMain as ipc } from "electron";
 
 const KERNEL_SPECS = {
   node_nteract: {

--- a/applications/desktop/src/main/kernels.js
+++ b/applications/desktop/src/main/kernels.js
@@ -8,7 +8,6 @@ import {
   mergeAll,
   toArray
 } from "rxjs/operators";
-
 import { spawn } from "spawn-rx";
 
 const path = require("path");

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -1,11 +1,13 @@
 /* @flow strict */
-import { dialog, app, shell, Menu, BrowserWindow} from "electron";
 import * as path from "path";
+
+import { dialog, app, shell, Menu, BrowserWindow} from "electron";
 import { sortBy } from "lodash";
+import { manifest } from "@nteract/examples";
+
 import { launch, launchNewNotebook } from "./launch";
 import { installShellCommand } from "./cli";
 
-import { manifest } from "@nteract/examples";
 
 // Overwrite the type for `process` to match Electron's process
 // https://electronjs.org/docs/api/process

--- a/applications/desktop/src/main/prepare-env.js
+++ b/applications/desktop/src/main/prepare-env.js
@@ -1,6 +1,5 @@
 /* @flow strict */
 import shellEnv from "shell-env";
-
 import { from } from "rxjs";
 import { first, tap, publishReplay } from "rxjs/operators";
 

--- a/applications/desktop/src/main/store.js
+++ b/applications/desktop/src/main/store.js
@@ -2,8 +2,9 @@
 import { createStore, applyMiddleware, compose } from "redux";
 import { electronEnhancer } from "redux-electron-store";
 
-import reducers from "./reducers.js";
 import logger from "../notebook/logger.js";
+
+import reducers from "./reducers.js";
 
 const middlewares = [];
 

--- a/applications/desktop/src/notebook/actions.js
+++ b/applications/desktop/src/notebook/actions.js
@@ -1,9 +1,8 @@
 // @flow strict
 
-import * as actionTypes from "./actionTypes";
-
 import type { ContentRef } from "@nteract/core";
 
+import * as actionTypes from "./actionTypes";
 import type { DesktopNotebookClosingState } from "./state";
 
 export function closeNotebook(payload: {

--- a/applications/desktop/src/notebook/epics/close-notebook.js
+++ b/applications/desktop/src/notebook/epics/close-notebook.js
@@ -3,22 +3,14 @@
 // Lots of open bugs around intersection types, and they're used inside Immutable.js too, so layers upon layers.
 // https://github.com/facebook/flow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+intersect
 
-import * as actions from "../actions";
-import * as actionTypes from "../actionTypes";
 
-import {
-  DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
-  DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
-} from "../state.js";
 
 import {
   actionTypes as coreActionTypes,
   actions as coreActions,
   selectors
 } from "@nteract/core";
-
 import { Observable, empty, of, zip, concat } from "rxjs";
-
 import {
   catchError,
   concatMap,
@@ -28,10 +20,15 @@ import {
   tap,
   timeout
 } from "rxjs/operators";
-
 import { ActionsObservable, ofType } from "redux-observable";
-
 import { ipcRenderer as ipc } from "electron";
+
+import {
+  DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,
+  DESKTOP_NOTEBOOK_CLOSING_READY_TO_CLOSE
+} from "../state.js";
+import * as actionTypes from "../actionTypes";
+import * as actions from "../actions";
 
 export const closeNotebookEpic = (action$: ActionsObservable<redux$Action>, state$: *) =>
   action$.pipe(

--- a/applications/desktop/src/notebook/epics/config.js
+++ b/applications/desktop/src/notebook/epics/config.js
@@ -1,11 +1,9 @@
 /* @flow strict */
 import { remote } from "electron";
-
 import { actions, actionTypes } from "@nteract/core";
 import { readFileObservable, writeFileObservable } from "fs-observable";
 import { mapTo, mergeMap, map, switchMap } from "rxjs/operators";
 import { ofType } from "redux-observable";
-
 import type { ActionsObservable, StateObservable } from "redux-observable";
 import type { AppState } from "@nteract/core";
 

--- a/applications/desktop/src/notebook/epics/github-publish.js
+++ b/applications/desktop/src/notebook/epics/github-publish.js
@@ -1,18 +1,14 @@
 // @flow strict
 import { shell } from "electron";
-
 import { selectors, actions, actionTypes } from "@nteract/core";
-
-const path = require("path");
-
 import { of, empty } from "rxjs";
 import { ajax } from "rxjs/ajax";
 import { mergeMap, catchError } from "rxjs/operators";
-
 import { ofType } from "redux-observable";
-
 import type { ActionsObservable, StateObservable } from "redux-observable";
 import type { AppState } from "@nteract/core";
+
+const path = require("path");
 
 type GithubFiles = {
   [string]: {

--- a/applications/desktop/src/notebook/epics/index.js
+++ b/applications/desktop/src/notebook/epics/index.js
@@ -1,15 +1,15 @@
 /* @flow strict */
 import { catchError, startWith } from "rxjs/operators";
-import { saveEpic, saveAsEpic } from "./saving";
+import { epics as coreEpics } from "@nteract/core";
+import type { AppState } from "@nteract/core";
+import type { Epic } from "redux-observable";
 
+import { saveEpic, saveAsEpic } from "./saving";
 import {
   fetchContentEpic,
   newNotebookEpic,
   launchKernelWhenNotebookSetEpic
 } from "./loading";
-
-import type { Epic } from "redux-observable";
-
 import {
   launchKernelEpic,
   launchKernelByNameEpic,
@@ -17,18 +17,12 @@ import {
   killKernelEpic,
   watchSpawn
 } from "./zeromq-kernels";
-
-import { epics as coreEpics } from "@nteract/core";
-import type { AppState } from "@nteract/core";
-
 import { publishEpic } from "./github-publish";
-
 import {
   loadConfigEpic,
   saveConfigEpic,
   saveConfigOnChangeEpic
 } from "./config";
-
 import { closeNotebookEpic } from "./close-notebook";
 
 export function retryAndEmitError(

--- a/applications/desktop/src/notebook/epics/loading.js
+++ b/applications/desktop/src/notebook/epics/loading.js
@@ -5,15 +5,11 @@ import * as fs from "fs";
 
 import { of, forkJoin, empty } from "rxjs";
 import { map, tap, switchMap, catchError, timeout } from "rxjs/operators";
-
 import { ActionsObservable, ofType } from "redux-observable";
 import type { StateObservable } from "redux-observable";
-
 import { readFileObservable, statObservable } from "fs-observable";
-
 import { monocellNotebook, toJS } from "@nteract/commutable";
 import type { ImmutableNotebook } from "@nteract/commutable";
-
 import { actionTypes, actions, selectors } from "@nteract/core";
 import type { AppState } from "@nteract/core";
 

--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -1,14 +1,10 @@
 /* @flow strict */
 import { ofType } from "redux-observable";
 import type { ActionsObservable, StateObservable } from "redux-observable";
-
 import { writeFileObservable } from "fs-observable";
-
 import { actionTypes, selectors, actions } from "@nteract/core";
 import type { AppState } from "@nteract/core";
-
 import { toJS, stringifyNotebook } from "@nteract/commutable";
-
 import { of } from "rxjs";
 import { mergeMap, catchError, map } from "rxjs/operators";
 

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.js
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.js
@@ -3,9 +3,7 @@
 import type { ChildProcess } from "child_process";
 
 import { Observable, of, merge, empty } from "rxjs";
-
 import { sample } from "lodash";
-
 import {
   filter,
   map,
@@ -17,27 +15,20 @@ import {
   timeout,
   first
 } from "rxjs/operators";
-
 import { launchSpec } from "spawnteract";
-
 import { ActionsObservable, ofType } from "redux-observable";
 import type { StateObservable } from "redux-observable";
-
 import { ipcRenderer as ipc } from "electron";
-
 import { createMainChannel } from "enchannel-zmq-backend";
 import * as jmp from "jmp";
-
 import { selectors, actions, actionTypes } from "@nteract/core";
-import type { AppState } from "@nteract/core";
-
 import type {
+  AppState,
   KernelspecInfo,
   KernelRef,
   ContentRef,
   LocalKernelProps
 } from "@nteract/core";
-
 import { childOf, ofMessageType, shutdownRequest } from "@nteract/messaging";
 
 /**

--- a/applications/desktop/src/notebook/fonts.js
+++ b/applications/desktop/src/notebook/fonts.js
@@ -1,7 +1,8 @@
 /* @flow */
 
-const WebFont = require("webfontloader");
 const path = require("path");
+
+const WebFont = require("webfontloader");
 
 const fontFolder = ["..", "node_modules", "nteract-assets", "fonts"];
 

--- a/applications/desktop/src/notebook/global-events.js
+++ b/applications/desktop/src/notebook/global-events.js
@@ -1,15 +1,11 @@
 /* @flow strict */
 
 import type { Store } from "redux";
-
 import { ipcRenderer as ipc } from "electron";
-
 import { selectors } from "@nteract/core";
-
 import type { ContentRef } from "@nteract/core";
 
 import * as actions from "./actions";
-
 import type { DesktopNotebookAppState } from "./state.js";
 import {
   DESKTOP_NOTEBOOK_CLOSING_NOT_STARTED,

--- a/applications/desktop/src/notebook/index.js
+++ b/applications/desktop/src/notebook/index.js
@@ -3,19 +3,10 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 import { ipcRenderer as ipc, remote } from "electron";
 import { Provider } from "react-redux";
-
-// Load the nteract fonts
-require("./fonts");
-
 import MathJax from "@nteract/mathjax";
 import { mathJaxPath } from "mathjax-electron";
-
 import NotificationSystem from "react-notification-system";
-
-import configureStore from "./store";
-
 import { Styles } from "@nteract/presentational-components";
-
 import {
   actions,
   createContentRef,
@@ -27,19 +18,19 @@ import {
   makeLocalHostRecord,
   makeEntitiesRecord
 } from "@nteract/core";
-
 import type { ContentRef, ContentRecord } from "@nteract/core";
-
 import NotebookApp from "@nteract/notebook-app-component";
-
 import { displayOrder, transforms } from "@nteract/transforms-full";
+import * as Immutable from "immutable";
 
 import { initMenuHandlers } from "./menu";
 import { initNativeHandlers } from "./native-window";
 import { initGlobalHandlers } from "./global-events";
 import { makeDesktopNotebookRecord } from "./state.js";
+import configureStore from "./store";
 
-import * as Immutable from "immutable";
+// Load the nteract fonts
+require("./fonts");
 
 const contentRef = createContentRef();
 

--- a/applications/desktop/src/notebook/logger.js
+++ b/applications/desktop/src/notebook/logger.js
@@ -1,6 +1,5 @@
 /* @flow strict */
 import { isCollection } from "immutable";
-
 import { createLogger } from "redux-logger";
 
 export function clogger() {

--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -1,13 +1,11 @@
 /* @flow strict */
 /* eslint-disable no-unused-vars, no-use-before-define */
-import { ipcRenderer as ipc, webFrame, shell, remote } from "electron";
 
 import * as path from "path";
-
 import * as fs from "fs";
 
+import { ipcRenderer as ipc, webFrame, shell, remote } from "electron";
 import { throttle } from "lodash";
-
 import {
   actions,
   actionTypes,
@@ -15,7 +13,6 @@ import {
   createKernelRef
 } from "@nteract/core";
 import type { AppState, ContentRef, KernelRef } from "@nteract/core";
-
 import type { Store } from "redux";
 
 import type { DesktopNotebookAppState } from "./state.js";

--- a/applications/desktop/src/notebook/native-window.js
+++ b/applications/desktop/src/notebook/native-window.js
@@ -1,13 +1,10 @@
 /* @flow */
-import { remote } from "electron";
-
 import path from "path";
 
+import { remote } from "electron";
 import { selectors } from "@nteract/core";
 import type { ContentRef, KernelRef, AppState } from "@nteract/core";
-
 import { empty, of, from, combineLatest } from "rxjs";
-
 import {
   map,
   distinctUntilChanged,

--- a/applications/desktop/src/notebook/reducers.js
+++ b/applications/desktop/src/notebook/reducers.js
@@ -1,7 +1,6 @@
 /* @flow strict */
 
 import * as actionTypes from "./actionTypes";
-
 import type { DesktopNotebookRecord } from "./state";
 import {
   makeDesktopNotebookRecord,

--- a/applications/desktop/src/notebook/state.js
+++ b/applications/desktop/src/notebook/state.js
@@ -1,7 +1,6 @@
 /* @flow strict */
 
 import * as Immutable from "immutable";
-
 import type { AppState } from "@nteract/core";
 
 export opaque type DesktopNotebookClosingState =

--- a/applications/desktop/src/notebook/store.js
+++ b/applications/desktop/src/notebook/store.js
@@ -5,7 +5,6 @@ import { middlewares as coreMiddlewares, reducers } from "@nteract/core";
 
 import type { DesktopNotebookAppState } from "./state";
 import { handleDesktopNotebook } from "./reducers";
-
 import logger from "./logger";
 import epics from "./epics";
 

--- a/applications/desktop/webpack.common.js
+++ b/applications/desktop/webpack.common.js
@@ -1,6 +1,6 @@
-const webpack = require("webpack");
 const path = require("path");
 
+const webpack = require("webpack");
 const configurator = require("@nteract/webpack-configurator");
 
 const nodeModules = {

--- a/applications/desktop/webpack.prod.js
+++ b/applications/desktop/webpack.prod.js
@@ -1,5 +1,4 @@
 const merge = require("webpack-merge");
-
 const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
 
 const { commonMainConfig, commonRendererConfig } = require("./webpack.common");

--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.js
@@ -1,13 +1,11 @@
 /* @flow strict */
 import { hot } from "react-hot-loader";
-
 import * as React from "react";
-
 import NotificationSystem from "react-notification-system";
-
 import { Styles, themes } from "@nteract/presentational-components";
-import { default as Contents } from "./contents";
 import type { ContentRef } from "@nteract/core";
+
+import { default as Contents } from "./contents";
 
 class App extends React.Component<{ contentRef: ContentRef }, null> {
   notificationSystem: NotificationSystem;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/components/last-saved.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/components/last-saved.js
@@ -14,12 +14,9 @@
  */
 
 import * as React from "react";
-
 import { selectors } from "@nteract/core";
 import type { ContentRef, AppState } from "@nteract/core";
-
 import moment from "moment";
-
 import { connect } from "react-redux";
 
 type LastSavedProps = {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/components/themed-logo.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/components/themed-logo.js
@@ -1,6 +1,5 @@
 /* @flow strict */
 import * as React from "react";
-
 import { WideLogo } from "@nteract/logos";
 
 type ThemedLogoProps = {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.js
@@ -1,15 +1,7 @@
 /* @flow strict */
 
 import * as React from "react";
-const urljoin = require("url-join");
-
 import { selectors } from "@nteract/core";
-
-import { ThemedLogo } from "../components/themed-logo.js";
-
-import { openNotebook } from "../triggers/open-notebook";
-
-import { Nav, NavSection } from "../components/nav";
 import { NewNotebookNavigation } from "@nteract/connected-components";
 import {
   Entry,
@@ -18,7 +10,6 @@ import {
   Name,
   LastSaved
 } from "@nteract/directory-listing";
-
 import type {
   AppState,
   KernelspecRecord,
@@ -27,8 +18,13 @@ import type {
   ContentRef,
   DirectoryContentRecord
 } from "@nteract/core";
-
 import { connect } from "react-redux";
+
+import { Nav, NavSection } from "../components/nav";
+import { openNotebook } from "../triggers/open-notebook";
+import { ThemedLogo } from "../components/themed-logo.js";
+
+const urljoin = require("url-join");
 
 type DirectoryProps = {
   content: DirectoryContentRecord,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.js
@@ -1,23 +1,20 @@
 /* @flow strict */
 
-import * as React from "react";
+import { dirname } from "path";
 
+import * as React from "react";
 import { selectors } from "@nteract/core";
 import type { ContentRef, AppState } from "@nteract/core";
-
 import { LoadingIcon, SavingingIcon, ErrorIcon } from "@nteract/iron-icons";
+import { connect } from "react-redux";
 
 import { ThemedLogo } from "../../components/themed-logo";
 import { Nav, NavSection } from "../../components/nav";
-
 import LastSaved from "../../components/last-saved.js";
-
-import { dirname } from "path";
-
-import * as TextFile from "./text-file.js";
 import { default as Notebook } from "../notebook";
 
-import { connect } from "react-redux";
+import * as TextFile from "./text-file.js";
+
 
 const urljoin = require("url-join");
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/text-file.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/text-file.js
@@ -1,10 +1,9 @@
 /* @flow strict */
 import * as React from "react";
-
 import type { AppState, ContentRef } from "@nteract/core";
 import { selectors, actions } from "@nteract/core";
-
 import { connect } from "react-redux";
+
 import type { MonacoEditorProps } from "../../../../../../node_modules/@nteract/monaco-editor";
 
 type MappedStateProps = {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.js
@@ -4,23 +4,22 @@
 // instead of a dev dependency as it automatically ensures it is not executed
 // in production and the footprint is minimal.
 import { hot } from "react-hot-loader";
-
 import * as React from "react";
-
 import { selectors } from "@nteract/core";
-
 import type { AppState, ContentRef } from "@nteract/core";
+import { connect } from "react-redux";
 
-const urljoin = require("url-join");
+import { ThemedLogo } from "../components/themed-logo";
+import { Nav, NavSection } from "../components/nav";
 
 import { default as Directory } from "./directory";
 import { default as File } from "./file";
 
-import { ThemedLogo } from "../components/themed-logo";
+const urljoin = require("url-join");
 
-import { Nav, NavSection } from "../components/nav";
 
-import { connect } from "react-redux";
+
+
 
 type ContentsProps = {
   contentType: "dummy" | "notebook" | "directory" | "file",

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.js
@@ -1,11 +1,8 @@
 /* @flow strict */
 
 import * as React from "react";
-
 import { NotebookMenu } from "@nteract/connected-components";
-
 import type { ContentRef } from "@nteract/core";
-
 import {
   displayOrder as defaultDisplayOrder,
   transforms as defaultTransforms

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.js
@@ -2,15 +2,10 @@
 // NOTE: We _must_ load hot _before_ React, even though we don't use it in this file
 // eslint-disable-next-line no-unused-vars
 import { hot } from "react-hot-loader";
-
 import * as React from "react";
 import ReactDOM from "react-dom";
-
-import App from "./app";
-
 import { Provider } from "react-redux";
 import * as Immutable from "immutable";
-import configureStore from "./store";
 import {
   actions,
   createKernelspecsRef,
@@ -26,8 +21,10 @@ import {
   createHostRef,
   makeJupyterHostRecord
 } from "@nteract/core";
-
 import type { AppState } from "@nteract/core";
+
+import configureStore from "./store";
+import App from "./app";
 
 const urljoin = require("url-join");
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.js
@@ -1,12 +1,10 @@
 /* @flow strict */
 import { combineReducers, createStore, applyMiddleware, compose } from "redux";
 import { createEpicMiddleware, combineEpics } from "redux-observable";
-
 import type { AppState } from "@nteract/core";
+import { reducers, epics as coreEpics } from "@nteract/core";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
-
-import { reducers, epics as coreEpics } from "@nteract/core";
 
 const rootReducer = combineReducers({
   app: reducers.app,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/triggers/open-notebook.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/triggers/open-notebook.js
@@ -5,12 +5,9 @@ import type {
   KernelspecProps,
   JupyterHostRecord
 } from "@nteract/core";
-
 import { selectors } from "@nteract/core";
-
 // TODO: Make a proper epic
 import { contents, sessions } from "rx-jupyter";
-
 import { first, map, mergeMap } from "rxjs/operators";
 import { forkJoin } from "rxjs";
 

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -1,7 +1,6 @@
 // @flow
 
 const configurator = require("@nteract/webpack-configurator");
-
 const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
 const webpack = require("webpack");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");

--- a/applications/play/components/Main.js
+++ b/applications/play/components/Main.js
@@ -2,16 +2,17 @@
 import * as React from "react";
 import Head from "next/head";
 import Router from "next/router";
-
 import CodeMirrorEditor from "@nteract/editor";
-import { BinderConsole } from "./consoles";
 import { Display } from "@nteract/display-area";
-import { KernelUI } from "./kernelUI";
 import { Outputs } from "@nteract/presentational-components";
 import { connect } from "react-redux";
-import { actions } from "../redux";
 import objectPath from "object-path";
+
+import { actions } from "../redux";
 import * as utils from "../utils";
+
+import { KernelUI } from "./kernelUI";
+import { BinderConsole } from "./consoles";
 
 const NTERACT_LOGO_URL =
   "https://media.githubusercontent.com/media/nteract/logos/master/nteract_logo_cube_book/exports/images/svg/nteract_logo_wide_purple_inverted.svg";

--- a/applications/play/pages/_app.js
+++ b/applications/play/pages/_app.js
@@ -1,12 +1,10 @@
 // @flow
 import React from "react";
-
-import { createStore } from "../redux";
-
 import App, { Container } from "next/app";
 import withRedux from "next-redux-wrapper";
-
 import { Provider } from "react-redux";
+
+import { createStore } from "../redux";
 
 /**
  * @param {object} initialState

--- a/applications/play/pages/_document.js
+++ b/applications/play/pages/_document.js
@@ -1,9 +1,7 @@
 // @flow
 import * as React from "react";
 import Document, { Head, Main, NextScript } from "next/document";
-
 import flush from "styled-jsx/server";
-
 import PropTypes from "prop-types";
 
 class MyDocument extends Document {

--- a/applications/play/pages/index.js
+++ b/applications/play/pages/index.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from "react";
+import { connect } from "react-redux";
+
 import Main from "../components/Main";
 import { actions } from "../redux";
-import { connect } from "react-redux";
 
 function detectPlatform(req) {
   if (req && req.headers) {

--- a/applications/play/redux/createStore.js
+++ b/applications/play/redux/createStore.js
@@ -2,11 +2,11 @@
 import { applyMiddleware, compose, createStore } from "redux";
 import { createEpicMiddleware } from "redux-observable";
 import { middlewares as coreMiddlewares } from "@nteract/core";
+import merge from "deepmerge";
 
 import epics from "./epics";
 import reducer from "./reducer";
 import getInitialState from "./getInitialState";
-import merge from "deepmerge";
 
 /**
  * Not that we need to here, but I thought I'd write it out

--- a/applications/play/redux/epics.js
+++ b/applications/play/redux/epics.js
@@ -1,17 +1,16 @@
 // @flow
-import * as actionTypes from "./actionTypes";
-import * as actions from "./actions";
 
 import { ActionsObservable, combineEpics, ofType } from "redux-observable";
-
 import { from, merge } from "rxjs";
-
 import { filter, catchError, mergeMap, switchMap } from "rxjs/operators";
 import { binder } from "rx-binder";
 import { kernels, shutdown, kernelspecs } from "rx-jupyter";
 import uuid from "uuid/v4";
 import { executeRequest, kernelInfoRequest } from "@nteract/messaging";
 import objectPath from "object-path";
+
+import * as actions from "./actions";
+import * as actionTypes from "./actionTypes";
 
 const of = ActionsObservable.of;
 

--- a/applications/play/redux/index.js
+++ b/applications/play/redux/index.js
@@ -1,4 +1,5 @@
 // @flow
 import * as actions from "./actions.js";
+
 export { actions };
 export { default as createStore } from "./createStore";

--- a/applications/play/redux/reducer.js
+++ b/applications/play/redux/reducer.js
@@ -1,9 +1,11 @@
 // @flow
 import { combineReducers } from "redux";
 import { omit } from "lodash";
-import * as actionTypes from "./actionTypes";
-import * as utils from "../utils";
 import objectPath from "object-path";
+
+import * as utils from "../utils";
+
+import * as actionTypes from "./actionTypes";
 
 const repo = (state = "", action) => {
   switch (action.type) {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^3.0.0",
     "eslint-plugin-flowtype": "^3.0.0",
-    "eslint-plugin-import": "^2.11.0",
+    "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.11.1",

--- a/packages/ansi-to-react/__tests__/index-spec.js
+++ b/packages/ansi-to-react/__tests__/index-spec.js
@@ -1,7 +1,8 @@
-import Ansi from "../src/index";
 import * as React from "react";
 import { configure, shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+
+import Ansi from "../src/index";
 
 configure({ adapter: new Adapter() });
 

--- a/packages/commutable/src/index.js
+++ b/packages/commutable/src/index.js
@@ -1,17 +1,9 @@
 /* @flow */
 
-import type { Notebook as v4Notebook } from "./v4";
-import type { Notebook as v3Notebook } from "./v3";
-
 import * as Immutable from "immutable";
 
-export type ExecutionCount = number | null;
-
-export type MimeBundle = JSONObject;
-
-export type CellType = "markdown" | "code";
-export type CellID = string;
-
+import type { Notebook as v4Notebook } from "./v4";
+import type { Notebook as v3Notebook } from "./v3";
 import type {
   ImmutableNotebook,
   ImmutableCodeCell,
@@ -42,7 +34,6 @@ export type {
 
 const v4 = require("./v4");
 const v3 = require("./v3");
-
 // Deprecation Warning: removeCell() is being deprecated. Please use deleteCell() instead
 const {
   emptyNotebook,
@@ -52,13 +43,16 @@ const {
   monocellNotebook,
   createCodeCell,
   appendCellToNotebook,
-
   insertCellAt,
   insertCellAfter,
   removeCell,
   deleteCell
 } = require("./structures");
 
+export type ExecutionCount = number | null;
+export type MimeBundle = JSONObject;
+export type CellType = "markdown" | "code";
+export type CellID = string;
 export type Notebook = v4Notebook | v3Notebook;
 
 function freezeReviver(k: string, v: JSONType): JSONType {

--- a/packages/commutable/src/structures.js
+++ b/packages/commutable/src/structures.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import uuid from "uuid/v4";
+
 import type {
   ImmutableOutput,
   ImmutableCell,
@@ -12,7 +14,6 @@ import type {
   ExecutionCount
 } from "./types";
 
-import uuid from "uuid/v4";
 const Immutable = require("immutable");
 
 // We're hardset to nbformat v4.4 for what we use in-memory

--- a/packages/commutable/src/v3.js
+++ b/packages/commutable/src/v3.js
@@ -8,14 +8,12 @@ import type {
   ImmutableOutput,
   ImmutableMimeBundle
 } from "./types";
-
 import type { CellStructure } from "./structures";
-
 import type { MultiLineString, ErrorOutput, RawCell, MarkdownCell } from "./v4";
-
 import { cleanMimeAtKey } from "./v4";
 
 const Immutable = require("immutable");
+
 const appendCell = require("./structures").appendCell;
 
 function demultiline(s: string | Array<string>) {

--- a/packages/commutable/src/v4.js
+++ b/packages/commutable/src/v4.js
@@ -25,10 +25,10 @@ import type {
   ImmutableOutput,
   ImmutableMimeBundle
 } from "./types";
-
 import type { CellStructure } from "./structures";
 
 const Immutable = require("immutable");
+
 const appendCell = require("./structures").appendCell;
 
 export type ExecutionCount = number | null;

--- a/packages/connected-components/__tests__/new-notebook-navigation.js
+++ b/packages/connected-components/__tests__/new-notebook-navigation.js
@@ -2,9 +2,10 @@
 
 import React from "react";
 import renderer from "react-test-renderer";
+import * as Immutable from "immutable";
+
 import { PureNewNotebookNavigation } from "../src/new-notebook-navigation";
 
-import * as Immutable from "immutable";
 
 describe("NewNotebookNavigation", () => {
   test("snapshots", () => {

--- a/packages/connected-components/__tests__/notebook-menu-spec.js
+++ b/packages/connected-components/__tests__/notebook-menu-spec.js
@@ -2,8 +2,8 @@
 import React from "react";
 import renderer from "react-test-renderer";
 import { shallow, mount } from "enzyme";
-import { PureNotebookMenu } from "../src/notebook-menu";
 
+import { PureNotebookMenu } from "../src/notebook-menu";
 import { MENU_ITEM_ACTIONS, MENUS } from "../src/notebook-menu/constants";
 
 describe("PureNotebookMenu ", () => {

--- a/packages/connected-components/src/modal-controller/about-modal.js
+++ b/packages/connected-components/src/modal-controller/about-modal.js
@@ -8,10 +8,10 @@
 /* eslint jsx-a11y/no-static-element-interactions: 0 */
 
 import React from "react";
-import { modalCss } from "./styles";
 import { connect } from "react-redux";
-
 import { actions, selectors } from "@nteract/core";
+
+import { modalCss } from "./styles";
 
 type Props = {
   appVersion?: string,

--- a/packages/connected-components/src/modal-controller/index.js
+++ b/packages/connected-components/src/modal-controller/index.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from "react";
-import { MODAL_TYPES } from "./constants";
-import AboutModal from "./about-modal";
 import { connect } from "react-redux";
 import { selectors } from "@nteract/core";
+
+import { MODAL_TYPES } from "./constants";
+import AboutModal from "./about-modal";
 
 class ModalController extends React.Component<*, *> {
   getModal = () => {

--- a/packages/connected-components/src/new-notebook-navigation/index.js
+++ b/packages/connected-components/src/new-notebook-navigation/index.js
@@ -15,18 +15,16 @@
  */
 
 import * as React from "react";
-
 import { connect } from "react-redux";
-
 import type {
   AppState,
   KernelspecRecord,
   KernelspecProps
 } from "@nteract/core";
+import * as Immutable from "immutable";
 
 import { default as Logo } from "./logos";
 
-import * as Immutable from "immutable";
 
 export type AvailableNotebook = {
   kernelspec: KernelspecRecord | KernelspecProps

--- a/packages/connected-components/src/notebook-menu/index.js
+++ b/packages/connected-components/src/notebook-menu/index.js
@@ -2,9 +2,7 @@
 import * as Immutable from "immutable";
 import * as React from "react";
 import Menu, { SubMenu, Divider, MenuItem } from "rc-menu";
-
 import { actions, selectors } from "@nteract/core";
-
 import type {
   AppState,
   ContentRef,
@@ -12,10 +10,11 @@ import type {
   KernelspecsRef,
   KernelspecsByRefRecord
 } from "@nteract/core";
+import { connect } from "react-redux";
+
+import { MODAL_TYPES } from "../modal-controller";
 
 import { MENU_ITEM_ACTIONS, MENUS } from "./constants";
-import { MODAL_TYPES } from "../modal-controller";
-import { connect } from "react-redux";
 import StyleWrapper from "./styles";
 
 // To allow actions that can take dynamic arguments (like selecting a kernel

--- a/packages/core/__tests__/comms-spec.js
+++ b/packages/core/__tests__/comms-spec.js
@@ -1,5 +1,6 @@
-import commsReducer from "../src/reducers/comms";
 import { state as stateModule } from "@nteract/core";
+
+import commsReducer from "../src/reducers/comms";
 
 describe("registerCommTarget", () => {
   test("sets comm targets", () => {

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -2,6 +2,13 @@
 /* eslint-disable max-len */
 
 import uuid from "uuid/v4";
+import {
+  emptyCodeCell,
+  emptyMarkdownCell,
+  appendCellToNotebook,
+  emptyNotebook
+} from "@nteract/commutable";
+import * as Immutable from "immutable";
 
 import * as actions from "../src/actions";
 import {
@@ -9,19 +16,9 @@ import {
   reduceOutputs,
   cleanCellTransient
 } from "../src/reducers/core/entities/contents/notebook";
-
-import {
-  emptyCodeCell,
-  emptyMarkdownCell,
-  appendCellToNotebook,
-  emptyNotebook
-} from "@nteract/commutable";
-
 import { makeDocumentRecord } from "../src/state";
-
 import { dummyCommutable } from "../src/dummy";
 
-import * as Immutable from "immutable";
 
 const initialDocument = new Immutable.Map();
 const monocellDocument = initialDocument

--- a/packages/core/__tests__/epics/comm-spec.js
+++ b/packages/core/__tests__/epics/comm-spec.js
@@ -1,17 +1,16 @@
 // @flow
+import { of } from "rxjs";
+import { toArray } from "rxjs/operators";
+
 import {
   createCommMessage,
   createCommCloseMessage,
   createCommOpenMessage,
   commActionObservable
 } from "../../src/epics/comm";
-
 import * as actions from "../../src/actions";
-
 import { COMM_OPEN, COMM_MESSAGE } from "../../src/actionTypes";
 
-import { of } from "rxjs";
-import { toArray } from "rxjs/operators";
 
 describe("createCommMessage", () => {
   test("creates a comm_msg", () => {

--- a/packages/core/__tests__/epics/contents-spec.js
+++ b/packages/core/__tests__/epics/contents-spec.js
@@ -2,10 +2,11 @@
 jest.mock("file-saver");
 
 import FileSaver from "file-saver";
+import { stringifyNotebook } from "@nteract/commutable";
+
 import { downloadString } from "../../src/epics/contents";
 import { bigDummyJSON } from "../../src/dummy/dummy-nb";
 
-import { stringifyNotebook } from "@nteract/commutable";
 
 describe("downloadString", () => {
   beforeEach(() => {

--- a/packages/core/__tests__/epics/execute-spec.js
+++ b/packages/core/__tests__/epics/execute-spec.js
@@ -1,9 +1,9 @@
 // @flow
 import { ActionsObservable } from "redux-observable";
-
 import { actionTypes, actions, state as stateModule } from "@nteract/core";
-
 import { createExecuteRequest } from "@nteract/messaging";
+import { Subject, from } from "rxjs";
+import { toArray, share, catchError } from "rxjs/operators";
 
 import {
   executeCellStream,
@@ -14,8 +14,6 @@ import {
 
 const Immutable = require("immutable");
 
-import { Subject, from } from "rxjs";
-import { toArray, share, catchError } from "rxjs/operators";
 
 describe("executeCell", () => {
   test("returns an executeCell action", () => {

--- a/packages/core/__tests__/epics/kernel-lifecycle-spec.js
+++ b/packages/core/__tests__/epics/kernel-lifecycle-spec.js
@@ -1,14 +1,9 @@
 import * as Immutable from "immutable";
-
 import { ActionsObservable } from "redux-observable";
-
 import { actions, actionTypes, state as stateModule } from "@nteract/core";
-
 import { createMessage } from "@nteract/messaging";
-
 import { Subject, of } from "rxjs";
 import { toArray } from "rxjs/operators";
-
 import { TestScheduler } from "rxjs/testing";
 
 import {

--- a/packages/core/__tests__/epics/kernelspecs-spec.js
+++ b/packages/core/__tests__/epics/kernelspecs-spec.js
@@ -1,8 +1,9 @@
 // @flow
 import { ActionsObservable } from "redux-observable";
+import { toArray } from "rxjs/operators";
+
 import { fetchKernelspecs } from "../../src/actions";
 import { fetchKernelspecsEpic } from "../../src/epics/kernelspecs";
-import { toArray } from "rxjs/operators";
 
 describe("fetchKernelspecsEpic", () => {
   test("calls kernelspecs.list with appropriate jupyter host config", done => {

--- a/packages/core/__tests__/epics/websocket-kernel-spec.js
+++ b/packages/core/__tests__/epics/websocket-kernel-spec.js
@@ -2,8 +2,9 @@
 import * as Immutable from "immutable";
 import { ActionsObservable } from "redux-observable";
 import { Subject } from "rxjs";
-import { actions, state as stateModule, epics as coreEpics } from "../../src";
 import { toArray } from "rxjs/operators";
+
+import { actions, state as stateModule, epics as coreEpics } from "../../src";
 
 describe("launchWebSocketKernelEpic", () => {
   test("launches remote kernels", async function() {

--- a/packages/core/__tests__/reducers/core/entities/kernels.js
+++ b/packages/core/__tests__/reducers/core/entities/kernels.js
@@ -1,7 +1,9 @@
 // @flow strict
+import { actions } from "@nteract/core";
+
 import { makeKernelsRecord } from "../../../../src/state/entities/kernels";
 import { kernels } from "../../../../src/reducers/core/entities/kernels";
-import { actions } from "@nteract/core";
+
 describe("LAUNCH_KERNEL reducers", () => {
   test("set launching state", () => {
     const originalState = makeKernelsRecord();

--- a/packages/core/__tests__/selectors-spec.js
+++ b/packages/core/__tests__/selectors-spec.js
@@ -1,4 +1,5 @@
 import Immutable from "immutable";
+
 import { dummyCommutable } from "../src/dummy";
 import * as selectors from "../src/selectors";
 import * as stateModule from "../src/state";

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -1,5 +1,14 @@
 /* @flow */
 import type {
+  CellID,
+  CellType,
+  ImmutableJSONType,
+  MimeBundle
+} from "@nteract/commutable";
+import type { ExecuteRequest } from "@nteract/messaging";
+import type { Output } from "@nteract/commutable/src/v4";
+
+import type {
   ContentRef,
   HostRef,
   KernelRef,
@@ -8,14 +17,6 @@ import type {
 import type { HostRecord } from "./state/entities/hosts";
 import type { KernelspecProps } from "./state/entities/kernelspecs";
 import type { KernelInfo } from "./state/entities/kernel-info";
-
-import type {
-  CellID,
-  CellType,
-  ImmutableJSONType,
-  MimeBundle
-} from "@nteract/commutable";
-
 import type {
   KernelspecInfo,
   LanguageInfoMetadata,
@@ -23,9 +24,7 @@ import type {
   RemoteKernelProps
 } from "./state";
 
-import type { ExecuteRequest } from "@nteract/messaging";
 
-import type { Output } from "@nteract/commutable/src/v4";
 
 export type ErrorAction<T: string> = {
   type: T,

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -1,6 +1,12 @@
 // @flow
-import * as actionTypes from "./actionTypes";
+import type {
+  CellID,
+  CellType,
+  MimeBundle
+} from "@nteract/commutable/src/types";
+import type { Output } from "@nteract/commutable/src/v4";
 
+import * as actionTypes from "./actionTypes";
 import type {
   ContentRef,
   HostRef,
@@ -8,7 +14,6 @@ import type {
   KernelspecsRef
 } from "./state/refs";
 import type { KernelspecProps } from "./state/entities/kernelspecs";
-
 import type {
   LanguageInfoMetadata,
   LocalKernelProps,
@@ -16,13 +21,7 @@ import type {
   KernelInfo
 } from "./state";
 
-import type {
-  CellID,
-  CellType,
-  MimeBundle
-} from "@nteract/commutable/src/types";
 
-import type { Output } from "@nteract/commutable/src/v4";
 
 export const openModal = (payload: { modalType: string }) => ({
   type: actionTypes.OPEN_MODAL,

--- a/packages/core/src/dummy/index.js
+++ b/packages/core/src/dummy/index.js
@@ -2,22 +2,16 @@
 /* eslint-disable no-plusplus */
 
 import * as Immutable from "immutable";
-
 import { Subject } from "rxjs";
-
 import {
   monocellNotebook,
   emptyCodeCell,
   appendCellToNotebook,
   emptyNotebook
 } from "@nteract/commutable";
-
-/* Our createStore */
 import { combineReducers, createStore } from "redux";
+
 import { comms, config, core } from "../reducers";
-
-export { dummyCommutable, dummy, dummyJSON } from "./dummy-nb";
-
 import {
   makeNotebookContentRecord,
   makeRemoteKernelRecord,
@@ -31,6 +25,8 @@ import {
   createContentRef,
   createKernelRef
 } from "../state";
+
+export { dummyCommutable, dummy, dummyJSON } from "./dummy-nb";
 
 const rootReducer = combineReducers({
   app: (state = makeAppRecord()) => state,

--- a/packages/core/src/epics/comm.js
+++ b/packages/core/src/epics/comm.js
@@ -2,13 +2,10 @@
 import { merge } from "rxjs";
 import { map, retry, switchMap } from "rxjs/operators";
 import { ofType } from "redux-observable";
-
-import { commOpenAction, commMessageAction } from "../actions";
-
 import { createMessage, ofMessageType } from "@nteract/messaging";
-
 import type { ActionsObservable } from "redux-observable";
 
+import { commOpenAction, commMessageAction } from "../actions";
 import type { NewKernelAction } from "../actionTypes";
 import { LAUNCH_KERNEL_SUCCESSFUL } from "../actionTypes";
 

--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -1,24 +1,21 @@
 /* @flow */
 import { empty, from, interval } from "rxjs";
-
 import { tap, map, mergeMap, switchMap, catchError } from "rxjs/operators";
 import { ofType, ActionsObservable } from "redux-observable";
-
 import { sample } from "lodash";
-
 import FileSaver from "file-saver";
+import type { StateObservable } from "redux-observable";
+import { contents } from "rx-jupyter";
+import { toJS, stringifyNotebook } from "@nteract/commutable";
+import type { Notebook } from "@nteract/commutable";
 
 import * as actions from "../actions";
 import * as actionTypes from "../actionTypes";
 import * as selectors from "../selectors";
 import type { ContentRef, AppState } from "../state";
 
-import type { StateObservable } from "redux-observable";
 
-import { contents } from "rx-jupyter";
 
-import { toJS, stringifyNotebook } from "@nteract/commutable";
-import type { Notebook } from "@nteract/commutable";
 
 // Flow complains otherwise since of would return an rxjs$Observable rather than an ActionsObservable
 // Ask Jay Phelps about this ;)

--- a/packages/core/src/epics/execute.js
+++ b/packages/core/src/epics/execute.js
@@ -8,12 +8,7 @@ import {
   kernelStatuses,
   executionCounts
 } from "@nteract/messaging";
-
 import { Observable, of, merge, empty, throwError } from "rxjs";
-
-import type { ContentRef } from "../state/refs";
-import type { AppState } from "../state";
-
 import {
   groupBy,
   filter,
@@ -28,15 +23,14 @@ import {
   tap,
   share
 } from "rxjs/operators";
-
 import { ofType } from "redux-observable";
+import type { ActionsObservable, StateObservable } from "redux-observable";
 
+import type { ContentRef } from "../state/refs";
+import type { AppState } from "../state";
 import * as actions from "../actions";
 import * as actionTypes from "../actionTypes";
 import * as selectors from "../selectors";
-
-import type { ActionsObservable, StateObservable } from "redux-observable";
-
 import type {
   NewKernelAction,
   ExecuteCell,

--- a/packages/core/src/epics/index.js
+++ b/packages/core/src/epics/index.js
@@ -5,25 +5,20 @@ import {
   updateDisplayEpic,
   executeAllCellsEpic
 } from "./execute";
-
 import { commListenEpic } from "./comm";
-
 import {
   launchWebSocketKernelEpic,
   interruptKernelEpic,
   killKernelEpic,
   changeWebSocketKernelEpic
 } from "./websocket-kernel";
-
 import {
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
   launchKernelWhenNotebookSetEpic,
   restartKernelEpic
 } from "./kernel-lifecycle";
-
 import { fetchKernelspecsEpic } from "./kernelspecs";
-
 import {
   fetchContentEpic,
   saveContentEpic,

--- a/packages/core/src/epics/kernel-lifecycle.js
+++ b/packages/core/src/epics/kernel-lifecycle.js
@@ -1,15 +1,8 @@
 /* @flow */
 
 import { Observable, of, empty, merge } from "rxjs";
-import { createKernelRef } from "../state/refs";
-
 import { createMessage, childOf, ofMessageType } from "@nteract/messaging";
-
 import type { ImmutableNotebook } from "@nteract/commutable";
-import type { ContentRef, KernelRef } from "../state/refs";
-
-const path = require("path");
-
 import {
   filter,
   map,
@@ -21,13 +14,16 @@ import {
   take,
   timeout
 } from "rxjs/operators";
-
 import { ActionsObservable, ofType } from "redux-observable";
 
+import type { ContentRef, KernelRef } from "../state/refs";
+import { createKernelRef } from "../state/refs";
 import * as selectors from "../selectors";
 import * as actions from "../actions";
 import * as actionTypes from "../actionTypes";
 import type { AppState, KernelInfo } from "../state";
+
+const path = require("path");
 
 /**
  * Sets the execution state after a kernel has been launched.

--- a/packages/core/src/epics/kernelspecs.js
+++ b/packages/core/src/epics/kernelspecs.js
@@ -1,13 +1,13 @@
 // @flow
-import * as actionTypes from "../actionTypes";
-import * as actions from "../actions";
 import { empty, of } from "rxjs";
 import { catchError, map, mergeMap } from "rxjs/operators";
 import { kernelspecs } from "rx-jupyter";
 import { ofType } from "redux-observable";
 import type { ActionsObservable } from "redux-observable";
-import type { FetchKernelspecs } from "../actionTypes";
 
+import * as actions from "../actions";
+import * as actionTypes from "../actionTypes";
+import type { FetchKernelspecs } from "../actionTypes";
 import * as selectors from "../selectors";
 
 export const fetchKernelspecsEpic = (

--- a/packages/core/src/epics/websocket-kernel.js
+++ b/packages/core/src/epics/websocket-kernel.js
@@ -2,7 +2,6 @@
 
 import { ofType } from "redux-observable";
 import type { ActionsObservable, StateObservable } from "redux-observable";
-
 import {
   catchError,
   map,
@@ -12,20 +11,18 @@ import {
   filter
 } from "rxjs/operators";
 import { of, empty } from "rxjs";
-import { extractNewKernel } from "./kernel-lifecycle";
-
 import { kernels, sessions } from "rx-jupyter";
+import { kernelInfoRequest } from "@nteract/messaging";
 
 import * as actions from "../actions";
 import * as selectors from "../selectors";
 import * as actionTypes from "../actionTypes";
 import { castToSessionId } from "../state/ids";
 import { createKernelRef } from "../state/refs";
-
 import type { AppState } from "../state";
 import type { RemoteKernelProps } from "../state/entities/kernels";
 
-import { kernelInfoRequest } from "@nteract/messaging";
+import { extractNewKernel } from "./kernel-lifecycle";
 
 export const launchWebSocketKernelEpic = (
   action$: ActionsObservable<redux$Action>,

--- a/packages/core/src/reducers/app.js
+++ b/packages/core/src/reducers/app.js
@@ -1,10 +1,7 @@
 // @flow
 import { makeAppRecord } from "../state";
-
 import type { AppRecord } from "../state";
-
 import * as actionTypes from "../actionTypes";
-
 import type {
   SetNotificationSystemAction,
   SetGithubTokenAction,

--- a/packages/core/src/reducers/comms.js
+++ b/packages/core/src/reducers/comms.js
@@ -6,7 +6,6 @@ import type {
   CommOpenAction,
   CommMessageAction
 } from "../actionTypes";
-
 import { makeCommsRecord } from "../state";
 import type { CommsRecord } from "../state";
 

--- a/packages/core/src/reducers/core/communication/contents.js
+++ b/packages/core/src/reducers/core/communication/contents.js
@@ -1,11 +1,12 @@
 // @flow
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
 import {
   makeContentCommunicationRecord,
   makeContentsCommunicationRecord
 } from "../../../state/communication/contents";
 import * as actionTypes from "../../../actionTypes";
-import { combineReducers } from "redux-immutable";
-import * as Immutable from "immutable";
 
 const byRef = (state = Immutable.Map(), action) => {
   switch (action.type) {

--- a/packages/core/src/reducers/core/communication/index.js
+++ b/packages/core/src/reducers/core/communication/index.js
@@ -1,9 +1,11 @@
 // @flow
 import { combineReducers } from "redux-immutable";
+
+import { makeCommunicationRecord } from "../../../state/communication";
+
 import { contents } from "./contents";
 import { kernels } from "./kernels";
 import { kernelspecs } from "./kernelspecs";
-import { makeCommunicationRecord } from "../../../state/communication";
 
 export const communication = combineReducers(
   {

--- a/packages/core/src/reducers/core/communication/kernels.js
+++ b/packages/core/src/reducers/core/communication/kernels.js
@@ -1,11 +1,12 @@
 // @flow
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
 import {
   makeKernelCommunicationRecord,
   makeKernelsCommunicationRecord
 } from "../../../state/communication/kernels";
 import * as actionTypes from "../../../actionTypes";
-import { combineReducers } from "redux-immutable";
-import * as Immutable from "immutable";
 
 // TODO: we should spec out a way to watch the killKernel lifecycle.
 const byRef = (state = Immutable.Map(), action) => {

--- a/packages/core/src/reducers/core/communication/kernelspecs.js
+++ b/packages/core/src/reducers/core/communication/kernelspecs.js
@@ -1,11 +1,12 @@
 // @flow
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
 import {
   makeKernelspecsByRefCommunicationRecord,
   makeKernelspecsCommunicationRecord
 } from "../../../state/communication/kernelspecs";
 import * as actionTypes from "../../../actionTypes";
-import { combineReducers } from "redux-immutable";
-import * as Immutable from "immutable";
 
 export const byRef = (state = Immutable.Map(), action: *) => {
   switch (action.type) {

--- a/packages/core/src/reducers/core/entities/contents/file.js
+++ b/packages/core/src/reducers/core/entities/contents/file.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as actionTypes from "../../../../actionTypes";
-
 import type { FileModelRecord } from "../../../../state/entities/contents";
 
 function updateFileText(

--- a/packages/core/src/reducers/core/entities/contents/index.js
+++ b/packages/core/src/reducers/core/entities/contents/index.js
@@ -1,7 +1,9 @@
 /* @flow */
 import * as Immutable from "immutable";
-import * as actionTypes from "../../../../actionTypes";
+import { fromJS } from "@nteract/commutable";
+import { combineReducers } from "redux-immutable";
 
+import * as actionTypes from "../../../../actionTypes";
 import {
   makeFileContentRecord,
   makeFileModelRecord,
@@ -12,15 +14,12 @@ import {
   makeDocumentRecord,
   makeNotebookContentRecord
 } from "../../../../state/entities/contents";
-
-import { fromJS } from "@nteract/commutable";
+import { createContentRef } from "../../../../state/refs";
 
 import { notebook } from "./notebook";
 import { file } from "./file";
 
-import { createContentRef } from "../../../../state/refs";
 
-import { combineReducers } from "redux-immutable";
 
 const byRef = (state = Immutable.Map(), action) => {
   switch (action.type) {

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -1,12 +1,7 @@
 // @flow
 
-import { makeDocumentRecord } from "../../../../state/entities/contents";
 import uuid from "uuid/v4";
-
-import * as actionTypes from "../../../../actionTypes";
-
 import * as Immutable from "immutable";
-
 import type {
   ImmutableCell,
   ImmutableCellMap,
@@ -16,7 +11,6 @@ import type {
   ImmutableOutput,
   ImmutableOutputs
 } from "@nteract/commutable";
-
 import {
   emptyCodeCell,
   emptyMarkdownCell,
@@ -27,12 +21,12 @@ import {
   createImmutableOutput,
   createImmutableMimeBundle
 } from "@nteract/commutable";
-
 import { has } from "lodash";
-
 import type { Output, StreamOutput } from "@nteract/commutable/src/v4";
 import { escapeCarriageReturnSafe } from "escape-carriage";
 
+import * as actionTypes from "../../../../actionTypes";
+import { makeDocumentRecord } from "../../../../state/entities/contents";
 import type { NotebookModel } from "../../../../state/entities/contents";
 
 type KeyPath = Immutable.List<string | number>;

--- a/packages/core/src/reducers/core/entities/hosts.js
+++ b/packages/core/src/reducers/core/entities/hosts.js
@@ -1,7 +1,8 @@
 // @flow
 import * as Immutable from "immutable";
-import * as actionTypes from "../../../actionTypes";
 import { combineReducers } from "redux-immutable";
+
+import * as actionTypes from "../../../actionTypes";
 import {
   makeHostsRecord,
   makeJupyterHostRecord,

--- a/packages/core/src/reducers/core/entities/index.js
+++ b/packages/core/src/reducers/core/entities/index.js
@@ -1,6 +1,8 @@
 // @flow
 import { combineReducers } from "redux-immutable";
+
 import { makeEntitiesRecord } from "../../../state/entities";
+
 import { contents } from "./contents";
 import { hosts } from "./hosts";
 import { kernels } from "./kernels";

--- a/packages/core/src/reducers/core/entities/kernels.js
+++ b/packages/core/src/reducers/core/entities/kernels.js
@@ -1,19 +1,18 @@
 // @flow
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
 import {
   makeKernelNotStartedRecord,
   makeLocalKernelRecord,
   makeRemoteKernelRecord,
   makeKernelsRecord
 } from "../../../state/entities/kernels";
-
 import {
   makeKernelInfoRecord,
   makeHelpLinkRecord
 } from "../../../state/entities/kernel-info";
-
 import * as actionTypes from "../../../actionTypes";
-import { combineReducers } from "redux-immutable";
-import * as Immutable from "immutable";
 
 // TODO: we need to clean up references to old kernels at some point. Listening
 // for KILL_KERNEL_SUCCESSFUL seems like a good candidate, but I think you can

--- a/packages/core/src/reducers/core/entities/kernelspecs.js
+++ b/packages/core/src/reducers/core/entities/kernelspecs.js
@@ -1,12 +1,13 @@
 // @flow
+import { combineReducers } from "redux-immutable";
+import * as Immutable from "immutable";
+
 import {
   makeKernelspec,
   makeKernelspecsByRefRecord,
   makeKernelspecsRecord
 } from "../../../state/entities/kernelspecs";
 import * as actionTypes from "../../../actionTypes";
-import { combineReducers } from "redux-immutable";
-import * as Immutable from "immutable";
 
 const byRef = (state = Immutable.Map(), action: *) => {
   switch (action.type) {

--- a/packages/core/src/reducers/core/entities/modals.js
+++ b/packages/core/src/reducers/core/entities/modals.js
@@ -1,6 +1,7 @@
 // @flow
-import * as actionTypes from "../../../actionTypes";
 import { combineReducers } from "redux-immutable";
+
+import * as actionTypes from "../../../actionTypes";
 import { makeModalsRecord } from "../../../state/entities/modals";
 
 const modalType = (state = "", action) => {

--- a/packages/core/src/reducers/core/index.js
+++ b/packages/core/src/reducers/core/index.js
@@ -1,9 +1,11 @@
 // @flow
-import * as actionTypes from "../../actionTypes";
 import { combineReducers } from "redux-immutable";
+
+import * as actionTypes from "../../actionTypes";
+import { makeStateRecord } from "../../state";
+
 import { communication } from "./communication";
 import { entities } from "./entities";
-import { makeStateRecord } from "../../state";
 
 // TODO: #2618: This should at a minimum be moved into a contents entry.
 // TODO: This is temporary until we have sessions in place. Ideally, we point to

--- a/packages/core/src/selectors/index.js
+++ b/packages/core/src/selectors/index.js
@@ -1,6 +1,5 @@
 // @flow
 
-import * as notebook from "./notebook";
 import { createSelector } from "reselect";
 
 import type {
@@ -10,6 +9,8 @@ import type {
   KernelRef,
   KernelspecsByRefRecord
 } from "../state";
+
+import * as notebook from "./notebook";
 
 // Export sub-selectors (those that operate on contents models for instance)
 export { notebook };

--- a/packages/core/src/selectors/notebook.js
+++ b/packages/core/src/selectors/notebook.js
@@ -1,9 +1,7 @@
 // @flow
 import * as Immutable from "immutable";
-
 import * as commutable from "@nteract/commutable";
 import type { CellID } from "@nteract/commutable";
-
 import { createSelector } from "reselect";
 
 // All these selectors expect a NotebookModel as the top level state

--- a/packages/core/src/state/communication/contents.js
+++ b/packages/core/src/state/communication/contents.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { ContentRef } from "../refs";
 
 export type ContentCommunicationRecordProps = {

--- a/packages/core/src/state/communication/index.js
+++ b/packages/core/src/state/communication/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { ContentsCommunicationRecordProps } from "./contents";
 import type { KernelsCommunicationRecordProps } from "./kernels";
 import type { KernelspecsCommunicationRecordProps } from "./kernelspecs";

--- a/packages/core/src/state/communication/kernels.js
+++ b/packages/core/src/state/communication/kernels.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { KernelRef } from "../refs";
 
 export type KernelCommunicationRecordProps = {

--- a/packages/core/src/state/communication/kernelspecs.js
+++ b/packages/core/src/state/communication/kernelspecs.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { KernelspecsRef } from "../refs";
 
 export type KernelspecsByRefCommunicationRecordProps = {

--- a/packages/core/src/state/entities/contents/index.js
+++ b/packages/core/src/state/entities/contents/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { ContentRef } from "../../refs";
 
 import type { NotebookContentRecord, NotebookModel } from "./notebook";

--- a/packages/core/src/state/entities/contents/notebook.js
+++ b/packages/core/src/state/entities/contents/notebook.js
@@ -1,6 +1,5 @@
 // @flow
 import * as Immutable from "immutable";
-
 import { emptyNotebook } from "@nteract/commutable";
 import type { CellID } from "@nteract/commutable";
 

--- a/packages/core/src/state/entities/hosts.js
+++ b/packages/core/src/state/entities/hosts.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { HostId } from "../ids";
 import type { HostRef } from "../refs";
 

--- a/packages/core/src/state/entities/index.js
+++ b/packages/core/src/state/entities/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { ContentsRecordProps } from "./contents";
 import type { HostsRecordProps } from "./hosts";
 import type { KernelsRecordProps } from "./kernels";

--- a/packages/core/src/state/entities/kernels.js
+++ b/packages/core/src/state/entities/kernels.js
@@ -1,11 +1,14 @@
 // @flow
-import * as Immutable from "immutable";
 import type { ChildProcess } from "child_process";
-import type { HostRef, KernelRef } from "../refs";
-import type { KernelId, SessionId } from "../ids";
+
+import * as Immutable from "immutable";
 import { Subject } from "rxjs";
 
+import type { HostRef, KernelRef } from "../refs";
+import type { KernelId, SessionId } from "../ids";
+
 import type { KernelInfo } from "./kernel-info";
+
 export type { KernelInfo };
 
 // See #3427. This represents the kernel early in the launch process.

--- a/packages/core/src/state/entities/kernelspecs.js
+++ b/packages/core/src/state/entities/kernelspecs.js
@@ -1,7 +1,8 @@
 // @flow
-import type { HostRef, KernelspecsRef } from "../refs";
 import type { RecordFactory, RecordOf } from "immutable";
 import { List, Map, Record } from "immutable";
+
+import type { HostRef, KernelspecsRef } from "../refs";
 
 export type KernelspecProps = {
   name: string,

--- a/packages/core/src/state/index.js
+++ b/packages/core/src/state/index.js
@@ -1,10 +1,10 @@
 // @flow
 import * as Immutable from "immutable";
+
 import type { CommunicationRecordProps } from "./communication";
 import type { EntitiesRecordProps } from "./entities";
 import type { KernelRef, KernelspecsRef } from "./refs";
 import type { HostRecord } from "./entities/hosts";
-
 import { makeCommunicationRecord } from "./communication";
 import { makeEntitiesRecord, makeEmptyHostRecord } from "./entities";
 

--- a/packages/directory-listing/__tests__/index-spec.js
+++ b/packages/directory-listing/__tests__/index-spec.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { shallow } from "enzyme";
 import toJson from "enzyme-to-json";
+
 import { Entry, Listing, Name, Icon, LastSaved } from "../src";
 
 describe("Listing", () => {

--- a/packages/directory-listing/src/components/entry.js
+++ b/packages/directory-listing/src/components/entry.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-
 import { areComponentsEqual } from "react-hot-loader";
 
 import { Icon } from "./icon";

--- a/packages/directory-listing/src/components/icon.js
+++ b/packages/directory-listing/src/components/icon.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-
 import { Book, FileText, FileDirectory } from "@nteract/octicons";
 
 type IconProps = {

--- a/packages/directory-listing/src/components/lastsaved.js
+++ b/packages/directory-listing/src/components/lastsaved.js
@@ -1,6 +1,5 @@
 /* @flow strict */
 import * as React from "react";
-
 import TimeAgo from "@nteract/timeago";
 
 type LastSavedProps = {

--- a/packages/display-area/__tests__/display-spec.js
+++ b/packages/display-area/__tests__/display-spec.js
@@ -1,8 +1,7 @@
 import React from "react";
-
 import { shallow } from "enzyme";
-
 import { displayOrder, transforms } from "@nteract/transforms";
+
 import { Display } from "../src";
 import { DEFAULT_SCROLL_HEIGHT } from "../src/display";
 

--- a/packages/display-area/__tests__/output-spec.js
+++ b/packages/display-area/__tests__/output-spec.js
@@ -1,10 +1,9 @@
 import * as React from "react";
-
 import { shallow } from "enzyme";
+import Ansi from "ansi-to-react";
 
 import Output from "../src/output";
 import RichestMime from "../src/richest-mime";
-import Ansi from "ansi-to-react";
 
 describe("Output", () => {
   it("handles display data", () => {

--- a/packages/display-area/__tests__/richest-mime-spec.js
+++ b/packages/display-area/__tests__/richest-mime-spec.js
@@ -1,9 +1,8 @@
 import React from "react";
-
 import { shallow } from "enzyme";
 import toJson from "enzyme-to-json";
-
 import { displayOrder, transforms } from "@nteract/transforms";
+
 import { RichestMime } from "../src";
 
 describe("RichestMime", () => {

--- a/packages/display-area/src/display.js
+++ b/packages/display-area/src/display.js
@@ -1,8 +1,6 @@
 // @flow
 import React from "react";
-
 import { transforms, displayOrder } from "@nteract/transforms";
-
 import * as Immutable from "immutable";
 
 import Output from "./output";

--- a/packages/display-area/src/output.js
+++ b/packages/display-area/src/output.js
@@ -1,12 +1,11 @@
 // @flow
 import React from "react";
 import Ansi from "ansi-to-react";
-
 import { transforms, displayOrder } from "@nteract/transforms";
+import * as Immutable from "immutable";
 
 import RichestMime from "./richest-mime";
 
-import * as Immutable from "immutable";
 
 type Props = {
   displayOrder: Array<string>,

--- a/packages/display-area/src/richest-mime.js
+++ b/packages/display-area/src/richest-mime.js
@@ -1,6 +1,5 @@
 // @flow
 import React from "react";
-
 import { richestMimetype, transforms, displayOrder } from "@nteract/transforms";
 
 type Props = {

--- a/packages/dropdown-menu/__tests__/index-spec.js
+++ b/packages/dropdown-menu/__tests__/index-spec.js
@@ -4,9 +4,10 @@
 /* eslint jsx-a11y/no-noninteractive-element-interactions: 0 */
 
 import * as React from "react";
-import { DropdownMenu, DropdownContent, DropdownTrigger } from "../src";
 import { mount } from "enzyme";
 import toJSON from "enzyme-to-json";
+
+import { DropdownMenu, DropdownContent, DropdownTrigger } from "../src";
 
 describe("DropdownMenu", () => {
   test("clicking dropdown content triggers the items callback and closes the menu", () => {

--- a/packages/editor/__tests__/complete-spec.js
+++ b/packages/editor/__tests__/complete-spec.js
@@ -1,5 +1,4 @@
 import { Subject } from "rxjs";
-
 import { createMessage } from "@nteract/messaging";
 
 const complete = require("../src/jupyter/complete");

--- a/packages/editor/__tests__/editor-spec.js
+++ b/packages/editor/__tests__/editor-spec.js
@@ -1,9 +1,8 @@
 import React from "react";
 import { empty, Subject } from "rxjs";
-
 import { mount } from "enzyme";
-
 import { createMessage } from "@nteract/messaging";
+
 import Editor from "../src/";
 
 const complete = require("../src/jupyter/complete");

--- a/packages/editor/src/index.js
+++ b/packages/editor/src/index.js
@@ -2,7 +2,6 @@
 /* eslint-disable class-methods-use-this */
 import * as React from "react";
 import ReactDOM from "react-dom";
-
 import { empty, of, fromEvent, merge, Subject } from "rxjs";
 import type { Subscription } from "rxjs";
 import {
@@ -14,23 +13,18 @@ import {
   switchMap,
   takeUntil
 } from "rxjs/operators";
-
 import { RichestMime } from "@nteract/display-area";
-
-import excludedIntelliSenseTriggerKeys from "./excludedIntelliSenseKeys";
-
-import { codeComplete, pick } from "./jupyter/complete";
-import { tool } from "./jupyter/tooltip";
-
 import { debounce } from "lodash";
 
-import type { Options, EditorChange, CMI, CMDoc } from "./types";
-export type { EditorChange, Options };
-
+import excludedIntelliSenseTriggerKeys from "./excludedIntelliSenseKeys";
+import { codeComplete, pick } from "./jupyter/complete";
+import { tool } from "./jupyter/tooltip";
 import styles from "./styles";
-
 import codemirrorStyles from "./vendored/codemirror";
 import showHintStyles from "./vendored/show-hint";
+import type { Options, EditorChange, CMI, CMDoc } from "./types";
+
+export type { EditorChange, Options };
 
 function normalizeLineEndings(str) {
   if (!str) return str;

--- a/packages/editor/src/jupyter/complete.js
+++ b/packages/editor/src/jupyter/complete.js
@@ -1,12 +1,12 @@
 // @flow
 import { Observable } from "rxjs";
 import { first, map, timeout } from "rxjs/operators";
-
 import { createMessage, childOf, ofMessageType } from "@nteract/messaging";
+
+import type { EditorChange, CMI } from "../types";
 
 import { js_idx_to_char_idx, char_idx_to_js_idx } from "./surrogate";
 
-import type { EditorChange, CMI } from "../types";
 
 // Hint picker
 export const pick = (cm: any, handle: { pick: () => void }) => handle.pick();

--- a/packages/editor/src/jupyter/tooltip.js
+++ b/packages/editor/src/jupyter/tooltip.js
@@ -1,12 +1,12 @@
 // @flow
 import { Observable } from "rxjs";
 import { first, map } from "rxjs/operators";
-
 import { createMessage, childOf, ofMessageType } from "@nteract/messaging";
+
+import type { Channels, CMI } from "../types";
 
 import { js_idx_to_char_idx } from "./surrogate";
 
-import type { Channels, CMI } from "../types";
 
 export function tooltipObservable(
   channels: Channels,

--- a/packages/enchannel-zmq-backend/__mocks__/jmp.js
+++ b/packages/enchannel-zmq-backend/__mocks__/jmp.js
@@ -1,4 +1,5 @@
 const EventEmitter = require("events");
+
 class Socket extends EventEmitter {
   constructor(zmqType, scheme, key) {
     super();

--- a/packages/enchannel-zmq-backend/__tests__/index_spec.js
+++ b/packages/enchannel-zmq-backend/__tests__/index_spec.js
@@ -1,8 +1,5 @@
 import uuid from "uuid/v4";
 import { Subject } from "rxjs";
-
-const EventEmitter = require("events");
-
 import { toArray, take } from "rxjs/operators";
 
 import {
@@ -12,6 +9,8 @@ import {
   createMainChannelFromSockets,
   verifiedConnect
 } from "../src";
+
+const EventEmitter = require("events");
 
 describe("createSocket", () => {
   test("creates a JMP socket on the channel with identity", async function(done) {

--- a/packages/enchannel-zmq-backend/src/index.js
+++ b/packages/enchannel-zmq-backend/src/index.js
@@ -1,8 +1,8 @@
 // @flow
 import { Subject, Subscriber, fromEvent, merge } from "rxjs";
 import { map, publish, refCount } from "rxjs/operators";
-
 import * as moduleJMP from "jmp";
+import uuid from "uuid/v4";
 
 export const ZMQType = {
   frontend: {
@@ -12,8 +12,6 @@ export const ZMQType = {
     control: "dealer"
   }
 };
-
-import uuid from "uuid/v4";
 
 export type CHANNEL_NAME = "iopub" | "stdin" | "shell" | "control";
 

--- a/packages/fs-observable/src/index.js
+++ b/packages/fs-observable/src/index.js
@@ -1,10 +1,11 @@
 // @flow
 import * as fs from "fs";
 
-const mkdirp = require("mkdirp");
 
 import { Observable, bindNodeCallback } from "rxjs";
 import { mergeMap } from "rxjs/operators";
+
+const mkdirp = require("mkdirp");
 
 export const unlinkObservable = (path: string) =>
   Observable.create(observer => {

--- a/packages/host-cache/src/components/host.js
+++ b/packages/host-cache/src/components/host.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 
 import { LocalHostStorage } from "../host-storage.js";
+import type { ServerConfig } from "../host-storage";
 
 const { Provider, Consumer } = React.createContext(null);
 
@@ -13,8 +14,6 @@ type HostProps = {
   gitRef?: string,
   binderURL?: string
 };
-
-import type { ServerConfig } from "../host-storage";
 
 class Host extends React.Component<HostProps, ServerConfig> {
   lhs: LocalHostStorage;

--- a/packages/host-cache/src/components/kernel.js
+++ b/packages/host-cache/src/components/kernel.js
@@ -1,15 +1,15 @@
 // @flow
 import * as React from "react";
+// NOTE: This could use the sessions API so these kernels aren't "on the loose"
+import { kernels } from "rx-jupyter";
+
+import type { ServerConfig } from "../host-storage";
+
 import Host from "./host";
 
 const { Provider, Consumer } = React.createContext(null);
 
 export { Consumer };
-
-import type { ServerConfig } from "../host-storage";
-
-// NOTE: This could use the sessions API so these kernels aren't "on the loose"
-import { kernels } from "rx-jupyter";
 
 type KernelAllocatorProps = {
   children?: React.Node,

--- a/packages/host-cache/src/host-storage.js
+++ b/packages/host-cache/src/host-storage.js
@@ -2,7 +2,6 @@
 
 import { binder } from "rx-binder";
 import { kernels } from "rx-jupyter";
-
 import { of } from "rxjs";
 import { tap, map, catchError, filter } from "rxjs/operators";
 

--- a/packages/iron-icons/src/index.js
+++ b/packages/iron-icons/src/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React from "react";
-
 import type { ChildrenArray } from "react";
 
 type WrapperProps<T> = {

--- a/packages/markdown/__tests__/index-spec.js
+++ b/packages/markdown/__tests__/index-spec.js
@@ -1,10 +1,10 @@
 // @flow
 
 import * as React from "react";
-import Markdown from "../src";
-
 import { mount } from "enzyme";
 import toJson from "enzyme-to-json";
+
+import Markdown from "../src";
 
 const cases = [
   {

--- a/packages/markdown/__tests__/remark-math-spec.js
+++ b/packages/markdown/__tests__/remark-math-spec.js
@@ -1,8 +1,9 @@
-import math from "../src/remark-math";
 import unified from "unified";
 import parse from "remark-parse";
 import stringify from "remark-stringify";
 import u from "unist-builder";
+
+import math from "../src/remark-math";
 
 function remark() {
   return unified()

--- a/packages/markdown/src/index.js
+++ b/packages/markdown/src/index.js
@@ -2,6 +2,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import MathJax from "@nteract/mathjax";
+
 import RemarkMathPlugin from "./remark-math";
 
 const math = (props: { value: string }) => (

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -7,7 +7,6 @@ const types = {
 };
 
 import MathJaxContext, { type MathJaxContextValue } from "./context";
-
 import Provider from "./provider";
 
 type Props = {

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -1,8 +1,8 @@
 // @flow strict
 
 import * as React from "react";
-import loadScript from "./load-script";
 
+import loadScript from "./load-script";
 import MathJaxContext, {
   type MathJaxObject, // eslint-disable-line no-unused-vars
   type MathJaxContextValue

--- a/packages/mathjax/src/text.js
+++ b/packages/mathjax/src/text.js
@@ -2,7 +2,6 @@
 import * as React from "react";
 
 import MathJaxContext, { type MathJaxContextValue } from "./context";
-
 import Provider from "./provider";
 
 type Props = {

--- a/packages/messaging/__tests__/messaging-spec.js
+++ b/packages/messaging/__tests__/messaging-spec.js
@@ -1,8 +1,10 @@
 import { from, of } from "rxjs";
 import { map, tap, count, toArray } from "rxjs/operators";
-import { ofMessageType, childOf } from "../src/index";
+import { cloneDeep } from "lodash";
 
 import {
+  ofMessageType,
+  childOf,
   createMessage,
   createExecuteRequest,
   convertOutputMessageToNotebookFormat,
@@ -11,7 +13,6 @@ import {
   executionCounts,
   kernelStatuses
 } from "../src";
-
 import {
   executeInput,
   displayData,
@@ -19,8 +20,6 @@ import {
   executeReply,
   message
 } from "../src/messages";
-
-import { cloneDeep } from "lodash";
 
 describe("createMessage", () => {
   it("makes a msg", () => {

--- a/packages/monaco-editor/src/index.js
+++ b/packages/monaco-editor/src/index.js
@@ -1,9 +1,7 @@
 // @flow
 /* eslint-disable class-methods-use-this */
 import * as React from "react";
-
 import { debounce } from "lodash";
-
 // $FlowFixMe
 import * as monaco from "monaco-editor";
 

--- a/packages/notebook-app-component/__tests__/cell-creator-spec.js
+++ b/packages/notebook-app-component/__tests__/cell-creator-spec.js
@@ -2,9 +2,7 @@
 import React from "react";
 import { mount, shallow } from "enzyme";
 import { Provider } from "react-redux";
-
 import { actionTypes } from "@nteract/core";
-
 import { dummyStore } from "@nteract/core/dummy";
 
 import CellCreator, { PureCellCreator } from "../src/cell-creator";

--- a/packages/notebook-app-component/__tests__/draggable-cell-spec.js
+++ b/packages/notebook-app-component/__tests__/draggable-cell-spec.js
@@ -1,12 +1,9 @@
 import React from "react";
-
 import { shallow } from "enzyme";
+import { emptyMarkdownCell } from "@nteract/commutable";
+import { displayOrder, transforms } from "@nteract/transforms";
 
 import DraggableCell from "../src/draggable-cell";
-
-import { emptyMarkdownCell } from "@nteract/commutable";
-
-import { displayOrder, transforms } from "@nteract/transforms";
 
 // Spoof DND manager for tests.
 const dragDropManager = {

--- a/packages/notebook-app-component/__tests__/editor-spec.js
+++ b/packages/notebook-app-component/__tests__/editor-spec.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
-
-import Editor from "../src/editor";
 import { dummyStore } from "@nteract/core/dummy";
 import { actionTypes } from "@nteract/core";
+
+import Editor from "../src/editor";
 
 describe("EditorProvider", () => {
   const store = dummyStore();

--- a/packages/notebook-app-component/__tests__/markdown-preview-spec.js
+++ b/packages/notebook-app-component/__tests__/markdown-preview-spec.js
@@ -1,11 +1,10 @@
 // @flow
 import React from "react";
-
 import { shallow, mount } from "enzyme";
+import { emptyMarkdownCell } from "@nteract/commutable";
 
 import MarkdownPreview from "../src/markdown-preview";
 
-import { emptyMarkdownCell } from "@nteract/commutable";
 
 describe("MarkdownPreview ", () => {
   test("can be rendered", () => {

--- a/packages/notebook-app-component/__tests__/notebook-spec.js
+++ b/packages/notebook-app-component/__tests__/notebook-spec.js
@@ -2,10 +2,10 @@
 import React from "react";
 import Immutable from "immutable";
 import { shallow } from "enzyme";
+import { dummyStore, dummyCommutable } from "@nteract/core/dummy";
 
 import { NotebookApp } from "../src/notebook-app";
 
-import { dummyStore, dummyCommutable } from "@nteract/core/dummy";
 
 const dummyCellStatuses = dummyCommutable
   .get("cellOrder")

--- a/packages/notebook-app-component/__tests__/status-bar-spec.js
+++ b/packages/notebook-app-component/__tests__/status-bar-spec.js
@@ -1,9 +1,8 @@
 import React from "react";
-
 import { shallow } from "enzyme";
+import { dummyCommutable } from "@nteract/core/dummy";
 
 import { StatusBar } from "../src/status-bar";
-import { dummyCommutable } from "@nteract/core/dummy";
 
 describe("StatusBar", () => {
   test("can render on a dummyNotebook", () => {

--- a/packages/notebook-app-component/__tests__/toolbar-spec.js
+++ b/packages/notebook-app-component/__tests__/toolbar-spec.js
@@ -1,13 +1,12 @@
 // @flow
 import * as React from "react";
-
 import { mount } from "enzyme";
-import Toolbar, { PureToolbar } from "../src/toolbar";
 import toJSON from "enzyme-to-json";
 import { Provider } from "react-redux";
 import { dummyStore } from "@nteract/core/dummy";
-
 import { actionTypes } from "@nteract/core";
+
+import Toolbar, { PureToolbar } from "../src/toolbar";
 
 const {
   DELETE_CELL,

--- a/packages/notebook-app-component/src/cell-creator.js
+++ b/packages/notebook-app-component/src/cell-creator.js
@@ -1,7 +1,7 @@
 // @flow strict
 import * as React from "react";
 import { connect } from "react-redux";
-
+import { CodeOcticon, MarkdownOcticon } from "@nteract/octicons";
 import { actions } from "@nteract/core";
 import type { ContentRef } from "@nteract/core";
 
@@ -18,8 +18,6 @@ type ConnectedProps = {
   id?: string,
   contentRef: ContentRef
 };
-
-import { CodeOcticon, MarkdownOcticon } from "@nteract/octicons";
 
 export class PureCellCreator extends React.Component<Props, null> {
   createMarkdownCell = () => {

--- a/packages/notebook-app-component/src/draggable-cell.js
+++ b/packages/notebook-app-component/src/draggable-cell.js
@@ -13,7 +13,6 @@ import {
   ConnectDragPreview,
   ConnectDropTarget
 } from "react-dnd";
-
 import type { ContentRef } from "@nteract/core";
 
 /**

--- a/packages/notebook-app-component/src/editor.js
+++ b/packages/notebook-app-component/src/editor.js
@@ -1,11 +1,8 @@
 // @flow
 import { connect } from "react-redux";
-
 import { actions, selectors } from "@nteract/core";
 import type { ContentRef, AppState } from "@nteract/core";
-
 import { omit } from "lodash";
-
 import EditorView from "@nteract/editor";
 
 type Props = {

--- a/packages/notebook-app-component/src/index.js
+++ b/packages/notebook-app-component/src/index.js
@@ -2,4 +2,5 @@
 import { hot } from "react-hot-loader";
 
 import NotebookApp from "./notebook-app";
+
 export default hot(module)(NotebookApp);

--- a/packages/notebook-app-component/src/markdown-preview.js
+++ b/packages/notebook-app-component/src/markdown-preview.js
@@ -4,9 +4,7 @@
 /* eslint jsx-a11y/no-noninteractive-tabindex: 0 */
 
 import React from "react";
-
 import Markdown from "@nteract/markdown";
-
 import {
   Outputs,
   PromptBuffer,

--- a/packages/notebook-app-component/src/notebook-app.js
+++ b/packages/notebook-app-component/src/notebook-app.js
@@ -2,10 +2,8 @@
 /* @flow */
 import * as Immutable from "immutable";
 import * as React from "react";
-
 import { actions, selectors } from "@nteract/core";
 import type { AppState, ContentRef, KernelRef } from "@nteract/core";
-
 import {
   Input,
   Prompt,
@@ -15,6 +13,14 @@ import {
   Cell,
   themes
 } from "@nteract/presentational-components";
+import { DragDropContext as dragDropContext } from "react-dnd";
+import HTML5Backend from "react-dnd-html5-backend";
+import { connect } from "react-redux";
+import { RichestMime, Output } from "@nteract/display-area";
+import {
+  displayOrder as defaultDisplayOrder,
+  transforms as defaultTransforms
+} from "@nteract/transforms";
 
 import DraggableCell from "./draggable-cell";
 import CellCreator from "./cell-creator";
@@ -24,15 +30,7 @@ import Editor from "./editor";
 import Toolbar from "./toolbar";
 import { HijackScroll } from "./hijack-scroll";
 
-import { DragDropContext as dragDropContext } from "react-dnd";
-import HTML5Backend from "react-dnd-html5-backend";
-import { connect } from "react-redux";
 
-import { RichestMime, Output } from "@nteract/display-area";
-import {
-  displayOrder as defaultDisplayOrder,
-  transforms as defaultTransforms
-} from "@nteract/transforms";
 
 type AnyCellProps = {
   id: string,

--- a/packages/notebook-app-component/src/status-bar.js
+++ b/packages/notebook-app-component/src/status-bar.js
@@ -1,10 +1,7 @@
 /* @flow strict */
 import React from "react";
-
 import { connect } from "react-redux";
-
 import distanceInWordsToNow from "date-fns/distance_in_words_to_now";
-
 import { selectors } from "@nteract/core";
 import type { ContentRef, AppState, KernelRef } from "@nteract/core";
 

--- a/packages/notebook-app-component/src/toolbar.js
+++ b/packages/notebook-app-component/src/toolbar.js
@@ -8,16 +8,13 @@
 
 import * as React from "react";
 import { connect } from "react-redux";
-
 import { actions } from "@nteract/core";
 import type { ContentRef } from "@nteract/core";
-
 import {
   DropdownMenu,
   DropdownTrigger,
   DropdownContent
 } from "@nteract/dropdown-menu";
-
 import {
   TrashOcticon,
   ChevronDownOcticon,

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
       <Cell
         _hovered={false}
         isSelected={false}
-        key="3"
+        key="2"
       >
         <div
           className="jsx-2513275823 content-margin"
@@ -39,7 +39,7 @@ exports[`Notebook accepts an Immutable.List of cells 1`] = `
       <Cell
         _hovered={false}
         isSelected={false}
-        key="4"
+        key="3"
       >
         <PapermillView
           status={null}

--- a/packages/notebook-preview/__tests__/index.test.js
+++ b/packages/notebook-preview/__tests__/index.test.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { shallow } from "enzyme";
 import toJson from "enzyme-to-json";
-
 import { displayOrder, transforms } from "@nteract/transforms";
+
+import { dummyCommutable, dummyJSON } from "../../core/src/dummy";
 
 import NotebookPreview from "./../src";
 
-import { dummyCommutable, dummyJSON } from "../../core/src/dummy";
 
 // In order to get reproducable snapshots we need to mock the uuid package
 jest.mock("uuid/v4", () => {

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -1,19 +1,16 @@
 /* @flow */
 import * as React from "react";
-
 import { Display } from "@nteract/display-area";
 import {
   displayOrder as defaultDisplayOrder,
   transforms as defaultTransforms
 } from "@nteract/transforms";
-
 import {
   emptyNotebook,
   appendCellToNotebook,
   fromJS,
   createCodeCell
 } from "@nteract/commutable";
-
 import {
   themes,
   Cell,
@@ -23,11 +20,10 @@ import {
   Outputs,
   Cells
 } from "@nteract/presentational-components";
-
-import { PapermillView } from "./papermill";
-
 import Markdown from "@nteract/markdown";
 import MathJax from "@nteract/mathjax";
+
+import { PapermillView } from "./papermill";
 
 type Props = {
   displayOrder: Array<string>,

--- a/packages/notebook-preview/src/papermill.js
+++ b/packages/notebook-preview/src/papermill.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from "react";
+
 type PapermillMetadata = {
   status?: "pending" | "running" | "completed"
   // TODO: Acknowledge / use other papermill metadata

--- a/packages/notebook-render/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/notebook-render/__tests__/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Test NotebokRender snapshots accepts an Immutable.List of cells 1`] = `
     <Cell
       _hovered={false}
       isSelected={false}
-      key="3"
+      key="2"
     >
       <div
         className="jsx-2299737332 content-margin"
@@ -48,7 +48,7 @@ exports[`Test NotebokRender snapshots accepts an Immutable.List of cells 1`] = `
     <Cell
       _hovered={false}
       isSelected={false}
-      key="4"
+      key="3"
     >
       <Input
         hidden={false}

--- a/packages/notebook-render/__tests__/index.test.js
+++ b/packages/notebook-render/__tests__/index.test.js
@@ -2,12 +2,12 @@ import React from "react";
 import ReactDOMServer from "react-dom/server";
 import { shallow } from "enzyme";
 import toJson from "enzyme-to-json";
-
 import { displayOrder, transforms } from "@nteract/transforms";
+
+import { dummyCommutable, dummyJSON } from "../../core/src/dummy";
 
 import NotebookRender from "./../src";
 
-import { dummyCommutable, dummyJSON } from "../../core/src/dummy";
 
 // In order to get reproducable snapshots we need to mock the uuid package
 jest.mock("uuid/v4", () => {

--- a/packages/notebook-render/src/index.js
+++ b/packages/notebook-render/src/index.js
@@ -7,20 +7,17 @@ import katex from "rehype-katex";
 import stringify from "rehype-stringify";
 import { InlineMath, BlockMath } from "react-katex";
 import flush from "styled-jsx/server";
-
 import { Display } from "@nteract/display-area";
 import {
   displayOrder as defaultDisplayOrder,
   transforms as defaultTransforms
 } from "@nteract/transforms";
-
 import {
   emptyNotebook,
   appendCellToNotebook,
   fromJS,
   createCodeCell
 } from "@nteract/commutable";
-
 import {
   themes,
   Cell,

--- a/packages/octicons/src/index.js
+++ b/packages/octicons/src/index.js
@@ -1,6 +1,5 @@
 // @flow
 import React from "react";
-
 import type { ChildrenArray } from "react";
 
 type WrapperProps<T> = {

--- a/packages/outputs/__tests__/media-spec.js
+++ b/packages/outputs/__tests__/media-spec.js
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { mount } from "enzyme";
 import toJson from "enzyme-to-json";
-
 import renderer from "react-test-renderer";
 
 import { Media } from "../src";

--- a/packages/outputs/package.json
+++ b/packages/outputs/package.json
@@ -18,6 +18,9 @@
     "@babel/runtime-corejs2": "^7.0.0",
     "ansi-to-react": "^3.3.3"
   },
+  "peerDependencies": {
+    "react": "^16.3.2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/outputs/src/components/display-data.js
+++ b/packages/outputs/src/components/display-data.js
@@ -1,9 +1,9 @@
 // @flow strict
 import * as React from "react";
+import type { MediaBundle } from "@nteract/records";
 
 import { RichMedia } from "./rich-media";
 
-import type { MediaBundle } from "@nteract/records";
 
 type Props = {
   /**

--- a/packages/outputs/src/components/execute-result.js
+++ b/packages/outputs/src/components/execute-result.js
@@ -1,9 +1,9 @@
 // @flow strict
 import * as React from "react";
+import type { MediaBundle } from "@nteract/records";
 
 import { RichMedia } from "./rich-media";
 
-import type { MediaBundle } from "@nteract/records";
 
 type Props = {
   /**

--- a/packages/outputs/src/components/kernel-output-error.js
+++ b/packages/outputs/src/components/kernel-output-error.js
@@ -1,8 +1,8 @@
 // @flow strict
 import * as React from "react";
 import Ansi from "ansi-to-react";
-
 import type { ErrorOutput } from "@nteract/records";
+
 type Props = ErrorOutput;
 
 export const KernelOutputError = (props: Props) => {

--- a/packages/outputs/src/components/media/markdown.js
+++ b/packages/outputs/src/components/media/markdown.js
@@ -1,6 +1,5 @@
 /* @flow */
 import * as React from "react";
-
 import MarkdownComponent from "@nteract/markdown";
 
 type Props = {

--- a/packages/outputs/src/components/media/plain.js
+++ b/packages/outputs/src/components/media/plain.js
@@ -1,6 +1,5 @@
 /* @flow strict */
 import * as React from "react";
-
 import { ansiToInlineStyle } from "ansi-to-react";
 
 type Props = {

--- a/packages/outputs/src/components/output.js
+++ b/packages/outputs/src/components/output.js
@@ -1,7 +1,6 @@
 // @flow strict
 
 import * as React from "react";
-
 // We might only need this as a devDependency as it is only here for flow
 import type OutputType from "@nteract/records";
 

--- a/packages/outputs/src/components/rich-media.js
+++ b/packages/outputs/src/components/rich-media.js
@@ -1,7 +1,6 @@
 // @flow strict
 
 import * as React from "react";
-
 import type { MediaBundle } from "@nteract/records";
 
 /** Error handling types */

--- a/packages/outputs/src/components/stream-text.js
+++ b/packages/outputs/src/components/stream-text.js
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import Ansi from "ansi-to-react";
-
 import type { StreamOutput } from "@nteract/records";
 
 type Props = StreamOutput;

--- a/packages/outputs/src/index.js
+++ b/packages/outputs/src/index.js
@@ -7,4 +7,5 @@ export { ExecuteResult } from "./components/execute-result";
 export { StreamText } from "./components/stream-text";
 
 import * as Media from "./components/media";
+
 export { Media };

--- a/packages/presentational-components/__tests__/header-editor-spec.js
+++ b/packages/presentational-components/__tests__/header-editor-spec.js
@@ -1,10 +1,8 @@
 import * as React from "react";
+import { shallow } from "enzyme";
+import renderer from "react-test-renderer";
 
 import { HeaderEditor } from "../src/";
-
-import { shallow } from "enzyme";
-
-import renderer from "react-test-renderer";
 
 describe("Header Editor", () => {
   it("renders correctly with no props", () => {

--- a/packages/presentational-components/src/components/header-editor.js
+++ b/packages/presentational-components/src/components/header-editor.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from "react";
-
 import {
   H1,
   Tag,
@@ -9,7 +8,6 @@ import {
   Position,
   Tooltip
 } from "@blueprintjs/core";
-
 import { blueprintCSS } from "@nteract/styled-blueprintjsx";
 
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json#L67

--- a/packages/presentational-components/src/index.js
+++ b/packages/presentational-components/src/index.js
@@ -8,10 +8,10 @@ import { Source } from "./components/source.js";
 import { Cell } from "./components/cell.js";
 import { Cells } from "./components/cells.js";
 import { HeaderEditor } from "./components/header-editor.js";
+import * as themes from "./themes";
 
 export * from "./styles";
 
-import * as themes from "./themes";
 export {
   themes,
   Input,

--- a/packages/presentational-components/src/syntax-highlighter/index.js
+++ b/packages/presentational-components/src/syntax-highlighter/index.js
@@ -1,7 +1,6 @@
 // @flow
 import SyntaxHighlighter from "react-syntax-highlighter/prism";
 import * as React from "react";
-
 import {
   xonokai as darkTheme,
   vs as lightTheme

--- a/packages/records/__tests__/appendOutput-spec.js
+++ b/packages/records/__tests__/appendOutput-spec.js
@@ -1,6 +1,5 @@
 // @flow strict
-import appendOutput from "../src/outputs/append-output";
-import { mutate } from "../src/outputs/append-output";
+import appendOutput, { mutate } from "../src/outputs/append-output";
 
 describe("appendOutput", () => {
   test("puts new outputs at the end by default", () => {

--- a/packages/records/__tests__/index-spec.js
+++ b/packages/records/__tests__/index-spec.js
@@ -1,6 +1,5 @@
 // @flow strict
 import * as nteractRecords from "@nteract/records";
-
 import { executeResult } from "@nteract/records/src/outputs/execute-result";
 import { streamOutput } from "@nteract/records/src/outputs/stream";
 import { displayData } from "@nteract/records/src/outputs/display-data";

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -19,7 +19,8 @@
     "babel-runtime": "^6.26.0",
     "escape-carriage": "^1.2.0",
     "immer": "^1.5.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "uuid": "^3.1.0"
   },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9"

--- a/packages/records/src/cells/code-cell.js
+++ b/packages/records/src/cells/code-cell.js
@@ -1,10 +1,9 @@
 // @flow
 import produce from "immer";
-import { outputFromNbformat } from "../outputs";
 
+import { outputFromNbformat } from "../outputs";
 import type { MultilineString } from "../common";
 import type { OutputType, NbformatOutput } from "../outputs";
-
 import type { ExecutionCount } from "../outputs/execute-result";
 
 export type CodeCellType = "code";

--- a/packages/records/src/cells/markdown-cell.js
+++ b/packages/records/src/cells/markdown-cell.js
@@ -1,5 +1,6 @@
 // @flow
 import produce from "immer";
+
 import type { MultilineString } from "../common";
 
 export type MarkdownCellType = "markdown";

--- a/packages/records/src/cells/raw-cell.js
+++ b/packages/records/src/cells/raw-cell.js
@@ -1,5 +1,6 @@
 // @flow
 import produce from "immer";
+
 import type { MultilineString } from "../common";
 
 export type RawCellType = "raw";

--- a/packages/records/src/index.js
+++ b/packages/records/src/index.js
@@ -4,16 +4,7 @@ export * from "./outputs";
 export * from "./cells";
 export * from "./common";
 import * as outputs from "./outputs";
-
 import type { Notebook as v4Notebook } from "./structures";
-
-export type ExecutionCount = number | null;
-
-export type MimeBundle = JSONObject;
-
-export type CellType = "markdown" | "code";
-export type CellID = string;
-
 import type {
   ImmutableNotebook,
   ImmutableCodeCell,
@@ -26,6 +17,11 @@ import type {
   ImmutableCellOrder,
   ImmutableCellMap
 } from "./types";
+
+export type ExecutionCount = number | null;
+export type MimeBundle = JSONObject;
+export type CellType = "markdown" | "code";
+export type CellID = string;
 
 export type {
   ImmutableCellOrder,

--- a/packages/records/src/outputs/display-data.js
+++ b/packages/records/src/outputs/display-data.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 import produce from "immer";
+
 import * as common from "../common";
 
 /**

--- a/packages/records/src/outputs/execute-result.js
+++ b/packages/records/src/outputs/execute-result.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 import produce from "immer";
+
 import * as common from "../common";
 
 /**

--- a/packages/records/src/outputs/index.js
+++ b/packages/records/src/outputs/index.js
@@ -12,7 +12,6 @@ import type {
   ExecuteResultOutput
 } from "./execute-result";
 import type { UnrecognizedOutput } from "./unrecognized";
-
 import { unrecognized } from "./unrecognized";
 import { displayData } from "./display-data";
 import { streamOutput } from "./stream";

--- a/packages/records/src/structures.js
+++ b/packages/records/src/structures.js
@@ -1,11 +1,10 @@
 /* @flow */
 
 import produce from "immer";
+import uuid from "uuid/v4";
 
 import type { NbformatCell } from "./cells";
-
 import type { NbformatOutput } from "./outputs";
-
 import type {
   ImmutableNotebook,
   ImmutableCellOrder,
@@ -13,7 +12,6 @@ import type {
   ExecutionCount
 } from "./types";
 
-import uuid from "uuid/v4";
 
 // We're hardset to nbformat v4.4 for what we use in-memory
 export type Notebook = {|

--- a/packages/rx-binder/__tests__/index.test.js
+++ b/packages/rx-binder/__tests__/index.test.js
@@ -1,7 +1,7 @@
 // @flow
-const { binder, formBinderURL } = require("../src");
-
 import { toArray } from "rxjs/operators";
+
+const { binder, formBinderURL } = require("../src");
 
 test("formBinderURL has default values with empty options", () => {
   expect(formBinderURL()).toEqual(

--- a/packages/rx-jupyter/src/contents.js
+++ b/packages/rx-jupyter/src/contents.js
@@ -6,6 +6,7 @@ import { Observable } from "rxjs";
 import { createAJAXSettings } from "./base";
 
 const querystring = require("querystring");
+
 const urljoin = require("url-join");
 
 function formURI(path: string): string {

--- a/packages/rx-jupyter/src/index.js
+++ b/packages/rx-jupyter/src/index.js
@@ -8,7 +8,6 @@ import * as kernelspecs from "./kernelspecs";
 import * as sessions from "./sessions";
 import * as contents from "./contents";
 import * as terminals from "./terminals";
-
 import { createAJAXSettings } from "./base";
 
 function apiVersion(serverConfig: Object) {

--- a/packages/rx-jupyter/src/kernels.js
+++ b/packages/rx-jupyter/src/kernels.js
@@ -3,11 +3,11 @@
 import { ajax } from "rxjs/ajax";
 import { webSocket } from "rxjs/webSocket";
 import { Observable, Subject, Subscriber } from "rxjs";
-
 import type { WebSocketSubject } from "rxjs/webSocket";
+import { retryWhen, tap, delay, share } from "rxjs/operators";
+
 import { createAJAXSettings } from "./base";
 
-import { retryWhen, tap, delay, share } from "rxjs/operators";
 
 const urljoin = require("url-join");
 const URLSearchParams = require("url-search-params");

--- a/packages/styleguide-components/package.json
+++ b/packages/styleguide-components/package.json
@@ -15,5 +15,8 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0"
-  }
+  },
+  "peerDependencies": {
+      "react": "^16.3.2"
+    }
 }

--- a/packages/styles/buildStyles.js
+++ b/packages/styles/buildStyles.js
@@ -1,5 +1,4 @@
 // Note: This file is ES5 because it doesn't get transpiled, only gets used for building the module
-const config = require("./src/config.json");
 const fs = require("fs");
 const path = require("path");
 
@@ -18,6 +17,8 @@ const makeName = name => {
 };
 
 const lodash = require("lodash");
+
+const config = require("./src/config.json");
 
 function makeDeclarationSet(groupKey, isAlias) {
   const modifiers = config.theme.modifiers[groupKey];

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
-    "babel-runtime": "^6.26.0"
+    "babel-runtime": "^6.26.0",
+    "lodash": "^4.17.4"
   },
   "author": "Andrew Seier <andseier@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/timeago/src/index.js
+++ b/packages/timeago/src/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import * as React from "react";
+
 import defaultFormatter from "./defaultFormatter";
 import dateParser from "./dateParser";
 

--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -33,6 +33,9 @@
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/octicons": "^0.4.3",
     "@nteract/transform-plotly": "^3.2.3",
+    "d3-collection": "^1.0.7",
+    "d3-scale": "^2.1.2",
+    "d3-shape": "^1.2.2",
     "d3-time-format": "^2.0.5",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
@@ -42,6 +45,7 @@
     "react-table": "^6.8.6",
     "react-table-hoc-fixed-columns": "1.0.2",
     "semiotic": "^1.14.4",
+    "styled-jsx": "^3.1.0",
     "tv4": "^1.3.0"
   }
 }

--- a/packages/transform-dataresource/src/HTMLLegend.js
+++ b/packages/transform-dataresource/src/HTMLLegend.js
@@ -1,5 +1,6 @@
 /* @flow */
 import * as React from "react";
+
 import PalettePicker from "./PalettePicker";
 
 type HTMLLegendProps = {

--- a/packages/transform-dataresource/src/PalettePicker.js
+++ b/packages/transform-dataresource/src/PalettePicker.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as React from "react";
 import { ChromePicker } from "react-color";
+
 import paletteStyle from "./css/palette-picker";
 
 type Props = {

--- a/packages/transform-dataresource/src/ParallelCoordinatesController.js
+++ b/packages/transform-dataresource/src/ParallelCoordinatesController.js
@@ -3,10 +3,10 @@
 import * as React from "react";
 import { scaleLinear } from "d3-scale";
 import { ResponsiveOrdinalFrame, Axis } from "semiotic";
+
 import HTMLLegend from "./HTMLLegend";
 import { numeralFormatting } from "./utilities";
 import buttonGroupStyle from "./css/button-group";
-
 import TooltipContent from "./tooltip-content";
 
 type State = {

--- a/packages/transform-dataresource/src/charts/bar.js
+++ b/packages/transform-dataresource/src/charts/bar.js
@@ -2,10 +2,10 @@
 import * as React from "react";
 
 import TooltipContent from "../tooltip-content";
-
-import { sortByOrdinalRange } from "./shared";
 import HTMLLegend from "../HTMLLegend";
 import { numeralFormatting } from "../utilities";
+
+import { sortByOrdinalRange } from "./shared";
 
 export const semioticBarChart = (
   data: Array<Object>,

--- a/packages/transform-dataresource/src/charts/grid.js
+++ b/packages/transform-dataresource/src/charts/grid.js
@@ -1,7 +1,9 @@
 import * as React from "react";
 import ReactTable from "react-table";
-import ReactTableStyles from "../css/react-table";
 import withFixedColumns from "react-table-hoc-fixed-columns";
+
+import ReactTableStyles from "../css/react-table";
+
 const ReactTableFixedColumns = withFixedColumns(ReactTable);
 
 export const DataResourceTransformGrid = ({

--- a/packages/transform-dataresource/src/charts/hierarchical.js
+++ b/packages/transform-dataresource/src/charts/hierarchical.js
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { nest } from "d3-collection";
 import { scaleLinear } from "d3-scale";
+
 import TooltipContent from "../tooltip-content";
 
 const parentPath = (d, pathArray) => {

--- a/packages/transform-dataresource/src/charts/line.js
+++ b/packages/transform-dataresource/src/charts/line.js
@@ -1,10 +1,9 @@
 /* @flow */
 import * as React from "react";
-
-import TooltipContent from "../tooltip-content";
-
 import { curveMonotone } from "d3-shape";
 import { scaleLinear, scaleTime } from "d3-scale";
+
+import TooltipContent from "../tooltip-content";
 import { numeralFormatting } from "../utilities";
 
 export const semioticLineChart = (

--- a/packages/transform-dataresource/src/charts/summary.js
+++ b/packages/transform-dataresource/src/charts/summary.js
@@ -1,9 +1,9 @@
 /* @flow */
 import * as React from "react";
-import HTMLLegend from "../HTMLLegend";
-import { numeralFormatting } from "../utilities";
 import { scaleLinear } from "d3-scale";
 
+import HTMLLegend from "../HTMLLegend";
+import { numeralFormatting } from "../utilities";
 import TooltipContent from "../tooltip-content";
 
 const fontScale = scaleLinear()

--- a/packages/transform-dataresource/src/charts/xyplot.js
+++ b/packages/transform-dataresource/src/charts/xyplot.js
@@ -1,12 +1,12 @@
 /* @flow */
 import * as React from "react";
-
-import { sortByOrdinalRange } from "./shared";
 import { scaleLinear, scaleThreshold } from "d3-scale";
+
 import { numeralFormatting } from "../utilities";
 import HTMLLegend from "../HTMLLegend";
-
 import TooltipContent from "../tooltip-content";
+
+import { sortByOrdinalRange } from "./shared";
 
 const steps = ["none", "#FBEEEC", "#f3c8c2", "#e39787", "#ce6751", "#b3331d"];
 const thresholds = scaleThreshold()

--- a/packages/transform-dataresource/src/index.js
+++ b/packages/transform-dataresource/src/index.js
@@ -1,6 +1,5 @@
 /* @flow */
 import { hot } from "react-hot-loader";
-
 import * as React from "react";
 import { DatabaseOcticon } from "@nteract/octicons";
 
@@ -9,7 +8,6 @@ import { semioticSettings } from "./charts/settings";
 import { DataResourceTransformGrid } from "./charts/grid";
 import VizControls from "./VizControls";
 import semioticStyle from "./css/semiotic";
-
 import {
   TreeIcon,
   NetworkIcon,
@@ -20,7 +18,6 @@ import {
   HexbinIcon,
   ParallelCoordinatesIcon
 } from "./icons";
-
 import { chartHelpText } from "./docs/chart-docs";
 
 type Props = {

--- a/packages/transform-dataresource/src/infer.js
+++ b/packages/transform-dataresource/src/infer.js
@@ -1,6 +1,6 @@
 import lodash from "lodash";
-import * as types from "./types";
 
+import * as types from "./types";
 import { ERROR } from "./types/error";
 
 /**

--- a/packages/transform-geojson/__tests__/geojson.test.js
+++ b/packages/transform-geojson/__tests__/geojson.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import _ from "lodash";
-
 import { mount } from "enzyme";
 
 import GeoJSONTransform, { getTheme } from "../src";

--- a/packages/transform-model-debug/__tests__/model-debug.test.js
+++ b/packages/transform-model-debug/__tests__/model-debug.test.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { mount } from "enzyme";
 
 import ModelDebug from "../src";

--- a/packages/transform-plotly/__tests__/plotly.test.js
+++ b/packages/transform-plotly/__tests__/plotly.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import _ from "lodash";
-
 import { mount } from "enzyme";
 
 import PlotlyTransform from "../src";

--- a/packages/transform-plotly/src/index.js
+++ b/packages/transform-plotly/src/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 /* eslint class-methods-use-this: 0 */
 import React from "react";
-
 import { cloneDeep } from "lodash";
 
 type Props = {

--- a/packages/transform-vdom/__tests__/index.test.js
+++ b/packages/transform-vdom/__tests__/index.test.js
@@ -1,6 +1,7 @@
 import React from "react";
-import TransformVDOM from "../src";
 import renderer from "react-test-renderer";
+
+import TransformVDOM from "../src";
 
 test("VDOM Transform is cool", () => {
   const component = renderer.create(

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
-    "babel-runtime": "^6.26.0"
+    "babel-runtime": "^6.26.0",
+    "lodash": "^4.17.4"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/transform-vdom/src/index.js
+++ b/packages/transform-vdom/src/index.js
@@ -1,8 +1,8 @@
 /* @flow */
 import * as React from "react";
+import { cloneDeep } from "lodash";
 
 import { objectToReactElement } from "./object-to-react";
-import { cloneDeep } from "lodash";
 
 type Props = {
   data: Object

--- a/packages/transform-vega/__tests__/vega.test.js
+++ b/packages/transform-vega/__tests__/vega.test.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { shallow, mount } from "enzyme";
 
 import { Vega2, Vega3, VegaLite1, VegaLite2, VegaEmbed } from "../src/";

--- a/packages/transform-vega/src/index.js
+++ b/packages/transform-vega/src/index.js
@@ -1,6 +1,5 @@
 /* @flow */
 import * as React from "react";
-
 import { merge } from "lodash";
 import vegaEmbed2 from "@nteract/vega-embed-v2";
 import vegaEmbed3 from "vega-embed";

--- a/packages/transforms-full/src/index.js
+++ b/packages/transforms-full/src/index.js
@@ -6,14 +6,10 @@ import PlotlyTransform, {
   PlotlyNullTransform
 } from "@nteract/transform-plotly";
 import GeoJSONTransform from "@nteract/transform-geojson";
-
 import ModelDebug from "@nteract/transform-model-debug";
-
 import DataResourceTransform from "@nteract/transform-dataresource";
-
 import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 import { WidgetDisplay } from "@nteract/jupyter-widgets";
-
 import {
   standardTransforms,
   standardDisplayOrder,

--- a/packages/transforms/__tests__/index-spec.js
+++ b/packages/transforms/__tests__/index-spec.js
@@ -1,5 +1,4 @@
 import TextDisplay from "../src/text";
-
 import { richestMimetype, transforms } from "../src";
 
 describe("richestMimetype", () => {

--- a/packages/transforms/__tests__/json-spec.js
+++ b/packages/transforms/__tests__/json-spec.js
@@ -1,6 +1,5 @@
 import React from "react";
 import JSONTree from "react-json-tree";
-
 import { shallow } from "enzyme";
 
 import JsonDisplay from "../src/json";

--- a/packages/transforms/__tests__/latex-spec.js
+++ b/packages/transforms/__tests__/latex-spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { shallow } from "enzyme";
 import toJson from "enzyme-to-json";
 

--- a/packages/transforms/__tests__/markdown-spec.js
+++ b/packages/transforms/__tests__/markdown-spec.js
@@ -1,5 +1,4 @@
 import React from "react";
-
 import { shallow } from "enzyme";
 
 import MarkdownDisplay from "../src/markdown";

--- a/packages/transforms/src/index.js
+++ b/packages/transforms/src/index.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import VDOMDisplay from "@nteract/transform-vdom";
+
 import TextDisplay from "./text.js";
 import JsonDisplay from "./json.js";
 import JavaScriptDisplay from "./javascript.js";
@@ -8,7 +10,6 @@ import MarkdownDisplay from "./markdown.js";
 import LaTeXDisplay from "./latex.js";
 import SVGDisplay from "./svg.js";
 import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image.js";
-import VDOMDisplay from "@nteract/transform-vdom";
 
 type Transform = {
   MIMETYPE: string

--- a/packages/transforms/src/latex.js
+++ b/packages/transforms/src/latex.js
@@ -1,6 +1,5 @@
 /* @flow */
 import React from "react";
-
 import MathJax from "@nteract/mathjax";
 
 type Props = {

--- a/packages/transforms/src/markdown.js
+++ b/packages/transforms/src/markdown.js
@@ -1,6 +1,5 @@
 /* @flow */
 import * as React from "react";
-
 import Markdown from "@nteract/markdown";
 
 type Props = {

--- a/packages/transforms/src/text.js
+++ b/packages/transforms/src/text.js
@@ -1,6 +1,5 @@
 /* @flow */
 import React from "react";
-
 import { ansiToInlineStyle } from "ansi-to-react";
 
 type Props = {

--- a/packages/webpack-configurator/index.js
+++ b/packages/webpack-configurator/index.js
@@ -8,6 +8,7 @@ opaque type Aliases = {[string]: string }
 */
 
 const rxAliases /* : Aliases */ = require("rxjs/_esm5/path-mapping")();
+
 const { aliases } = require("./aliases");
 
 // We don't transpile packages in node_modules, unless it's _our_ package

--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,7 +5414,7 @@ eslint-plugin-flowtype@^3.0.0:
   dependencies:
     lodash "^4.17.10"
 
-eslint-plugin-import@^2.11.0:
+eslint-plugin-import@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
   integrity sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==


### PR DESCRIPTION
This adds [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) to our ESLINT setup and enforces correctly ordered imports. This helps to quickly find the right place to add additional dependencies. The nice thing about the plugin is that it integrates well with our prettier setups since this rule is auto-fixable. So almost no action required by our contributors.

This PR was intended to lower the entry barrier for #3471 since it already adds the the plugin to our ESLINT config and I figured I can do a bit of cleanup when I'm at it.