### PR TITLE
include styles for errors inside the component

### DIFF
--- a/packages/outputs/src/components/kernel-output-error.js
+++ b/packages/outputs/src/components/kernel-output-error.js
@@ -46,9 +46,7 @@ export const KernelOutputError = (props: Props) => {
         <Ansi>{kernelOutputError.join("\n")}</Ansi>
         <style jsx>{`
           .kernel-output-error :global(code) {
-            font-family: "Source Code Pro";
             white-space: pre-wrap;
-            font-size: 14px;
           }
         `}</style>
       </div>

--- a/packages/outputs/src/components/kernel-output-error.js
+++ b/packages/outputs/src/components/kernel-output-error.js
@@ -26,11 +26,34 @@ type Props = {
 export const KernelOutputError = (props: Props) => {
   const { ename, evalue, traceback } = props;
 
-  if (!Array.isArray(traceback) || !traceback.length) {
-    return <Ansi>{`${ename}: ${evalue}`}</Ansi>;
+  const joinedTraceback = Array.isArray(traceback)
+    ? traceback.join("\n")
+    : traceback;
+
+  let kernelOutputError = [];
+
+  if (joinedTraceback) {
+    kernelOutputError.push(joinedTraceback);
+  } else {
+    if (ename && evalue) {
+      kernelOutputError.push(`${ename}: ${evalue}`);
+    }
   }
 
-  return <Ansi>{traceback.join("\n")}</Ansi>;
+  return (
+    <React.Fragment>
+      <div className="kernel-output-error">
+        <Ansi>{kernelOutputError.join("\n")}</Ansi>
+        <style jsx>{`
+          .kernel-output-error :global(code) {
+            font-family: "Source Code Pro";
+            white-space: pre-wrap;
+            font-size: 14px;
+          }
+        `}</style>
+      </div>
+    </React.Fragment>
+  );
 };
 
 KernelOutputError.defaultProps = {

--- a/packages/outputs/src/components/kernel-output-error.md
+++ b/packages/outputs/src/components/kernel-output-error.md
@@ -1,7 +1,4 @@
-The `<KernelOutputError />` component will render a Jupyter error, with primacy towards
-`traceback` and falling back on `ename` + `evalue` (old error style that is still sent by kernels). Tracebacks usually include the `ename` and `evalue` at the bottom.
-
-Per the Jupyter Messaging Protocol, the kernel will return the following payload if it encountered an error during the execution of a code cell.
+The `<KernelOutputError />` component will render a Jupyter error, commonly done as a traceback. An old error style that is still sent by kernels is the `ename` and `evalue`. Per the Jupyter Messaging Protocol, the kernel will return the following payload if it encountered an error during the execution of a code cell.
 
 ```json
 {
@@ -12,9 +9,11 @@ Per the Jupyter Messaging Protocol, the kernel will return the following payload
 }
 ```
 
-The `ename` property contains the name of the error (`OutOfMemory` or `NameError`). The `evalue` property contains the value of the error. This is usually the first line you see before the complete tracebook. The `traceback` property contains the stacktrace of the error as a list of strings, which each string consisting of a line within the stacktrace.
+The `ename` property contains the name of the error (`OutOfMemory` or `NameError`). The `evalue` property contains the value of the error. This is usually the first line you see before the complete traceback. The `traceback` property contains the stacktrace of the error as a list of strings, with each string consisting of a line within the stacktrace.
 
-We provide a special `KernelOutputError` component that will allow you to render the error payloads received from the kernel. You can pass the `ename,` `evalue`, and `tracebook` property values to render the error and tracebook in a clean format.
+We provide a special `KernelOutputError` component that will allow you to render the error payloads received from the kernel. You can pass the `ename,` `evalue`, and `traceback` property values to render the error and traceback in a clean format.
+
+Tracebacks usually include the `ename` and `evalue` at the bottom in python tracebacks. Hence we currently only render the traceback.
 
 ```jsx
 const errorMessage = {

--- a/packages/outputs/src/components/kernel-output-error.md
+++ b/packages/outputs/src/components/kernel-output-error.md
@@ -1,4 +1,5 @@
-The `<KernelOutputError />` component will render a Jupyter error with or without a traceback.
+The `<KernelOutputError />` component will render a Jupyter error, with primacy towards
+`traceback` and falling back on `ename` + `evalue` (old error style that is still sent by kernels). Tracebacks usually include the `ename` and `evalue` at the bottom.
 
 Per the Jupyter Messaging Protocol, the kernel will return the following payload if it encountered an error during the execution of a code cell.
 
@@ -16,10 +17,26 @@ The `ename` property contains the name of the error (`OutOfMemory` or `NameError
 We provide a special `KernelOutputError` component that will allow you to render the error payloads received from the kernel. You can pass the `ename,` `evalue`, and `tracebook` property values to render the error and tracebook in a clean format.
 
 ```jsx
-<KernelOutputError ename="NameError" evalue="Yikes!" traceback={["Yikes, never heard of that one!"]} />
+const errorMessage = {
+  output_type: "error",
+  ename: "NameError",
+  evalue: "name 'asdfaljsd' is not defined",
+  traceback: [
+    "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+    "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+    "\u001b[0;32m<ipython-input-2-e818d3730d2b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0masdfaljsd\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+    "\u001b[0;31mNameError\u001b[0m: name 'asdfaljsd' is not defined"
+  ]
+};
+
+<KernelOutputError
+  ename={errorMessage.ename}
+  evalue={errorMessage.evalue}
+  traceback={errorMessage.traceback}
+/>;
 ```
 
-You can also just render the `ename` and `evalue` for a more simplified view of error messages.
+With no traceback, the `ename` and `evalue` is used. This is common in older versions of this output type.
 
 ```jsx
 <KernelOutputError ename="NameError" evalue="Yikes!" />


### PR DESCRIPTION
In pursuit of https://github.com/nteract/nteract/issues/3342

I noticed that the error component on our components docs doesn't include the default styling. This sticks it in and includes a _real_ kernel error.

<img width="969" alt="screen shot 2018-10-25 at 1 43 25 pm" src="https://user-images.githubusercontent.com/836375/47529255-25594b80-d85c-11e8-80b2-f552d70d0ffb.png">

We're probably going to need to do the same bundling of style for `Media.HTML`, `Media.Image`, and 
possibly others. Possible issue though -- Hydrogen may want to override these styles but use the base component.

One approach that @emeeks and I talked about is passing in a `styled-jsx` stylesheet to override the default one.

```
<KernelOutputError styledJsx={css``} />
```

Thoughts @lgeiger @BenRussert?