### PR TITLE
Fix parallel coordinate plot and d3 import

### DIFF
--- a/packages/transform-dataresource/src/ParallelCoordinatesController.js
+++ b/packages/transform-dataresource/src/ParallelCoordinatesController.js
@@ -243,11 +243,13 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
           oPadding={40}
           pixelColumnWidth={80}
           interaction={
-            filterMode && {
-              columnsBrush: true,
-              during: this.brushing,
-              extent: Object.keys(this.state.columnExtent)
-            }
+            filterMode
+              ? {
+                  columnsBrush: true,
+                  during: this.brushing,
+                  extent: Object.keys(this.state.columnExtent)
+                }
+              : null
           }
           pieceHoverAnnotation={!filterMode}
           tooltipContent={d => (

--- a/packages/transform-dataresource/src/charts/line.js
+++ b/packages/transform-dataresource/src/charts/line.js
@@ -1,6 +1,6 @@
 /* @flow */
 import * as React from "react";
-import { curveMonotone } from "d3-shape";
+import { curveMonotoneX } from "d3-shape";
 import { scaleLinear, scaleTime } from "d3-scale";
 
 import TooltipContent from "../tooltip-content";
@@ -61,7 +61,7 @@ export const semioticLineChart = (
     );
 
   return {
-    lineType: { type: lineType, interpolator: curveMonotone },
+    lineType: { type: lineType, interpolator: curveMonotoneX },
     lines: lineData,
     xScaleType: xScale,
     renderKey: (d: Object, i: number) => {


### PR DESCRIPTION
`curveMonotone` was replaced with `curveMonotone{X,Y} in [`d3-shape@0.5`](https://github.com/d3/d3-shape/commit/510357dd858cfc99c27fc119ed1b26930959a172).

Additionally this fixes the parallel coordinate plot since `interaction` expects a object instead of a boolean.