### PR TITLE
Update styleguide docs for KernelOutputError

### DIFF
--- a/packages/outputs/src/components/kernel-output-error.js
+++ b/packages/outputs/src/components/kernel-output-error.js
@@ -2,9 +2,26 @@
 import * as React from "react";
 // $FlowFixMe
 import Ansi from "ansi-to-react";
-import type { ErrorOutput } from "@nteract/records";
 
-type Props = ErrorOutput;
+type Props = {
+  /**
+   *  The name of the exception. This value is returned by the kernel.
+   */
+  ename: string,
+  /**
+   * The value of the exception. This value is returned by the kernel.
+   */
+  evalue: string,
+  /**
+   * The output type passed to the Output component. This should be `error`
+   * if you would like to render a KernelOutputError component.
+   */
+  outputType: string,
+  /**
+   * The tracebook of the exception. This value is returned by the kernel.
+   */
+  traceback: Array<string>
+};
 
 export const KernelOutputError = (props: Props) => {
   const { ename, evalue, traceback } = props;

--- a/packages/outputs/src/components/kernel-output-error.md
+++ b/packages/outputs/src/components/kernel-output-error.md
@@ -1,8 +1,25 @@
 The `<KernelOutputError />` component will render a Jupyter error with or without a traceback.
 
+Per the Jupyter Messaging Protocol, the kernel will return the following payload if it encountered an error during the execution of a code cell.
+
+```json
+{
+   'status' : 'error',
+   'ename' : string,
+   'evalue' : string,
+   'traceback' : string[],
+}
+```
+
+The `ename` property contains the name of the error (`OutOfMemory` or `NameError`). The `evalue` property contains the value of the error. This is usually the first line you see before the complete tracebook. The `traceback` property contains the stacktrace of the error as a list of strings, which each string consisting of a line within the stacktrace.
+
+We provide a special `KernelOutputError` component that will allow you to render the error payloads received from the kernel. You can pass the `ename,` `evalue`, and `tracebook` property values to render the error and tracebook in a clean format.
+
 ```jsx
 <KernelOutputError ename="NameError" evalue="Yikes!" traceback={["Yikes, never heard of that one!"]} />
 ```
+
+You can also just render the `ename` and `evalue` for a more simplified view of error messages.
 
 ```jsx
 <KernelOutputError ename="NameError" evalue="Yikes!" />


### PR DESCRIPTION
A stab at updating the styleguide docs for KernelOutputError. I added some explainer text and brought in the prop types.