### PR TITLE
Remove unused .npmrc files

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-package-lock = false
-registry = https://registry.npmjs.org/

--- a/applications/commuter/.npmrc
+++ b/applications/commuter/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/applications/desktop/.npmrc
+++ b/applications/desktop/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/applications/jupyter-extension/.npmrc
+++ b/applications/jupyter-extension/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/applications/jupyter-extension/nteract_on_jupyter/.npmrc
+++ b/applications/jupyter-extension/nteract_on_jupyter/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/applications/play/.npmrc
+++ b/applications/play/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/ansi-to-react/.npmrc
+++ b/packages/ansi-to-react/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/commutable/.npmrc
+++ b/packages/commutable/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/core/.npmrc
+++ b/packages/core/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/directory-listing/.npmrc
+++ b/packages/directory-listing/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/display-area/.npmrc
+++ b/packages/display-area/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/dropdown-menu/.npmrc
+++ b/packages/dropdown-menu/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/editor/.npmrc
+++ b/packages/editor/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/enchannel-zmq-backend/.npmrc
+++ b/packages/enchannel-zmq-backend/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/fs-observable/.npmrc
+++ b/packages/fs-observable/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/gatsby-transformer-ipynb/.npmrc
+++ b/packages/gatsby-transformer-ipynb/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/host-cache/.npmrc
+++ b/packages/host-cache/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/iron-icons/.npmrc
+++ b/packages/iron-icons/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/logos/.npmrc
+++ b/packages/logos/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/markdown/.npmrc
+++ b/packages/markdown/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/mathjax/.npmrc
+++ b/packages/mathjax/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/messaging/.npmrc
+++ b/packages/messaging/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/monaco-editor/.npmrc
+++ b/packages/monaco-editor/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/notebook-app-component/.npmrc
+++ b/packages/notebook-app-component/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/notebook-preview/.npmrc
+++ b/packages/notebook-preview/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/notebook-render/.npmrc
+++ b/packages/notebook-render/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/octicons/.npmrc
+++ b/packages/octicons/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/presentational-components/.npmrc
+++ b/packages/presentational-components/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/records/.npmrc
+++ b/packages/records/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/rx-binder/.npmrc
+++ b/packages/rx-binder/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/rx-jupyter/.npmrc
+++ b/packages/rx-jupyter/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/styles/.npmrc
+++ b/packages/styles/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/timeago/.npmrc
+++ b/packages/timeago/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transform-dataresource/.npmrc
+++ b/packages/transform-dataresource/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transform-geojson/.npmrc
+++ b/packages/transform-geojson/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transform-model-debug/.npmrc
+++ b/packages/transform-model-debug/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transform-plotly/.npmrc
+++ b/packages/transform-plotly/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transform-vdom/.npmrc
+++ b/packages/transform-vdom/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transform-vega/.npmrc
+++ b/packages/transform-vega/.npmrc
@@ -1,2 +1,0 @@
-package-lock = false
-optional = false

--- a/packages/transforms-full/.npmrc
+++ b/packages/transforms-full/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false

--- a/packages/transforms/.npmrc
+++ b/packages/transforms/.npmrc
@@ -1,1 +1,0 @@
-package-lock = false


### PR DESCRIPTION
We're using `yarn` workspaces to install our dependencies. This makes the `.npmrc` files useless.