### PR TITLE
dont globally apply non-scoped styles

### DIFF
--- a/packages/presentational-components/__tests__/__snapshots__/header-editor-spec.js.snap
+++ b/packages/presentational-components/__tests__/__snapshots__/header-editor-spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Header Editor renders a static view when not editable 1`] = `
 <header
-  className="jsx-2279537447"
+  className="jsx-165954720"
 >
   <div
-    className="jsx-2279537447"
+    className="jsx-165954720"
     style={
       Object {
         "background": "#EEE",
@@ -36,7 +36,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </div>
     </h1>
     <div
-      className="jsx-2279537447"
+      className="jsx-165954720"
     >
       <span
         className="bp3-popover-wrapper"
@@ -80,7 +80,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </span>
     </div>
     <div
-      className="jsx-2279537447"
+      className="jsx-165954720"
     >
       <span
         className="bp3-popover-wrapper"
@@ -124,7 +124,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </span>
     </div>
     <div
-      className="jsx-2279537447"
+      className="jsx-165954720"
       style={
         Object {
           "marginTop": "10px",
@@ -154,10 +154,10 @@ exports[`Header Editor renders a static view when not editable 1`] = `
 
 exports[`Header Editor renders correctly with no props 1`] = `
 <header
-  className="jsx-2279537447"
+  className="jsx-165954720"
 >
   <div
-    className="jsx-2279537447"
+    className="jsx-165954720"
     style={
       Object {
         "background": "#EEE",
@@ -188,7 +188,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </div>
     </h1>
     <div
-      className="jsx-2279537447"
+      className="jsx-165954720"
     >
       <span
         className="bp3-popover-wrapper"
@@ -232,7 +232,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </span>
     </div>
     <div
-      className="jsx-2279537447"
+      className="jsx-165954720"
     >
       <span
         className="bp3-popover-wrapper"
@@ -276,7 +276,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </span>
     </div>
     <div
-      className="jsx-2279537447"
+      className="jsx-165954720"
       style={
         Object {
           "marginTop": "10px",

--- a/packages/styled-blueprintjsx/src/vendor/blueprint.css.js
+++ b/packages/styled-blueprintjsx/src/vendor/blueprint.css.js
@@ -1,4 +1,4 @@
-import css from 'styled-jsx/css';
+import css from "styled-jsx/css";
 
 export default css.global`@charset "UTF-8";
 /*!
@@ -7,6 +7,7 @@ Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
 Licensed under the terms of the LICENSE file distributed with this project.
 
 */
+/*
 html{
   -webkit-box-sizing:border-box;
           box-sizing:border-box; }
@@ -41,11 +42,15 @@ strong{
 
 ::selection{
   background:rgba(125, 188, 255, 0.6); }
+
+  */
+
 .bp3-heading{
   color:#182026;
   font-weight:600;
   margin:0 0 10px;
   padding:0; }
+
   .bp3-dark .bp3-heading{
     color:#f5f8fa; }
 
@@ -7301,4 +7306,4 @@ span.bp3-popover-target{
 
 .bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
   background-color:#137cbd; }
-/*# sourceMappingURL=blueprint.css.map */`
+/*# sourceMappingURL=blueprint.css.map */`;


### PR DESCRIPTION
Closes #3489 

I simply commented out the blueprint.js css that wasn't using class names.

Ideally, these styles would end up scoped along with the component.