### PR TITLE
unpack the nteract examples folder

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -60,6 +60,10 @@
         "zip"
       ]
     },
+    "asar": true,
+    "asarUnpack": [
+      "**/@nteract/examples/**"
+    ],
     "nsis": {
       "perMachine": true,
       "oneClick": false

--- a/applications/desktop/src/main/menu.js
+++ b/applications/desktop/src/main/menu.js
@@ -198,7 +198,11 @@ export function loadFullMenu(store: * = global.store) {
     })
   );
 
-  // Plan: iterate over the manifest, creating example notebooks for multiple categories
+  // Iterate over the manifest, creating example notebooks for multiple categories
+
+  const examplesBaseDir = path
+    .join(__dirname, "..", "node_modules", "@nteract/examples")
+    .replace("app.asar", "app.asar.unpacked");
 
   const openExampleNotebooks = {
     label: "&Open Example Notebook",
@@ -209,17 +213,7 @@ export function loadFullMenu(store: * = global.store) {
         label: `&${collection.language}`,
         submenu: collection.files.map(fileInfo => {
           return {
-            click: launch.bind(
-              null,
-              path.join(
-                // Compute the path based on this file
-                __dirname,
-                "..",
-                "node_modules",
-                "@nteract/examples",
-                fileInfo.path
-              )
-            ),
+            click: launch.bind(null, path.join(examplesBaseDir, fileInfo.path)),
             label: `&${fileInfo.metadata.title}`
           };
         })

--- a/applications/desktop/webpack.common.js
+++ b/applications/desktop/webpack.common.js
@@ -7,7 +7,8 @@ const nodeModules = {
   jmp: "commonjs jmp",
   canvas: "commonjs canvas",
   "nteract-assets": "commonjs nteract-assets",
-  "mathjax-electron": "commonjs mathjax-electron"
+  "mathjax-electron": "commonjs mathjax-electron",
+  "@nteract/examples": "commonjs @nteract/examples"
 };
 
 const mainConfig = {


### PR DESCRIPTION
This extracts `@nteract/examples` to being outside the asar, for #3335 and then makes sure to load notebooks from the `app.asar.unpacked` location.