### PR TITLE
Update transform-vdom to work with vdom's event handlers

### DIFF
--- a/packages/transform-vdom/src/event-to-object.ts
+++ b/packages/transform-vdom/src/event-to-object.ts
@@ -1,0 +1,186 @@
+import * as React from "react";
+
+import { Attributes } from "./object-to-react";
+
+export function serializeEvent<T>(event: React.SyntheticEvent<T>): Attributes {
+  switch (event.type) {
+    // Clipboard events
+    case "copy":
+    case "cut":
+    case "paste":
+      const clipboardEvent = event as React.ClipboardEvent<T>;
+      return { clipboardData: clipboardEvent.clipboardData };
+    // Composition events
+    case "compositionend":
+    case "compositionstart":
+    case "compositionupdate":
+      const compositionEvent = event as React.CompositionEvent<T>;
+      return { data: compositionEvent.data };
+    // Keyboard events
+    case "keydown":
+    case "keypress":
+    case "keyup":
+      const keyboardEvent = event as React.KeyboardEvent<T>;
+      return {
+        altKey: keyboardEvent.altKey,
+        charCode: keyboardEvent.charCode,
+        ctrlKey: keyboardEvent.ctrlKey,
+        key: keyboardEvent.key,
+        keyCode: keyboardEvent.keyCode,
+        locale: keyboardEvent.locale,
+        location: keyboardEvent.location,
+        metaKey: keyboardEvent.metaKey,
+        repeat: keyboardEvent.repeat,
+        shiftKey: keyboardEvent.shiftKey,
+        which: keyboardEvent.which
+      };
+    // Focus events
+    case "focus":
+    case "blur":
+      return {};
+    // Form events
+    case "change":
+    case "input":
+    case "invalid":
+    case "submit":
+      const formEvent = event as React.ChangeEvent<T>;
+      return { value: (formEvent.target as any).value };
+    // Mouse events
+    case "click":
+    case "contextmenu":
+    case "doubleclick":
+    case "drag":
+    case "dragend":
+    case "dragenter":
+    case "dragexit":
+    case "dragleave":
+    case "dragover":
+    case "dragstart":
+    case "drop":
+    case "mousedown":
+    case "mouseenter":
+    case "mouseleave":
+    case "mousemove":
+    case "mouseout":
+    case "mouseover":
+    case "mouseup":
+      const mouseEvent = event as React.MouseEvent<T>;
+      return {
+        altKey: mouseEvent.altKey,
+        button: mouseEvent.button,
+        buttons: mouseEvent.buttons,
+        clientX: mouseEvent.clientX,
+        clientY: mouseEvent.clientY,
+        ctrlKey: mouseEvent.ctrlKey,
+        metaKey: mouseEvent.metaKey,
+        pageX: mouseEvent.pageX,
+        pageY: mouseEvent.pageY,
+        screenX: mouseEvent.screenX,
+        screenY: mouseEvent.screenY,
+        shiftKey: mouseEvent.shiftKey
+      };
+    // Pointer events
+    case "pointerdown":
+    case "pointermove":
+    case "pointerup":
+    case "pointercancel":
+    case "gotpointercapture":
+    case "lostpointercapture":
+    case "pointerenter":
+    case "pointerleave":
+    case "pointerover":
+    case "pointerout":
+      const pointerEvent = event as React.PointerEvent<T>;
+      return {
+        pointerId: pointerEvent.pointerId,
+        width: pointerEvent.width,
+        height: pointerEvent.height,
+        pressure: pointerEvent.pressure,
+        tiltX: pointerEvent.tiltX,
+        tiltY: pointerEvent.tiltY,
+        pointerType: pointerEvent.pointerType,
+        isPrimary: pointerEvent.isPrimary
+      };
+    // Selection events
+    case "select":
+      return {};
+    // return {value: selectEvent.target.value};
+    // Touch events
+    case "touchcancel":
+    case "touchend":
+    case "touchmove":
+    case "touchstart":
+      const touchEvent = event as React.TouchEvent<T>;
+      return {
+        altKey: touchEvent.altKey,
+        ctrlKey: touchEvent.ctrlKey,
+        metaKey: touchEvent.metaKey,
+        shiftKey: touchEvent.shiftKey
+      };
+    // UI events
+    case "scroll":
+      const uiEvent = event as React.UIEvent<T>;
+      return { detail: uiEvent.detail };
+    // Wheel events
+    case "wheel":
+      const wheelEvent = event as React.WheelEvent<T>;
+      return {
+        deltaMode: wheelEvent.deltaMode,
+        deltaX: wheelEvent.deltaX,
+        deltaY: wheelEvent.deltaY,
+        deltaZ: wheelEvent.deltaZ
+      };
+    // Media events
+    case "abort":
+    case "canplay":
+    case "canplaythrough":
+    case "durationchange":
+    case "emptied":
+    case "encrypted":
+    case "ended":
+    case "error":
+    case "loadeddata":
+    case "loadedmetadata":
+    case "loadstart":
+    case "pause":
+    case "play":
+    case "playing":
+    case "progress":
+    case "ratechange":
+    case "seeked":
+    case "seeking":
+    case "stalled":
+    case "suspend":
+    case "timeupdate":
+    case "volumechange":
+    case "waiting":
+      return {};
+    // Image events
+    case "load":
+    case "error":
+      return {};
+    // Animation events
+    case "animationstart":
+    case "animationend":
+    case "animationiteration":
+      const animationEvent = event as React.AnimationEvent<T>;
+      return {
+        animationName: animationEvent.animationName,
+        pseudoElement: animationEvent.pseudoElement,
+        elapsedTime: animationEvent.elapsedTime
+      };
+    // Transition events
+    case "transitionend":
+      const transitionEvent = event as React.TransitionEvent<T>;
+      return {
+        propertyName: transitionEvent.propertyName,
+        pseudoElement: transitionEvent.pseudoElement,
+        elapsedTime: transitionEvent.elapsedTime
+      };
+    // Other events
+    case "toggle":
+      return {};
+    default:
+      return {};
+  }
+}

