### PR TITLE
dont serialize objects for rxjs 6 WebSockets

### DIFF
--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -169,7 +169,7 @@ export const connect = (
             }
           };
 
-          wsSubject.next(JSON.stringify(sessionizedMessage));
+          wsSubject.next(sessionizedMessage);
         } else {
           console.error(
             "Message must be a string or object, app sent",

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -156,11 +156,8 @@ export const connect = (
   // and ensuring it's serialized
   return Subject.create(
     Subscriber.create(
-      (message: string | any) => {
-        if (typeof message === "string") {
-          // Assume serialized
-          wsSubject.next(message);
-        } else if (typeof message === "object") {
+      (message: any) => {
+        if (typeof message === "object") {
           const sessionizedMessage = {
             ...message,
             header: {
@@ -171,10 +168,7 @@ export const connect = (
 
           wsSubject.next(sessionizedMessage);
         } else {
-          console.error(
-            "Message must be a string or object, app sent",
-            message
-          );
+          console.error("Message must be an object, the app sent", message);
         }
       },
       e => wsSubject.error(e),


### PR DESCRIPTION
RxJS 6 now serializes objects for us so we no longer need to `JSON.stringify` messages.

Major thank you to @mpacer for tracking this down on the python side to notice it was double serializing. 🙇 