### PR TITLE
WIP fake opaque types for {Host|Kernel|Session|Cell}Id

### DIFF
--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -37,7 +37,8 @@ export {
   makeRawCell,
   makeCodeCell,
   makeMarkdownCell,
-  ImmutableCodeCell
+  ImmutableCodeCell,
+  ImmutableCell
 } from "./cells";
 
 export {

--- a/packages/selectors/src/notebook.ts
+++ b/packages/selectors/src/notebook.ts
@@ -38,7 +38,7 @@ export const codeCellIdsBelow = (model: NotebookModel) => {
   return cellOrder
     .skip(index)
     .filter(
-      (id: string) =>
+      (id: CellId) =>
         model.notebook.getIn(["cellMap", id, "cell_type"]) === "code"
     );
 };

--- a/packages/selectors/src/notebook.ts
+++ b/packages/selectors/src/notebook.ts
@@ -1,5 +1,8 @@
 import * as Immutable from "immutable";
 import * as commutable from "@nteract/commutable";
+
+import { ImmutableCell } from "@nteract/commutable";
+
 // All these selectors expect a NotebookModel as the top level state
 import { NotebookModel, CellId } from "@nteract/types";
 import { createSelector } from "reselect";
@@ -11,14 +14,16 @@ import { createSelector } from "reselect";
  * @param model {NotebookModel}
  * @returns {Immutable.Map}
  */
-export const cellMap = (model: NotebookModel) =>
-  model.notebook.get("cellMap", Immutable.Map());
+export const cellMap = (
+  model: NotebookModel
+): Immutable.Map<CellId, ImmutableCell> =>
+  model.notebook.get("cellMap", Immutable.Map<CellId, ImmutableCell>());
 
 export const cellById = (model: NotebookModel, { id }: { id: CellId }) =>
   cellMap(model).get(id);
 
 export const cellOrder = (model: NotebookModel): Immutable.List<CellId> =>
-  model.notebook.get("cellOrder", Immutable.List());
+  model.notebook.get("cellOrder", Immutable.List<CellId>());
 
 export const cellFocused = (model: NotebookModel): CellId | null | undefined =>
   model.cellFocused;

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -1,9 +1,9 @@
-export type HostId = string;
-export type KernelId = string;
-export type SessionId = string;
-export type CellId = string;
+export type HostId = string & { readonly __tag: unique symbol };
+export type KernelId = string & { readonly __tag: unique symbol };
+export type SessionId = string & { readonly __tag: unique symbol };
+export type CellId = string & { readonly __tag: unique symbol };
 
-export const castToHostId = (id: string): HostId => id;
-export const castToKernelId = (id: string): KernelId => id;
-export const castToSessionId = (id: string): SessionId => id;
-export const castToCellId = (id: string): CellId => id;
+export const castToHostId = (id: string): HostId => id as HostId;
+export const castToKernelId = (id: string): KernelId => id as KernelId;
+export const castToSessionId = (id: string): SessionId => id as SessionId;
+export const castToCellId = (id: string): CellId => id as CellId;


### PR DESCRIPTION
Following the post @Deteam linked within [a tweet thread about these types](https://twitter.com/TimurAmirov/status/1066979897250390016), this implements what we previously had as  "opaque type"s in flow and is called a newtype in Haskell.

This takes the intersection type approach so that current code matches up well with little change (had to fix one type in the selectors package).