### PR TITLE
Allow environment variable NTERACT_DESKTOP_DISABLE_AUTO_UPDATE to disable desktop auto updater.

### DIFF
--- a/applications/desktop/src/main/auto-updater.js
+++ b/applications/desktop/src/main/auto-updater.js
@@ -2,8 +2,10 @@
 import { autoUpdater } from "electron-updater";
 
 export function initAutoUpdater() {
-  const log = require("electron-log");
-  log.transports.file.level = "info";
-  autoUpdater.logger = log;
-  autoUpdater.checkForUpdatesAndNotify();
+  if (process.env.NTERACT_DESKTOP_DISABLE_AUTO_UPDATE !== "1") {
+    const log = require("electron-log");
+    log.transports.file.level = "info";
+    autoUpdater.logger = log;
+    autoUpdater.checkForUpdatesAndNotify();
+  }
 }


### PR DESCRIPTION
- Requested in #3517.
- Seems generally useful in minimizing log spew on machines not connected to the Internet.
- Gives an option for working around Electron 3.x crashing upon shutdown in certain Windows httpproxy environments - https://github.com/electron/electron/issues/14411
