### PR TITLE
Resolve packages for typescript via src

### DIFF
--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -41,8 +41,7 @@ export {
   ImmutableMarkdownCell,
   ImmutableRawCell,
   ImmutableCell,
-  CellType,
-  ImmutableMarkdownCell
+  CellType
 } from "./cells";
 
 export {

--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -38,6 +38,7 @@ export {
   makeCodeCell,
   makeMarkdownCell,
   ImmutableCodeCell,
+  ImmutableMarkdownCell,
   ImmutableRawCell,
   ImmutableCell,
   CellType

--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -41,7 +41,8 @@ export {
   ImmutableMarkdownCell,
   ImmutableRawCell,
   ImmutableCell,
-  CellType
+  CellType,
+  ImmutableMarkdownCell
 } from "./cells";
 
 export {

--- a/packages/display-area/src/richest-mime.tsx
+++ b/packages/display-area/src/richest-mime.tsx
@@ -94,9 +94,12 @@ export default class RichestMime extends React.Component<Props, State> {
       return null;
     }
 
-    const Transform = this.props.transforms[mimetype];
-    const data = this.props.bundle[mimetype];
-    const metadata = this.props.metadata[mimetype];
+    // NOTE: When we transition to the compound component interface these should no longer be
+    //       any (they were implicit any before based on prior code paths).
+    //       Once the TypeScript migration is nearing completion we can clean this up.
+    const Transform: any = this.props.transforms[mimetype];
+    const data: any = this.props.bundle[mimetype];
+    const metadata: any  = this.props.metadata[mimetype];
     return (
       <Transform
         data={data}

--- a/packages/display-area/src/richest-mime.tsx
+++ b/packages/display-area/src/richest-mime.tsx
@@ -10,9 +10,9 @@ import { Subject } from "rxjs";
 
 type Props = {
   displayOrder: string[];
-  transforms: object;
-  bundle: object;
-  metadata: object;
+  transforms: { [key: string]: any };
+  bundle: { [key: string]: any };
+  metadata: { [key: string]: any };
   theme: string;
   models?: object;
   channels?: Subject<any>;
@@ -99,7 +99,7 @@ export default class RichestMime extends React.Component<Props, State> {
     //       Once the TypeScript migration is nearing completion we can clean this up.
     const Transform: any = this.props.transforms[mimetype];
     const data: any = this.props.bundle[mimetype];
-    const metadata: any  = this.props.metadata[mimetype];
+    const metadata: any = this.props.metadata[mimetype];
     return (
       <Transform
         data={data}

--- a/packages/selectors/src/notebook.ts
+++ b/packages/selectors/src/notebook.ts
@@ -15,7 +15,7 @@ import { createSelector } from "reselect";
  * Immutable.Map if no cellMap exists in the NotebookModel.
  *
  * @param   model   The notebook model to extract the cell map from
- * 
+ *
  * @returns         The cell map within the notebook or an empty map
  */
 export const cellMap = (model: NotebookModel) =>
@@ -24,10 +24,10 @@ export const cellMap = (model: NotebookModel) =>
 /**
  * Returns the cell within a notebook with a particular ID. Returns
  * undefined if no cell with that ID is found in the model
- * 
+ *
  * @param   model           The notebook model to extract the cell from
  * @param   { id: CellId }  The ID of the cell to extract
- * 
+ *
  * @returns                 Undefined or a cell with the given ID
  */
 export const cellById = (model: NotebookModel, { id }: { id: CellId }) =>
@@ -36,9 +36,9 @@ export const cellById = (model: NotebookModel, { id }: { id: CellId }) =>
 /**
  * Returns the cell order within a notebook. Returns an empty list if the
  * notebook contains no cellOrder.
- * 
+ *
  * @param   model   The notebook model to extract the cell order list from
- * 
+ *
  * @returns         The cell order within a notebook or an empty list
  */
 export const cellOrder = (model: NotebookModel): Immutable.List<CellId> =>
@@ -46,10 +46,10 @@ export const cellOrder = (model: NotebookModel): Immutable.List<CellId> =>
 
 /**
  * Returns the ID of the focused cell within a notebook.
- * 
+ *
  * @param   model   The notebook to extract the focused cell from
- * 
- * @returns         The ID of the focused cell 
+ *
+ * @returns         The ID of the focused cell
  */
 export const cellFocused = (model: NotebookModel): CellId | null | undefined =>
   model.cellFocused;
@@ -57,9 +57,9 @@ export const cellFocused = (model: NotebookModel): CellId | null | undefined =>
 /**
  * Returns the CellId of the cell with the currently focused editor within
  * the notebook.
- * 
+ *
  * @param   model   The notebook to extract the focused editor from
- * 
+ *
  * @returns         The ID of the cell with the currently focused editor
  */
 export const editorFocusedId = (
@@ -68,12 +68,14 @@ export const editorFocusedId = (
 
 /**
  * Returns a list of CellIds below the currently focused cell in a notebook.
- * 
+ *
  * @param   model   The notebook to extract the code cells from
- * 
+ *
  * @returns         The IDs of cells below the currently focused cell
  */
-export const codeCellIdsBelow = (model: NotebookModel): Immutable.List<CellId> => {
+export const codeCellIdsBelow = (
+  model: NotebookModel
+): Immutable.List<CellId> => {
   const cellFocused = model.cellFocused;
   if (!cellFocused) {
     // NOTE: if there is no focused cell, this runs none of the cells
@@ -122,9 +124,9 @@ export const idsOfHiddenOutputs = createSelector(
 /**
  * Returns a transient version of the cell map within a notebook. This cell
  * map is a copy of the original cell map that is transient.
- * 
+ *
  * @param   model   The notebook to extract the transient cell map from
- * 
+ *
  * @returns         The tranisent cell map
  */
 export const transientCellMap = (model: NotebookModel) =>
@@ -143,9 +145,9 @@ export const codeCellIds = createSelector(
 /**
  * Returns the metadata of a notebook. Returns an empty Immutable.Map if
  * no metadata is defined.
- * 
+ *
  * @param   model   The notebook to extract the metadata from
- * 
+ *
  * @returns         An empty Map or a Map containing the metadata of the notebook
  */
 export const metadata = (model: NotebookModel) =>

--- a/packages/transform-vdom/src/object-to-react.ts
+++ b/packages/transform-vdom/src/object-to-react.ts
@@ -66,7 +66,7 @@ export function objectToReactElement(
   onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void
 ): React.ReactElement<any> {
   // Pack args for React.createElement
-  let args = [];
+  var args: any = [];
 
   if (!obj.tagName || typeof obj.tagName !== "string") {
     throw new Error(`Invalid tagName on ${JSON.stringify(obj, null, 2)}`);
@@ -121,7 +121,10 @@ export function objectToReactElement(
       if (args[1] === undefined) {
         args[1] = null;
       }
-      args = args.concat(arrayToReactChildren(children as VDOMEl[], onVDOMEvent) as any);
+      args = args.concat(arrayToReactChildren(
+        children as VDOMEl[],
+        onVDOMEvent
+      ) as any);
     } else if (typeof children === "string") {
       args[2] = children;
     } else if (typeof children === "object") {
@@ -133,50 +136,42 @@ export function objectToReactElement(
     }
   }
 
-  // $FlowFixMe: React
   return React.createElement.apply({}, args);
 }
 
 /**
-   * Convert an array of items to React children.
-   *
-   * @param  {Array} arr - The array.
-   * @return {Array}     - The array of mixed values.
-   */
-  function arrayToReactChildren(
-    arr: Array<VDOMEl>,
-    onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void
-  ): React.ReactNodeArray {
-    let result = [];
+ * Convert an array of items to React children.
+ *
+ * @param  {Array} arr - The array.
+ * @return {Array}     - The array of mixed values.
+ */
+export function arrayToReactChildren(arr: Array<VDOMEl>): React.ReactNodeArray {
+  var result: React.ReactNodeArray = [];
 
-    // iterate through the `children`
-    for (let i = 0, len = arr.length; i < len; i++) {
-      // child can have mixed values: text, React element, or array
-      const item = arr[i];
-      if (item === null) {
-        continue;
-      } else if (Array.isArray(item)) {
-        result.push(arrayToReactChildren(item, onVDOMEvent));
-      } else if (typeof item === "string") {
-        result.push(item);
-      } else if (typeof item === "object") {
-        // Create a new object so that if we have to set the key, we are not
-        // mutating the original object
-        const keyedItem = {
-          tagName: item.tagName,
-          attributes: item.attributes,
-          children: item.children,
-          eventHandlers: item.eventHandlers,
-          key: i
-        };
-        if (item.attributes && item.attributes.key) {
-          keyedItem.key = item.attributes.key;
-        }
-        result.push(objectToReactElement(keyedItem, onVDOMEvent));
-      } else {
-        throw new Error(`invalid vdom child: "${item}"`);
+  // iterate through the `children`
+  for (var i = 0, len = arr.length; i < len; i++) {
+    // child can have mixed values: text, React element, or array
+    const item = arr[i];
+    if (item === null) {
+      continue;
+    } else if (Array.isArray(item)) {
+      result.push(arrayToReactChildren(item));
+    } else if (typeof item === "string") {
+      result.push(item);
+    } else if (typeof item === "object") {
+      // Create a new object so that if we have to set the key, we are not
+      // mutating the original object
+      const keyedItem = {
+        tagName: item.tagName,
+        attributes: item.attributes,
+        children: item.children,
+        key: i
+      };
+      if (item.attributes && item.attributes.key) {
+        keyedItem.key = item.attributes.key;
       }
     }
 
     return result;
   }
+}

--- a/packages/transforms/src/index.tsx
+++ b/packages/transforms/src/index.tsx
@@ -9,9 +9,7 @@ import LaTeXDisplay from "./latex";
 import SVGDisplay from "./svg";
 import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image";
 
-type Transform = {
-  MIMETYPE: string;
-};
+type Transform  = {MIMETYPE: string} & React.ComponentType
 
 type ObjectType = object;
 export interface Transforms extends ObjectType {

--- a/packages/transforms/src/index.tsx
+++ b/packages/transforms/src/index.tsx
@@ -9,7 +9,7 @@ import LaTeXDisplay from "./latex";
 import SVGDisplay from "./svg";
 import { PNGDisplay, JPEGDisplay, GIFDisplay } from "./image";
 
-type Transform  = {MIMETYPE: string} & React.ComponentType
+type Transform = { MIMETYPE: string } & React.ComponentType;
 
 type ObjectType = object;
 export interface Transforms extends ObjectType {
@@ -36,7 +36,7 @@ const tfs = [
   TextDisplay
 ];
 
-export const standardTransforms: Transforms = {};
+export const standardTransforms: any = {};
 
 tfs.forEach(transform => {
   standardTransforms[transform.MIMETYPE] = transform;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,15 +8,16 @@
     "lib": ["esnext", "dom"],
     "jsx": "react",
     "typeRoots": ["./node_modules/@types", "types"],
-    "baseUrl": "./packages",
+    "baseUrl": ".",
     "moduleResolution": "node",
     "paths": {
-      "@nteract/*": ["./*/src"],
-      "@mybinder/*": ["./*/src"],
-      "rx-jupyter": ["./rx-jupyter/src"],
-      "rx-binder": ["./rx-binder/src"],
-      "enchannel-zmq-backend": ["./enchannel-zmq-backend/src"],
-      "fs-observable": ["./fs-observable/src"]
+      // Attempt to allow our namespace packages to get resolved 
+      "@nteract/*": ["./packages/*/src"],
+      "@mybinder/*": ["./packages/*/src"],
+      "rx-jupyter": ["./packages/rx-jupyter/src"],
+      "rx-binder": ["./packages/rx-binder/src"],
+      "enchannel-zmq-backend": ["./packages/enchannel-zmq-backend/src"],
+      "fs-observable": ["./packages/fs-observable/src"]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "baseUrl": "./packages",
     "moduleResolution": "node",
     "paths": {
-      "@nteract/*": ["./*"]
+      "@nteract/*": ["./*/src"]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
     "baseUrl": ".",
     "moduleResolution": "node",
     "paths": {
-      // Attempt to allow our namespace packages to get resolved 
+      // Attempt to allow our namespace packages to get resolved
       "@nteract/*": ["./packages/*/src"],
       "@mybinder/*": ["./packages/*/src"],
       "rx-jupyter": ["./packages/rx-jupyter/src"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,12 @@
     "baseUrl": "./packages",
     "moduleResolution": "node",
     "paths": {
-      "@nteract/*": ["./*/src"]
+      "@nteract/*": ["./*/src"],
+      "@mybinder/*": ["./*/src"],
+      "rx-jupyter": ["./rx-jupyter/src"],
+      "rx-binder": ["./rx-binder/src"],
+      "enchannel-zmq-backend": ["./enchannel-zmq-backend/src"],
+      "fs-observable": ["./fs-observable/src"]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,8 +7,11 @@
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "jsx": "react",
-    "typeRoots": ["./node_modules/@types", "types"]
-  },
-  // Within VS Code & Atom, compile to keep types up to date
-  "compileOnSave": true
+    "typeRoots": ["./node_modules/@types", "types"],
+    "baseUrl": "./packages",
+    "moduleResolution": "node",
+    "paths": {
+      "@nteract/*": ["./*"]
+    }
+  }
 }


### PR DESCRIPTION
I was going to refactor the `selectors` module to make sure to use generics on Immutable data structures when I ran into #3713. So long as you don't run `yarn build`, you'll see an issue in the typescript setup of `ImmutableCell` not being an exported member of commutable. If you build, it will be available. This is because typescript is resolving based on what's in `lib`, because that's what our `main` points to in each `package.json`. When we were on flow, we remapped the locations like this: https://github.com/nteract/nteract/blob/e9fa8be823b92dc36f2d1b3624d181c30f55620f/.flowconfig#L8

I'd love to do the same.