### PR TITLE
lock down all CellId usage

### DIFF
--- a/applications/desktop/src/notebook/menu.js
+++ b/applications/desktop/src/notebook/menu.js
@@ -593,10 +593,10 @@ export function exportPDF(
   //       and we especially shouldn't be relying on all these actions to
   //       run through before we print...
   // Expand unexpanded cells
-  unexpandedCells.map(cellID =>
+  unexpandedCells.map(cellId =>
     store.dispatch(
       actions.toggleOutputExpansion({
-        id: cellID,
+        id: cellId,
         contentRef: ownProps.contentRef
       })
     )
@@ -610,10 +610,10 @@ export function exportPDF(
       if (error) throw error;
 
       // Restore the modified cells to their unexpanded state.
-      unexpandedCells.map(cellID =>
+      unexpandedCells.map(cellId =>
         store.dispatch(
           actions.toggleOutputExpansion({
-            id: cellID,
+            id: cellId,
             contentRef: ownProps.contentRef
           })
         )

--- a/packages/actions/src/actionTypes.ts
+++ b/packages/actions/src/actionTypes.ts
@@ -1,5 +1,5 @@
 import {
-  CellID,
+  CellId,
   CellType,
   MimeBundle,
   Output,
@@ -122,7 +122,7 @@ export type ToggleTagInCell = {
   // if the tag is already in the collection of tags it will delete it
   type: "CORE/TOGGLE_TAG_IN_CELL";
   payload: {
-    id: CellID;
+    id: CellId;
     tag: string;
     contentRef: ContentRef;
   };
@@ -132,7 +132,7 @@ export const SET_IN_CELL = "SET_IN_CELL";
 export type SetInCell<T> = {
   type: "SET_IN_CELL";
   payload: {
-    id: CellID;
+    id: CellId;
     path: Array<string>;
     value: T;
     contentRef: ContentRef;
@@ -143,8 +143,8 @@ export const MOVE_CELL = "MOVE_CELL";
 export type MoveCell = {
   type: "MOVE_CELL";
   payload: {
-    id: CellID;
-    destinationId: CellID;
+    id: CellId;
+    destinationId: CellId;
     above: boolean;
     contentRef: ContentRef;
   };
@@ -154,7 +154,7 @@ export const DELETE_CELL = "DELETE_CELL";
 export type DeleteCell = {
   type: "DELETE_CELL";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -163,7 +163,7 @@ export const CREATE_CELL_BELOW = "CREATE_CELL_BELOW";
 export type CreateCellBelow = {
   type: "CREATE_CELL_BELOW";
   payload: {
-    id?: CellID;
+    id?: CellId;
     cellType: CellType;
     source: string;
     contentRef: ContentRef;
@@ -175,7 +175,7 @@ export type CreateCellAbove = {
   type: "CREATE_CELL_ABOVE";
   payload: {
     cellType: CellType;
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -185,7 +185,7 @@ export const REMOVE_CELL = "REMOVE_CELL";
 export type RemoveCell = {
   type: "REMOVE_CELL";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -195,7 +195,7 @@ export const CREATE_CELL_AFTER = "CREATE_CELL_AFTER";
 export type CreateCellAfter = {
   type: "CREATE_CELL_AFTER";
   payload: {
-    id?: CellID;
+    id?: CellId;
     cellType: CellType;
     source: string;
     contentRef: ContentRef;
@@ -208,7 +208,7 @@ export type CreateCellBefore = {
   type: "CREATE_CELL_BEFORE";
   payload: {
     cellType: CellType;
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -226,7 +226,7 @@ export const APPEND_OUTPUT = "APPEND_OUTPUT";
 export type AppendOutput = {
   type: "APPEND_OUTPUT";
   payload: {
-    id: CellID;
+    id: CellId;
     output: Output;
     contentRef: ContentRef;
   };
@@ -269,7 +269,7 @@ export const TOGGLE_CELL_OUTPUT_VISIBILITY = "TOGGLE_CELL_OUTPUT_VISIBILITY";
 export type ToggleCellOutputVisibility = {
   type: "TOGGLE_CELL_OUTPUT_VISIBILITY";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -278,7 +278,7 @@ export const TOGGLE_CELL_INPUT_VISIBILITY = "TOGGLE_CELL_INPUT_VISIBILITY";
 export type ToggleCellInputVisibility = {
   type: "TOGGLE_CELL_INPUT_VISIBILITY";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -287,7 +287,7 @@ export const CLEAR_OUTPUTS = "CLEAR_OUTPUTS";
 export type ClearOutputs = {
   type: "CLEAR_OUTPUTS";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -302,7 +302,7 @@ export const ACCEPT_PAYLOAD_MESSAGE = "ACCEPT_PAYLOAD_MESSAGE";
 export type AcceptPayloadMessage = {
   type: "ACCEPT_PAYLOAD_MESSAGE";
   payload: {
-    id: CellID;
+    id: CellId;
     payload: object;
     contentRef: ContentRef;
   };
@@ -331,7 +331,7 @@ export const SEND_EXECUTE_REQUEST = "SEND_EXECUTE_REQUEST";
 export type SendExecuteRequest = {
   type: "SEND_EXECUTE_REQUEST";
   payload: {
-    id: CellID;
+    id: CellId;
     message: ExecuteRequest;
     contentRef: ContentRef;
   };
@@ -341,7 +341,7 @@ export const EXECUTE_CELL = "EXECUTE_CELL";
 export type ExecuteCell = {
   type: "EXECUTE_CELL";
   payload: {
-    id: CellID;
+    id: CellId;
     contentRef: ContentRef;
   };
 };
@@ -374,7 +374,7 @@ export const EXECUTE_CANCELED = "EXECUTE_CANCELED";
 export type ExecuteCanceled = {
   type: "EXECUTE_CANCELED";
   payload: {
-    id: CellID;
+    id: CellId;
     contentRef: ContentRef;
   };
 };
@@ -393,7 +393,7 @@ export const FOCUS_CELL = "FOCUS_CELL";
 export type FocusCell = {
   type: "FOCUS_CELL";
   payload: {
-    id: CellID;
+    id: CellId;
     contentRef: ContentRef;
   };
 };
@@ -402,7 +402,7 @@ export const FOCUS_NEXT_CELL = "FOCUS_NEXT_CELL";
 export type FocusNextCell = {
   type: "FOCUS_NEXT_CELL";
   payload: {
-    id?: CellID;
+    id?: CellId;
     createCellIfUndefined: boolean;
     contentRef: ContentRef;
   };
@@ -412,7 +412,7 @@ export const FOCUS_PREVIOUS_CELL = "FOCUS_PREVIOUS_CELL";
 export type FocusPreviousCell = {
   type: "FOCUS_PREVIOUS_CELL";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -421,7 +421,7 @@ export const FOCUS_CELL_EDITOR = "FOCUS_CELL_EDITOR";
 export type FocusCellEditor = {
   type: "FOCUS_CELL_EDITOR";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -430,7 +430,7 @@ export const FOCUS_NEXT_CELL_EDITOR = "FOCUS_NEXT_CELL_EDITOR";
 export type FocusNextCellEditor = {
   type: "FOCUS_NEXT_CELL_EDITOR";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -439,7 +439,7 @@ export const FOCUS_PREVIOUS_CELL_EDITOR = "FOCUS_PREVIOUS_CELL_EDITOR";
 export type FocusPreviousCellEditor = {
   type: "FOCUS_PREVIOUS_CELL_EDITOR";
   payload: {
-    id?: CellID;
+    id?: CellId;
     contentRef: ContentRef;
   };
 };
@@ -478,7 +478,7 @@ export const UPDATE_CELL_STATUS = "UPDATE_CELL_STATUS";
 export type UpdateCellStatus = {
   type: "UPDATE_CELL_STATUS";
   payload: {
-    id: CellID;
+    id: CellId;
     status: string;
     contentRef: ContentRef;
   };
@@ -533,7 +533,7 @@ export const TOGGLE_OUTPUT_EXPANSION = "TOGGLE_OUTPUT_EXPANSION";
 export type ToggleCellExpansion = {
   type: "TOGGLE_OUTPUT_EXPANSION";
   payload: {
-    id: CellID;
+    id: CellId;
     contentRef: ContentRef;
   };
 };
@@ -541,13 +541,13 @@ export type ToggleCellExpansion = {
 export const CUT_CELL = "CUT_CELL";
 export type CutCell = {
   type: "CUT_CELL";
-  payload: { id?: CellID; contentRef: ContentRef };
+  payload: { id?: CellId; contentRef: ContentRef };
 };
 
 export const COPY_CELL = "COPY_CELL";
 export type CopyCell = {
   type: "COPY_CELL";
-  payload: { id?: CellID; contentRef: ContentRef };
+  payload: { id?: CellId; contentRef: ContentRef };
 };
 
 export const PASTE_CELL = "PASTE_CELL";
@@ -560,7 +560,7 @@ export const CHANGE_CELL_TYPE = "CHANGE_CELL_TYPE";
 export type ChangeCellType = {
   type: "CHANGE_CELL_TYPE";
   payload: {
-    id?: CellID;
+    id?: CellId;
     to: CellType;
     contentRef: ContentRef;
   };

--- a/packages/actions/src/actions.ts
+++ b/packages/actions/src/actions.ts
@@ -1,5 +1,5 @@
 import {
-  CellID,
+  CellId,
   CellType,
   MimeBundle,
   Output,
@@ -246,7 +246,7 @@ export function deleteCell(payload: {
 }
 
 export function createCellBelow(payload: {
-  id?: CellID;
+  id?: CellId;
   cellType: CellType;
   source: string;
   contentRef: ContentRef;
@@ -281,7 +281,7 @@ export function removeCell(payload: {
 
 // Deprecation Warning: createCellAfter() is being deprecated. Please use createCellBelow() instead
 export function createCellAfter(payload: {
-  id?: CellID;
+  id?: CellId;
   cellType: CellType;
   source: string;
   contentRef: ContentRef;
@@ -315,7 +315,7 @@ export function createCellAppend(payload: {
 }
 
 export function toggleParameterCell(payload: {
-  id: CellID;
+  id: CellId;
   contentRef: ContentRef;
 }): actionTypes.ToggleTagInCell {
   // Tag comes via Papermill
@@ -327,7 +327,7 @@ export function toggleParameterCell(payload: {
 }
 
 export function toggleTagInCell(payload: {
-  id: CellID;
+  id: CellId;
   contentRef: ContentRef;
   tag: string;
 }): actionTypes.ToggleTagInCell {
@@ -340,7 +340,7 @@ export function toggleTagInCell(payload: {
 /**
  * setInCell can generically be used to set any attribute on a cell, including
  * and especially for changing metadata per cell.
- * @param {CellID} payload.id    cell ID
+ * @param {CellId} payload.id    cell ID
  * @param {Array<string>} payload.path  path within a cell to set
  * @param {any} payload.value what to set it to
  *
@@ -359,7 +359,7 @@ export function toggleTagInCell(payload: {
  *
  */
 export function setInCell<T>(payload: {
-  id: CellID;
+  id: CellId;
   path: Array<string>;
   value: T;
   contentRef: ContentRef;
@@ -371,7 +371,7 @@ export function setInCell<T>(payload: {
 }
 
 export function updateCellSource(payload: {
-  id: CellID;
+  id: CellId;
   value: string;
   contentRef: ContentRef;
 }): actionTypes.SetInCell<string> {
@@ -379,7 +379,7 @@ export function updateCellSource(payload: {
 }
 
 export function updateCellExecutionCount(payload: {
-  id: CellID;
+  id: CellId;
   value: number;
   contentRef: ContentRef;
 }): actionTypes.SetInCell<number> {
@@ -398,7 +398,7 @@ export function unhideAll(payload: {
 }
 
 export function toggleCellOutputVisibility(payload: {
-  id?: CellID;
+  id?: CellId;
   contentRef: ContentRef;
 }): actionTypes.ToggleCellOutputVisibility {
   return {
@@ -431,7 +431,7 @@ export function updateCellStatus(payload: {
 /* Unlike focus next & previous, to set focus, we require an ID,
    because the others are based on there already being a focused cell */
 export function focusCell(payload: {
-  id: CellID;
+  id: CellId;
   contentRef: ContentRef;
 }): actionTypes.FocusCell {
   return {
@@ -581,7 +581,7 @@ export function setNotificationSystem(
 }
 
 export function copyCell(payload: {
-  id?: CellID;
+  id?: CellId;
   contentRef: ContentRef;
 }): actionTypes.CopyCell {
   return {
@@ -591,7 +591,7 @@ export function copyCell(payload: {
 }
 
 export function cutCell(payload: {
-  id?: CellID;
+  id?: CellId;
   contentRef: ContentRef;
 }): actionTypes.CutCell {
   return {
@@ -610,7 +610,7 @@ export function pasteCell(payload: {
 }
 
 export function changeCellType(payload: {
-  id?: CellID;
+  id?: CellId;
   to: CellType;
   contentRef: ContentRef;
 }): actionTypes.ChangeCellType {
@@ -888,7 +888,7 @@ export function commMessageAction(message: any) {
 }
 
 export function appendOutput(payload: {
-  id: CellID;
+  id: CellId;
   output: Output;
   contentRef: ContentRef;
 }): actionTypes.AppendOutput {
@@ -899,7 +899,7 @@ export function appendOutput(payload: {
 }
 
 export function acceptPayloadMessage(payload: {
-  id: CellID;
+  id: CellId;
   // TODO: Properly type acceptPayloadMessage as taking jupyter payload message
   // Not to be confused with a redux style action payload
   payload: any;

--- a/packages/commutable/src/index.js.flow
+++ b/packages/commutable/src/index.js.flow
@@ -29,7 +29,7 @@ export type ExecutionCount = number | null;
 export type MimeBundle = JSONObject;
 
 export type CellType = "markdown" | "code";
-export type CellID = string;
+export type CellId = string;
 
 // On disk multi-line strings are used to accomodate line-by-line diffs in
 // tools like git and GitHub. They get converted to strings for the in-memory
@@ -47,8 +47,8 @@ export type ImmutableOutputs = ImmutableList<ImmutableOutput>;
 
 export type ImmutableMimeBundle = ImmutableMap<string, any>;
 
-export type ImmutableCellOrder = ImmutableList<CellID>;
-export type ImmutableCellMap = ImmutableMap<CellID, ImmutableCell>;
+export type ImmutableCellOrder = ImmutableList<CellId>;
+export type ImmutableCellMap = ImmutableMap<CellId, ImmutableCell>;
 
 // .....................................
 // from structures
@@ -74,20 +74,20 @@ declare export function createCodeCell(
 declare export function insertCellAt(
   notebook: ImmutableNotebook,
   cell: ImmutableCell,
-  cellID: string,
+  cellId: string,
   index: number
 ): ImmutableNotebook;
 
 declare export function insertCellAfter(
   notebook: ImmutableNotebook,
   cell: ImmutableCell,
-  cellID: string,
-  priorCellID: string
+  cellId: string,
+  priorCellId: string
 ): ImmutableNotebook;
 
 declare export function deleteCell(
   notebook: ImmutableNotebook,
-  cellID: string
+  cellId: string
 ): ImmutableNotebook;
 
 declare export function appendCellToNotebook(

--- a/packages/commutable/src/index.ts
+++ b/packages/commutable/src/index.ts
@@ -6,7 +6,6 @@
 // Make sure the index.js.flow types stay in sync with this section
 //
 
-// from types
 export * from "./primitives";
 
 // from structures
@@ -45,7 +44,6 @@ export {
 } from "./cells";
 
 export {
-  CellID,
   toJS,
   stringifyNotebook,
   fromJS,

--- a/packages/commutable/src/notebook.ts
+++ b/packages/commutable/src/notebook.ts
@@ -13,13 +13,11 @@ import * as v3 from "./v3";
 import { Map as ImmutableMap, List as ImmutableList, Record } from "immutable";
 
 import { ImmutableCell } from "./cells";
-import { JSONType } from "./primitives";
-
-export type CellID = string;
+import { JSONType, CellId } from "./primitives";
 
 export type NotebookRecordParams = {
-  cellOrder: ImmutableList<string>;
-  cellMap: ImmutableMap<string, ImmutableCell>;
+  cellOrder: ImmutableList<CellId>;
+  cellMap: ImmutableMap<CellId, ImmutableCell>;
   nbformat_minor: number;
   nbformat: number;
   metadata: ImmutableMap<string, any>;

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -1,9 +1,10 @@
 /**
  * @module commutable
  */
-export type ExecutionCount = number | null;
-
+import uuid from "uuid/v4";
 import * as Immutable from "immutable";
+
+export type ExecutionCount = number | null;
 
 // Mutable JSON types
 export type PrimitiveImmutable = string | number | boolean | null;
@@ -13,6 +14,9 @@ export interface JSONObject {
 }
 export interface JSONArray extends Array<JSONType> {}
 
+export type CellId = string;
+export const createCellId = (): CellId => uuid();
+
 // On disk multi-line strings are used to accomodate line-by-line diffs in tools
 // like git and GitHub. They get converted to strings for the in-memory format.
 export type MultiLineString = string | string[];
@@ -20,9 +24,8 @@ export type MultiLineString = string | string[];
 export type ImmutableJSONType =
   | PrimitiveImmutable
   | ImmutableJSONMap
-  | ImmutableJSONList
+  | ImmutableJSONList;
 
 // Can't (easily) write circularly referenced types so this'll have to do for now
 export type ImmutableJSONMap = Immutable.Map<string, any>;
 export type ImmutableJSONList = Immutable.List<any>;
-

--- a/packages/commutable/src/structures.ts
+++ b/packages/commutable/src/structures.ts
@@ -3,7 +3,9 @@
  */
 import uuid from "uuid/v4";
 
-import { CellID, makeNotebookRecord, ImmutableNotebook } from "./notebook";
+import { CellId, createCellId } from "./primitives";
+
+import { makeNotebookRecord, ImmutableNotebook } from "./notebook";
 
 import { makeCodeCell, makeMarkdownCell, ImmutableCell } from "./cells";
 
@@ -24,8 +26,8 @@ export const createNotebook = makeNotebookRecord;
 export const emptyNotebook = makeNotebookRecord();
 
 export type CellStructure = {
-  cellOrder: ImmutableList<CellID>;
-  cellMap: ImmutableMap<CellID, ImmutableCell>;
+  cellOrder: ImmutableList<CellId>;
+  cellMap: ImmutableMap<CellId, ImmutableCell>;
 };
 
 // Intended to make it easy to use this with (temporary mutable cellOrder +
@@ -33,7 +35,7 @@ export type CellStructure = {
 export const appendCell = (
   cellStructure: CellStructure,
   immutableCell: ImmutableCell,
-  id: string = uuid()
+  id: CellId = createCellId()
 ): CellStructure => ({
   cellOrder: cellStructure.cellOrder.push(id),
   cellMap: cellStructure.cellMap.set(id, immutableCell)
@@ -55,26 +57,26 @@ export const appendCellToNotebook = (
 export const insertCellAt = (
   notebook: ImmutableNotebook,
   cell: ImmutableCell,
-  cellID: string,
+  cellId: string,
   index: number
 ): ImmutableNotebook =>
   notebook.withMutations(nb =>
     nb
-      .setIn(["cellMap", cellID], cell)
-      .set("cellOrder", nb.get("cellOrder").insert(index, cellID))
+      .setIn(["cellMap", cellId], cell)
+      .set("cellOrder", nb.get("cellOrder").insert(index, cellId))
   );
 
 export const insertCellAfter = (
   notebook: ImmutableNotebook,
   cell: ImmutableCell,
-  cellID: string,
-  priorCellID: string
+  cellId: string,
+  priorCellId: string
 ): ImmutableNotebook =>
   insertCellAt(
     notebook,
     cell,
-    cellID,
-    notebook.get("cellOrder").indexOf(priorCellID) + 1
+    cellId,
+    notebook.get("cellOrder").indexOf(priorCellId) + 1
   );
 
 /**
@@ -82,22 +84,22 @@ export const insertCellAfter = (
  */
 export const removeCell = (
   notebook: ImmutableNotebook,
-  cellID: string
+  cellId: string
 ): ImmutableNotebook => {
   console.log(
     "Deprecation Warning: removeCell() is being deprecated. Please use deleteCell() instead"
   );
 
-  return deleteCell(notebook, cellID);
+  return deleteCell(notebook, cellId);
 };
 
 export const deleteCell = (
   notebook: ImmutableNotebook,
-  cellID: string
+  cellId: string
 ): ImmutableNotebook =>
   notebook
-    .removeIn(["cellMap", cellID])
-    .update("cellOrder", cellOrder => cellOrder.filterNot(id => id === cellID));
+    .removeIn(["cellMap", cellId])
+    .update("cellOrder", cellOrder => cellOrder.filterNot(id => id === cellId));
 
 export const monocellNotebook = appendCellToNotebook(
   emptyNotebook,

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -338,8 +338,8 @@ export const toJS = (immnb: ImmutableNotebook): Notebook => {
     [key: string]: ImmutableCell;
   } = plainNotebook.cellMap.toObject();
 
-  const cells = plainCellOrder.map((cellID: string) =>
-    cellToJS(plainCellMap[cellID])
+  const cells = plainCellOrder.map((cellId: string) =>
+    cellToJS(plainCellMap[cellId])
   );
 
   return {

--- a/packages/core/__tests__/document-spec.js
+++ b/packages/core/__tests__/document-spec.js
@@ -451,8 +451,8 @@ describe("createCellBelow", () => {
       actions.createCellBelow({ cellType: "markdown", id })
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
-    const cellID = state.getIn(["notebook", "cellOrder"]).last();
-    const cell = state.getIn(["notebook", "cellMap", cellID]);
+    const cellId = state.getIn(["notebook", "cellOrder"]).last();
+    const cell = state.getIn(["notebook", "cellMap", cellId]);
     expect(cell.get("cell_type")).toBe("markdown");
   });
 });
@@ -479,8 +479,8 @@ describe("createCellAfter", () => {
       actions.createCellAfter({ cellType: "markdown", id })
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
-    const cellID = state.getIn(["notebook", "cellOrder"]).last();
-    const cell = state.getIn(["notebook", "cellMap", cellID]);
+    const cellId = state.getIn(["notebook", "cellOrder"]).last();
+    const cell = state.getIn(["notebook", "cellMap", cellId]);
     expect(cell.get("cell_type")).toBe("markdown");
   });
 });

--- a/packages/core/src/actionTypes.js
+++ b/packages/core/src/actionTypes.js
@@ -1,6 +1,6 @@
 /* @flow */
 import type {
-  CellID,
+  CellId,
   CellType,
   ImmutableJSONType,
   MimeBundle,
@@ -128,7 +128,7 @@ export type ToggleTagInCell = {
   // if the tag is already in the collection of tags it will delete it
   type: "CORE/TOGGLE_TAG_IN_CELL",
   payload: {
-    id: CellID,
+    id: CellId,
     tag: string,
     contentRef: ContentRef
   }
@@ -138,7 +138,7 @@ export const SET_IN_CELL = "SET_IN_CELL";
 export type SetInCell<T> = {
   type: "SET_IN_CELL",
   payload: {
-    id: CellID,
+    id: CellId,
     path: Array<string>,
     value: T,
     contentRef: ContentRef
@@ -149,8 +149,8 @@ export const MOVE_CELL = "MOVE_CELL";
 export type MoveCell = {
   type: "MOVE_CELL",
   payload: {
-    id: CellID,
-    destinationId: CellID,
+    id: CellId,
+    destinationId: CellId,
     above: boolean,
     contentRef: ContentRef
   }
@@ -160,7 +160,7 @@ export const DELETE_CELL = "DELETE_CELL";
 export type DeleteCell = {
   type: "DELETE_CELL",
   payload: {
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -169,7 +169,7 @@ export const CREATE_CELL_BELOW = "CREATE_CELL_BELOW";
 export type CreateCellBelow = {
   type: "CREATE_CELL_BELOW",
   payload: {
-    id?: CellID,
+    id?: CellId,
     cellType: CellType,
     source: string,
     contentRef: ContentRef
@@ -181,7 +181,7 @@ export type CreateCellAbove = {
   type: "CREATE_CELL_ABOVE",
   payload: {
     cellType: CellType,
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -191,7 +191,7 @@ export const REMOVE_CELL = "REMOVE_CELL";
 export type RemoveCell = {
   type: "REMOVE_CELL",
   payload: {
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -201,7 +201,7 @@ export const CREATE_CELL_AFTER = "CREATE_CELL_AFTER";
 export type CreateCellAfter = {
   type: "CREATE_CELL_AFTER",
   payload: {
-    id?: CellID,
+    id?: CellId,
     cellType: CellType,
     source: string,
     contentRef: ContentRef
@@ -214,7 +214,7 @@ export type CreateCellBefore = {
   type: "CREATE_CELL_BEFORE",
   payload: {
     cellType: CellType,
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -232,7 +232,7 @@ export const APPEND_OUTPUT = "APPEND_OUTPUT";
 export type AppendOutput = {
   type: "APPEND_OUTPUT",
   payload: {
-    id: CellID,
+    id: CellId,
     output: Output,
     contentRef: ContentRef
   }
@@ -275,7 +275,7 @@ export const TOGGLE_CELL_OUTPUT_VISIBILITY = "TOGGLE_CELL_OUTPUT_VISIBILITY";
 export type ToggleCellOutputVisibility = {
   type: "TOGGLE_CELL_OUTPUT_VISIBILITY",
   payload: {
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -284,7 +284,7 @@ export const TOGGLE_CELL_INPUT_VISIBILITY = "TOGGLE_CELL_INPUT_VISIBILITY";
 export type ToggleCellInputVisibility = {
   type: "TOGGLE_CELL_INPUT_VISIBILITY",
   payload: {
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -293,7 +293,7 @@ export const CLEAR_OUTPUTS = "CLEAR_OUTPUTS";
 export type ClearOutputs = {
   type: "CLEAR_OUTPUTS",
   payload: {
-    id?: CellID,
+    id?: CellId,
     contentRef: ContentRef
   }
 };
@@ -308,7 +308,7 @@ export const ACCEPT_PAYLOAD_MESSAGE = "ACCEPT_PAYLOAD_MESSAGE";
 export type AcceptPayloadMessage = {
   type: "ACCEPT_PAYLOAD_MESSAGE",
   payload: {
-    id: CellID,
+    id: CellId,
     payload: *,
     contentRef: ContentRef
   }
@@ -337,7 +337,7 @@ export const SEND_EXECUTE_REQUEST = "SEND_EXECUTE_REQUEST";
 export type SendExecuteRequest = {
   type: "SEND_EXECUTE_REQUEST",
   payload: {
-    id: CellID,
+    id: CellId,
     message: ExecuteRequest,
     contentRef: ContentRef
   }
@@ -347,7 +347,7 @@ export const EXECUTE_CELL = "EXECUTE_CELL";
 export type ExecuteCell = {
   type: "EXECUTE_CELL",
   payload: {
-    id: CellID,
+    id: CellId,
     contentRef: ContentRef
   }
 };
@@ -380,7 +380,7 @@ export const EXECUTE_CANCELED = "EXECUTE_CANCELED";
 export type ExecuteCanceled = {
   type: "EXECUTE_CANCELED",
   payload: {
-    id: CellID,
+    id: CellId,
     contentRef: ContentRef
   }
 };
@@ -399,7 +399,7 @@ export const FOCUS_CELL = "FOCUS_CELL";
 export type FocusCell = {
   type: "FOCUS_CELL",
   payload: {
-    id: CellID,
+    id: CellId,
     contentRef: ContentRef
   }
 };
@@ -408,7 +408,7 @@ export const FOCUS_NEXT_CELL = "FOCUS_NEXT_CELL";
 export type FocusNextCell = {
   type: "FOCUS_NEXT_CELL",
   payload: {
-    id: ?CellID,
+    id: ?CellId,
     createCellIfUndefined: boolean,
     contentRef: ContentRef
   }
@@ -418,7 +418,7 @@ export const FOCUS_PREVIOUS_CELL = "FOCUS_PREVIOUS_CELL";
 export type FocusPreviousCell = {
   type: "FOCUS_PREVIOUS_CELL",
   payload: {
-    id: ?CellID,
+    id: ?CellId,
     contentRef: ContentRef
   }
 };
@@ -427,7 +427,7 @@ export const FOCUS_CELL_EDITOR = "FOCUS_CELL_EDITOR";
 export type FocusCellEditor = {
   type: "FOCUS_CELL_EDITOR",
   payload: {
-    id: ?CellID,
+    id: ?CellId,
     contentRef: ContentRef
   }
 };
@@ -436,7 +436,7 @@ export const FOCUS_NEXT_CELL_EDITOR = "FOCUS_NEXT_CELL_EDITOR";
 export type FocusNextCellEditor = {
   type: "FOCUS_NEXT_CELL_EDITOR",
   payload: {
-    id: ?CellID,
+    id: ?CellId,
     contentRef: ContentRef
   }
 };
@@ -445,7 +445,7 @@ export const FOCUS_PREVIOUS_CELL_EDITOR = "FOCUS_PREVIOUS_CELL_EDITOR";
 export type FocusPreviousCellEditor = {
   type: "FOCUS_PREVIOUS_CELL_EDITOR",
   payload: {
-    id: ?CellID,
+    id: ?CellId,
     contentRef: ContentRef
   }
 };
@@ -484,7 +484,7 @@ export const UPDATE_CELL_STATUS = "UPDATE_CELL_STATUS";
 export type UpdateCellStatus = {
   type: "UPDATE_CELL_STATUS",
   payload: {
-    id: CellID,
+    id: CellId,
     status: string,
     contentRef: ContentRef
   }
@@ -539,7 +539,7 @@ export const TOGGLE_OUTPUT_EXPANSION = "TOGGLE_OUTPUT_EXPANSION";
 export type ToggleCellExpansion = {
   type: "TOGGLE_OUTPUT_EXPANSION",
   payload: {
-    id: CellID,
+    id: CellId,
     contentRef: ContentRef
   }
 };
@@ -547,13 +547,13 @@ export type ToggleCellExpansion = {
 export const CUT_CELL = "CUT_CELL";
 export type CutCell = {
   type: "CUT_CELL",
-  payload: { id?: CellID, contentRef: ContentRef }
+  payload: { id?: CellId, contentRef: ContentRef }
 };
 
 export const COPY_CELL = "COPY_CELL";
 export type CopyCell = {
   type: "COPY_CELL",
-  payload: { id?: CellID, contentRef: ContentRef }
+  payload: { id?: CellId, contentRef: ContentRef }
 };
 
 export const PASTE_CELL = "PASTE_CELL";
@@ -566,7 +566,7 @@ export const CHANGE_CELL_TYPE = "CHANGE_CELL_TYPE";
 export type ChangeCellType = {
   type: "CHANGE_CELL_TYPE",
   payload: {
-    id?: CellID,
+    id?: CellId,
     to: CellType,
     contentRef: ContentRef
   }

--- a/packages/core/src/actions.js
+++ b/packages/core/src/actions.js
@@ -1,6 +1,6 @@
 // @flow
 import type {
-  CellID,
+  CellId,
   CellType,
   MimeBundle,
   Output,
@@ -248,7 +248,7 @@ export function deleteCell(payload: {
 }
 
 export function createCellBelow(payload: {
-  id?: CellID,
+  id?: CellId,
   cellType: CellType,
   source: string,
   contentRef: ContentRef
@@ -283,7 +283,7 @@ export function removeCell(payload: {
 
 // Deprecation Warning: createCellAfter() is being deprecated. Please use createCellBelow() instead
 export function createCellAfter(payload: {
-  id?: CellID,
+  id?: CellId,
   cellType: CellType,
   source: string,
   contentRef: ContentRef
@@ -317,7 +317,7 @@ export function createCellAppend(payload: {
 }
 
 export function toggleParameterCell(payload: {
-  id: CellID,
+  id: CellId,
   contentRef: ContentRef
 }): actionTypes.ToggleTagInCell {
   // Tag comes via Papermill
@@ -329,7 +329,7 @@ export function toggleParameterCell(payload: {
 }
 
 export function toggleTagInCell(payload: {
-  id: CellID,
+  id: CellId,
   contentRef: ContentRef,
   tag: string
 }): actionTypes.ToggleTagInCell {
@@ -342,7 +342,7 @@ export function toggleTagInCell(payload: {
 /**
  * setInCell can generically be used to set any attribute on a cell, including
  * and especially for changing metadata per cell.
- * @param {CellID} payload.id    cell ID
+ * @param {CellId} payload.id    cell ID
  * @param {Array<string>} payload.path  path within a cell to set
  * @param {any} payload.value what to set it to
  *
@@ -361,7 +361,7 @@ export function toggleTagInCell(payload: {
  *
  */
 export function setInCell<T>(payload: {
-  id: CellID,
+  id: CellId,
   path: Array<string>,
   value: T,
   contentRef: ContentRef
@@ -373,7 +373,7 @@ export function setInCell<T>(payload: {
 }
 
 export function updateCellSource(payload: {
-  id: CellID,
+  id: CellId,
   value: string,
   contentRef: ContentRef
 }): actionTypes.SetInCell<string> {
@@ -381,7 +381,7 @@ export function updateCellSource(payload: {
 }
 
 export function updateCellExecutionCount(payload: {
-  id: CellID,
+  id: CellId,
   value: number,
   contentRef: ContentRef
 }): actionTypes.SetInCell<number> {
@@ -400,7 +400,7 @@ export function unhideAll(payload: {
 }
 
 export function toggleCellOutputVisibility(payload: {
-  id?: CellID,
+  id?: CellId,
   contentRef: ContentRef
 }): actionTypes.ToggleCellOutputVisibility {
   return {
@@ -433,7 +433,7 @@ export function updateCellStatus(payload: {
 /* Unlike focus next & previous, to set focus, we require an ID,
    because the others are based on there already being a focused cell */
 export function focusCell(payload: {
-  id: CellID,
+  id: CellId,
   contentRef: ContentRef
 }): actionTypes.FocusCell {
   return {
@@ -583,7 +583,7 @@ export function setNotificationSystem(
 }
 
 export function copyCell(payload: {
-  id?: CellID,
+  id?: CellId,
   contentRef: ContentRef
 }): actionTypes.CopyCell {
   return {
@@ -593,7 +593,7 @@ export function copyCell(payload: {
 }
 
 export function cutCell(payload: {
-  id?: CellID,
+  id?: CellId,
   contentRef: ContentRef
 }): actionTypes.CutCell {
   return {
@@ -612,7 +612,7 @@ export function pasteCell(payload: {
 }
 
 export function changeCellType(payload: {
-  id?: CellID,
+  id?: CellId,
   to: CellType,
   contentRef: ContentRef
 }): actionTypes.ChangeCellType {
@@ -892,7 +892,7 @@ export function commMessageAction(message: any) {
 }
 
 export function appendOutput(payload: {
-  id: CellID,
+  id: CellId,
   output: Output,
   contentRef: ContentRef
 }): actionTypes.AppendOutput {
@@ -903,7 +903,7 @@ export function appendOutput(payload: {
 }
 
 export function acceptPayloadMessage(payload: {
-  id: CellID,
+  id: CellId,
   payload: *,
   contentRef: ContentRef
 }): actionTypes.AcceptPayloadMessage {

--- a/packages/core/src/reducers/core/entities/contents/notebook.js
+++ b/packages/core/src/reducers/core/entities/contents/notebook.js
@@ -6,7 +6,7 @@ import type {
   ImmutableCell,
   ImmutableCellMap,
   ImmutableNotebook,
-  CellID,
+  CellId,
   ImmutableCellOrder,
   ImmutableOutput,
   ImmutableOutputs,
@@ -188,7 +188,7 @@ function clearAllOutputs(
 
 function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
   const output = action.payload.output;
-  const cellID = action.payload.id;
+  const cellId = action.payload.id;
 
   // If it's display data and it doesn't have a display id, fold it in like non
   // display data
@@ -197,7 +197,7 @@ function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
     !has(output, "transient.display_id")
   ) {
     return state.updateIn(
-      ["notebook", "cellMap", cellID, "outputs"],
+      ["notebook", "cellMap", cellId, "outputs"],
       (outputs: ImmutableOutputs): ImmutableOutputs =>
         reduceOutputs(outputs, output)
     );
@@ -218,14 +218,14 @@ function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
 
   // Determine the next output index
   const outputIndex = state
-    .getIn(["notebook", "cellMap", cellID, "outputs"], Immutable.List())
+    .getIn(["notebook", "cellMap", cellId, "outputs"], Immutable.List())
     .count();
 
   // Construct the path to the output for updating later
   const keyPath: KeyPath = Immutable.List([
     "notebook",
     "cellMap",
-    cellID,
+    cellId,
     "outputs",
     outputIndex
   ]);
@@ -295,7 +295,7 @@ function focusNextCell(
     return state;
   }
 
-  const curIndex = cellOrder.findIndex((foundId: CellID) => id === foundId);
+  const curIndex = cellOrder.findIndex((foundId: CellId) => id === foundId);
   const curCellType = state.getIn(["notebook", "cellMap", id, "cell_type"]);
 
   const nextIndex = curIndex + 1;
@@ -306,14 +306,14 @@ function focusNextCell(
       return state;
     }
 
-    const cellID: string = uuid();
+    const cellId: string = uuid();
     const cell = curCellType === "code" ? emptyCodeCell : emptyMarkdownCell;
 
     const notebook: ImmutableNotebook = state.get("notebook");
 
     return state
-      .set("cellFocused", cellID)
-      .set("notebook", insertCellAt(notebook, cell, cellID, nextIndex));
+      .set("cellFocused", cellId)
+      .set("notebook", insertCellAt(notebook, cell, cellId, nextIndex));
   }
 
   // When in the middle of the notebook document, move to the next cell
@@ -326,7 +326,7 @@ function focusPreviousCell(
 ): NotebookModel {
   const cellOrder = state.getIn(["notebook", "cellOrder"], Immutable.List());
   const curIndex = cellOrder.findIndex(
-    (id: CellID) => id === action.payload.id
+    (id: CellId) => id === action.payload.id
   );
   const nextIndex = Math.max(0, curIndex - 1);
 
@@ -357,7 +357,7 @@ function focusNextCellEditor(
     return state;
   }
 
-  const curIndex = cellOrder.findIndex((foundId: CellID) => id === foundId);
+  const curIndex = cellOrder.findIndex((foundId: CellId) => id === foundId);
   const nextIndex = curIndex + 1;
 
   return state.set("editorFocused", cellOrder.get(nextIndex));
@@ -372,7 +372,7 @@ function focusPreviousCellEditor(
     Immutable.List()
   );
   const curIndex = cellOrder.findIndex(
-    (id: CellID) => id === action.payload.id
+    (id: CellId) => id === action.payload.id
   );
   const nextIndex = Math.max(0, curIndex - 1);
 
@@ -425,10 +425,10 @@ function createCellBelow(
 
   const { cellType, source } = action.payload;
   const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
-  const cellID = uuid();
+  const cellId = uuid();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
     const index = notebook.get("cellOrder", Immutable.List()).indexOf(id) + 1;
-    return insertCellAt(notebook, cell.set("source", source), cellID, index);
+    return insertCellAt(notebook, cell.set("source", source), cellId, index);
   });
 }
 
@@ -443,14 +443,14 @@ function createCellAbove(
 
   const { cellType } = action.payload;
   const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
-  const cellID = uuid();
+  const cellId = uuid();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
     const cellOrder: ImmutableCellOrder = notebook.get(
       "cellOrder",
       Immutable.List()
     );
     const index = cellOrder.indexOf(id);
-    return insertCellAt(notebook, cell, cellID, index);
+    return insertCellAt(notebook, cell, cellId, index);
   });
 }
 
@@ -468,10 +468,10 @@ function createCellAfter(
 
   const { cellType, source } = action.payload;
   const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
-  const cellID = uuid();
+  const cellId = uuid();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
     const index = notebook.get("cellOrder", Immutable.List()).indexOf(id) + 1;
-    return insertCellAt(notebook, cell.set("source", source), cellID, index);
+    return insertCellAt(notebook, cell.set("source", source), cellId, index);
   });
 }
 
@@ -489,14 +489,14 @@ function createCellBefore(
 
   const { cellType } = action.payload;
   const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
-  const cellID = uuid();
+  const cellId = uuid();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
     const cellOrder: ImmutableCellOrder = notebook.get(
       "cellOrder",
       Immutable.List()
     );
     const index = cellOrder.indexOf(id);
-    return insertCellAt(notebook, cell, cellID, index);
+    return insertCellAt(notebook, cell, cellId, index);
   });
 }
 
@@ -513,8 +513,8 @@ function createCellAppend(
   const cell: ImmutableCell =
     cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
   const index = cellOrder.count();
-  const cellID = uuid();
-  return state.set("notebook", insertCellAt(notebook, cell, cellID, index));
+  const cellId = uuid();
+  return state.set("notebook", insertCellAt(notebook, cell, cellId, index));
 }
 
 function acceptPayloadMessage(

--- a/packages/core/src/selectors/notebook.js
+++ b/packages/core/src/selectors/notebook.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Immutable from "immutable";
 import * as commutable from "@nteract/commutable";
-import type { CellID } from "@nteract/commutable";
+import type { CellId } from "@nteract/commutable";
 import { createSelector } from "reselect";
 
 // All these selectors expect a NotebookModel as the top level state
@@ -10,14 +10,14 @@ import type { NotebookModel } from "../state/entities/contents/notebook";
 export const cellMap = (model: NotebookModel) =>
   model.notebook.get("cellMap", Immutable.Map());
 
-export const cellById = (model: NotebookModel, { id }: { id: CellID }) =>
+export const cellById = (model: NotebookModel, { id }: { id: CellId }) =>
   cellMap(model).get(id);
 
-export const cellOrder = (model: NotebookModel): Immutable.List<CellID> =>
+export const cellOrder = (model: NotebookModel): Immutable.List<CellId> =>
   model.notebook.get("cellOrder", Immutable.List());
 
-export const cellFocused = (model: NotebookModel): ?CellID => model.cellFocused;
-export const editorFocusedId = (model: NotebookModel): ?CellID =>
+export const cellFocused = (model: NotebookModel): ?CellId => model.cellFocused;
+export const editorFocusedId = (model: NotebookModel): ?CellId =>
   model.editorFocused;
 
 export const codeCellIdsBelow = (model: NotebookModel) => {

--- a/packages/core/src/state/entities/contents/notebook.js
+++ b/packages/core/src/state/entities/contents/notebook.js
@@ -1,7 +1,7 @@
 // @flow
 import * as Immutable from "immutable";
 import { emptyNotebook } from "@nteract/commutable";
-import type { CellID, ImmutableNotebook } from "@nteract/commutable";
+import type { CellId, ImmutableNotebook } from "@nteract/commutable";
 
 import type { KernelRef } from "../..";
 
@@ -15,8 +15,8 @@ export type DocumentRecordProps = {
   // right now it's keypaths and then it looks like it's able to handle any per
   // cell transient data that will be deleted when the kernel is restarted
   cellPagers: any,
-  editorFocused: ?CellID,
-  cellFocused: ?CellID,
+  editorFocused: ?CellId,
+  cellFocused: ?CellId,
   copied: Immutable.Map<any, any>,
   kernelRef: ?KernelRef
 };

--- a/packages/notebook-app-component/__tests__/notebook-spec.js
+++ b/packages/notebook-app-component/__tests__/notebook-spec.js
@@ -9,9 +9,9 @@ import { NotebookApp } from "../src/notebook-app";
 const dummyCellStatuses = dummyCommutable
   .get("cellOrder")
   .reduce(
-    (statuses, cellID) =>
+    (statuses, cellId) =>
       statuses.set(
-        cellID,
+        cellId,
         Immutable.fromJS({ outputHidden: false, inputHidden: false })
       ),
     new Immutable.Map()

--- a/packages/notebook-preview/src/index.js
+++ b/packages/notebook-preview/src/index.js
@@ -85,8 +85,8 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
       <MathJax.Provider>
         <div className="notebook-preview">
           <Cells>
-            {cellOrder.map(cellID => {
-              const cell = cellMap.get(cellID);
+            {cellOrder.map(cellId => {
+              const cell = cellMap.get(cellId);
               const cellType = cell.get("cell_type");
               const source = cell.get("source");
 
@@ -107,7 +107,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
                   );
 
                   return (
-                    <Cell key={cellID}>
+                    <Cell key={cellId}>
                       <PapermillView status={papermillStatus} />
                       <Input hidden={sourceHidden}>
                         <Prompt
@@ -135,7 +135,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
                   );
                 case "markdown":
                   return (
-                    <Cell key={cellID}>
+                    <Cell key={cellId}>
                       <div className="content-margin">
                         <Markdown source={source} />
                       </div>
@@ -151,7 +151,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
                   );
                 case "raw":
                   return (
-                    <Cell key={cellID}>
+                    <Cell key={cellId}>
                       <pre className="raw-cell">
                         {source}
                         <style jsx>{`
@@ -171,7 +171,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
 
                 default:
                   return (
-                    <Cell key={cellID}>
+                    <Cell key={cellId}>
                       <Outputs>
                         <pre>{`Cell Type "${cellType}" is not implemented`}</pre>
                       </Outputs>

--- a/packages/notebook-render/src/index.tsx
+++ b/packages/notebook-render/src/index.tsx
@@ -87,8 +87,8 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
     return (
       <div className="notebook-render">
         <Cells>
-          {cellOrder.map((cellID: string) => {
-            const cell = cellMap.get(cellID);
+          {cellOrder.map((cellId: string) => {
+            const cell = cellMap.get(cellId);
             const cellType: string = cell!.get("cell_type");
             const source = cell!.get("source");
 
@@ -104,7 +104,7 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
                   cell!.getIn(["metadata", "outputHidden"]);
 
                 return (
-                  <Cell key={cellID}>
+                  <Cell key={cellId}>
                     <Input hidden={sourceHidden}>
                       <Prompt
                         counter={(cell as ImmutableCodeCell).get(
@@ -142,7 +142,7 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
                   }
                 } as any;
                 return (
-                  <Cell key={cellID}>
+                  <Cell key={cellId}>
                     <div className="content-margin">
                       <ReactMarkdown
                         escapeHtml={false}
@@ -163,7 +163,7 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
                 );
               case "raw":
                 return (
-                  <Cell key={cellID}>
+                  <Cell key={cellId}>
                     <pre className="raw-cell">
                       {source}
                       <style jsx>{`
@@ -183,7 +183,7 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
 
               default:
                 return (
-                  <Cell key={cellID}>
+                  <Cell key={cellId}>
                     <Outputs>
                       <pre>{`Cell Type "${cellType}" is not implemented`}</pre>
                     </Outputs>

--- a/packages/records/src/index.ts
+++ b/packages/records/src/index.ts
@@ -21,7 +21,7 @@ import {
 export type ExecutionCount = number | null;
 export type MimeBundle = JSONObject;
 export type CellType = "markdown" | "code";
-export type CellID = string;
+export type CellId = string;
 
 export {
   ImmutableCellOrder,

--- a/packages/records/src/structures.ts
+++ b/packages/records/src/structures.ts
@@ -1,7 +1,15 @@
 import produce from "immer";
 import uuid from "uuid/v4";
 
-import { NbformatCell, NbformatCodeCell, CodeCellType, MarkdownCellType, NbformatMarkdownCell, CODECELL, MARKDOWNCELL } from "./cells";
+import {
+  NbformatCell,
+  NbformatCodeCell,
+  CodeCellType,
+  MarkdownCellType,
+  NbformatMarkdownCell,
+  CODECELL,
+  MARKDOWNCELL
+} from "./cells";
 import { NbformatOutput } from "./outputs";
 import {
   ImmutableNotebook,
@@ -20,7 +28,7 @@ export interface Notebook {
   metadata: object;
   cellOrder: Array<string>;
   cellMap: object;
-};
+}
 
 export interface CodeCell {
   cell_type: CodeCellType;
@@ -28,13 +36,13 @@ export interface CodeCell {
   execution_count: ExecutionCount;
   source: string;
   outputs: Array<NbformatOutput>;
-};
+}
 
 export interface MarkdownCell {
   cell_type: MarkdownCellType;
   source: string;
   metadata: object;
-};
+}
 
 const defaultCodeCell = {
   cell_type: CODECELL,
@@ -54,7 +62,9 @@ const defaultMarkdownCell = {
   source: ""
 };
 
-export function createCodeCell(cell: CodeCell = defaultCodeCell): NbformatCodeCell {
+export function createCodeCell(
+  cell: CodeCell = defaultCodeCell
+): NbformatCodeCell {
   return produce(defaultCodeCell, draft => Object.assign(draft, cell));
 }
 
@@ -86,7 +96,7 @@ export const emptyNotebook = createNotebook();
 export interface CellStructure {
   cellOrder: ImmutableCellOrder;
   cellMap: ImmutableCellMap;
-};
+}
 
 // Intended to make it easy to use this with (temporary mutable cellOrder + cellMap)
 export function appendCell(
@@ -118,41 +128,45 @@ export function appendCellToNotebook(
 export function insertCellAt(
   notebook: ImmutableNotebook,
   cell: NbformatCell,
-  cellID: string,
+  cellId: string,
   index: number
 ): ImmutableNotebook {
-  notebook["cellMap"][cellID] = cell;
-  notebook["cellOrder"][index] = cellID;
+  notebook["cellMap"][cellId] = cell;
+  notebook["cellOrder"][index] = cellId;
   return notebook;
 }
 
 export function insertCellAfter(
   notebook: ImmutableNotebook,
   cell: NbformatCell,
-  cellID: string,
-  priorCellID: string
+  cellId: string,
+  priorCellId: string
 ): ImmutableNotebook {
   return insertCellAt(
     notebook,
     cell,
-    cellID,
-    notebook["cellOrder"].indexOf(priorCellID) + 1
+    cellId,
+    notebook["cellOrder"].indexOf(priorCellId) + 1
   );
 }
 
 // Deprecation Warning: removeCell() is being deprecated. Please use deleteCell() instead
-export function removeCell(notebook: ImmutableNotebook, cellID: string) {
+export function removeCell(notebook: ImmutableNotebook, cellId: string) {
   console.log(
     "Deprecation Warning: removeCell() is being deprecated. Please use deleteCell() instead"
   );
-  delete notebook["cellMap"][cellID];
-  notebook["cellOrder"] = notebook["cellOrder"].filter((id: string) => id !== cellID);
+  delete notebook["cellMap"][cellId];
+  notebook["cellOrder"] = notebook["cellOrder"].filter(
+    (id: string) => id !== cellId
+  );
   return notebook;
 }
 
-export function deleteCell(notebook: ImmutableNotebook, cellID: string) {
-  delete notebook["cellMap"][cellID];
-  notebook["cellOrder"] = notebook["cellOrder"].filter((id: string) => id !== cellID);
+export function deleteCell(notebook: ImmutableNotebook, cellId: string) {
+  delete notebook["cellMap"][cellId];
+  notebook["cellOrder"] = notebook["cellOrder"].filter(
+    (id: string) => id !== cellId
+  );
   return notebook;
 }
 

--- a/packages/records/src/types.ts
+++ b/packages/records/src/types.ts
@@ -1,25 +1,25 @@
 export type PrimitiveImmutable = string | boolean | null;
 export type JSONType = PrimitiveImmutable | JSONObject | JSONArray;
 export type JSONObject = { [key: string]: JSONType };
-export interface JSONArray extends Array<JSONType> {};
+export interface JSONArray extends Array<JSONType> {}
 
 export type ExecutionCount = number | null;
 
 export type MimeBundle = JSONObject;
 
 export type CellType = "markdown" | "code";
-export type CellID = string;
+export type CellId = string;
 
 // These are very unserious types, since Records are not quite typable
-export type ImmutableNotebook = { [key: string]: any};
-export type ImmutableCodeCell = { [key: string]: any};
-export type ImmutableMarkdownCell = { [key: string]: any};
-export type ImmutableRawCell = { [key: string]: any};
+export type ImmutableNotebook = { [key: string]: any };
+export type ImmutableCodeCell = { [key: string]: any };
+export type ImmutableMarkdownCell = { [key: string]: any };
+export type ImmutableRawCell = { [key: string]: any };
 export type ImmutableCell = ImmutableCodeCell | ImmutableMarkdownCell;
-export type ImmutableOutput = { [key: string]: any};
+export type ImmutableOutput = { [key: string]: any };
 export type ImmutableOutputs = Array<ImmutableOutput>;
 
-export type ImmutableMimeBundle = { [key: string]: any};
+export type ImmutableMimeBundle = { [key: string]: any };
 
-export type ImmutableCellOrder = Array<CellID>;
-export type ImmutableCellMap = { [key: string]: any};
+export type ImmutableCellOrder = Array<CellId>;
+export type ImmutableCellMap = { [key: string]: any };

--- a/packages/selectors/src/notebook.ts
+++ b/packages/selectors/src/notebook.ts
@@ -3,8 +3,11 @@
  */
 import * as Immutable from "immutable";
 import * as commutable from "@nteract/commutable";
+
+import { ImmutableCell, CellId } from "@nteract/commutable";
+
 // All these selectors expect a NotebookModel as the top level state
-import { NotebookModel, CellId } from "@nteract/types";
+import { NotebookModel } from "@nteract/types";
 import { createSelector } from "reselect";
 
 /**
@@ -16,7 +19,7 @@ import { createSelector } from "reselect";
  * @returns         The cell map within the notebook or an empty map
  */
 export const cellMap = (model: NotebookModel) =>
-  model.notebook.get("cellMap", Immutable.Map());
+  model.notebook.get("cellMap", Immutable.Map<CellId, ImmutableCell>());
 
 /**
  * Returns the cell within a notebook with a particular ID. Returns
@@ -39,7 +42,7 @@ export const cellById = (model: NotebookModel, { id }: { id: CellId }) =>
  * @returns         The cell order within a notebook or an empty list
  */
 export const cellOrder = (model: NotebookModel): Immutable.List<CellId> =>
-  model.notebook.get("cellOrder", Immutable.List());
+  model.notebook.get("cellOrder", Immutable.List<CellId>());
 
 /**
  * Returns the ID of the focused cell within a notebook.
@@ -74,9 +77,9 @@ export const codeCellIdsBelow = (model: NotebookModel): Immutable.List<CellId> =
   const cellFocused = model.cellFocused;
   if (!cellFocused) {
     // NOTE: if there is no focused cell, this runs none of the cells
-    return Immutable.List();
+    return Immutable.List<CellId>();
   }
-  const cellOrder = model.notebook.get("cellOrder", Immutable.List());
+  const cellOrder = model.notebook.get("cellOrder", Immutable.List<CellId>());
 
   const index = cellOrder.indexOf(cellFocused);
   return cellOrder
@@ -105,9 +108,9 @@ export const hiddenCellIds = createSelector(
  */
 export const idsOfHiddenOutputs = createSelector(
   [cellMap, cellOrder],
-  (cellMap, cellOrder): Immutable.List<any> => {
+  (cellMap, cellOrder): Immutable.List<CellId> => {
     if (!cellOrder || !cellMap) {
-      return Immutable.List();
+      return Immutable.List<CellId>();
     }
 
     return cellOrder.filter(CellId =>

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,6 +18,7 @@
   "author": "Safia Abdalla <safia@safia.rocks>",
   "license": "MIT",
   "dependencies": {
+    "@nteract/commutable": "^6.0.0-alpha.0",
     "rxjs": "^6.3.3",
     "uuid": "^3.1.0",
     "immutable": "^4.0.0-rc.12"

--- a/packages/types/src/entities/contents/notebook.ts
+++ b/packages/types/src/entities/contents/notebook.ts
@@ -1,8 +1,7 @@
 import * as Immutable from "immutable";
-import { emptyNotebook } from "@nteract/commutable";
-import { ImmutableNotebook } from "@nteract/commutable";
+import { ImmutableNotebook, emptyNotebook, CellId } from "@nteract/commutable";
 
-import { KernelRef, CellId } from "../..";
+import { KernelRef } from "../..";
 
 export type DocumentRecordProps = {
   type: "notebook";

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -1,9 +1,7 @@
 export type HostId = string;
 export type KernelId = string;
 export type SessionId = string;
-export type CellId = string;
 
 export const castToHostId = (id: string): HostId => id;
 export const castToKernelId = (id: string): KernelId => id;
 export const castToSessionId = (id: string): SessionId => id;
-export const castToCellId = (id: string): CellId => id;


### PR DESCRIPTION
This switches over `CellID` to `CellId` wherever possible. It also adds generics for the `cellOrder` and `cellMap` so they can resolve types within selectors well.