### PR TITLE
Add TypeDoc configuration for monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,7 @@ packages/styles/src/index.js
 
 styleguide
 
+# Ignore built TypeDocs
+nteract-packages/dist
+
 .idea/

--- a/nteract-packages/now.json
+++ b/nteract-packages/now.json
@@ -1,0 +1,9 @@
+{
+    "version": "1",
+    "name": "nteract-packages",
+    "alias": "packages.nteract.io",
+    "static": {
+      "public": "dist"
+    }
+  }
+  

--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
     "predocs:deploy": "npm run docs:build",
     "docs:deploy": "now ./styleguide",
     "docs:promote": "cd ./styleguide && now alias",
+    "package:docs": "typedoc --options typedoc.js packages/commutable/ packages/rx-jupyter/",
+    "prepackage:docs:deploy": "npm run package:docs",
+    "package:docs:deploy": "now ./nteract-packages",
+    "package:docs:promote": "cd ./nteract-packages && now alias",
     "test": "jest --reporters=default --reporters=jest-junit",
     "test:unit": "npm run test",
     "test:coverage": "npm run test -- --coverage",
@@ -199,6 +203,8 @@
     "style-loader": "^0.23.0",
     "styled-jsx": "^3.1.0",
     "ts-jest": "^23.10.4",
+    "typedoc": "^0.13.0",
+    "typedoc-plugin-external-module-name": "^1.1.3",
     "typescript": "^3.1.3",
     "unified": "^7.0.0",
     "unist-builder": "^1.0.2",
@@ -229,5 +235,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/commutable/index.ts
+++ b/packages/commutable/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module commutable
+ */
+
 export * from "./src";

--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 import { ImmutableOutput } from "./outputs";
 
 import { ExecutionCount } from "./primitives";

--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 // .....................................
 // API Exports
 // Make sure the index.js.flow types stay in sync with this section

--- a/packages/commutable/src/notebook.ts
+++ b/packages/commutable/src/notebook.ts
@@ -1,4 +1,7 @@
 /**
+ * @module commutable
+ */
+/**
  *
  * This is the top level data structure for in memory data structures,
  * and allows converting from on-disk v4 and v3 Jupyter Notebooks

--- a/packages/commutable/src/outputs.ts
+++ b/packages/commutable/src/outputs.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 import {
   Map as ImmutableMap,
   List as ImmutableList,

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 export type ExecutionCount = number | null;
 
 // Mutable JSON types

--- a/packages/commutable/src/structures.ts
+++ b/packages/commutable/src/structures.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 import uuid from "uuid/v4";
 
 import { CellID, makeNotebookRecord, ImmutableNotebook } from "./notebook";

--- a/packages/commutable/src/v3.ts
+++ b/packages/commutable/src/v3.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 import {
   Map as ImmutableMap,
   fromJS as immutableFromJS,

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -1,3 +1,6 @@
+/**
+ * @module commutable
+ */
 /*
  * Functions in this module are provided for converting from Jupyter Notebook
  * Format v4 to nteract's in-memory format, affectionately referred to as

--- a/packages/rx-jupyter/index.ts
+++ b/packages/rx-jupyter/index.ts
@@ -1,1 +1,4 @@
+/**
+ * @module rx-jupyter
+ */
 export * from "./src";

--- a/packages/rx-jupyter/src/base.ts
+++ b/packages/rx-jupyter/src/base.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import Cookies from "js-cookie";
 import { AjaxRequest } from "rxjs/ajax";
 

--- a/packages/rx-jupyter/src/contents.ts
+++ b/packages/rx-jupyter/src/contents.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import { ajax } from "rxjs/ajax";
 import querystring from "querystring";
 import urljoin from "url-join";

--- a/packages/rx-jupyter/src/index.ts
+++ b/packages/rx-jupyter/src/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import { ajax } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import { ajax } from "rxjs/ajax";
 import { webSocket } from "rxjs/webSocket";
 import { Subject, Subscriber } from "rxjs";

--- a/packages/rx-jupyter/src/kernelspecs.ts
+++ b/packages/rx-jupyter/src/kernelspecs.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import { ajax } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 

--- a/packages/rx-jupyter/src/sessions.ts
+++ b/packages/rx-jupyter/src/sessions.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import { ajax } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 

--- a/packages/rx-jupyter/src/terminals.ts
+++ b/packages/rx-jupyter/src/terminals.ts
@@ -1,3 +1,6 @@
+/**
+ * @module rx-jupyter
+ */
 import { ajax } from "rxjs/ajax";
 import urljoin from "url-join";
 import { Observable } from "rxjs";

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  name: "nteract",
+  mode: "modules",
+  out: "nteract-packages/dist",
+  theme: "default",
+  ignoreCompilerErrors: "true",
+  preserveConstEnums: "true",
+  exclude: [
+    "*.spec.ts",
+    "*.test.ts",
+    "**/node_modules/**",
+    "**/__tests__/**",
+    "**/packages/vega-embed2/**",
+    "*.js"
+  ],
+  externalPattern: "**/node_modules/**",
+  excludeExternals: "true",
+  stripInternal: "false",
+  tsconfig: "tsconfig.base.json"
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,6 +1602,11 @@
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.1.tgz#506d5781b9bcab81bd9a878b198aec7dee2a6033"
   integrity sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA==
 
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+  integrity sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==
+
 "@types/form-data@0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
