### PR TITLE
commutable: switch Notebook and Outputs from Maps to Records

### DIFF
--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -54,9 +54,6 @@ export const fromJS = (
       `commutable was passed an Immutable.Record structure that is not a notebook`
     );
   }
-  if (notebook.nbformat === 4) {
-    console.log(notebook);
-  }
 
   if (notebook.nbformat === 4 && notebook.nbformat_minor >= 0) {
     var v4Notebook = notebook as v4.Notebook;

--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -1,4 +1,4 @@
-import { Map as ImmutableMap, Record, RecordOf } from "immutable";
+import { Record } from "immutable";
 import * as v4 from "./v4";
 import * as v3 from "./v3";
 import { ImmutableNotebook, JSONType } from "./types";
@@ -25,16 +25,15 @@ export {
 } from "./structures";
 
 // v4
+export { StreamOutput, Output, createImmutableOutput } from "./v4";
+
 export {
-  StreamOutput,
-  Output,
   createImmutableMimeBundle,
-  createImmutableOutput,
   makeDisplayData,
   makeErrorOutput,
   makeStreamOutput,
   makeExecuteResult
-} from "./v4";
+} from "./outputs";
 
 // general
 

--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -29,7 +29,11 @@ export {
   StreamOutput,
   Output,
   createImmutableMimeBundle,
-  createImmutableOutput
+  createImmutableOutput,
+  makeDisplayData,
+  makeErrorOutput,
+  makeStreamOutput,
+  makeExecuteResult
 } from "./v4";
 
 // general

--- a/packages/commutable/src/outputs.ts
+++ b/packages/commutable/src/outputs.ts
@@ -1,0 +1,160 @@
+import {
+  Map as ImmutableMap,
+  List as ImmutableList,
+  Record,
+  RecordOf
+} from "immutable";
+
+export type ExecutionCount = number | null;
+
+export type ImmutableMimeBundle = ImmutableMap<string, any>;
+
+//
+// MimeBundle example (disk format)
+//
+// {
+//   "application/json": {"a": 3, "b": 2},
+//   "text/html": ["<p>\n", "Hey\n", "</p>"],
+//   "text/plain": "Hey"
+// }
+//
+export type MimeBundle = { [key: string]: string | string[] | Object };
+
+// Map over all the mimetypes, turning them into our in-memory format
+//
+// {
+//   "application/json": {"a": 3, "b": 2},
+//   "text/html": ["<p>\n", "Hey\n", "</p>"],
+//   "text/plain": "Hey"
+// }
+//
+// to
+//
+// {
+//   "application/json": {"a": 3, "b": 2},
+//   "text/html": "<p>\nHey\n</p>",
+//   "text/plain": "Hey"
+// }
+//
+export const cleanMimeAtKey = (
+  mimeBundle: MimeBundle,
+  previous: ImmutableMimeBundle,
+  key: string
+): ImmutableMimeBundle =>
+  previous.set(key, cleanMimeData(key, mimeBundle[key]));
+
+export const cleanMimeData = (
+  key: string,
+  data: string | string[] | object
+) => {
+  // See https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L368
+  if (isJSONKey(key)) {
+    // Data stays as is for JSON types
+    return data;
+  }
+
+  if (typeof data === "string" || Array.isArray(data)) {
+    return demultiline(data);
+  }
+
+  throw new TypeError(
+    `Data for ${key} is expected to be a string or an Array of strings`
+  );
+};
+
+export const createImmutableMimeBundle = (
+  mimeBundle: MimeBundle
+): ImmutableMimeBundle =>
+  Object.keys(mimeBundle).reduce(
+    cleanMimeAtKey.bind(null, mimeBundle),
+    ImmutableMap()
+  );
+
+export const demultiline = (s: string | string[]): string =>
+  Array.isArray(s) ? s.join("") : s;
+
+/**
+ * Split string into a list of strings delimited by newlines
+ */
+export const remultiline = (s: string | string[]): string[] =>
+  Array.isArray(s) ? s : s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== "");
+
+export const isJSONKey = (key: string) =>
+  /^application\/(.*\+)?json$/.test(key);
+
+/** ExecuteResult Record Boilerplate */
+type ExecuteResultParams = {
+  output_type: "execute_result";
+  execution_count: ExecutionCount;
+  data: ImmutableMimeBundle;
+  metadata?: any;
+};
+
+export const makeExecuteResult = Record<ExecuteResultParams>({
+  output_type: "execute_result",
+  execution_count: null,
+  data: ImmutableMap(),
+  metadata: ImmutableMap()
+});
+
+type ImmutableExecuteResult = RecordOf<ExecuteResultParams>;
+
+/** DisplayData Record Boilerplate */
+
+type DisplayDataParams = {
+  output_type: "display_data";
+  data: ImmutableMimeBundle;
+  metadata?: any;
+};
+
+export const makeDisplayData = Record<DisplayDataParams>({
+  output_type: "display_data",
+  data: ImmutableMap(),
+  metadata: ImmutableMap()
+});
+
+type ImmutableDisplayData = RecordOf<DisplayDataParams>;
+
+/** StreamOutput Record Boilerplate */
+
+type StreamOutputParams = {
+  output_type: "stream";
+  name: "stdout" | "stderr";
+  text: string;
+};
+
+export const makeStreamOutput = Record<StreamOutputParams>({
+  output_type: "stream",
+  name: "stdout",
+  text: ""
+});
+
+type ImmutableStreamOutput = RecordOf<StreamOutputParams>;
+
+/** ErrorOutput Record Boilerplate */
+
+type ErrorOutputParams = {
+  output_type: "error";
+  ename: string;
+  evalue: string;
+  traceback: ImmutableList<string>;
+};
+
+export const makeErrorOutput = Record<ErrorOutputParams>({
+  output_type: "error",
+  ename: "",
+  evalue: "",
+  traceback: ImmutableList()
+});
+
+type ImmutableErrorOutput = RecordOf<ErrorOutputParams>;
+
+//////////////
+
+export type ImmutableOutput =
+  | ImmutableExecuteResult
+  | ImmutableDisplayData
+  | ImmutableStreamOutput
+  | ImmutableErrorOutput;
+
+//////// OUTPUTS /////

