### PR TITLE
stop running package builds in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build:apps": "lerna run build --scope nteract --scope @nteract/play --scope @nteract/commuter --scope nteract-on-jupyter --parallel --stream",
     "build:desktop": "lerna run build --scope nteract --stream",
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
-    "build:packages": "NODE_ENV=production lerna run build --parallel --ignore @nteract/play --ignore @nteract/commuter --ignore nteract --ignore nteract-on-jupyter",
+    "build:packages": "NODE_ENV=production lerna run build --ignore @nteract/play --ignore @nteract/commuter --ignore nteract --ignore nteract-on-jupyter",
     "build:packages:ci": "NODE_ENV=production lerna run build --ignore @nteract/play --ignore @nteract/commuter --ignore nteract --ignore nteract-on-jupyter",
     "build:packages:watch": "lerna run build:lib:watch --parallel --ignore @nteract/play --ignore @nteract/commuter --ignore nteract --ignore nteract-on-jupyter",
     "build:icon": "./scripts/make_icons.sh && cd static/icons && iconutil -c icns nteract.iconset && mv nteract.icns ../icon.icns",


### PR DESCRIPTION
Currently our setup can lead to running out of memory (empirically, on both mine and @captainsafia's laptops).