### PR TITLE
Include scientists list in desktop release section

### DIFF
--- a/applications/desktop/scientists.txt
+++ b/applications/desktop/scientists.txt
@@ -1,0 +1,338 @@
+Louis Agassiz
+Maria Gaetana Agnesi
+Mihailo Petrovic Alas
+Angel Alcala
+Salim Ali
+Luis Alvarez
+Andre Marie Ampère
+Anaximander
+Mary Anning
+Virginia Apgar
+Agnes Arber
+Archimedes
+Aristarchus
+Aristotle
+Svante Arrhenius
+Avicenna
+Amedeo Avogadro
+Charles Babbage
+Francis Bacon
+Alexander Bain
+John Logie Baird
+Joseph Banks
+Ramon Barba
+John Bardeen
+Al-Battani
+Ibn Battuta
+William Bayliss
+George Beadle
+Arnold Orville Beckman
+Henri Becquerel
+Emil Adolf Behring
+Alexander Graham Bell
+Emile Berliner
+Claude Bernard
+Daniel Bernoulli
+Henry Bessemer
+Hans Bethe
+Homi Jehangir Bhabha
+Alfred Binet
+Clarence Birdseye
+Kristian Birkeland
+Elizabeth Blackwell
+Alfred Blalock
+Katharine Burr Blodgett # v0.12.1
+Franz Boas #v0.12.2
+David Bohm
+Aage Bohr
+Niels Bohr
+Ludwig Boltzmann
+Max Born
+Carl Bosch
+Robert Bosch
+Jagadish Chandra Bose
+Walther Wilhelm Georg Bothe
+Robert Boyle
+Tycho Brahe
+Brahmagupta
+Wernher Von Braun
+Louis de Broglie
+Alexander Brongniart
+Lester R. Brown
+Michael E. Brown
+Robert Brown
+William Buckland
+Georges-Louis Leclerc, Comte de Buffon
+Robert Bunsen
+Luther Burbank
+Jocelyn Bell Burnell
+Thomas Burnet
+Benjamin Cabrera
+Santiago Ramon y Cajal
+Rachel Carson
+George Washington Carver
+Henry Cavendish
+Anders Celsius
+James Chadwick
+Subrahmanyan Chandrasekhar
+Erwin Chargaff
+Noam Chomsky
+Steven Chu
+Leland Clark
+Nicolaus Copernicus
+Gerty Theresa Cori
+Charles-Augustin de Coulomb
+Jacques Cousteau
+Brian Cox
+Francis Crick
+Nicholas Culpeper
+Irene Joliot-Curie
+Marie Curie
+Pierre Curie
+Adalbert Czerny
+Gottlieb Daimler
+John Dalton
+James Dwight Dana
+Charles Darwin
+Humphry Davy
+Peter Debye
+Max Delbruck
+Jean Andre Deluc
+René Descartes
+Rudolf Christian Karl Diesel
+Paul Dirac
+Prokop Divis
+Theodosius Dobzhansky
+K. Eric Drexler
+Alberto Santos-Dumont
+Arthur Eddington
+Thomas Alva Edison
+Paul Ehrlich
+Albert Einstein
+Gertrude Elion
+Empedocles
+Eratosthenes
+Euclid
+Leonhard Euler
+Abu Nasr Al-Farabi
+Michael Faraday
+Pierre de Fermat
+Enrico Fermi
+Richard Feynman
+Emil Fischer
+Ronald Fisher
+Alexander Fleming
+Henry Ford
+Lee De Forest
+Dian Fossey
+Leon Foucault
+Benjamin Franklin
+Rosalind Franklin
+Sigmund Freud
+Galen
+Galileo Galilei
+Francis Galton
+Luigi Galvani
+George Gamow
+Carl Friedrich Gauss
+Willard Gibbs
+Sheldon Lee Glashow
+Robert Goddard
+Jane Goodall
+Fritz Haber
+Ernst Haeckel
+Otto Hahn
+Albrecht von Haller
+Edmund Halley
+William Harvey
+Stephen Hawking
+Otto Haxel
+Werner Heisenberg
+Hermann von Helmholtz
+Jan Baptist von Helmont
+Joseph Henry
+William Herschel
+Gustav Ludwig Hertz
+Heinrich Hertz
+Karl F. Herzfeld
+Antony Hewish
+David Hilbert
+Shintaro Hirase
+Dorothy Hodgkin
+Robert Hooke
+Frederick Gowland Hopkins
+William Hopkins
+Grace Murray Hopper
+Frank Hornby
+Jack Horner
+Bernardo Houssay
+Edwin Hubble
+Alexander Von Humboldt
+Zora Neale Hurston
+James Hutton
+Christiaan Huygens
+Ernesto Illy
+Ernst Ising
+Keisuke Ito
+Mae Carol Jemison
+Edward Jenner
+J. Hans D. Jensen
+James Prescott Joule
+Percy Lavon Julian
+Michio Kaku
+Friedrich August Kekulé
+Pearl Kendrick
+Johannes Kepler
+Jim Al-Khalili
+Abdul Qadeer Khan
+Omar Khayyam
+Muhammad ibn Musa al-Khwarizmi
+Alfred Kinsey
+Gustav Kirchoff
+Robert Koch
+Emil Kraepelin
+Thomas Kuhn
+Stephanie Kwolek
+Jean-Baptiste Lamarck
+Hedy Lamarr
+Edwin Herbert Land
+Karl Landsteiner
+Pierre-Simon Laplace
+Max von Laue
+Antoine Lavoisier
+Ernest Lawrence
+Henrietta Swan Leavitt
+Timothy John Berners-Lee
+Antonie van Leeuwenhoek
+Inge Lehmann
+Gottfried Leibniz
+Niccolo Leoniceno
+Aldo Leopold
+Willard Frank Libby
+Justus von Liebig
+Carolus Linnaeus
+Joseph Lister
+John Locke
+Hendrik Antoon Lorentz
+Konrad Lorenz
+Ada Lovelace
+Lucretius
+Charles Lyell
+Trofim Lysenko
+Ernst Mach
+Marcello Malpighi
+Murray Gell-Mann
+Jane Marcet
+Guglielmo Marconi
+Lynn Margulis
+James Clerk Maxwell
+Maria Goeppert-Mayer
+Ernst Mayr
+Barbara McClintock
+Lise Meitner
+Gregor Mendel
+Dmitri Mendeleev
+Antonio Meucci
+Albert Abraham Michelson
+Thomas Midgeley Jr.
+Thales of Miletus
+Maria Mitchell
+Mario Molina
+Rita Levi-Montalcini
+Thomas Hunt Morgan
+Henry Moseley
+Ukichiro Nakaya
+John Napier
+John Needham
+John von Neumann
+Thomas Newcomen
+Isaac Newton
+Tim Noakes
+Alfred Nobel
+Emmy Noether
+Bill Nye
+Hans Christian Oersted
+Georg Ohm
+Heike Kamerlingh Onnes
+J. Robert Oppenheimer
+Wilhelm Ostwald
+Blaise Pascal
+Louis Pasteur
+Wolfgang Ernst Pauli
+Linus Pauling
+Randy Pausch
+Ivan Pavlov
+Marguerite Perey
+Jean Piaget
+Fibonacci – Leonardo of Pisa
+Max Planck
+Beatrix Potter
+Joseph Priestley
+Pythagoras
+Harriet Quimby
+Thabit ibn Qurra
+C. V. Raman
+Srinivasa Ramanujan
+William Ramsay
+John Ray
+Prafulla Chandra Ray
+Francesco Redi
+Sally Ride
+Wilhelm Röntgen
+Hermann Rorschach
+Ronald Ross
+Ibn Rushd
+Ernest Rutherford
+Carl Sagan
+Mohammad Abdus Salam
+Jonas Salk
+Frederick Sanger
+Walter Schottky
+Erwin Schrödinger
+Theodor Schwann
+Glenn Seaborg
+Hans Selye
+Charles Sherrington
+Gene Shoemaker
+Ernst Werner von Siemens
+George Gaylord Simpson
+B. F. Skinner
+William Smith
+Frederick Soddy
+Arnold Sommerfeld
+Claude Levi-Strauss
+William John Swainson
+Leo Szilard
+Edward Teller
+Nikola Tesla
+Benjamin Thompson
+J. J. Thomson
+William Thomson
+Henry David Thoreau
+Kip S. Thorne
+Clyde Tombaugh
+Evangelista Torricelli
+Alan Turing
+Neil deGrasse Tyson
+Harold Urey
+Vladimir Vernadsky
+Andreas Vesalius
+Leonardo da Vinci
+Rudolf Virchow
+Artturi Virtanen
+Christiane Nusslein-Volhard
+Alessandro Volta
+Alfred Russel Wallace
+James Watson
+James Watt
+Alfred Wegener
+John Archibald Wheeler
+Thomas Willis
+E. O. Wilson
+Sven Wingqvist
+Sergei Winogradsky
+Friedrich Wöhler
+Wilbur and Orville Wright
+Wilhelm Wundt
+Chen-Ning Yang
+Ahmed Zewail


### PR DESCRIPTION
We use these on release (and could use them in a more automated fashion) so prompted by https://github.com/nteract/naming/issues/3 this introduces them into the desktop app dir.