### PR TITLE
Quit app when all windows closed on non-mac platforms

### DIFF
--- a/applications/desktop/src/main/index.js
+++ b/applications/desktop/src/main/index.js
@@ -233,6 +233,7 @@ windowAllClosed.pipe(skipUntil(appAndKernelSpecsReady)).subscribe(() => {
     process.platform !== "darwin" ||
     store.getState().get("quittingState") === QUITTING_STATE_QUITTING
   ) {
+    store.dispatch(setQuittingState(QUITTING_STATE_QUITTING));
     app.quit();
   }
 });


### PR DESCRIPTION
For non-mac platforms:
- If user closes last window, `window-all-closed` is called, followed by `before-quit`.
- If user quits via menu/ctrl-q, `before-quit` is called, each window is closed, then`window-all-closed` fires.

Fixes #3656