### PR TITLE
Move @nteract/core/dummy to its own TypeScript package

### DIFF
--- a/packages/fixtures/README.md
+++ b/packages/fixtures/README.md
@@ -1,0 +1,38 @@
+# @nteract/fixtures
+
+This package contains fixtures for immutable and string notebooks for use in nteract test suites.
+
+## Installation
+
+```
+$ yarn add @nteract/fixtures
+```
+
+```
+$ npm install --save @nteract/fixtures
+```
+
+## Usage
+
+The example below shows how we can use this package to create a Redux store for a notebook with two code cells.
+
+```javascript
+import { fixtureStore } from "@nteract/fixtures";
+
+export default () => {
+  const testStore = fixtureStore({ codeCellCount: 2 });
+  return testStore;
+};
+```
+
+## Documentation
+
+We're working on adding more documentation for this component. Stay tuned by watching this repository!
+
+## Support
+
+If you experience an issue while using this package or have a feature request, please file an issue on the [issue board](https://github.com/nteract/nteract/issues/new/choose) and add the `pkg:fixtures` label.
+
+## License
+
+[BSD-3-Clause](https://choosealicense.com/licenses/bsd-3-clause/)

--- a/packages/fixtures/index.ts
+++ b/packages/fixtures/index.ts
@@ -1,0 +1,3 @@
+export * from "./src";
+import def from "./src";
+export default def;

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@nteract/fixtures",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run:build",
+    "build": "npm run build:clean && npm run build:lib",
+    "build:clean": "tsc -b --clean",
+    "build:lib": "tsc -b",
+    "build:lib:watch": "tsc -b --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch"
+  },
+  "keywords": [],
+  "author": "Safia Abdalla <safia@safia.rocks>",
+  "license": "BSD-3-License"
+}

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -15,7 +15,7 @@
   },
   "keywords": [],
   "author": "Safia Abdalla <safia@safia.rocks>",
-  "license": "BSD-3-License",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "@nteract/commutable": "^6.0.0-alpha.0",
     "@nteract/types": "^3.1.0"

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -15,5 +15,9 @@
   },
   "keywords": [],
   "author": "Safia Abdalla <safia@safia.rocks>",
-  "license": "BSD-3-License"
+  "license": "BSD-3-License",
+  "dependencies": {
+    "@nteract/commutable": "^6.0.0-alpha.0",
+    "@nteract/types": "^3.1.0"
+  }
 }

