### PR TITLE
Use package name as styleguidist header

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -20,34 +20,34 @@ module.exports = {
   defaultExample: false,
   sections: [
     {
-      name: "Presentational Components",
+      name: "@nteract/presentational-components",
       components: "packages/presentational-components/src/components/*.tsx"
     },
     {
-      name: "Outputs",
+      name: "@nteract/outputs",
       components: "packages/outputs/src/components/*.js"
     },
     {
-      name: "Media Outputs",
+      name: "@nteract/outputs/media",
       components: "packages/outputs/src/components/media/*.js",
       content: "packages/outputs/src/components/media/index.md",
       ignore: "packages/outputs/src/components/media/index.js"
     },
     {
-      name: "Binder Hosts and Kernels",
+      name: "@mybinder/host-cache",
       components: "packages/host-cache/src/components/*.tsx",
       propsParser: typescriptPropsParser
     },
     {
-      name: "Directory Listing",
+      name: "@nteract/directory-listing",
       components: "packages/directory-listing/src/components/*.js"
     },
     {
-      name: "MarkdownRender",
+      name: "@nteract/markdown",
       content: "packages/markdown/examples.md"
     },
     {
-      name: "Maths",
+      name: "@nteract/mathjax",
       content: "packages/mathjax/examples.md"
     }
   ],


### PR DESCRIPTION
Realized while working on the play.nteract.io tutorial that it would make more sense for these titles to match up with the package names so they are easier to use in reference context.