### PR TITLE
ignore the gatsby transformer built output

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,6 @@ applications/**/node_modules
 coverage
 node_modules/
 */**/__snapshots__/
+
+# the gatsby transformer writes output to the root
+packages/gatsby-transformer-ipynb/*.js


### PR DESCRIPTION
When the gatsby transformer is built, it doesn't write out to `lib` (not sure if this has to be this way, but alas). The generated files don't match our linting setup so I've set them up to be ignored by eslint.