### PR TITLE
Update markdown component docs

### DIFF
--- a/packages/outputs/src/components/media/markdown.js
+++ b/packages/outputs/src/components/media/markdown.js
@@ -4,11 +4,12 @@ import MarkdownComponent from "@nteract/markdown";
 
 type Props = {
   /**
-   * Markdown string.
+   * Markdown text.
    */
   data: string,
   /**
-   * Mime type. Defaults to `text/markdown`.
+   * Media type. Defaults to `text/markdown`.
+   * For more on media types, see: https://www.w3.org/TR/CSS21/media.html%23media-types.
    */
   mediaType: string
 };


### PR DESCRIPTION
Changing description of mime type to media type and Markdown string to Markdown text.

This is in response to comments by @rgbkrk from PR #3510.