### PR TITLE
Prevent crashing of desktop app when running on Windows as a non-admin

### DIFF
--- a/applications/desktop/src/main/index.js
+++ b/applications/desktop/src/main/index.js
@@ -198,7 +198,14 @@ electronReady$
   .subscribe(createSplashSubscriber());
 
 app.on("before-quit", e => {
-  // When notebook windows are open we need to orchestrate shutdown manually.
+  // We use Electron's before-quit to give us a hook to into full app quit events,
+  // such as Command+Q on macOS.
+
+  // This is broken on Windows due to a bug in Electron; see #3549.
+  // For most Windows workflows the user will be closing individual notebook windows directly,
+  // so we just avoid this code path for now.
+  if (process.platform === "win32") return;
+
   const windows = BrowserWindow.getAllWindows();
   if (
     windows.length > 0 &&


### PR DESCRIPTION
Works-around #3549, which I would like to leave open so we eventually unwind this to ensure any initiation of an app-wide shutdown gracefully shuts down kernels. For example, if someone added a Quit option to the Windows system tray menu tomorrow, it would break given the hack in this PR.
