### PR TITLE
Fix imports in Media components

### DIFF
--- a/packages/outputs/src/components/media/html.md
+++ b/packages/outputs/src/components/media/html.md
@@ -1,6 +1,7 @@
 HTML, or HyperText Markup Language, is markup language used for create web pages and web apps. The `Media.HTML` component allows you to render raw HTML in your nteract contexts. To use the component, you'll need to the pass the HTML that you would like to render in string form to the `data` prop, like so.
 
 ```
+const HTML = require("./html").HTML;
 <HTML data={"<b>This is some <em>HTML</em> code.</b>"} />
 ```
 

--- a/packages/outputs/src/components/media/javascript.md
+++ b/packages/outputs/src/components/media/javascript.md
@@ -1,6 +1,7 @@
 The Media.JavaScript component allows you to execute JavaScript in the context of the current document.
 
-```jsx
+```
+const JavaScript = require("./javascript").JavaScript;
 <JavaScript
   data={`
 console.log('%cWelcome to the nteract.io component docs!', "color: #3d3d3d; font-size: 24px;");
@@ -15,6 +16,7 @@ window.el = element;
 Because of this, you can declare variables in the scope of the current window context. For example, view the source code for the component below.
 
 ```
+const JavaScript = require("./javascript").JavaScript;
 <JavaScript data={"window.this_is_our_special_variable = 10;"}/>
 ```
 
@@ -25,11 +27,12 @@ console.log(this_is_our_special_variable);
 > 10
 ```
 
-If you're familiar with the Jupyter ecosystem, note that this component executes JavaScript in a manner idential to Jupyter Notebook's JavaScript evaluation. The code you execute using this component will _not_ persist through reloads, so it's a good place to test and iterate on scripts.
+If you're familiar with the Jupyter ecosystem, note that this component executes JavaScript in a manner identical to Jupyter Notebook's JavaScript evaluation. The code you execute using this component will _not_ persist through reloads, so it's a good place to test and iterate on scripts.
 
 The `Media.JavaScript` component can also help you when things go wrong by printing an error trace. For example, here's what happens when you attempt to log invoke an undefined function.
 
 ```
+const JavaScript = require("./javascript").JavaScript;
 <JavaScript data={"there_is_no_way_this_function_exists_right_now(and_takes_this_parameter)"}/>
 ```
 

--- a/packages/outputs/src/components/media/svg.md
+++ b/packages/outputs/src/components/media/svg.md
@@ -10,6 +10,7 @@ SVG, or Scalable Vector Graphics, is an image format for two-dimensional graphic
 That's right! Under the hood, SVG images are just plain-text. Their scalability and responsiveness makes them great for rendering charts and graphs. The media type used to refer to SVGs in the Jupyter ecosystem, and elsewhere on the web, is `image/svg+xml`. To render SVGs, you can use the `Media.SVG` component. You'll need to pass a `data` prop that contains the plain-text contents of the SVG.
 
 ```
+const SVG = require("./svg").SVG;
 <SVG data={`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
 <circle cx="250" cy="250" r="210" fill="#fff" stroke="#000" stroke-width="8"/>


### PR DESCRIPTION
Follow-up on https://github.com/nteract/nteract/pull/3729.

Fixes up some import errors in Media components so that we can do a redeploy.