@@ -1609,10 +1614,36 @@
   dependencies:
     "@types/node" "*"
 
+"@types/fs-extra@^5.0.3":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.4.tgz#b971134d162cc0497d221adde3dbb67502225599"
+  integrity sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==
+  dependencies:
+    "@types/node" "*"
+
 "@types/geojson@*":
   version "7946.0.4"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.4.tgz#4e049756383c3f055dd8f3d24e63fb543e98eb07"
   integrity sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==
+
+"@types/glob@*":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/handlebars@^4.0.38":
+  version "4.0.39"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.39.tgz#961fb54db68030890942e6aeffe9f93a957807bd"
+  integrity sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==
+
+"@types/highlight.js@^9.12.3":
+  version "9.12.3"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
+  integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
 "@types/jest@^23.3.8":
   version "23.3.9"
@@ -1636,10 +1667,20 @@
   dependencies:
     "@types/geojson" "*"
 
-"@types/lodash@^4.14.117":
+"@types/lodash@^4.14.110", "@types/lodash@^4.14.117":
   version "4.14.118"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
   integrity sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==
+
+"@types/marked@^0.4.0":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
+  integrity sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==
+
+"@types/minimatch@*", "@types/minimatch@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
+  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/mkdirp@^0.5.1":
   version "0.5.2"
@@ -1701,6 +1742,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/shelljs@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.0.tgz#0caa56b68baae4f68f44e0dd666ab30b098e3632"
+  integrity sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/styled-jsx@^2.2.7":
   version "2.2.7"
@@ -6867,7 +6916,7 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
 
-handlebars@^4.0.2, handlebars@^4.0.3:
+handlebars@^4.0.2, handlebars@^4.0.3, handlebars@^4.0.6:
   version "4.0.12"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
   integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
@@ -7040,7 +7089,7 @@ hastscript@^4.0.0:
     property-information "^4.0.0"
     space-separated-tokens "^1.0.0"
 
-highlight.js@^9.12.0:
+highlight.js@^9.0.0, highlight.js@^9.12.0:
   version "9.13.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
@@ -7492,7 +7541,7 @@ internal-ip@^3.0.1:
     default-gateway "^2.6.0"
     ipaddr.js "^1.5.2"
 
-interpret@^1.1.0:
+interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
   integrity sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=
@@ -9308,6 +9357,11 @@ markdown-to-jsx@^6.8.3:
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"
+
+marked@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
+  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
 
 martinez-polygon-clipping@^0.1.5:
   version "0.1.5"
@@ -12080,6 +12134,13 @@ recast@^0.13.0:
     private "~0.1.5"
     source-map "~0.6.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 recompose@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.1.tgz#1a49e931f183634516633bbb4f4edbfd3f38a7ba"
@@ -12537,7 +12598,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -12986,6 +13047,15 @@ shell-quote@1.6.1, shell-quote@^1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shelljs@^0.8.2:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -14204,7 +14274,40 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1.3:
+typedoc-default-themes@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
+  integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
+
+typedoc-plugin-external-module-name@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-1.1.3.tgz#ea1c8c7650dae7a105f0d9d55a6aa5cab7816db2"
+  integrity sha512-/VMawTW4NnUUsgq0o8O37y9MmXFaOCDrH1dvDg7SZUS5ZSpUPSILVWwGJP+7g4I8vKZ5bBKZKHfPIEA4xUC+PQ==
+
+typedoc@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.13.0.tgz#9efdf352bd54873955cd161bd4b75f24a8c59dde"
+  integrity sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==
+  dependencies:
+    "@types/fs-extra" "^5.0.3"
+    "@types/handlebars" "^4.0.38"
+    "@types/highlight.js" "^9.12.3"
+    "@types/lodash" "^4.14.110"
+    "@types/marked" "^0.4.0"
+    "@types/minimatch" "3.0.3"
+    "@types/shelljs" "^0.8.0"
+    fs-extra "^7.0.0"
+    handlebars "^4.0.6"
+    highlight.js "^9.0.0"
+    lodash "^4.17.10"
+    marked "^0.4.0"
+    minimatch "^3.0.0"
+    progress "^2.0.0"
+    shelljs "^0.8.2"
+    typedoc-default-themes "^0.5.0"
+    typescript "3.1.x"
+
+typescript@3.1.x, typescript@^3.1.3:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==


### PR DESCRIPTION
Huzzah! Finally figured this out.

Here's an example of the deployment for rx-jupyter and commutable: https://packages.nteract.io.

![screen shot 2018-11-23 at 10 28 31 pm](https://user-images.githubusercontent.com/1857993/48964537-39818d00-ef6f-11e8-84dd-b1cb5b048307.png)

We'll need to pass in the name of each package that we'd like to generate docs for to the `package:docs` command and we'll also need to add a `@module package-name` comment to the top of every file in a package but this documents all our functions and types.
