### PR TITLE
Correctly use MathJax Queue to render math

### DIFF
--- a/packages/core/src/epics/contents.js
+++ b/packages/core/src/epics/contents.js
@@ -152,7 +152,7 @@ export function autoSaveCurrentContentEpic(
 
       // document.hidden appears well supported
       if (typeof document.hidden !== "undefined") {
-        // // Opera 12.10 and Firefox 18 and later support
+        // Opera 12.10 and Firefox 18 and later support
         isVisible = !document.hidden;
         // $FlowAllowFeatureDetection
       } else if (typeof document.msHidden !== "undefined") {

--- a/packages/mathjax/src/context.js
+++ b/packages/mathjax/src/context.js
@@ -9,9 +9,7 @@ export type MathJaxObject = {
       StartupHook: (str: string, cb: () => void) => void,
       MessageHook: (string, cb: (msg: string) => void) => void
     },
-    Reprocess: (HTMLElement, cb: ?() => void) => *,
-    Typeset: (HTMLElement, cb: ?() => void) => *,
-    Queue: (*) => void,
+    Queue(...*): void,
     processSectionDelay: number
   }
 };

--- a/packages/mathjax/src/node.js
+++ b/packages/mathjax/src/node.js
@@ -95,7 +95,13 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
 
     if (!this.script) return;
 
-    MathJax.Hub.Queue(MathJax.Hub.Reprocess(this.script, this.props.onRender));
+    const reprocess = ["Reprocess", MathJax.Hub, this.script];
+
+    if (!this.props.onRender) {
+      MathJax.Hub.Queue(reprocess);
+    } else {
+      MathJax.Hub.Queue(reprocess, this.props.onRender);
+    }
   }
 
   /**
@@ -130,7 +136,7 @@ class MathJaxNode_ extends React.Component<Props & MathJaxContextValue, null> {
   }
 }
 
-class MathJaxNode extends React.Component<Props, null> {
+class MathJaxNode extends React.PureComponent<Props, null> {
   static defaultProps = {
     inline: false,
     onRender: null

--- a/packages/mathjax/src/provider.js
+++ b/packages/mathjax/src/provider.js
@@ -99,10 +99,6 @@ class Provider extends React.Component<Props, State> {
       if (this.props.didFinishTypeset) {
         this.props.didFinishTypeset();
       }
-
-      this.setState({
-        MathJax
-      });
     });
 
     MathJax.Hub.Register.MessageHook("Math Processing Error", message => {
@@ -114,6 +110,10 @@ class Provider extends React.Component<Props, State> {
     if (this.props.onLoad) {
       this.props.onLoad();
     }
+
+    this.setState({
+      MathJax
+    });
   };
 
   render() {

--- a/packages/mathjax/src/text.js
+++ b/packages/mathjax/src/text.js
@@ -33,10 +33,13 @@ class MathJaxText_ extends React.Component<Props & MathJaxContextValue, null> {
         "Could not find MathJax while attempting typeset! It's likely the MathJax script hasn't been loaded or MathJax.Context is not in the hierarchy."
       );
     }
+    const typeset = ["Typeset", MathJax.Hub, this.nodeRef.current];
 
-    MathJax.Hub.Queue(
-      MathJax.Hub.Typeset(this.nodeRef.current, this.props.onRender)
-    );
+    if (!this.props.onRender) {
+      MathJax.Hub.Queue(typeset);
+    } else {
+      MathJax.Hub.Queue(typeset, this.props.onRender);
+    }
   }
 
   render() {
@@ -44,7 +47,7 @@ class MathJaxText_ extends React.Component<Props & MathJaxContextValue, null> {
   }
 }
 
-class MathJaxText extends React.Component<Props, null> {
+class MathJaxText extends React.PureComponent<Props, null> {
   static defaultProps = {
     onRender: null
   };


### PR DESCRIPTION
Calling `MathJax.Hub.Typeset` executes the command right away and doesn't make use of the MathJax Queue wich leads to MathJax errors or broken rendering when opening a new notebook containing math.

It would be great to make a bugfix release for the `@nteract/mathjax` package so we can start using it in Hydrogen.

This largely reverts #3431 and properly fixes the root cause of the problem.

