### PR TITLE
lead unused arg with _ to indicate non-use

### DIFF
--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -37,7 +37,7 @@ export {
 
 // general
 
-const freezeReviver = <T extends JSONType>(k: string, v: T) =>
+const freezeReviver = <T extends JSONType>(_k: string, v: T) =>
   Object.freeze(v) as T;
 
 export type Notebook = v4.Notebook | v3.Notebook;


### PR DESCRIPTION
Just a quick little TypeScript cleanup to make this info warning go away:

<img width="604" alt="screen shot 2018-11-07 at 10 14 04 am" src="https://user-images.githubusercontent.com/836375/48151380-fdafad80-e275-11e8-8dfc-fd1447327189.png">