--- a/packages/transform-vdom/src/event-to-object.ts
+++ b/packages/transform-vdom/src/event-to-object.ts
@@ -1,8 +1,22 @@
 import * as React from "react";
 
-import { Attributes } from "./object-to-react";
+export type SerializedEvent<T> =
+  | Partial<React.ClipboardEvent<T>>
+  | Partial<React.CompositionEvent<T>>
+  | Partial<React.KeyboardEvent<T>>
+  | Partial<React.ChangeEvent<T>>
+  | Partial<React.MouseEvent<T>>
+  | Partial<React.PointerEvent<T>>
+  | Partial<React.TouchEvent<T>>
+  | Partial<React.UIEvent<T>>
+  | Partial<React.WheelEvent<T>>
+  | Partial<React.AnimationEvent<T>>
+  | Partial<React.TransitionEvent<T>>
+  | {};
 
-export function serializeEvent<T>(event: React.SyntheticEvent<T>): Attributes {
+export function serializeEvent<T>(
+  event: React.SyntheticEvent<T>
+): SerializedEvent<T> {
   switch (event.type) {
     // Clipboard events
     case "copy":

--- a/packages/transform-vdom/src/index.tsx
+++ b/packages/transform-vdom/src/index.tsx
@@ -18,7 +18,10 @@ export default class VDOM extends React.PureComponent<Props> {
   static MIMETYPE = mediaType;
 
   static defaultProps = {
-    mediaType
+    mediaType,
+    onVDOMEvent: () => {
+      console.log("This app doesn't support vdom events ☹️ See @nteract/transform-vdom for more info: https://github.com/nteract/nteract/tree/master/packages/transform-vdom");
+    }
   };
 
   render(): React.ReactElement<any> {

--- a/packages/transform-vdom/src/index.tsx
+++ b/packages/transform-vdom/src/index.tsx
@@ -27,7 +27,7 @@ export default class VDOM extends React.PureComponent<Props> {
   render(): React.ReactElement<any> {
     try {
       // objectToReactElement is mutatitve so we'll clone our object
-      var obj = cloneDeep(this.props.data);
+      const obj = cloneDeep(this.props.data);
       return objectToReactElement(obj, this.props.onVDOMEvent);
     } catch (err) {
       return (

--- a/packages/transform-vdom/src/index.tsx
+++ b/packages/transform-vdom/src/index.tsx
@@ -2,16 +2,16 @@ import * as React from "react";
 import { cloneDeep } from "lodash";
 
 import { objectToReactElement, VDOMEl, Attributes } from "./object-to-react";
-import { serializeEvent } from "./event-to-object";
+import { serializeEvent, SerializedEvent } from "./event-to-object";
 
 interface Props {
   mediaType: "application/vdom.v1+json";
   data: VDOMEl;
-  onVDOMEvent: (targetName: string, event: Attributes) => void;
+  onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void;
 }
 
 // Provide object-to-react as an available helper on the library
-export { objectToReactElement, serializeEvent, VDOMEl, Attributes };
+export { objectToReactElement, serializeEvent, VDOMEl, Attributes, SerializedEvent };
 
 const mediaType = "application/vdom.v1+json";
 

--- a/packages/transform-vdom/src/object-to-react.ts
+++ b/packages/transform-vdom/src/object-to-react.ts
@@ -32,6 +32,9 @@
  */
 
 import * as React from "react";
+import { serializeEvent, SerializedEvent } from "./event-to-object";
+
+export { SerializedEvent } from "./event-to-object";
 
 export interface Attributes {
   [key: string]: any;
@@ -58,13 +61,59 @@ export interface VDOMEl {
  * @param  {Object}       obj - The element object.
  * @return {ReactElement}
  */
-export function objectToReactElement(obj: VDOMEl): React.ReactElement<any> {
+export function objectToReactElement(
+  obj: VDOMEl,
+  onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void
+): React.ReactElement<any> {
+  /**
+   * Convert an array of items to React children.
+   *
+   * @param  {Array} arr - The array.
+   * @return {Array}     - The array of mixed values.
+   */
+  function arrayToReactChildren(
+    arr: Array<VDOMEl>
+  ): React.ReactNodeArray {
+    let result = [];
+
+    // iterate through the `children`
+    for (let i = 0, len = arr.length; i < len; i++) {
+      // child can have mixed values: text, React element, or array
+      const item = arr[i];
+      if (item === null) {
+        continue;
+      } else if (Array.isArray(item)) {
+        result.push(arrayToReactChildren(item));
+      } else if (typeof item === "string") {
+        result.push(item);
+      } else if (typeof item === "object") {
+        // Create a new object so that if we have to set the key, we are not
+        // mutating the original object
+        const keyedItem = {
+          tagName: item.tagName,
+          attributes: item.attributes,
+          children: item.children,
+          key: i
+        };
+        if (item.attributes && item.attributes.key) {
+          keyedItem.key = item.attributes.key;
+        }
+        result.push(objectToReactElement(keyedItem, onVDOMEvent));
+      } else {
+        throw new Error(`invalid vdom child: "${item}"`);
+      }
+    }
+
+    return result;
+  }
+
   // Pack args for React.createElement
   let args = [];
 
   if (!obj.tagName || typeof obj.tagName !== "string") {
     throw new Error(`Invalid tagName on ${JSON.stringify(obj, null, 2)}`);
   }
+
   if (
     !obj.attributes ||
     Array.isArray(obj.attributes) ||
@@ -86,6 +135,22 @@ export function objectToReactElement(obj: VDOMEl): React.ReactElement<any> {
     );
   }
 
+  // Add event handlers to attributes.
+  // Replace event handlers values (target name) with callback functions that
+  // serialize the event object and call `onVDOMEvent` with the comm target name
+  // and serialized event.
+  // `onVDOMEvent` will send a comm message to a comm channel of target name
+  // with a body of serialized event and vdom on kernel will handle the event.
+  if (obj.eventHandlers) {
+    for (let eventType in obj.eventHandlers) {
+      const targetName = obj.eventHandlers[eventType];
+      obj.attributes[eventType] = (event: React.SyntheticEvent<any>) => {
+        const serializedEvent = serializeEvent(event);
+        onVDOMEvent(targetName, serializedEvent);
+      };
+    }
+  }
+
   // `React.createElement` 1st argument: type
   args[0] = obj.tagName;
   args[1] = obj.attributes;
@@ -102,7 +167,7 @@ export function objectToReactElement(obj: VDOMEl): React.ReactElement<any> {
     } else if (typeof children === "string") {
       args[2] = children;
     } else if (typeof children === "object") {
-      args[2] = objectToReactElement(children as VDOMEl);
+      args[2] = objectToReactElement(children as VDOMEl, onVDOMEvent);
     } else {
       throw new Error(
         "children of a vdom element must be a string, object, null, or array of vdom nodes"
@@ -112,44 +177,4 @@ export function objectToReactElement(obj: VDOMEl): React.ReactElement<any> {
 
   // $FlowFixMe: React
   return React.createElement.apply({}, args);
-}
-
-/**
- * Convert an array of items to React children.
- *
- * @param  {Array} arr - The array.
- * @return {Array}     - The array of mixed values.
- */
-export function arrayToReactChildren(arr: Array<VDOMEl>): React.ReactNodeArray {
-  let result = [];
-
-  // iterate through the `children`
-  for (let i = 0, len = arr.length; i < len; i++) {
-    // child can have mixed values: text, React element, or array
-    const item = arr[i];
-    if (item === null) {
-      continue;
-    } else if (Array.isArray(item)) {
-      result.push(arrayToReactChildren(item));
-    } else if (typeof item === "string") {
-      result.push(item);
-    } else if (typeof item === "object") {
-      // Create a new object so that if we have to set the key, we are not
-      // mutating the original object
-      const keyedItem = {
-        tagName: item.tagName,
-        attributes: item.attributes,
-        children: item.children,
-        key: i
-      };
-      if (item.attributes && item.attributes.key) {
-        keyedItem.key = item.attributes.key;
-      }
-      result.push(objectToReactElement(keyedItem));
-    } else {
-      throw new Error(`invalid vdom child: "${item}"`);
-    }
-  }
-
-  return result;
 }

--- a/packages/transform-vdom/src/object-to-react.ts
+++ b/packages/transform-vdom/src/object-to-react.ts
@@ -166,6 +166,7 @@ export function objectToReactElement(
           tagName: item.tagName,
           attributes: item.attributes,
           children: item.children,
+          eventHandlers: item.eventHandlers,
           key: i
         };
         if (item.attributes && item.attributes.key) {

--- a/packages/transform-vdom/src/object-to-react.ts
+++ b/packages/transform-vdom/src/object-to-react.ts
@@ -31,17 +31,21 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const React = require("react");
+import * as React from "react";
 
-interface Attributes {
-  style: object;
-  key: number;
+export interface Attributes {
+  [key: string]: any;
+}
+
+export interface EventHandlers {
+  [key: string]: string;
 }
 
 export interface VDOMEl {
   tagName: string; // Could be an enum honestly
   children: React.ReactNode | VDOMEl | Array<React.ReactNode | VDOMEl>;
   attributes: Attributes;
+  eventHandlers?: EventHandlers;
   key: number | string | null;
 }
 
@@ -56,7 +60,7 @@ export interface VDOMEl {
  */
 export function objectToReactElement(obj: VDOMEl): React.ReactElement<any> {
   // Pack args for React.createElement
-  var args = [];
+  let args = [];
 
   if (!obj.tagName || typeof obj.tagName !== "string") {
     throw new Error(`Invalid tagName on ${JSON.stringify(obj, null, 2)}`);
@@ -117,10 +121,10 @@ export function objectToReactElement(obj: VDOMEl): React.ReactElement<any> {
  * @return {Array}     - The array of mixed values.
  */
 export function arrayToReactChildren(arr: Array<VDOMEl>): React.ReactNodeArray {
-  var result = [];
+  let result = [];
 
   // iterate through the `children`
-  for (var i = 0, len = arr.length; i < len; i++) {
+  for (let i = 0, len = arr.length; i < len; i++) {
     // child can have mixed values: text, React element, or array
     const item = arr[i];
     if (item === null) {

--- a/packages/transform-vdom/src/object-to-react.ts
+++ b/packages/transform-vdom/src/object-to-react.ts
@@ -65,48 +65,6 @@ export function objectToReactElement(
   obj: VDOMEl,
   onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void
 ): React.ReactElement<any> {
-  /**
-   * Convert an array of items to React children.
-   *
-   * @param  {Array} arr - The array.
-   * @return {Array}     - The array of mixed values.
-   */
-  function arrayToReactChildren(
-    arr: Array<VDOMEl>
-  ): React.ReactNodeArray {
-    let result = [];
-
-    // iterate through the `children`
-    for (let i = 0, len = arr.length; i < len; i++) {
-      // child can have mixed values: text, React element, or array
-      const item = arr[i];
-      if (item === null) {
-        continue;
-      } else if (Array.isArray(item)) {
-        result.push(arrayToReactChildren(item));
-      } else if (typeof item === "string") {
-        result.push(item);
-      } else if (typeof item === "object") {
-        // Create a new object so that if we have to set the key, we are not
-        // mutating the original object
-        const keyedItem = {
-          tagName: item.tagName,
-          attributes: item.attributes,
-          children: item.children,
-          key: i
-        };
-        if (item.attributes && item.attributes.key) {
-          keyedItem.key = item.attributes.key;
-        }
-        result.push(objectToReactElement(keyedItem, onVDOMEvent));
-      } else {
-        throw new Error(`invalid vdom child: "${item}"`);
-      }
-    }
-
-    return result;
-  }
-
   // Pack args for React.createElement
   let args = [];
 
@@ -163,7 +121,7 @@ export function objectToReactElement(
       if (args[1] === undefined) {
         args[1] = null;
       }
-      args = args.concat(arrayToReactChildren(children as VDOMEl[]) as any);
+      args = args.concat(arrayToReactChildren(children as VDOMEl[], onVDOMEvent) as any);
     } else if (typeof children === "string") {
       args[2] = children;
     } else if (typeof children === "object") {
@@ -178,3 +136,46 @@ export function objectToReactElement(
   // $FlowFixMe: React
   return React.createElement.apply({}, args);
 }
+
+/**
+   * Convert an array of items to React children.
+   *
+   * @param  {Array} arr - The array.
+   * @return {Array}     - The array of mixed values.
+   */
+  function arrayToReactChildren(
+    arr: Array<VDOMEl>,
+    onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void
+  ): React.ReactNodeArray {
+    let result = [];
+
+    // iterate through the `children`
+    for (let i = 0, len = arr.length; i < len; i++) {
+      // child can have mixed values: text, React element, or array
+      const item = arr[i];
+      if (item === null) {
+        continue;
+      } else if (Array.isArray(item)) {
+        result.push(arrayToReactChildren(item, onVDOMEvent));
+      } else if (typeof item === "string") {
+        result.push(item);
+      } else if (typeof item === "object") {
+        // Create a new object so that if we have to set the key, we are not
+        // mutating the original object
+        const keyedItem = {
+          tagName: item.tagName,
+          attributes: item.attributes,
+          children: item.children,
+          key: i
+        };
+        if (item.attributes && item.attributes.key) {
+          keyedItem.key = item.attributes.key;
+        }
+        result.push(objectToReactElement(keyedItem, onVDOMEvent));
+      } else {
+        throw new Error(`invalid vdom child: "${item}"`);
+      }
+    }
+
+    return result;
+  }


### PR DESCRIPTION
This depends on https://github.com/nteract/vdom/pull/76

This adds support for event handlers in transform-vdom. See https://github.com/nteract/vdom/pull/44 for more details on how it works.

Jupyter clients must provide a `onVDOMEvent` prop to `<VDOM>` now with the following signature:

```ts
onVDOMEvent(targetName: string, event: Attributes) => void
```

that sends a comm message to a comm channel given a target name and a body of `JSON.stringify(event)`. 

A reference implementation for JupyterLab: https://github.com/jupyterlab/jupyterlab/pull/5670