### PR TITLE
Update payload types in AcceptPayloadMessage

### DIFF
--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -537,8 +537,9 @@ function acceptPayloadMessage(
     data: object;
     text: string;
     replace: boolean;
+    start: number;
   };
-  const payload = action.payload.payload as ActionPayload;
+  const payload = action.payload.payload as Partial<ActionPayload>;
 
   if (payload.source === "page") {
     // append pager


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/3805.

Per the [JMP spec](https://jupyter-client.readthedocs.io/en/stable/messaging.html#payloads-deprecated), the text property only exists on set_next_input payloads so I updated the types to reflect this.