### PR TITLE
Data Explorer clean up parallel coordinates

### DIFF
--- a/packages/transform-dataresource/src/HTMLLegend.js
+++ b/packages/transform-dataresource/src/HTMLLegend.js
@@ -24,11 +24,11 @@ const HTMLLegend = ({
         [...values.filter((d, index) => index < 18), "Other"]
       : values
     ).map(
-      (value, valuePosition) =>
+      (value, index) =>
         colorHash[value] && (
           <span
             style={{ display: "inline-block", minWidth: "80px", margin: "5px" }}
-            key={`legend-item-${valuePosition}`}
+            key={`legend-item-${index}`}
           >
             <span
               style={{


### PR DESCRIPTION
* Remove reference to Country in connector and replace with primary key based method
* Do the same for the grey color of points
* Go back to a fixed color regardless of brushing
* Suppress legend if < 18 instead of < 10 to match 18 max colors elsewhere
* Adjust point style and transparency to make filtered lines less prominent
* Make filtered values appear in grey on hover in Explore mode
* update valuePosition -> index in HTMLLegend