--- a/packages/fixtures/src/dummy-nb.ts
+++ b/packages/fixtures/src/dummy-nb.ts
@@ -1,0 +1,152 @@
+/* eslint-disable no-multi-str */
+import { fromJS } from "@nteract/commutable";
+
+export const dummy =
+  '{"cells":[{"cell_type":"markdown","metadata":{},\
+"source":["## The Notable Nteract Notebook\\n","\\n","**It\'s a notebook!**\\n"]},\
+{"cell_type":"code","execution_count":11,"metadata":{"collapsed":false},\
+"outputs":[{"data":{"text/plain":["<h1>Multiple</h1>"],\
+"text/plain":["<IPython.core.display.HTML object>"]},"metadata":{},"output_type":"display_data"}],\
+"source":["import IPython\\n","\\n","from IPython.display import HTML\\n",\
+"from IPython.display import Markdown\\n","from IPython.display import display\\n","\\n",\
+"display(HTML(\'<h1>Multiple</h1>\'))\\n","display(HTML(\'<p>Display Elements</p>\'))\\n",\
+"display(Markdown(\'**awesome**\'))\\n","\\n","print(\'hey\')\\n","42"]}],\
+"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},\
+"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py",\
+"mimetype":"text/x-python","name":"python","nbconvert_exporter":"python",\
+"pygments_lexer":"ipython3","version":"3.5.1"}},"nbformat":4,"nbformat_minor":0}';
+
+export const dummyJSON = JSON.parse(dummy);
+
+export const dummyCommutable = fromJS(dummyJSON);
+
+export const bigDummyJSON = {
+  cells: [
+    {
+      cell_type: "markdown",
+      source: [
+        "# This is an example notebook\n",
+        "\n",
+        "## Used for test purposes...\n",
+        "\nThe idea is to have enough real data in here to make a non-trivial NB."
+      ],
+      metadata: {
+        trusted: false
+      }
+    },
+    {
+      cell_type: "code",
+      source: ["import math\n", "import IPython.display"],
+      outputs: [],
+      execution_count: 17,
+      metadata: {
+        trusted: false
+      }
+    },
+    {
+      cell_type: "markdown",
+      source: [
+        "Here, we intersperse markdown to make sure it isn't simply a bunch of consecutive code blocks."
+      ],
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "code",
+      source: [
+        "data = [round(math.sin(i*2*math.pi/10)*100) + 100 for i in range(0, 10)]"
+      ],
+      outputs: [],
+      execution_count: 23,
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "markdown",
+      source: [
+        "Finally, we even display some HTML in the output to ensure that we have more than simple text output."
+      ],
+      metadata: {}
+    },
+    {
+      cell_type: "code",
+      source: [
+        'bars = "".join([\'<div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: {}px;"></div>\'.format(datum) for datum in data])\n',
+        "IPython.display.HTML(bars)"
+      ],
+      outputs: [
+        {
+          output_type: "execute_result",
+          execution_count: 33,
+          data: {
+            "text/plain": ["<IPython.core.display.HTML object>"],
+            "text/html": [
+              '<div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 100px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 159px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 195px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 195px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 159px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 100px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 41px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 5px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 5px;"></div><div style="display: inline-block; margin: 5px; background-color: #0074D9; width: 20px; height: 41px;"></div>'
+            ]
+          },
+          metadata: {}
+        }
+      ],
+      execution_count: 33,
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "code",
+      source: [],
+      outputs: [],
+      execution_count: 28,
+      metadata: {
+        collapsed: false,
+        outputHidden: false,
+        inputHidden: false
+      }
+    },
+    {
+      cell_type: "markdown",
+      source: [
+        "^^ Add an empty code cell above and an empty markdown cell below for kicks. Et, voila."
+      ],
+      metadata: {}
+    },
+    {
+      cell_type: "markdown",
+      source: [],
+      metadata: {}
+    }
+  ],
+  metadata: {
+    kernelspec: {
+      display_name: "Python 3",
+      language: "python",
+      name: "python3"
+    },
+    language_info: {
+      name: "python",
+      version: "3.6.0",
+      mimetype: "text/x-python",
+      codemirror_mode: {
+        name: "ipython",
+        version: 3
+      },
+      pygments_lexer: "ipython3",
+      nbconvert_exporter: "python",
+      file_extension: ".py"
+    }
+  },
+  nbformat: 4,
+  nbformat_minor: 2
+};
+
+export const bigDummyCommutable = fromJS(bigDummyJSON);
+
+export const bigDummy = JSON.stringify(bigDummyJSON);

--- a/packages/fixtures/src/dummy-nb.ts
+++ b/packages/fixtures/src/dummy-nb.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-multi-str */
-import { fromJS } from "@nteract/commutable";
+import { fromJS, Notebook } from "@nteract/commutable";
 
 export const dummy =
   '{"cells":[{"cell_type":"markdown","metadata":{},\
@@ -20,7 +20,7 @@ export const dummyJSON = JSON.parse(dummy);
 
 export const dummyCommutable = fromJS(dummyJSON);
 
