### PR TITLE
Add styled-jsx as a dependency to packages that depend on it

### DIFF
--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -34,12 +34,12 @@
     "babel-runtime": "^6.26.0",
     "rc-menu": "6.2.11",
     "react-redux": "^5.0.7",
-    "redux": "^4.0.0"
+    "redux": "^4.0.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
-    "react": "^16.3.2",
-    "styled-jsx": "^3.1.0"
+    "react": "^16.3.2"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/directory-listing/package.json
+++ b/packages/directory-listing/package.json
@@ -19,7 +19,8 @@
     "@babel/runtime-corejs2": "^7.0.0",
     "@nteract/octicons": "^1.0.0-alpha.0",
     "@nteract/timeago": "^3.6.5",
-    "react-hot-loader": "^4.1.2"
+    "react-hot-loader": "^4.1.2",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -37,12 +37,12 @@
     "react-dnd-html5-backend": "^5.0.0",
     "react-hot-loader": "^4.1.2",
     "react-redux": "^5.0.7",
-    "redux": "^4.0.0"
+    "redux": "^4.0.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
-    "react": "^16.3.2",
-    "styled-jsx": "^3.1.0"
+    "react": "^16.3.2"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-preview/package.json
+++ b/packages/notebook-preview/package.json
@@ -26,12 +26,12 @@
     "@nteract/mathjax": "^3.0.1",
     "@nteract/presentational-components": "^2.0.0-alpha.0",
     "@nteract/transforms": "^5.0.0-alpha.0",
-    "babel-runtime": "^6.26.0"
+    "babel-runtime": "^6.26.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
-    "react": "^16.3.2",
-    "styled-jsx": "^3.1.0"
+    "react": "^16.3.2"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause"

--- a/packages/notebook-render/package.json
+++ b/packages/notebook-render/package.json
@@ -30,12 +30,12 @@
     "rehype-stringify": "^4.0.0",
     "remark": "^9.0.0",
     "remark-math": "^1.0.4",
-    "remark-rehype": "^3.0.0"
+    "remark-rehype": "^3.0.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.9",
-    "react": "^16.3.2",
-    "styled-jsx": "^3.1.0"
+    "react": "^16.3.2"
   },
   "author": "Benjamin Abel <dev.abel@laposte.net>",
   "license": "BSD-3-Clause"

--- a/packages/outputs/package.json
+++ b/packages/outputs/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
-    "ansi-to-react": "^4.0.0-alpha.0"
+    "ansi-to-react": "^4.0.0-alpha.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -22,8 +22,7 @@
     "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
-    "react": "^16.3.2",
-    "styled-jsx": "^3.1.0"
+    "react": "^16.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/styleguide-components/package.json
+++ b/packages/styleguide-components/package.json
@@ -14,7 +14,8 @@
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@babel/runtime-corejs2": "^7.0.0"
+    "@babel/runtime-corejs2": "^7.0.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/transforms/package.json
+++ b/packages/transforms/package.json
@@ -35,7 +35,8 @@
     "@nteract/transform-vdom": "^3.0.0-alpha.0",
     "ansi-to-react": "^4.0.0-alpha.0",
     "babel-runtime": "^6.26.0",
-    "react-json-tree": "^0.11.0"
+    "react-json-tree": "^0.11.0",
+    "styled-jsx": "^3.1.0"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
I've run into issues using certain nteract packages outside of nteract because package may depend on styled-jsx but it doesn't include it in its dependencies. Some packages list it in `peerDependencies` but I don't think this makes sense because it assumes that the app consuming it depends on styled-jsx. Some of these packages may not be intended to use outside of nteract, in which case styled-jsx should be `peerDependencies`. 