### PR TITLE
include dependencies that nteract/types relies on

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,6 +18,8 @@
   "author": "Safia Abdalla <safia@safia.rocks>",
   "license": "MIT",
   "dependencies": {
+    "rxjs": "^6.3.3",
+    "uuid": "^3.1.0",
     "immutable": "^4.0.0-rc.12"
   }
 }


### PR DESCRIPTION
Noticed these were missing while working on #3718.
