### PR TITLE
Add enzyme to dev dependencies with yarn

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,10 @@
     "react-perf/jsx-no-jsx-as-prop": "error",
     "import/order": ["error", { "newlines-between": "always" }],
     "import/newline-after-import": "error",
-    "import/no-duplicates": "warn"
+    "import/no-duplicates": "warn",
+    "import/no-extraneous-dependencies": [
+      "error", { "peerDependencies": true }
+    ]
   },
   "settings": {
     "react": {

--- a/packages/ansi-to-react/package.json
+++ b/packages/ansi-to-react/package.json
@@ -19,5 +19,8 @@
   "peerDependencies": {
     "react": "^16.3.2",
     "react-dom": "^16.3.2"
+  },
+  "devDependencies": {
+    "enzyme": "^3.7.0"
   }
 }

--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -42,5 +42,8 @@
     "styled-jsx": "^3.1.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/directory-listing/package.json
+++ b/packages/directory-listing/package.json
@@ -33,5 +33,8 @@
     "notebook tree view"
   ],
   "author": "Alexander C. Booth <alexander.c.booth@gmail.com",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -35,5 +35,8 @@
     "react-dom": "^16.3.2"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -29,5 +29,8 @@
     "@nteract/mathjax": "^3.0.1",
     "babel-runtime": "^6.26.0",
     "react-markdown": "^4.0.0"
+  },
+  "devDependencies": {
+    "enzyme": "^3.7.0"
   }
 }

--- a/packages/mathjax/package.json
+++ b/packages/mathjax/package.json
@@ -26,5 +26,8 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"
+  },
+  "devDependencies": {
+    "enzyme": "^3.7.0"
   }
 }

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -45,5 +45,8 @@
     "styled-jsx": "^3.1.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -34,5 +34,8 @@
     "styled-jsx": "^3.1.0"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/notebook-render/package.json
+++ b/packages/notebook-render/package.json
@@ -40,5 +40,8 @@
     "styled-jsx": "^3.1.0"
   },
   "author": "Benjamin Abel <dev.abel@laposte.net>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/outputs/package.json
+++ b/packages/outputs/package.json
@@ -31,5 +31,8 @@
     "outputs"
   ],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -35,5 +35,8 @@
     "components"
   ],
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "enzyme": "^3.7.0"
+  }
 }

--- a/packages/timeago/package.json
+++ b/packages/timeago/package.json
@@ -41,5 +41,8 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "babel-runtime": "^6.26.0"
+  },
+  "devDependencies": {
+    "enzyme": "^3.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,7 +5231,7 @@ enzyme-to-json@^3.3.1:
   dependencies:
     lodash "^4.17.4"
 
-enzyme@^3.3.0:
+enzyme@^3.3.0, enzyme@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.7.0.tgz#9b499e8ca155df44fef64d9f1558961ba1385a46"
   integrity sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==
@@ -7629,7 +7629,7 @@ is-root@2.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -9737,10 +9737,18 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.1.2, node-fetch@^1.0.1, node-fetch@^2.0.0, node-fetch@^2.1.2:
+node-fetch@2.1.2, node-fetch@^2.0.0, node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"


### PR DESCRIPTION
*~I was unable to add enzyme as a dev dependency to~
  ~@nteract/ansi-to-react with this method, as I was getting~
  ~an error: "Unknown workspace @nteract/ansi-to-react"~
Edit: solved and updated

After our discussion on issue #3473, this is the first per-package PR to add dependencies along with the no-extraneous-imports eslint rule. This PR covers 'enzyme' ~minus the workspace mentioned above~