### PR TITLE
Expect app version to exist in app state

### DIFF
--- a/applications/desktop/src/notebook/epics/saving.js
+++ b/applications/desktop/src/notebook/epics/saving.js
@@ -44,8 +44,7 @@ export function saveEpic(
       }
 
       const filepath = content.filepath;
-      // TODO: this default version should probably not be here.
-      const appVersion = selectors.appVersion(state) || "0.0.0-beta";
+      const appVersion = selectors.appVersion(state);
       const notebook = stringifyNotebook(
         toJS(
           model.notebook.setIn(["metadata", "nteract", "version"], appVersion)

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -247,8 +247,7 @@ export function saveContentEpic(
         let serializedData: Notebook | string;
         let saveModel: Partial<contents.Payload> = {};
         if (content.type === "notebook") {
-          // TODO: this default version should probably not be here.
-          const appVersion = selectors.appVersion(state) || "0.0.0-beta";
+          const appVersion = selectors.appVersion(state);
 
           // contents API takes notebook as raw JSON whereas downloading takes
           // a string


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/3499.

The app version is set on boot so I think it is safe to remove this default value.