### PR TITLE
[WIP] Added a minimal draft.js markdown component

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "electron": "3.0.7",
     "electron-builder": "20.31.2",
     "electron-context-menu": "^0.10.0",
+    "electron-devtools-installer": "^2.2.4",
     "electron-log": "^2.2.13",
     "electron-updater": "^3.0.0",
     "enzyme": "^3.3.0",

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -33,6 +33,7 @@
     "@nteract/transforms": "^5.0.0-alpha.0",
     "babel-runtime": "^6.26.0",
     "date-fns": "^1.29.0",
+    "draft-js": "^0.10.5",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.0",
     "react-hot-loader": "^4.1.2",

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -34,6 +34,7 @@
     "babel-runtime": "^6.26.0",
     "date-fns": "^1.29.0",
     "draft-js": "^0.10.5",
+    "markdown-draft-js": "^1.3.0",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.0",
     "react-hot-loader": "^4.1.2",

--- a/packages/notebook-app-component/src/markdown-draft.js
+++ b/packages/notebook-app-component/src/markdown-draft.js
@@ -1,60 +1,55 @@
 import React from "react";
-import {Editor, EditorState, RichUtils, convertFromRaw} from 'draft-js';
 
-import { markdownToDraft } from 'markdown-draft-js';
+import {
+  Outputs,
+  PromptBuffer,
+  Input
+} from "@nteract/presentational-components";
 
