### PR TITLE
switch to a makeMapStateToProps function in file

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.js
@@ -43,7 +43,7 @@ type FileProps = {
   error: ?{}
 };
 
-export class File extends React.PureComponent<FileProps, *> {
+export class File extends React.PureComponent<FileProps, null> {
   render() {
     // Determine the file handler
     let choice = null;
@@ -102,37 +102,44 @@ export class File extends React.PureComponent<FileProps, *> {
   }
 }
 
-const mapStateToProps = (
-  state: AppState,
-  ownProps: { contentRef: ContentRef, appBase: string }
-): FileProps => {
-  const content = selectors.content(state, ownProps);
+function makeMapStateToProps(
+  initialState: AppState,
+  initialOwnProps: { contentRef: ContentRef, appBase: string }
+): * {
+  const { contentRef, appBase } = initialOwnProps;
+  console.log(contentRef);
+  console.log(initialState);
+  console.log(appBase);
 
-  if (!content || content.type === "directory") {
-    throw new Error(
-      "The file component should only be used with files and notebooks"
-    );
-  }
+  return function mapStateToProps(state: AppState): FileProps {
+    const content = selectors.content(initialState, initialOwnProps);
 
-  const comms = selectors.communication(state, ownProps);
-  if (!comms) {
-    throw new Error("CommunicationByRef information not found");
-  }
+    if (!content || content.type === "directory") {
+      throw new Error(
+        "The file component should only be used with files and notebooks"
+      );
+    }
 
-  return {
-    type: content.type,
-    mimetype: content.mimetype,
-    contentRef: ownProps.contentRef,
-    lastSavedStatement: "recently",
-    appBase: ownProps.appBase,
-    baseDir: dirname(content.filepath),
-    displayName: content.filepath.split("/").pop(),
-    saving: comms.saving,
-    loading: comms.loading,
-    error: comms.error
+    const comms = selectors.communication(initialState, initialOwnProps);
+    if (!comms) {
+      throw new Error("CommunicationByRef information not found");
+    }
+
+    return {
+      type: content.type,
+      mimetype: content.mimetype,
+      contentRef,
+      lastSavedStatement: "recently",
+      appBase,
+      baseDir: dirname(content.filepath),
+      displayName: content.filepath.split("/").pop(),
+      saving: comms.saving,
+      loading: comms.loading,
+      error: comms.error
+    };
   };
-};
+}
 
-export const ConnectedFile = connect(mapStateToProps)(File);
+export const ConnectedFile = connect(makeMapStateToProps)(File);
 
 export default ConnectedFile;


### PR DESCRIPTION
This intends to replace `ownProps` usage with `makeMapStateToProps`.

I've started on #3434 via the approach outlined in https://github.com/nteract/nteract/issues/3434#issuecomment-432724332. I'm running into a few issues though. Flow is expecting an object instead of a function returned (do we have a global type override set somewhere...?):

![screen shot 2018-10-24 at 9 48 26 am](https://user-images.githubusercontent.com/836375/47447283-f9fa3200-d771-11e8-90af-078b2b3b8b0d.png)

The notebook doesn't show on load immediately (pure components blocking updates or something related to how I'm wielding `connect()` here?):

<img width="696" alt="screen shot 2018-10-24 at 9 49 07 am" src="https://user-images.githubusercontent.com/836375/47447338-1a29f100-d772-11e8-83ee-213cbf33d395.png">

Due to hot reload though if I make a change it will force a render:

<img width="696" alt="screen shot 2018-10-24 at 9 50 07 am" src="https://user-images.githubusercontent.com/836375/47447383-34fc6580-d772-11e8-8a2b-f035dc729776.png">