-export const bigDummyJSON = {
+export const bigDummyJSON: Notebook = {
   cells: [
     {
       cell_type: "markdown",

--- a/packages/fixtures/src/fixture-nb.ts
+++ b/packages/fixtures/src/fixture-nb.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-multi-str */
 import { fromJS, Notebook } from "@nteract/commutable";
 
-export const dummy =
+export const fixture =
   '{"cells":[{"cell_type":"markdown","metadata":{},\
 "source":["## The Notable Nteract Notebook\\n","\\n","**It\'s a notebook!**\\n"]},\
 {"cell_type":"code","execution_count":11,"metadata":{"collapsed":false},\
@@ -16,11 +16,11 @@ export const dummy =
 "mimetype":"text/x-python","name":"python","nbconvert_exporter":"python",\
 "pygments_lexer":"ipython3","version":"3.5.1"}},"nbformat":4,"nbformat_minor":0}';
 
-export const dummyJSON = JSON.parse(dummy);
+export const fixtureJSON = JSON.parse(fixture);
 
-export const dummyCommutable = fromJS(dummyJSON);
+export const fixtureCommutable = fromJS(fixtureJSON);
 
-export const bigDummyJSON: Notebook = {
+export const bigfixtureJSON: Notebook = {
   cells: [
     {
       cell_type: "markdown",
@@ -147,6 +147,6 @@ export const bigDummyJSON: Notebook = {
   nbformat_minor: 2
 };
 
-export const bigDummyCommutable = fromJS(bigDummyJSON);
+export const bigfixtureCommutable = fromJS(bigfixtureJSON);
 
-export const bigDummy = JSON.stringify(bigDummyJSON);
+export const bigfixture = JSON.stringify(bigfixtureJSON);

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -101,10 +101,10 @@ export function fixtureStore(config: { [key: string]: any }) {
   return createStore(rootReducer, {
     core: makeStateRecord({
       kernelRef,
+      currentKernelspecsRef: kernelRef,
       entities: makeEntitiesRecord({
         contents: makeContentsRecord({
           byRef: Immutable.Map({
-            // $FlowFixMe: This really is a content ref, Flow can't handle typing it though
             [contentRef]: makeNotebookContentRecord({
               model: makeDocumentRecord({
                 notebook: fixtureNotebook,

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -8,7 +8,8 @@ import {
   appendCellToNotebook,
   emptyNotebook,
   emptyMarkdownCell,
-  ImmutableNotebook
+  ImmutableNotebook,
+  JSONObject
 } from "@nteract/commutable";
 import { combineReducers, createStore } from "redux";
 
@@ -57,7 +58,7 @@ function hideCells(notebook: ImmutableNotebook) {
  * @returns {object} - A notebook for {@link DocumentRecord} for Redux store.
  * Created using the config object passed in.
  */
-function buildFixtureNotebook(config: { [key: string]: any }) {
+function buildFixtureNotebook(config: JSONObject) {
   let notebook = monocellNotebook.setIn(
     ["metadata", "kernelspec", "name"],
     "python2"
@@ -87,8 +88,8 @@ function buildFixtureNotebook(config: { [key: string]: any }) {
   return notebook;
 }
 
-export function fixtureStore(config: { [key: string]: any }) {
-  const fixtureNotebook = buildFixtureNotebook(config);
+export function fixtureStore(config: JSONObject) {
+  const dummyNotebook = buildFixtureNotebook(config);
 
   const frontendToShell = new Subject();
   const shellToFrontend = new Subject();
@@ -101,21 +102,20 @@ export function fixtureStore(config: { [key: string]: any }) {
   return createStore(rootReducer, {
     core: makeStateRecord({
       kernelRef,
-      currentKernelspecsRef: kernelRef,
       entities: makeEntitiesRecord({
         contents: makeContentsRecord({
           byRef: Immutable.Map({
             [contentRef]: makeNotebookContentRecord({
               model: makeDocumentRecord({
-                notebook: fixtureNotebook,
+                notebook: dummyNotebook,
                 savedNotebook:
                   config && config.saved === true
-                    ? fixtureNotebook
+                    ? dummyNotebook
                     : emptyNotebook,
                 cellPagers: Immutable.Map(),
                 cellFocused:
-                  config && config.codeCellCount > 1
-                    ? fixtureNotebook.get("cellOrder", Immutable.List()).get(1)
+                  config && config.codeCellCount && config.codeCellCount > 1
+                    ? dummyNotebook.get("cellOrder", Immutable.List()).get(1)
                     : null
               }),
               filepath:
@@ -133,7 +133,7 @@ export function fixtureStore(config: { [key: string]: any }) {
           })
         })
       })
-    }),
+    }) as any,
     app: makeAppRecord({
       notificationSystem: {
         addNotification: () => {} // most of the time you'll want to mock this

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -1,0 +1,147 @@
+/* eslint-disable no-plusplus */
+
+import * as Immutable from "immutable";
+import { Subject } from "rxjs";
+import {
+  monocellNotebook,
+  emptyCodeCell,
+  appendCellToNotebook,
+  emptyNotebook
+} from "@nteract/commutable";
+import { combineReducers, createStore } from "redux";
+
+import { comms, config, core } from "../reducers";
+import {
+  makeNotebookContentRecord,
+  makeRemoteKernelRecord,
+  makeAppRecord,
+  makeCommsRecord,
+  makeKernelsRecord,
+  makeDocumentRecord,
+  makeContentsRecord,
+  makeEntitiesRecord,
+  makeStateRecord,
+  createContentRef,
+  createKernelRef
+} from "../state";
+
+export { dummyCommutable, dummy, dummyJSON } from "./dummy-nb";
+
+const rootReducer = combineReducers({
+  app: (state = makeAppRecord()) => state,
+  comms,
+  config,
+  core
+});
+
+function hideCells(notebook) {
+  return notebook.update("cellMap", cells =>
+    notebook
+      .get("cellOrder", Immutable.List())
+      .reduce(
+        (acc, id) => acc.setIn([id, "metadata", "inputHidden"], true),
+        cells
+      )
+  );
+}
+
+/**
+ * Creates a dummy notebook for Redux state for testing.
+ *
+ * @param {object} config - Configuration options for notebook
+ * config.codeCellCount (number) - Number of empty code cells to be in notebook.
+ * config.markdownCellCount (number) - Number of empty markdown cells to be in notebook.
+ * config.hideAll (boolean) - Hide all cells in notebook
+ * @returns {object} - A notebook for {@link DocumentRecord} for Redux store.
+ * Created using the config object passed in.
+ */
+function buildDummyNotebook(config) {
+  let notebook = monocellNotebook.setIn(
+    ["metadata", "kernelspec", "name"],
+    "python2"
+  );
+
+  if (config) {
+    if (config.codeCellCount) {
+      for (let i = 1; i < config.codeCellCount; i++) {
+        notebook = appendCellToNotebook(notebook, emptyCodeCell);
+      }
+    }
+
+    if (config.markdownCellCount) {
+      for (let i = 0; i < config.markdownCellCount; i++) {
+        notebook = appendCellToNotebook(
+          notebook,
+          emptyCodeCell.set("cell_type", "markdown")
+        );
+      }
+    }
+
+    if (config.hideAll) {
+      notebook = hideCells(notebook);
+    }
+  }
+
+  return notebook;
+}
+
+export function dummyStore(config: *) {
+  const dummyNotebook = buildDummyNotebook(config);
+
+  const frontendToShell = new Subject();
+  const shellToFrontend = new Subject();
+  const mockShell = Subject.create(frontendToShell, shellToFrontend);
+  const channels = mockShell;
+
+  const kernelRef = createKernelRef();
+  const contentRef = createContentRef();
+
+  // $FlowFixMe
+  return createStore(rootReducer, {
+    core: makeStateRecord({
+      kernelRef,
+      entities: makeEntitiesRecord({
+        contents: makeContentsRecord({
+          byRef: Immutable.Map({
+            // $FlowFixMe: This really is a content ref, Flow can't handle typing it though
+            [contentRef]: makeNotebookContentRecord({
+              model: makeDocumentRecord({
+                notebook: dummyNotebook,
+                savedNotebook:
+                  config && config.saved === true
+                    ? dummyNotebook
+                    : emptyNotebook,
+                cellPagers: new Immutable.Map(),
+                cellFocused:
+                  config && config.codeCellCount > 1
+                    ? dummyNotebook.get("cellOrder", Immutable.List()).get(1)
+                    : null
+              }),
+              filepath:
+                config && config.noFilename ? "" : "dummy-store-nb.ipynb"
+            })
+          })
+        }),
+        kernels: makeKernelsRecord({
+          byRef: Immutable.Map({
+            // $FlowFixMe: This really is a kernel ref, Flow can't handle typing it though
+            [kernelRef]: makeRemoteKernelRecord({
+              channels,
+              status: "not connected"
+            })
+          })
+        })
+      })
+    }),
+    app: makeAppRecord({
+      notificationSystem: {
+        addNotification: () => {} // most of the time you'll want to mock this
+      },
+      githubToken: "TOKEN"
+    }),
+    config: Immutable.Map({
+      theme: "light"
+    }),
+    comms: makeCommsRecord()
+  });
+}

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -6,7 +6,8 @@ import {
   monocellNotebook,
   emptyCodeCell,
   appendCellToNotebook,
-  emptyNotebook
+  emptyNotebook,
+  emptyMarkdownCell
 } from "@nteract/commutable";
 import { combineReducers, createStore } from "redux";
 
@@ -23,7 +24,7 @@ import {
   makeStateRecord,
   createContentRef,
   createKernelRef
-} from "../state";
+} from "@nteract/types";
 
 export { dummyCommutable, dummy, dummyJSON } from "./dummy-nb";
 
@@ -72,7 +73,7 @@ function buildDummyNotebook(config) {
       for (let i = 0; i < config.markdownCellCount; i++) {
         notebook = appendCellToNotebook(
           notebook,
-          emptyCodeCell.set("cell_type", "markdown")
+          emptyMarkdownCell.set("cell_type", "markdown")
         );
       }
     }
@@ -85,7 +86,7 @@ function buildDummyNotebook(config) {
   return notebook;
 }
 
-export function dummyStore(config: *) {
+export function dummyStore(config: { [key: string]: any }) {
   const dummyNotebook = buildDummyNotebook(config);
 
   const frontendToShell = new Subject();
@@ -111,7 +112,7 @@ export function dummyStore(config: *) {
                   config && config.saved === true
                     ? dummyNotebook
                     : emptyNotebook,
-                cellPagers: new Immutable.Map(),
+                cellPagers: Immutable.Map(),
                 cellFocused:
                   config && config.codeCellCount > 1
                     ? dummyNotebook.get("cellOrder", Immutable.List()).get(1)

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -7,11 +7,12 @@ import {
   emptyCodeCell,
   appendCellToNotebook,
   emptyNotebook,
-  emptyMarkdownCell
+  emptyMarkdownCell,
+  ImmutableNotebook
 } from "@nteract/commutable";
 import { combineReducers, createStore } from "redux";
 
-import { comms, config, core } from "../reducers";
+import { comms, config, core } from "@nteract/reducers";
 import {
   makeNotebookContentRecord,
   makeRemoteKernelRecord,
@@ -26,7 +27,7 @@ import {
   createKernelRef
 } from "@nteract/types";
 
-export { dummyCommutable, dummy, dummyJSON } from "./dummy-nb";
+export { fixtureCommutable, fixture, fixtureJSON } from "./fixture-nb";
 
 const rootReducer = combineReducers({
   app: (state = makeAppRecord()) => state,
@@ -35,7 +36,7 @@ const rootReducer = combineReducers({
   core
 });
 
-function hideCells(notebook) {
+function hideCells(notebook: ImmutableNotebook) {
   return notebook.update("cellMap", cells =>
     notebook
       .get("cellOrder", Immutable.List())
@@ -56,7 +57,7 @@ function hideCells(notebook) {
  * @returns {object} - A notebook for {@link DocumentRecord} for Redux store.
  * Created using the config object passed in.
  */
-function buildDummyNotebook(config) {
+function buildFixtureNotebook(config: { [key: string]: any }) {
   let notebook = monocellNotebook.setIn(
     ["metadata", "kernelspec", "name"],
     "python2"
@@ -86,8 +87,8 @@ function buildDummyNotebook(config) {
   return notebook;
 }
 
-export function dummyStore(config: { [key: string]: any }) {
-  const dummyNotebook = buildDummyNotebook(config);
+export function fixtureStore(config: { [key: string]: any }) {
+  const fixtureNotebook = buildFixtureNotebook(config);
 
   const frontendToShell = new Subject();
   const shellToFrontend = new Subject();
@@ -97,7 +98,6 @@ export function dummyStore(config: { [key: string]: any }) {
   const kernelRef = createKernelRef();
   const contentRef = createContentRef();
 
-  // $FlowFixMe
   return createStore(rootReducer, {
     core: makeStateRecord({
       kernelRef,
@@ -107,15 +107,15 @@ export function dummyStore(config: { [key: string]: any }) {
             // $FlowFixMe: This really is a content ref, Flow can't handle typing it though
             [contentRef]: makeNotebookContentRecord({
               model: makeDocumentRecord({
-                notebook: dummyNotebook,
+                notebook: fixtureNotebook,
                 savedNotebook:
                   config && config.saved === true
-                    ? dummyNotebook
+                    ? fixtureNotebook
                     : emptyNotebook,
                 cellPagers: Immutable.Map(),
                 cellFocused:
                   config && config.codeCellCount > 1
-                    ? dummyNotebook.get("cellOrder", Immutable.List()).get(1)
+                    ? fixtureNotebook.get("cellOrder", Immutable.List()).get(1)
                     : null
               }),
               filepath:

--- a/packages/fixtures/tsconfig.json
+++ b/packages/fixtures/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
I moved it into its own package and converted to TypeScript.

Also renamed it.

This needs to be reviewed and merged after the reducers are pulled out of core.