+import {
+  TrashOcticon,
+  TriangleRightOcticon
+} from "@nteract/octicons";
+
+import { Editor, EditorState, RichUtils, getDefaultKeyBinding,
+         convertFromRaw } from "draft-js";
+
+import { markdownToDraft } from "markdown-draft-js";
 
 class StyleButton extends React.Component {
   constructor() {
     super();
-    this.onToggle = (e) => {
+    this.onToggle = e => {
       e.preventDefault();
       this.props.onToggle(this.props.style);
     };
   }
   render() {
-    let className = 'RichEditor-styleButton';
     if (this.props.active) {
-      className += ' RichEditor-activeButton';
+      //className += " RichEditor-activeButton";
     }
     return (
-      <React.Fragment>
-        <span className={className} onMouseDown={this.onToggle}>
-          {this.props.label}
+        <span className="octicon" onMouseDown={this.onToggle}>
+          <TrashOcticon />
         </span>
-        <style jsx>{`
-          .RichEditor-styleButton {
-            color: #999;
-            cursor: pointer;
-            margin-right: 16px;
-            padding: 2px 0;
-            display: inline-block;
-          }
-
-          .RichEditor-activeButton {
-            color: #5890ff;
-          }
-          `}
-          </style>
-        </React.Fragment>
     );
   }
 }
 
 const BLOCK_TYPES = [
-  {label: 'H1', style: 'header-one'},
-  {label: 'H2', style: 'header-two'},
-  {label: 'H3', style: 'header-three'},
-  {label: 'H4', style: 'header-four'},
-  {label: 'H5', style: 'header-five'},
-  {label: 'H6', style: 'header-six'},
-  {label: 'Blockquote', style: 'blockquote'},
-  {label: 'UL', style: 'unordered-list-item'},
-  {label: 'OL', style: 'ordered-list-item'},
-  {label: 'Code Block', style: 'code-block'},
+  { label: "H1", style: "header-one" },
+  { label: "H2", style: "header-two" },
+  { label: "H3", style: "header-three" },
+  { label: "H4", style: "header-four" },
+  { label: "H5", style: "header-five" },
+  { label: "H6", style: "header-six" },
+  { label: "Blockquote", style: "blockquote" },
+  { label: "UL", style: "unordered-list-item" },
+  { label: "OL", style: "ordered-list-item" },
+  { label: "Code Block", style: "code-block" }
 ];
-const BlockStyleControls = (props) => {
-  const {editorState} = props;
+const BlockStyleControls = props => {
+  const { editorState } = props;
   const selection = editorState.getSelection();
   const blockType = editorState
     .getCurrentContent()
@@ -63,7 +58,7 @@ const BlockStyleControls = (props) => {
   return (
     <React.Fragment>
       <div className="RichEditor-controls">
-        {BLOCK_TYPES.map((type) =>
+        {BLOCK_TYPES.map(type => (
           <StyleButton
             key={type.label}
             active={type.style === blockType}
@@ -71,11 +66,11 @@ const BlockStyleControls = (props) => {
             onToggle={props.onToggle}
             style={type.style}
           />
-        )}
+        ))}
       </div>
       <style jsx>{`
         .RichEditor-controls {
-          font-family: 'Helvetica', sans-serif;
+          font-family: "Helvetica", sans-serif;
           font-size: 14px;
           margin-bottom: 5px;
           user-select: none;
@@ -86,18 +81,18 @@ const BlockStyleControls = (props) => {
 };
 
 var INLINE_STYLES = [
-  {label: 'Bold', style: 'BOLD'},
-  {label: 'Italic', style: 'ITALIC'},
-  {label: 'Underline', style: 'UNDERLINE'},
-  {label: 'Monospace', style: 'CODE'},
+  { label: "Bold", style: "BOLD" },
+  { label: "Italic", style: "ITALIC" },
+  { label: "Underline", style: "UNDERLINE" },
+  { label: "Monospace", style: "CODE" }
 ];
-const InlineStyleControls = (props) => {
+const InlineStyleControls = props => {
   const currentStyle = props.editorState.getCurrentInlineStyle();
 
   return (
     <React.Fragment>
       <div className="RichEditor-controls">
-        {INLINE_STYLES.map((type) =>
+        {INLINE_STYLES.map(type => (
           <StyleButton
             key={type.label}
             active={currentStyle.has(type.style)}
@@ -105,11 +100,11 @@ const InlineStyleControls = (props) => {
             onToggle={props.onToggle}
             style={type.style}
           />
-        )}
+        ))}
       </div>
       <style jsx>{`
         .RichEditor-controls {
-          font-family: 'Helvetica', sans-serif;
+          font-family: "Helvetica", sans-serif;
           font-size: 14px;
           margin-bottom: 5px;
           user-select: none;
@@ -119,126 +114,196 @@ const InlineStyleControls = (props) => {
   );
 };
 
+const noop = function() {};
 
 export default class MyMarkdown extends React.Component {
+  static defaultProps = {
+    cellFocused: false,
+    editorFocused: false,
+    focusAbove: noop,
+    focusBelow: noop,
+    focusEditor: noop,
+    unfocusEditor: noop,
+    source: ""
+  };
+
   constructor(props) {
     super(props);
-    const raw = markdownToDraft(this.props.source);
-    this.state = {editorState: EditorState.createWithContent(convertFromRaw(raw))};
-    this.onChange = (editorState) => this.setState({editorState});
+    const raw = markdownToDraft(
+      this.props.source
+    );
+    this.state = {
+      editorState: EditorState.createWithContent(convertFromRaw(raw)),
+    };
+    this.onChange = editorState => {
+      this.setState({ editorState });
+    };
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
     this.toggleBlockType = this._toggleBlockType.bind(this);
     this.toggleInlineStyle = this._toggleInlineStyle.bind(this);
+    (this: any).openEditor = this.openEditor.bind(this);
+    (this: any).closeEditor = this.closeEditor.bind(this);
+    (this: any).editingKeyDown = this.editingKeyDown.bind(this);
+    this.editor = React.createRef();
   }
   _toggleBlockType(blockType) {
-    this.onChange(
-      RichUtils.toggleBlockType(
-        this.state.editorState,
-        blockType
-      )
-    );
+    this.onChange(RichUtils.toggleBlockType(this.state.editorState, blockType));
   }
   _toggleInlineStyle(inlineStyle) {
     this.onChange(
-      RichUtils.toggleInlineStyle(
-        this.state.editorState,
-        inlineStyle
-      )
+      RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
     );
   }
+  editingKeyDown(e: SyntheticKeyboardEvent<*>) {
+    console.log('edit keyed!', e.key)
+    const shift = e.shiftKey;
+    const ctrl = e.ctrlKey;
+    if ((shift || ctrl) && e.key === "Enter") {
+      this.closeEditor();
+      e.preventDefault();
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowUp":
+        this.props.focusAbove();
+        e.preventDefault();
+        return;
+      case "ArrowDown":
+        this.props.focusBelow();
+        e.preventDefault();
+        return;
+      default:
+    }
+    return getDefaultKeyBinding(e);
+  }
   handleKeyCommand(command, editorState) {
+    console.log('key command', command)
     const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {
       this.onChange(newState);
-      return 'handled';
+      return "handled";
     }
-    return 'not-handled';
+    return "not-handled";
+  }
+  openEditor(): void {
+    this.refs.editor.focus()
+    this.props.focusEditor();
+  }
+  closeEditor(): void {
+    this.props.unfocusEditor();
+  }
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.editorFocused) {
+      this.openEditor();
+      console.log('editor got focus, opened edit')
+    }
+    else {
+      this.closeEditor();
+      console.log('edit lost focus, closed edit')
+    }
   }
   render() {
     return (
       <React.Fragment>
-        <div className="RichEditor-root">
-          <BlockStyleControls
-            editorState={this.state.editorState}
-            onToggle={this.toggleBlockType}
-          />
-          <InlineStyleControls
-            editorState={this.state.editorState}
-            onToggle={this.toggleInlineStyle}
-          />
-          <Editor
-            editorState={this.state.editorState}
-            onChange={this.onChange}
-            handleKeyCommand={this.handleKeyCommand}
-          />
-        </div>
-        <style jsx>{`
-          .RichEditor-root {
-            background: #fff;
-            border: 1px solid #ddd;
-            font-family: 'Georgia', serif;
-            font-size: 14px;
-            padding: 15px;
-          }
+        <Outputs>
+          <div
+            className="RichEditor-root"
+            onDoubleClick={this.openEditor}
+          >
+            { this.props.editorFocused ?
+              (
+                <React.Fragment>
+                  <BlockStyleControls
+                    editorState={this.state.editorState}
+                    onToggle={this.toggleBlockType}
+                  />
+                  <InlineStyleControls
+                    editorState={this.state.editorState}
+                    onToggle={this.toggleInlineStyle}
+                  />
+                </React.Fragment>
+              )
+              :
+              ""
+            }
+            <Editor
+              readOnly={!this.props.editorFocused}
+              editorState={this.state.editorState}
+              onChange={this.onChange}
+              keyBindingFn={this.editingKeyDown}
+              onUpArrow={this.editingKeyDown}
+              onDownArrow={this.editingKeyDown}
+              handleKeyCommand={this.handleKeyCommand}
+              ref="editor"
+              placeholder={"Empty markdown cell, click me to add content."}
+            />
+          </div>
+        </Outputs>
+        <style jsx>
+          {`
+            .RichEditor-root {
+              background: var(--theme-app-bg);
+            }
 
-          .RichEditor-editor {
-            border-top: 1px solid #ddd;
-            cursor: text;
-            font-size: 16px;
-            margin-top: 10px;
-          }
+            .RichEditor-editor {
+              border-top: 1px solid #ddd;
+              cursor: text;
+              font-size: 16px;
+              margin-top: 10px;
+            }
 
-          .RichEditor-editor .public-DraftEditorPlaceholder-root,
-          .RichEditor-editor .public-DraftEditor-content {
-            margin: 0 -15px -15px;
-            padding: 15px;
-          }
+            .RichEditor-editor .public-DraftEditorPlaceholder-root,
+            .RichEditor-editor .public-DraftEditor-content {
+              margin: 0 -15px -15px;
+              padding: 15px;
+            }
 
-          .RichEditor-editor .public-DraftEditor-content {
-            min-height: 100px;
-          }
+            .RichEditor-editor .public-DraftEditor-content {
+              min-height: 100px;
+            }
 
-          .RichEditor-hidePlaceholder .public-DraftEditorPlaceholder-root {
-            display: none;
-          }
+            .RichEditor-hidePlaceholder .public-DraftEditorPlaceholder-root {
+              display: none;
+            }
 
-          .RichEditor-editor .RichEditor-blockquote {
-            border-left: 5px solid #eee;
-            color: #666;
-            font-family: 'Hoefler Text', 'Georgia', serif;
-            font-style: italic;
-            margin: 16px 0;
-            padding: 10px 20px;
-          }
+            .RichEditor-editor .RichEditor-blockquote {
+              border-left: 5px solid #eee;
+              color: #666;
+              font-family: "Hoefler Text", "Georgia", serif;
+              font-style: italic;
+              margin: 16px 0;
+              padding: 10px 20px;
+            }
 
-          .RichEditor-editor .public-DraftStyleDefault-pre {
-            background-color: rgba(0, 0, 0, 0.05);
-            font-family: 'Inconsolata', 'Menlo', 'Consolas', monospace;
-            font-size: 16px;
-            padding: 20px;
-          }
+            .RichEditor-editor .public-DraftStyleDefault-pre {
+              background-color: rgba(0, 0, 0, 0.05);
+              font-family: "Inconsolata", "Menlo", "Consolas", monospace;
+              font-size: 16px;
+              padding: 20px;
+            }
 
-          .RichEditor-controls {
-            font-family: 'Helvetica', sans-serif;
-            font-size: 14px;
-            margin-bottom: 5px;
-            user-select: none;
-          }
+            .RichEditor-controls {
+              font-family: "Helvetica", sans-serif;
+              font-size: 14px;
+              margin-bottom: 5px;
+              user-select: none;
+            }
 
-          .RichEditor-styleButton {
-            color: #999;
-            cursor: pointer;
-            margin-right: 16px;
-            padding: 2px 0;
-            display: inline-block;
-          }
+            .RichEditor-styleButton {
+              color: #999;
+              cursor: pointer;
+              margin-right: 16px;
+              padding: 2px 0;
+              display: inline-block;
+            }
 
-          .RichEditor-activeButton {
-            color: #5890ff;
-          }
-        `}
-      </style>
-    </React.Fragment>
+            .RichEditor-activeButton {
+              color: #5890ff;
+            }
+          `}
+        </style>
+      </React.Fragment>
     );
   }
 }

--- a/packages/notebook-app-component/src/markdown-draft.js
+++ b/packages/notebook-app-component/src/markdown-draft.js
@@ -1,0 +1,241 @@
+import React from "react";
+import {Editor, EditorState, RichUtils} from 'draft-js';
+
+
+class StyleButton extends React.Component {
+  constructor() {
+    super();
+    this.onToggle = (e) => {
+      e.preventDefault();
+      this.props.onToggle(this.props.style);
+    };
+  }
+  render() {
+    let className = 'RichEditor-styleButton';
+    if (this.props.active) {
+      className += ' RichEditor-activeButton';
+    }
+    return (
+      <React.Fragment>
+        <span className={className} onMouseDown={this.onToggle}>
+          {this.props.label}
+        </span>
+        <style jsx>{`
+          .RichEditor-styleButton {
+            color: #999;
+            cursor: pointer;
+            margin-right: 16px;
+            padding: 2px 0;
+            display: inline-block;
+          }
+
+          .RichEditor-activeButton {
+            color: #5890ff;
+          }
+          `}
+          </style>
+        </React.Fragment>
+    );
+  }
+}
+
+const BLOCK_TYPES = [
+  {label: 'H1', style: 'header-one'},
+  {label: 'H2', style: 'header-two'},
+  {label: 'H3', style: 'header-three'},
+  {label: 'H4', style: 'header-four'},
+  {label: 'H5', style: 'header-five'},
+  {label: 'H6', style: 'header-six'},
+  {label: 'Blockquote', style: 'blockquote'},
+  {label: 'UL', style: 'unordered-list-item'},
+  {label: 'OL', style: 'ordered-list-item'},
+  {label: 'Code Block', style: 'code-block'},
+];
+const BlockStyleControls = (props) => {
+  const {editorState} = props;
+  const selection = editorState.getSelection();
+  const blockType = editorState
+    .getCurrentContent()
+    .getBlockForKey(selection.getStartKey())
+    .getType();
+  return (
+    <React.Fragment>
+      <div className="RichEditor-controls">
+        {BLOCK_TYPES.map((type) =>
+          <StyleButton
+            key={type.label}
+            active={type.style === blockType}
+            label={type.label}
+            onToggle={props.onToggle}
+            style={type.style}
+          />
+        )}
+      </div>
+      <style jsx>{`
+        .RichEditor-controls {
+          font-family: 'Helvetica', sans-serif;
+          font-size: 14px;
+          margin-bottom: 5px;
+          user-select: none;
+        }
+      `}</style>
+    </React.Fragment>
+  );
+};
+
+var INLINE_STYLES = [
+  {label: 'Bold', style: 'BOLD'},
+  {label: 'Italic', style: 'ITALIC'},
+  {label: 'Underline', style: 'UNDERLINE'},
+  {label: 'Monospace', style: 'CODE'},
+];
+const InlineStyleControls = (props) => {
+  const currentStyle = props.editorState.getCurrentInlineStyle();
+
+  return (
+    <React.Fragment>
+      <div className="RichEditor-controls">
+        {INLINE_STYLES.map((type) =>
+          <StyleButton
+            key={type.label}
+            active={currentStyle.has(type.style)}
+            label={type.label}
+            onToggle={props.onToggle}
+            style={type.style}
+          />
+        )}
+      </div>
+      <style jsx>{`
+        .RichEditor-controls {
+          font-family: 'Helvetica', sans-serif;
+          font-size: 14px;
+          margin-bottom: 5px;
+          user-select: none;
+        }
+      `}</style>
+    </React.Fragment>
+  );
+};
+
+
+export default class MyMarkdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {editorState: EditorState.createEmpty()};
+    this.onChange = (editorState) => this.setState({editorState});
+    this.handleKeyCommand = this.handleKeyCommand.bind(this);
+    this.toggleBlockType = this._toggleBlockType.bind(this);
+    this.toggleInlineStyle = this._toggleInlineStyle.bind(this);
+  }
+  _toggleBlockType(blockType) {
+    this.onChange(
+      RichUtils.toggleBlockType(
+        this.state.editorState,
+        blockType
+      )
+    );
+  }
+  _toggleInlineStyle(inlineStyle) {
+    this.onChange(
+      RichUtils.toggleInlineStyle(
+        this.state.editorState,
+        inlineStyle
+      )
+    );
+  }
+  handleKeyCommand(command, editorState) {
+    const newState = RichUtils.handleKeyCommand(editorState, command);
+    if (newState) {
+      this.onChange(newState);
+      return 'handled';
+    }
+    return 'not-handled';
+  }
+  render() {
+    return (
+      <React.Fragment>
+        <div className="RichEditor-root">
+          <BlockStyleControls
+            editorState={this.state.editorState}
+            onToggle={this.toggleBlockType}
+          />
+          <InlineStyleControls
+            editorState={this.state.editorState}
+            onToggle={this.toggleInlineStyle}
+          />
+          <Editor
+            editorState={this.state.editorState}
+            onChange={this.onChange}
+            handleKeyCommand={this.handleKeyCommand}
+          />
+        </div>
+        <style jsx>{`
+          .RichEditor-root {
+            background: #fff;
+            border: 1px solid #ddd;
+            font-family: 'Georgia', serif;
+            font-size: 14px;
+            padding: 15px;
+          }
+
+          .RichEditor-editor {
+            border-top: 1px solid #ddd;
+            cursor: text;
+            font-size: 16px;
+            margin-top: 10px;
+          }
+
+          .RichEditor-editor .public-DraftEditorPlaceholder-root,
+          .RichEditor-editor .public-DraftEditor-content {
+            margin: 0 -15px -15px;
+            padding: 15px;
+          }
+
+          .RichEditor-editor .public-DraftEditor-content {
+            min-height: 100px;
+          }
+
+          .RichEditor-hidePlaceholder .public-DraftEditorPlaceholder-root {
+            display: none;
+          }
+
+          .RichEditor-editor .RichEditor-blockquote {
+            border-left: 5px solid #eee;
+            color: #666;
+            font-family: 'Hoefler Text', 'Georgia', serif;
+            font-style: italic;
+            margin: 16px 0;
+            padding: 10px 20px;
+          }
+
+          .RichEditor-editor .public-DraftStyleDefault-pre {
+            background-color: rgba(0, 0, 0, 0.05);
+            font-family: 'Inconsolata', 'Menlo', 'Consolas', monospace;
+            font-size: 16px;
+            padding: 20px;
+          }
+
+          .RichEditor-controls {
+            font-family: 'Helvetica', sans-serif;
+            font-size: 14px;
+            margin-bottom: 5px;
+            user-select: none;
+          }
+
+          .RichEditor-styleButton {
+            color: #999;
+            cursor: pointer;
+            margin-right: 16px;
+            padding: 2px 0;
+            display: inline-block;
+          }
+
+          .RichEditor-activeButton {
+            color: #5890ff;
+          }
+        `}
+      </style>
+    </React.Fragment>
+    );
+  }
+}

--- a/packages/notebook-app-component/src/markdown-draft.js
+++ b/packages/notebook-app-component/src/markdown-draft.js
@@ -1,5 +1,7 @@
 import React from "react";
-import {Editor, EditorState, RichUtils} from 'draft-js';
+import {Editor, EditorState, RichUtils, convertFromRaw} from 'draft-js';
+
+import { markdownToDraft } from 'markdown-draft-js';
 
 
 class StyleButton extends React.Component {
@@ -121,7 +123,8 @@ const InlineStyleControls = (props) => {
 export default class MyMarkdown extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {editorState: EditorState.createEmpty()};
+    const raw = markdownToDraft(this.props.source);
+    this.state = {editorState: EditorState.createWithContent(convertFromRaw(raw))};
     this.onChange = (editorState) => this.setState({editorState});
     this.handleKeyCommand = this.handleKeyCommand.bind(this);
     this.toggleBlockType = this._toggleBlockType.bind(this);

--- a/packages/notebook-app-component/src/markdown-draft.js
+++ b/packages/notebook-app-component/src/markdown-draft.js
@@ -25,13 +25,30 @@ class StyleButton extends React.Component {
     };
   }
   render() {
+    let className = 'RichEditor-styleButton';
     if (this.props.active) {
-      //className += " RichEditor-activeButton";
+      className += ' RichEditor-activeButton';
     }
     return (
-        <span className="octicon" onMouseDown={this.onToggle}>
-          <TrashOcticon />
+      <React.Fragment>
+        <span className={className} onMouseDown={this.onToggle}>
+          {this.props.label}
         </span>
+        <style jsx>{`
+          .RichEditor-styleButton {
+            color: #999;
+            cursor: pointer;
+            margin-right: 16px;
+            padding: 2px 0;
+            display: inline-block;
+          }
+
+          .RichEditor-activeButton {
+            color: #5890ff;
+          }
+          `}
+        </style>
+      </React.Fragment>
     );
   }
 }
@@ -40,9 +57,6 @@ const BLOCK_TYPES = [
   { label: "H1", style: "header-one" },
   { label: "H2", style: "header-two" },
   { label: "H3", style: "header-three" },
-  { label: "H4", style: "header-four" },
-  { label: "H5", style: "header-five" },
-  { label: "H6", style: "header-six" },
   { label: "Blockquote", style: "blockquote" },
   { label: "UL", style: "unordered-list-item" },
   { label: "OL", style: "ordered-list-item" },

--- a/packages/notebook-app-component/src/notebook-app.js
+++ b/packages/notebook-app-component/src/notebook-app.js
@@ -27,6 +27,7 @@ import DraggableCell from "./draggable-cell";
 import CellCreator from "./cell-creator";
 import StatusBar from "./status-bar";
 import MarkdownPreviewer from "./markdown-preview";
+import MyMarkdown from "./markdown-draft";
 import Editor from "./editor";
 import Toolbar from "./toolbar";
 import { HijackScroll } from "./hijack-scroll";
@@ -265,7 +266,8 @@ class AnyCell extends React.PureComponent<AnyCellProps, *> {
         break;
       case "markdown":
         element = (
-          <MarkdownPreviewer
+          <MyMarkdown />
+          /*<MarkdownPreviewer
             focusAbove={focusAboveCell}
             focusBelow={focusBelowCell}
             focusEditor={focusEditor}
@@ -287,7 +289,7 @@ class AnyCell extends React.PureComponent<AnyCellProps, *> {
                 options={markdownEditorOptions}
               />
             </Source>
-          </MarkdownPreviewer>
+          </MarkdownPreviewer> */
         );
         break;
 

--- a/packages/notebook-app-component/src/notebook-app.js
+++ b/packages/notebook-app-component/src/notebook-app.js
@@ -266,7 +266,9 @@ class AnyCell extends React.PureComponent<AnyCellProps, *> {
         break;
       case "markdown":
         element = (
-          <MyMarkdown />
+          <MyMarkdown
+            source={this.props.source}
+          />
           /*<MarkdownPreviewer
             focusAbove={focusAboveCell}
             focusBelow={focusBelowCell}

--- a/packages/notebook-app-component/src/notebook-app.js
+++ b/packages/notebook-app-component/src/notebook-app.js
@@ -267,7 +267,16 @@ class AnyCell extends React.PureComponent<AnyCellProps, *> {
       case "markdown":
         element = (
           <MyMarkdown
+            id={id}
             source={this.props.source}
+            selectCell={selectCell}
+            focusAbove={focusAboveCell}
+            focusBelow={focusBelowCell}
+            focusEditor={focusEditor}
+            cellFocused={cellFocused}
+            editorFocused={editorFocused}
+            unfocusEditor={unfocusEditor}
+            contentRef={contentRef}
           />
           /*<MarkdownPreviewer
             focusAbove={focusAboveCell}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/7zip-bin/-/7zip-bin-4.1.0.tgz#33eff662a5c39c0c2061170cc003c5120743fff0"
   integrity sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==
 
+"7zip@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
+  integrity sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=
+
 "@babel/cli@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.0.0.tgz#108b395fd43fff6681d36fb41274df4d8ffeb12e"
@@ -4379,6 +4384,11 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-unzip@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"
+  integrity sha1-UYO8R6CVWb78+YzEZXlkmZNZNy8=
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -5357,6 +5367,16 @@ electron-context-menu@^0.10.0:
   dependencies:
     electron-dl "^1.2.0"
     electron-is-dev "^1.0.1"
+
+electron-devtools-installer@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763"
+  integrity sha512-b5kcM3hmUqn64+RUcHjjr8ZMpHS2WJ5YO0pnG9+P/RTdx46of/JrEjuciHWux6pE+On6ynWhHJF53j/EDJN0PA==
+  dependencies:
+    "7zip" "0.0.6"
+    cross-unzip "0.0.2"
+    rimraf "^2.5.2"
+    semver "^5.3.0"
 
 electron-dl@^1.2.0:
   version "1.12.0"
@@ -7984,7 +8004,7 @@ is-root@2.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -10106,18 +10126,10 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.1.2, node-fetch@^2.0.0, node-fetch@^2.1.2:
+node-fetch@2.1.2, node-fetch@^1.0.1, node-fetch@^2.0.0, node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -12709,7 +12721,7 @@ reverse-arguments@1.0.0:
   resolved "https://registry.yarnpkg.com/reverse-arguments/-/reverse-arguments-1.0.0.tgz#c28095a3a921ac715d61834ddece9027992667cd"
   integrity sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5262,6 +5262,15 @@ dotenv@^6.1.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.1.0.tgz#9853b6ca98292acb7dec67a95018fa40bccff42c"
   integrity sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw==
 
+draft-js@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
+  integrity sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==
+  dependencies:
+    fbjs "^0.8.15"
+    immutable "~3.7.4"
+    object-assign "^4.1.0"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -6215,7 +6224,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7448,6 +7457,11 @@ immutable@^4.0.0-rc.12:
   version "4.0.0-rc.12"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
   integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
+immutable@~3.7.4:
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
 import-fresh@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,6 +2391,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@~0.1.15:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-0.1.16.tgz#cfd01e0fbba3d6caed049fbd758d40f65196f57c"
+  integrity sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=
+  dependencies:
+    underscore "~1.7.0"
+    underscore.string "~2.4.0"
+
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
@@ -2640,6 +2648,11 @@ autodll-webpack-plugin@0.4.2:
     tapable "^1.0.0"
     webpack-merge "^4.1.0"
     webpack-sources "^1.0.1"
+
+autolinker@~0.15.0:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-0.15.3.tgz#342417d8f2f3461b14cf09088d5edf8791dc9832"
+  integrity sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=
 
 aws-config@^1.0.7:
   version "1.2.0"
@@ -7971,7 +7984,7 @@ is-root@2.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -9377,6 +9390,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-draft-js@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/markdown-draft-js/-/markdown-draft-js-1.3.0.tgz#040b6900fae9238fb5b23e678f87e0658de97b35"
+  integrity sha512-/xsw6/6GmZGcNQcySEFHhidQgIXxdO6SYNAUWoWk7fa4j5oHv4dN5vkkDtmOyor48+Jv+jYOCHomdBeFDu1haw==
+  dependencies:
+    remarkable "1.7.1"
+
 markdown-escapes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
@@ -10086,10 +10106,18 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.1.2, node-fetch@^1.0.1, node-fetch@^2.0.0, node-fetch@^2.1.2:
+node-fetch@2.1.2, node-fetch@^2.0.0, node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -12476,6 +12504,14 @@ remark@^9.0.0:
     remark-stringify "^5.0.0"
     unified "^6.0.0"
 
+remarkable@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/remarkable/-/remarkable-1.7.1.tgz#aaca4972100b66a642a63a1021ca4bac1be3bff6"
+  integrity sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=
+  dependencies:
+    argparse "~0.1.15"
+    autolinker "~0.15.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -14409,10 +14445,20 @@ underscore.string@3.0.3:
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.0.3.tgz#4617b8c1a250cf6e5064fbbb363d0fa96cf14552"
   integrity sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=
 
+underscore.string@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
+  integrity sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=
+
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
   integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
+
+underscore@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 unfetch@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Explorations in using draft.js for markdown cells. This gives you WYSIWYG instead of having a place to write markdown "code" that then gets rendered as output.

![kapture 2018-11-25 at 21 31 24](https://user-images.githubusercontent.com/1448859/48984528-e4738180-f0fc-11e8-8751-6c3dba3123ff.gif)

Currently this doesn't do much except let you type and mash some buttons to change the style of the text. Need to work out how to pipe in source from a notebook and extract it again. As well as ... lots of other stuff.

My plan is to use https://github.com/Rosey/markdown-draft-js to handle the MD -> draft.js representation and draft.js representation -> markdown. Pointers and thoughts welcome.

Most of the code and CSS comes from https://github.com/facebook/draft-js/tree/master/examples/draft-0-10-0/rich