### PR TITLE
set box-sizing: border-box across all our apps

### DIFF
--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -21,6 +21,8 @@
       -webkit-text-size-adjust: 100%; /* 2 */
     }
 
+
+
     /* Sections
        ========================================================================== */
 
@@ -259,6 +261,20 @@
     summary {
       display: list-item;
     }
+
+    /** Cribbed from blueprint.js' CSS */
+    /** Default to including padding and border in element's total width + height */
+
+    html{
+      -webkit-box-sizing:border-box;
+              box-sizing:border-box; }
+
+    *,
+    *::before,
+    *::after{
+      -webkit-box-sizing:inherit;
+              box-sizing:inherit; }
+
 
     /**
      * styled-jsx can't handle nesting so these have to end up in an inline

--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.js
@@ -24,6 +24,19 @@ class App extends React.Component<{ contentRef: ContentRef }, null> {
           :root {
             ${themes.light};
           }
+
+          html {
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+          }
+
+          *,
+          *::before,
+          *::after {
+            -webkit-box-sizing: inherit;
+            box-sizing: inherit;
+          }
+
           body {
             font-family: "Source Sans Pro";
             font-size: 16px;

--- a/packages/presentational-components/__tests__/__snapshots__/header-editor-spec.js.snap
+++ b/packages/presentational-components/__tests__/__snapshots__/header-editor-spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Header Editor renders a static view when not editable 1`] = `
 <header
-  className="jsx-165954720"
+  className="jsx-4281394543"
 >
   <div
-    className="jsx-165954720"
+    className="jsx-4281394543"
     style={
       Object {
         "background": "#EEE",
@@ -36,7 +36,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </div>
     </h1>
     <div
-      className="jsx-165954720"
+      className="jsx-4281394543"
     >
       <span
         className="bp3-popover-wrapper"
@@ -80,7 +80,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </span>
     </div>
     <div
-      className="jsx-165954720"
+      className="jsx-4281394543"
     >
       <span
         className="bp3-popover-wrapper"
@@ -124,7 +124,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </span>
     </div>
     <div
-      className="jsx-165954720"
+      className="jsx-4281394543"
       style={
         Object {
           "marginTop": "10px",
@@ -154,10 +154,10 @@ exports[`Header Editor renders a static view when not editable 1`] = `
 
 exports[`Header Editor renders correctly with no props 1`] = `
 <header
-  className="jsx-165954720"
+  className="jsx-4281394543"
 >
   <div
-    className="jsx-165954720"
+    className="jsx-4281394543"
     style={
       Object {
         "background": "#EEE",
@@ -188,7 +188,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </div>
     </h1>
     <div
-      className="jsx-165954720"
+      className="jsx-4281394543"
     >
       <span
         className="bp3-popover-wrapper"
@@ -232,7 +232,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </span>
     </div>
     <div
-      className="jsx-165954720"
+      className="jsx-4281394543"
     >
       <span
         className="bp3-popover-wrapper"
@@ -276,7 +276,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </span>
     </div>
     <div
-      className="jsx-165954720"
+      className="jsx-4281394543"
       style={
         Object {
           "marginTop": "10px",

--- a/packages/styled-blueprintjsx/src/vendor/blueprint.css.js
+++ b/packages/styled-blueprintjsx/src/vendor/blueprint.css.js
@@ -7,7 +7,6 @@ Copyright 2015-present Palantir Technologies, Inc. All rights reserved.
 Licensed under the terms of the LICENSE file distributed with this project.
 
 */
-/*
 html{
   -webkit-box-sizing:border-box;
           box-sizing:border-box; }
@@ -18,6 +17,7 @@ html{
   -webkit-box-sizing:inherit;
           box-sizing:inherit; }
 
+/*
 body{
   text-transform:none;
   line-height:1.28581;


### PR DESCRIPTION
While checking on the data explorer after #3493 I ran into this styling issue with the select element:

![image](https://user-images.githubusercontent.com/836375/47332853-99fe7100-d635-11e8-814f-3c6c7e860fd1.png)

Seemed sensible to go ahead and set box sizing to `border-box` unless a `::before` or `::after`, which I cribbed from blueprint.js. App looks fine and data explorer is back in a good state:

![screen shot 2018-10-22 at 8 08 01 pm](https://user-images.githubusercontent.com/836375/47333014-33c61e00-d636-11e8-81e5-5b1983c75ae1.png)