--- a/packages/commutable/src/structures.ts
+++ b/packages/commutable/src/structures.ts
@@ -1,23 +1,17 @@
 import uuid from "uuid/v4";
-import {
-  Map as ImmutableMap,
-  List as ImmutableList,
-  Record,
-  RecordOf
-} from "immutable";
+import { Map as ImmutableMap, List as ImmutableList } from "immutable";
 
 import {
   makeNotebookRecord,
-  ImmutableOutput,
   ImmutableCell,
   ImmutableCodeCell,
   ImmutableMarkdownCell,
   ImmutableNotebook,
   ImmutableCellOrder,
-  ImmutableCellMap,
-  ImmutableJSONType,
-  ExecutionCount
+  ImmutableCellMap
 } from "./types";
+
+import { ExecutionCount, ImmutableOutput } from "./outputs";
 
 interface CodeCell {
   cell_type: "code";

--- a/packages/commutable/src/structures.ts
+++ b/packages/commutable/src/structures.ts
@@ -1,7 +1,13 @@
 import uuid from "uuid/v4";
-import { Map as ImmutableMap, List as ImmutableList } from "immutable";
+import {
+  Map as ImmutableMap,
+  List as ImmutableList,
+  Record,
+  RecordOf
+} from "immutable";
 
 import {
+  makeNotebookRecord,
   ImmutableOutput,
   ImmutableCell,
   ImmutableCodeCell,
@@ -12,15 +18,6 @@ import {
   ImmutableJSONType,
   ExecutionCount
 } from "./types";
-
-// We're hardset to nbformat v4.4 for what we use in-memory
-interface Notebook {
-  nbformat: 4;
-  nbformat_minor: 4;
-  metadata: ImmutableMap<string, ImmutableJSONType>;
-  cellOrder: ImmutableList<string>;
-  cellMap: ImmutableMap<string, ImmutableCell>;
-}
 
 interface CodeCell {
   cell_type: "code";
@@ -64,18 +61,12 @@ export const createMarkdownCell = (
 export const emptyCodeCell = createCodeCell();
 export const emptyMarkdownCell = createMarkdownCell();
 
-export const defaultNotebook = Object.freeze({
-  nbformat: 4,
-  nbformat_minor: 4,
-  metadata: ImmutableMap(),
-  cellOrder: ImmutableList(),
-  cellMap: ImmutableMap()
-}) as Notebook;
-
-export const createNotebook = (notebook = defaultNotebook): ImmutableNotebook =>
-  ImmutableMap(notebook);
-
-export const emptyNotebook = createNotebook();
+// These are all kind of duplicative now that we're on records
+// Since we export these though, they're left for
+// backwards compatiblity
+export const defaultNotebook = makeNotebookRecord();
+export const createNotebook = makeNotebookRecord;
+export const emptyNotebook = makeNotebookRecord();
 
 export type CellStructure = {
   cellOrder: ImmutableCellOrder;
@@ -98,10 +89,8 @@ export const appendCellToNotebook = (
   immCell: ImmutableCell
 ): ImmutableNotebook =>
   immnb.withMutations(nb => {
-    // $FlowFixMe: Fixed by making ImmutableNotebook a typed Record.
     const cellStructure: CellStructure = {
       cellOrder: nb.get("cellOrder"),
-      // $FlowFixMe: Fixed by making ImmutableNotebook a typed Record.
       cellMap: nb.get("cellMap")
     };
     const { cellOrder, cellMap } = appendCell(cellStructure, immCell);

--- a/packages/commutable/src/types.ts
+++ b/packages/commutable/src/types.ts
@@ -1,4 +1,9 @@
-import { Map as ImmutableMap, List as ImmutableList } from "immutable";
+import {
+  Map as ImmutableMap,
+  List as ImmutableList,
+  Record,
+  RecordOf
+} from "immutable";
 
 // Mutable JSON types
 export type PrimitiveImmutable = string | number | boolean | null;
@@ -23,8 +28,25 @@ export type MimeBundle = JSONObject;
 export type CellType = "markdown" | "code";
 export type CellID = string;
 
-// These are very unserious types, since Records are not quite typable
-export type ImmutableNotebook = ImmutableMap<string, any>;
+export type NotebookRecordParams = {
+  cellOrder: ImmutableList<string>;
+  cellMap: ImmutableMap<string, ImmutableCell>;
+  nbformat_minor: number;
+  nbformat: number;
+  metadata: ImmutableMap<string, any>;
+};
+
+export const makeNotebookRecord = Record<NotebookRecordParams>({
+  cellOrder: ImmutableList(),
+  cellMap: ImmutableMap(),
+  nbformat_minor: 0,
+  nbformat: 4,
+  metadata: ImmutableMap()
+});
+
+export type ImmutableNotebook = Record<NotebookRecordParams> &
+  Readonly<NotebookRecordParams>;
+
 export type ImmutableCodeCell = ImmutableMap<string, any>;
 export type ImmutableMarkdownCell = ImmutableMap<string, any>;
 export type ImmutableRawCell = ImmutableMap<string, any>;

--- a/packages/commutable/src/types.ts
+++ b/packages/commutable/src/types.ts
@@ -1,9 +1,6 @@
-import {
-  Map as ImmutableMap,
-  List as ImmutableList,
-  Record,
-  RecordOf
-} from "immutable";
+import { Map as ImmutableMap, List as ImmutableList, Record } from "immutable";
+
+import { ImmutableOutput } from "./outputs";
 
 // Mutable JSON types
 export type PrimitiveImmutable = string | number | boolean | null;
@@ -20,8 +17,6 @@ export type ImmutableJSONType =
   | ImmutableJSONList;
 interface ImmutableJSONMap extends ImmutableMap<string, ImmutableJSONType> {}
 interface ImmutableJSONList extends ImmutableList<ImmutableJSONType> {}
-
-export type ExecutionCount = number | null;
 
 export type MimeBundle = JSONObject;
 
@@ -51,10 +46,7 @@ export type ImmutableCodeCell = ImmutableMap<string, any>;
 export type ImmutableMarkdownCell = ImmutableMap<string, any>;
 export type ImmutableRawCell = ImmutableMap<string, any>;
 export type ImmutableCell = ImmutableCodeCell | ImmutableMarkdownCell;
-export type ImmutableOutput = ImmutableMap<string, any>;
 export type ImmutableOutputs = ImmutableList<ImmutableOutput>;
-
-export type ImmutableMimeBundle = ImmutableMap<string, any>;
 
 export type ImmutableCellOrder = ImmutableList<CellID>;
 export type ImmutableCellMap = ImmutableMap<CellID, ImmutableCell>;

--- a/packages/commutable/src/v3.ts
+++ b/packages/commutable/src/v3.ts
@@ -6,23 +6,26 @@ import {
 
 import {
   makeNotebookRecord,
-  ImmutableNotebook,
   ImmutableCodeCell,
   ImmutableMarkdownCell,
   ImmutableRawCell,
-  ImmutableOutput,
-  ImmutableMimeBundle,
   MultiLineString,
   JSONObject
 } from "./types";
-import { CellStructure, appendCell } from "./structures";
+
 import {
+  ImmutableOutput,
+  ImmutableMimeBundle,
+  makeExecuteResult,
+  makeDisplayData,
+  makeStreamOutput,
+  makeErrorOutput,
   demultiline,
-  cleanMimeAtKey,
-  ErrorOutput,
-  RawCell,
-  MarkdownCell
-} from "./v4";
+  cleanMimeAtKey
+} from "./outputs";
+
+import { CellStructure, appendCell } from "./structures";
+import { ErrorOutput, RawCell, MarkdownCell } from "./v4";
 
 const VALID_MIMETYPES = {
   text: "text/plain",
@@ -98,6 +101,7 @@ const createImmutableMarkdownCell = (
 const createImmutableMimeBundle = (output: MimeOutput): ImmutableMimeBundle => {
   const mimeBundle: { [key: string]: MultiLineString | undefined } = {};
   for (const key of Object.keys(output)) {
+    // v3 had non-media types for rich media
     if (key in VALID_MIMETYPES) {
       mimeBundle[VALID_MIMETYPES[key as MimeTypeKey]] =
         output[key as keyof MimePayload];
@@ -109,33 +113,30 @@ const createImmutableMimeBundle = (output: MimeOutput): ImmutableMimeBundle => {
   );
 };
 
-export const sanitize = (o: ExecuteResult | DisplayData) =>
-  o.metadata ? { metadata: immutableFromJS(o.metadata) } : {};
-
 const createImmutableOutput = (output: Output): ImmutableOutput => {
   switch (output.output_type) {
     case "pyout":
-      return ImmutableMap({
-        output_type: output.output_type,
+      return makeExecuteResult({
         execution_count: output.prompt_number,
+        // Note strangeness with v4 API
         data: createImmutableMimeBundle(output),
-        ...sanitize(output)
+        metadata: immutableFromJS(output.metadata)
       });
     case "display_data":
-      return ImmutableMap({
-        output_type: output.output_type,
+      return makeDisplayData({
         data: createImmutableMimeBundle(output),
-        ...sanitize(output)
+        metadata: immutableFromJS(output.metadata)
       });
     case "stream":
-      return ImmutableMap({
-        output_type: output.output_type,
-        name: output.stream,
+      // Default to stdout in all cases unless it's stderr
+      const name = output.stream === "stderr" ? "stderr" : "stdout";
+
+      return makeStreamOutput({
+        name,
         text: demultiline(output.text)
       });
     case "pyerr":
-      return ImmutableMap({
-        output_type: "error",
+      return makeErrorOutput({
         ename: output.ename,
         evalue: output.evalue,
         traceback: ImmutableList(output.traceback)

--- a/packages/commutable/src/v3.ts
+++ b/packages/commutable/src/v3.ts
@@ -5,6 +5,7 @@ import {
 } from "immutable";
 
 import {
+  makeNotebookRecord,
   ImmutableNotebook,
   ImmutableCodeCell,
   ImmutableMarkdownCell,
@@ -78,12 +79,12 @@ export interface Worksheet {
   metadata: object;
 }
 
-export interface Notebook {
+export type Notebook = {
   worksheets: Worksheet[];
   metadata: object;
   nbformat: 3;
   nbformat_minor: number;
-}
+};
 
 const createImmutableMarkdownCell = (
   cell: MarkdownCell
@@ -191,7 +192,7 @@ const createImmutableCell = (cell: Cell) => {
   }
 };
 
-export const fromJS = (notebook: Notebook): ImmutableNotebook => {
+export const fromJS = (notebook: Notebook) => {
   if (notebook.nbformat !== 3 || notebook.nbformat_minor < 0) {
     throw new TypeError(
       `Notebook is not a valid v3 notebook. v3 notebooks must be of form 3.x
@@ -214,7 +215,7 @@ export const fromJS = (notebook: Notebook): ImmutableNotebook => {
     )
   )[0];
 
-  return ImmutableMap({
+  return makeNotebookRecord({
     cellOrder: cellStructure.cellOrder.asImmutable(),
     cellMap: cellStructure.cellMap.asImmutable(),
     nbformat_minor: notebook.nbformat_minor,

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -18,9 +18,7 @@ import {
   Map as ImmutableMap,
   fromJS as immutableFromJS,
   List as ImmutableList,
-  Set as ImmutableSet,
-  Record,
-  RecordOf
+  Set as ImmutableSet
 } from "immutable";
 
 import {
@@ -31,25 +29,27 @@ import {
   ImmutableMarkdownCell,
   ImmutableRawCell,
   ImmutableCell,
-  ImmutableMimeBundle,
-  ExecutionCount,
   JSONObject,
   JSONType,
   MultiLineString
 } from "./types";
 
-import { appendCell, CellStructure } from "./structures";
+import {
+  createImmutableMimeBundle,
+  ImmutableOutput,
+  makeExecuteResult,
+  makeDisplayData,
+  makeStreamOutput,
+  makeErrorOutput,
+  demultiline,
+  remultiline,
+  isJSONKey,
+  MimeBundle,
+  ImmutableMimeBundle,
+  ExecutionCount
+} from "./outputs";
 
-//
-// MimeBundle example (disk format)
-//
-// {
-//   "application/json": {"a": 3, "b": 2},
-//   "text/html": ["<p>\n", "Hey\n", "</p>"],
-//   "text/plain": "Hey"
-// }
-//
-export type MimeBundle = { [key: string]: string | string[] | Object };
+import { appendCell, CellStructure } from "./structures";
 
 /** * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *                             Output Types
@@ -115,146 +115,6 @@ export type Notebook = {
   nbformat: 4;
   nbformat_minor: number;
 };
-
-export const demultiline = (s: string | string[]) =>
-  Array.isArray(s) ? s.join("") : s;
-
-/**
- * Split string into a list of strings delimited by newlines
- */
-export const remultiline = (s: string | string[]): string[] =>
-  Array.isArray(s) ? s : s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== "");
-
-export const isJSONKey = (key: string) =>
-  /^application\/(.*\+)?json$/.test(key);
-
-export const cleanMimeData = (
-  key: string,
-  data: string | string[] | object
-) => {
-  // See https://github.com/jupyter/nbformat/blob/62d6eb8803616d198eaa2024604d1fe923f2a7b3/nbformat/v4/nbformat.v4.schema.json#L368
-  if (isJSONKey(key)) {
-    // Data stays as is for JSON types
-    return data;
-  }
-
-  if (typeof data === "string" || Array.isArray(data)) {
-    return demultiline(data);
-  }
-
-  throw new TypeError(
-    `Data for ${key} is expected to be a string or an Array of strings`
-  );
-};
-
-// Map over all the mimetypes, turning them into our in-memory format
-//
-// {
-//   "application/json": {"a": 3, "b": 2},
-//   "text/html": ["<p>\n", "Hey\n", "</p>"],
-//   "text/plain": "Hey"
-// }
-//
-// to
-//
-// {
-//   "application/json": {"a": 3, "b": 2},
-//   "text/html": "<p>\nHey\n</p>",
-//   "text/plain": "Hey"
-// }
-//
-export const cleanMimeAtKey = (
-  mimeBundle: MimeBundle,
-  previous: ImmutableMimeBundle,
-  key: string
-): ImmutableMimeBundle =>
-  previous.set(key, cleanMimeData(key, mimeBundle[key]));
-
-export const createImmutableMimeBundle = (
-  mimeBundle: MimeBundle
-): ImmutableMimeBundle =>
-  Object.keys(mimeBundle).reduce(
-    cleanMimeAtKey.bind(null, mimeBundle),
-    ImmutableMap()
-  );
-
-export const sanitize = (o: ExecuteResult | DisplayData) =>
-  o.metadata ? { metadata: immutableFromJS(o.metadata) } : {};
-
-/** ExecuteResult Record Boilerplate */
-type ExecuteResultParams = {
-  output_type: "execute_result";
-  execution_count: ExecutionCount;
-  data: ImmutableMimeBundle;
-  metadata?: any;
-};
-
-export const makeExecuteResult = Record<ExecuteResultParams>({
-  output_type: "execute_result",
-  execution_count: null,
-  data: ImmutableMap(),
-  metadata: ImmutableMap()
-});
-
-type ImmutableExecuteResult = RecordOf<ExecuteResultParams>;
-
-/** DisplayData Record Boilerplate */
-
-type DisplayDataParams = {
-  output_type: "display_data";
-  data: ImmutableMimeBundle;
-  metadata?: any;
-};
-
-export const makeDisplayData = Record<DisplayDataParams>({
-  output_type: "display_data",
-  data: ImmutableMap(),
-  metadata: ImmutableMap()
-});
-
-type ImmutableDisplayData = RecordOf<DisplayDataParams>;
-
-/** StreamOutput Record Boilerplate */
-
-type StreamOutputParams = {
-  output_type: "stream";
-  name: "stdout" | "stderr";
-  text: string;
-};
-
-export const makeStreamOutput = Record<StreamOutputParams>({
-  output_type: "stream",
-  name: "stdout",
-  text: ""
-});
-
-type ImmutableStreamOutput = RecordOf<StreamOutputParams>;
-
-/** ErrorOutput Record Boilerplate */
-
-type ErrorOutputParams = {
-  output_type: "error";
-  ename: string;
-  evalue: string;
-  traceback: ImmutableList<string>;
-};
-
-export const makeErrorOutput = Record<ErrorOutputParams>({
-  output_type: "error",
-  ename: "",
-  evalue: "",
-  traceback: ImmutableList()
-});
-
-type ImmutableErrorOutput = RecordOf<ErrorOutputParams>;
-
-//////////////
-
-type ImmutableOutput =
-  | ImmutableExecuteResult
-  | ImmutableDisplayData
-  | ImmutableStreamOutput
-  | ImmutableErrorOutput;
 
 export const createImmutableOutput = (output: Output): ImmutableOutput => {
   switch (output.output_type) {

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -189,7 +189,7 @@ type ExecuteResultParams = {
   metadata?: any;
 };
 
-const makeExecuteResult = Record<ExecuteResultParams>({
+export const makeExecuteResult = Record<ExecuteResultParams>({
   output_type: "execute_result",
   execution_count: null,
   data: ImmutableMap(),
@@ -206,7 +206,7 @@ type DisplayDataParams = {
   metadata?: any;
 };
 
-const makeDisplayData = Record<DisplayDataParams>({
+export const makeDisplayData = Record<DisplayDataParams>({
   output_type: "display_data",
   data: ImmutableMap(),
   metadata: ImmutableMap()
@@ -222,7 +222,7 @@ type StreamOutputParams = {
   text: string;
 };
 
-const makeStreamOutput = Record<StreamOutputParams>({
+export const makeStreamOutput = Record<StreamOutputParams>({
   output_type: "stream",
   name: "stdout",
   text: ""
@@ -239,7 +239,7 @@ type ErrorOutputParams = {
   traceback: ImmutableList<string>;
 };
 
-const makeErrorOutput = Record<ErrorOutputParams>({
+export const makeErrorOutput = Record<ErrorOutputParams>({
   output_type: "error",
   ename: "",
   evalue: "",

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -24,7 +24,9 @@ import {
 } from "immutable";
 
 import {
+  makeNotebookRecord,
   ImmutableNotebook,
+  NotebookRecordParams,
   ImmutableCodeCell,
   ImmutableMarkdownCell,
   ImmutableRawCell,
@@ -107,12 +109,12 @@ export interface RawCell {
 
 export type Cell = CodeCell | MarkdownCell | RawCell;
 
-export interface Notebook {
+export type Notebook = {
   cells: Array<Cell>;
   metadata: Object;
   nbformat: 4;
   nbformat_minor: number;
-}
+};
 
 export const demultiline = (s: string | string[]) =>
   Array.isArray(s) ? s.join("") : s;
@@ -293,7 +295,7 @@ const createImmutableCell = (cell: Cell): ImmutableCell => {
   }
 };
 
-export const fromJS = (notebook: Notebook): ImmutableNotebook => {
+export const fromJS = (notebook: Notebook) => {
   if (notebook.nbformat !== 4 || notebook.nbformat_minor < 0) {
     throw new TypeError(
       `Notebook is not a valid v4 notebook. v4 notebooks must be of form 4.x
@@ -313,7 +315,7 @@ export const fromJS = (notebook: Notebook): ImmutableNotebook => {
     starterCellStructure as CellStructure
   );
 
-  return ImmutableMap({
+  return makeNotebookRecord({
     cellOrder: cellStructure.cellOrder.asImmutable(),
     cellMap: cellStructure.cellMap.asImmutable(),
     nbformat_minor: notebook.nbformat_minor,
@@ -321,14 +323,6 @@ export const fromJS = (notebook: Notebook): ImmutableNotebook => {
     metadata: immutableFromJS(notebook.metadata)
   });
 };
-
-interface PlainNotebook {
-  cellOrder: ImmutableList<string>;
-  cellMap: ImmutableMap<string, ImmutableCell>;
-  metadata: ImmutableMap<string, any>;
-  nbformat: 4;
-  nbformat_minor: number;
-}
 
 const metadataToJS = (immMetadata: ImmutableMap<string, any>) =>
   immMetadata.toJS() as JSONObject;
@@ -441,7 +435,7 @@ const cellToJS = (immCell: ImmutableCell): Cell => {
 };
 
 export const toJS = (immnb: ImmutableNotebook): Notebook => {
-  const plainNotebook = immnb.toObject() as PlainNotebook;
+  const plainNotebook = immnb.toObject() as NotebookRecordParams;
   const plainCellOrder: string[] = plainNotebook.cellOrder.toArray();
   const plainCellMap: {
     [key: string]: ImmutableCell;
@@ -454,7 +448,7 @@ export const toJS = (immnb: ImmutableNotebook): Notebook => {
   return {
     cells,
     metadata: plainNotebook.metadata.toJS(),
-    nbformat: plainNotebook.nbformat,
+    nbformat: 4,
     nbformat_minor: plainNotebook.nbformat_minor
   };
 };

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -18,7 +18,9 @@ import {
   Map as ImmutableMap,
   fromJS as immutableFromJS,
   List as ImmutableList,
-  Set as ImmutableSet
+  Set as ImmutableSet,
+  Record,
+  RecordOf
 } from "immutable";
 
 import {
@@ -27,7 +29,6 @@ import {
   ImmutableMarkdownCell,
   ImmutableRawCell,
   ImmutableCell,
-  ImmutableOutput,
   ImmutableMimeBundle,
   ExecutionCount,
   JSONObject,
@@ -175,12 +176,39 @@ export const createImmutableMimeBundle = (
     ImmutableMap()
   );
 
+const makeExecuteResult = Record({
+  output_type: "execute_result",
+  execution_count: null,
+  data: ImmutableMap(),
+  metadata: ImmutableMap()
+});
+
+type ExecuteResultParams = {
+  output_type: "execute_result";
+  execution_count: ExecutionCount;
+  data: ImmutableMimeBundle;
+  metadata?: any;
+};
+
+type ImmutableExecuteResult = RecordOf<ExecuteResultParams>;
+
 export const sanitize = (o: ExecuteResult | DisplayData) =>
   o.metadata ? { metadata: immutableFromJS(o.metadata) } : {};
+
+type ImmutableOutput = ImmutableExecuteResult | any;
 
 export const createImmutableOutput = (output: Output): ImmutableOutput => {
   switch (output.output_type) {
     case "execute_result":
+      /*
+    WISH
+      return makeExecuteResult({
+        execution_count: output.execution_count,
+        data: createImmutableMimeBundle(output.data),
+        metadata: immutableFromJS(output.metadata)
+      });
+     */
+
       return ImmutableMap({
         output_type: output.output_type,
         execution_count: output.execution_count,

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -6,7 +6,9 @@ import {
   emptyCodeCell,
   emptyMarkdownCell,
   appendCellToNotebook,
-  emptyNotebook
+  emptyNotebook,
+  makeDisplayData,
+  makeStreamOutput
 } from "@nteract/commutable";
 import * as Immutable from "immutable";
 
@@ -96,9 +98,7 @@ describe("reduceOutputs", () => {
     expect(
       Immutable.is(
         outputs,
-        Immutable.fromJS([
-          { name: "stdout", text: "hello", output_type: "stream" }
-        ])
+        Immutable.fromJS([makeStreamOutput({ name: "stdout", text: "hello" })])
       )
     ).toBe(true);
 
@@ -111,7 +111,7 @@ describe("reduceOutputs", () => {
       Immutable.is(
         outputs,
         Immutable.fromJS([
-          { name: "stdout", text: "hello world", output_type: "stream" }
+          makeStreamOutput({ name: "stdout", text: "hello world" })
         ])
       )
     ).toBe(true);
@@ -797,10 +797,10 @@ describe("appendOutput", () => {
       Immutable.is(
         state.getIn(["notebook", "cellMap", id, "outputs"]),
         Immutable.fromJS([
-          {
+          makeDisplayData({
             output_type: "display_data",
-            data: { "text/html": "<marquee>wee</marquee>" }
-          }
+            data: Immutable.Map({ "text/html": "<marquee>wee</marquee>" })
+          })
         ])
       )
     ).toBe(true);
@@ -824,17 +824,14 @@ describe("appendOutput", () => {
     });
 
     const state = reducers(originalState, action);
-    expect(
-      Immutable.is(
-        state.getIn(["notebook", "cellMap", id, "outputs"]),
-        Immutable.fromJS([
-          {
-            output_type: "display_data",
-            data: { "text/html": "<marquee>wee</marquee>" }
-          }
-        ])
-      )
-    ).toBe(true);
+    expect(state.getIn(["notebook", "cellMap", id, "outputs"])).toEqual(
+      Immutable.fromJS([
+        makeDisplayData({
+          data: Immutable.Map({ "text/html": "<marquee>wee</marquee>" })
+        })
+      ])
+    );
+
     expect(
       Immutable.is(
         state.getIn(["transient", "keyPathsForDisplays", "1234"]),
@@ -874,12 +871,12 @@ describe("updateDisplay", () => {
     );
 
     expect(state.getIn(["notebook", "cellMap", id, "outputs"])).toEqual(
-      Immutable.fromJS([
-        {
+      Immutable.List([
+        makeDisplayData({
           output_type: "display_data",
-          data: { "text/html": "<marquee>WOO</marquee>" },
-          metadata: {}
-        }
+          data: Immutable.Map({ "text/html": "<marquee>WOO</marquee>" }),
+          metadata: Immutable.Map({})
+        })
       ])
     );
   });


### PR DESCRIPTION
My goal is to turn everything that should be a record into a record (cells, outputs, notebook). Many of these have been `Map`s since the early days. One big benefit is that we can have a lot less `null` checking (no more `const outputType = output.get('output_type'); if(outputType) {...}`, we can just do `output.outputType`).

Some things must remain maps, like the aptly titled cell map (`Map<string, ImmutableCell>`) and then others should remain maps because they're unspecced areas like metadata.

* [x] Notebook
* [x] Output
  * [x] v4 Output
  * [x] v3 Output

Since this PR has gotten big enough, I will happily do cells in a new PR. We'll then be on fully typed records which should make it easier for us to transition off of Immutable (if we end up wanting to for sure).