### PR TITLE
Add READMEs for markdown and iron-icons packages

### DIFF
--- a/packages/iron-icons/README.md
+++ b/packages/iron-icons/README.md
@@ -1,0 +1,13 @@
+# `iron-icons`
+
+[`iron-icon`](https://www.webcomponents.org/element/@polymer/iron-icons) React components, styled for use within nteract packages.
+
+## Installation
+
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install --save @nteract/iron-icons
+# OR
+yarn add @nteract/iron-icons
+```

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -1,6 +1,6 @@
 # `markdown`
 
-The `MarkdownRender` component allows you to render Markdown text per the Commonmark specification. It's got one major power-up though, it allows you to render in-line and block math using LaTeX syntax too.
+Markdown/MathJax renderer for nteract. Allows Markdown text rendering as per the Commonmark specification, but also allows for in-line and block math rending using LaTeX syntax.
 
 ## Installation
 
@@ -14,24 +14,4 @@ yarn add @nteract/markdown
 
 ## Usage
 
-Under the hood, the component builds upon the open-source [ReactMarkdown](https://github.com/rexxars/react-markdown) component. The `MarkdownRender` component takes all the same props and passes them on to the `ReactMarkdown` component it uses under the hood.
-
-If you'd like to learn more about what props you can change, you can read [the documentation](https://github.com/rexxars/react-markdown#options) available on the ReactMarkdown component.
-
-So, when would you want to use nteract's `MarkdownRender` component? Quite simply, whenever you need to render Markdown with some math in it. As long as your math is written in valid LaTeX, you can expect to see beautifully rendered math in your user interface.
-
-To render Markdown using this component, you can pass the Markdown text to the `source` prop like so.
-
-```javascript
-const MarkdownRender = require("@nteract/markdown").default;
-
-<MarkdownRender source={`Just some $\delta_{\alpha}$ math.`}/>
-```
-
-Alternatively, you can pass the source as a child of the `MarkdownRender` component.
-
-```javascript
-const MarkdownRender = require("@nteract/markdown").default;
-
-<MarkdownRender>Some _sweet_, **sweet** Markdown.</MarkdownRender>
-```
+[See examples](./examples.md)

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -1,4 +1,18 @@
+# `markdown`
+
 The `MarkdownRender` component allows you to render Markdown text per the Commonmark specification. It's got one major power-up though, it allows you to render in-line and block math using LaTeX syntax too.
+
+## Installation
+
+You may use whichever package manager (`npm` or `yarn`) best suits your workflow. The `nteract` team internally uses `yarn`.
+
+```bash
+npm install --save @nteract/markdown
+# OR
+yarn add @nteract/markdown
+```
+
+## Usage
 
 Under the hood, the component builds upon the open-source [ReactMarkdown](https://github.com/rexxars/react-markdown) component. The `MarkdownRender` component takes all the same props and passes them on to the `ReactMarkdown` component it uses under the hood.
 
@@ -8,7 +22,7 @@ So, when would you want to use nteract's `MarkdownRender` component? Quite simpl
 
 To render Markdown using this component, you can pass the Markdown text to the `source` prop like so.
 
-```
+```javascript
 const MarkdownRender = require("@nteract/markdown").default;
 
 <MarkdownRender source={`Just some $\delta_{\alpha}$ math.`}/>
@@ -16,7 +30,7 @@ const MarkdownRender = require("@nteract/markdown").default;
 
 Alternatively, you can pass the source as a child of the `MarkdownRender` component.
 
-```
+```javascript
 const MarkdownRender = require("@nteract/markdown").default;
 
 <MarkdownRender>Some _sweet_, **sweet** Markdown.</MarkdownRender>

--- a/packages/markdown/examples.md
+++ b/packages/markdown/examples.md
@@ -1,0 +1,23 @@
+The `MarkdownRender` component allows you to render Markdown text per the Commonmark specification. It's got one major power-up though, it allows you to render in-line and block math using LaTeX syntax too.
+
+Under the hood, the component builds upon the open-source [ReactMarkdown](https://github.com/rexxars/react-markdown) component. The `MarkdownRender` component takes all the same props and passes them on to the `ReactMarkdown` component it uses under the hood.
+
+If you'd like to learn more about what props you can change, you can read [the documentation](https://github.com/rexxars/react-markdown#options) available on the ReactMarkdown component.
+
+So, when would you want to use nteract's `MarkdownRender` component? Quite simply, whenever you need to render Markdown with some math in it. As long as your math is written in valid LaTeX, you can expect to see beautifully rendered math in your user interface.
+
+To render Markdown using this component, you can pass the Markdown text to the `source` prop like so.
+
+```
+const MarkdownRender = require("@nteract/markdown").default;
+
+<MarkdownRender source={`Just some $\delta_{\alpha}$ math.`}/>
+```
+
+Alternatively, you can pass the source as a child of the `MarkdownRender` component.
+
+```
+const MarkdownRender = require("@nteract/markdown").default;
+
+<MarkdownRender>Some _sweet_, **sweet** Markdown.</MarkdownRender>
+```


### PR DESCRIPTION
I added basic READMEs with install instructions to `@nteract/markdown` and `@nteract/iron-icons`, to tackle some of #1577.

For the `markdown` package, I renamed @captainsafia's great `examples.md` file to be the README and added install instructions to it - so more people will see it on github and npm.

- [x ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

