### PR TITLE
Cleanup style guide errors

### DIFF
--- a/packages/outputs/src/components/output.md
+++ b/packages/outputs/src/components/output.md
@@ -28,7 +28,6 @@ const output = Object.freeze({
 <Output output={output}>
   <KernelOutputError />
 </Output>;
-
 ```
 
 ```jsx
@@ -69,8 +68,8 @@ const outputs = [
 ];
 
 <div>
-  {outputs.map(output => (
-    <Output output={output}>
+  {outputs.map((output, index) => (
+    <Output output={output} key={index}>
       <StreamText />
       <DisplayData>
         <Plain />

--- a/packages/outputs/src/components/output.md
+++ b/packages/outputs/src/components/output.md
@@ -2,7 +2,7 @@ The `<Output />` element is a glorified Switch statement for picking what to ren
 
 ```jsx
 // Until we create <Stream />
-const StreamText = require("./stream-text").default;
+const { StreamText } = require("./stream-text");
 
 const output = Object.freeze({
   outputType: "stream",
@@ -34,7 +34,7 @@ const output = Object.freeze({
 const { RichMedia } = require("./rich-media");
 const { DisplayData } = require("./display-data");
 
-const StreamText = require("./stream-text").default;
+const { StreamText } = require("./stream-text");
 
 // Some "rich" handlers for Media
 const Plain = props => <marquee>{props.data}</marquee>;

--- a/packages/outputs/src/components/rich-media.md
+++ b/packages/outputs/src/components/rich-media.md
@@ -1,5 +1,5 @@
 ```jsx
-const Media = require('./media')
+const Media = require("./media");
 
 /**
  * First we'll create some simple components that take data and a mediaType for rendering
@@ -93,7 +93,7 @@ const Media = require('./media')
 The `<RichMedia />` component will pass the appropriate data from the media bundle to the element that accepts the media type. In this case, `<Plain />` is picked as the richest since `text/plain` is the only available. `"SparkContext ⚡️"` is passed as `<Plain data="SparkContext ⚡️" />` to render the richest media.
 
 ```jsx
-const Media = require('./media')
+const Media = require("./media");
 
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
@@ -109,7 +109,7 @@ Plain.defaultProps = {
 Whereas this output has a richer HTML output:
 
 ```jsx
-const Media = require('./media')
+const Media = require("./media");
 
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
@@ -178,7 +178,7 @@ Plain.defaultProps = {
 Which means that you can customize outputs as props!
 
 ```jsx
-const Media = require('./media')
+const Media = require("./media");
 
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
@@ -245,11 +245,12 @@ class Output extends React.Component {
 
 ### Handling Errors from `<Media />` components
 
-The `<RichMedia />` component comes with a built-in `componentDidCatch` fallback
+The `<RichMedia />` component comes with a built-in `componentDidCatch` fallback. To spare this style guide from being spammed with errors, we're not showing the error. To trigger it, uncomment the `throw new Error` line after clicking "View Code"
 
 ```jsx
 const Plain = props => {
-  throw new Error("💥 Broken Media Component");
+  // throw new Error("💥 Broken Media Component");
+  return <pre>{props.data}</pre>;
 };
 Plain.defaultProps = {
   mediaType: "text/plain"
@@ -257,7 +258,7 @@ Plain.defaultProps = {
 
 <RichMedia
   data={{
-    "text/plain": "<b>.____.</b>"
+    "text/plain": "Click View Code below to edit"
   }}
 >
   <Plain />
@@ -269,7 +270,8 @@ You can override the error formatting by passing a render callback as `renderErr
 ```jsx
 /* Purposefully broken component */
 const Plain = props => {
-  throw new Error("💥 Broken Media Component");
+  // throw new Error("💥 Broken Media Component");
+  return <pre>{props.data}</pre>;
 };
 Plain.defaultProps = {
   mediaType: "text/plain"
@@ -326,7 +328,7 @@ ${info.componentStack}
 
 <RichMedia
   data={{
-    "text/plain": "<b>.____.</b>"
+    "text/plain": "Click View Code below to edit"
   }}
   renderError={IssueCreator}
 >

--- a/packages/presentational-components/src/components/cells.md
+++ b/packages/presentational-components/src/components/cells.md
@@ -1,7 +1,6 @@
 ```jsx static
-import { Cells } from "@nteract/presentational-components"
+import { Cells } from "@nteract/presentational-components";
 ```
-
 
 `<Cells />` is a wrapper component to provide buffers between cells if you're building a notebook app.
 
@@ -54,7 +53,7 @@ import { Cells } from "@nteract/presentational-components"
               <th>2</th>
               <td>3</td>
             </tr>
-          </tbody>{" "}
+          </tbody>
         </table>
       </div>
     </Outputs>


### PR DESCRIPTION
This cleans up some of the errors in the console that can be confusing while trying to get things working in the style guide.

The last one that remains (not in this PR) is to not show directory listing elements individually (only as part of the larger listing). Right now they error since we're embedding pure `<td>` and `<tr>` elements outside of a `<table>`.