### PR TITLE
migrate styled-blueprintjsx to typescript

### DIFF
--- a/packages/presentational-components/__tests__/__snapshots__/header-editor-spec.js.snap
+++ b/packages/presentational-components/__tests__/__snapshots__/header-editor-spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`Header Editor renders a static view when not editable 1`] = `
 <header
-  className="jsx-4281394543"
+  className="jsx-3922220714"
 >
   <div
-    className="jsx-4281394543"
+    className="jsx-3922220714"
     style={
       Object {
         "background": "#EEE",
@@ -36,7 +36,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </div>
     </h1>
     <div
-      className="jsx-4281394543"
+      className="jsx-3922220714"
     >
       <span
         className="bp3-popover-wrapper"
@@ -80,7 +80,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </span>
     </div>
     <div
-      className="jsx-4281394543"
+      className="jsx-3922220714"
     >
       <span
         className="bp3-popover-wrapper"
@@ -124,7 +124,7 @@ exports[`Header Editor renders a static view when not editable 1`] = `
       </span>
     </div>
     <div
-      className="jsx-4281394543"
+      className="jsx-3922220714"
       style={
         Object {
           "marginTop": "10px",
@@ -154,10 +154,10 @@ exports[`Header Editor renders a static view when not editable 1`] = `
 
 exports[`Header Editor renders correctly with no props 1`] = `
 <header
-  className="jsx-4281394543"
+  className="jsx-3922220714"
 >
   <div
-    className="jsx-4281394543"
+    className="jsx-3922220714"
     style={
       Object {
         "background": "#EEE",
@@ -188,7 +188,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </div>
     </h1>
     <div
-      className="jsx-4281394543"
+      className="jsx-3922220714"
     >
       <span
         className="bp3-popover-wrapper"
@@ -232,7 +232,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </span>
     </div>
     <div
-      className="jsx-4281394543"
+      className="jsx-3922220714"
     >
       <span
         className="bp3-popover-wrapper"
@@ -276,7 +276,7 @@ exports[`Header Editor renders correctly with no props 1`] = `
       </span>
     </div>
     <div
-      className="jsx-4281394543"
+      className="jsx-3922220714"
       style={
         Object {
           "marginTop": "10px",

--- a/packages/styled-blueprintjsx/package.json
+++ b/packages/styled-blueprintjsx/package.json
@@ -24,15 +24,14 @@
     "url": "git+https://github.com/nteract/nteract.git"
   },
   "scripts": {
-    "vendorize": "node scripts/vendorize-css.js",
+    "vendorize": "ts-node scripts/vendorize-css.ts",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run build && npm run build:flow",
+    "prepublishOnly": "npm run build",
     "build": "npm run build:clean && npm run build:lib",
-    "build:clean": "rimraf lib",
-    "build:flow": "flow-copy-source -v -i '**/__tests__/**' src lib",
-    "build:lib": "babel -d lib src --ignore '**/__tests__/**' --config-file ../../babel.config.js",
-    "build:lib:watch": "npm run build:lib -- --watch",
-    "build:watch": "npm run build:clean && npm run build:lib:watch && npm run build:flow"
+    "build:clean": "tsc -b --clean",
+    "build:lib": "tsc -b",
+    "build:lib:watch": "tsc -b --watch",
+    "build:watch": "npm run build:clean && npm run build:lib:watch"
   },
   "bugs": {
     "url": "https://github.com/nteract/nteract/issues"

--- a/packages/styled-blueprintjsx/scripts/vendorize-css.ts
+++ b/packages/styled-blueprintjsx/scripts/vendorize-css.ts
@@ -1,31 +1,29 @@
-// @flow
 /**
  * This script is used to create styled-jsx css`` strings for use by components.
  *
  * One problem though -- this doesn't solve the issue of loading fonts. We still have to tackle that.
  */
 
-const fs = require("fs");
-const util = require("util");
-const path = require("path");
+import * as fs from "fs";
+import * as util from "util";
+import * as path from "path";
 
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 const mkdirp = util.promisify(require("mkdirp"));
 
-async function loadCSS(filename) /*: Promise<string> */ {
+async function loadCSS(filename: string): Promise<string> {
   const rawCSS = await readFile(filename);
 
-  // $FlowFixMe Don't actually fix, flow is hoping for a string literal, for which we will not have here
   const loader = require(require("styled-jsx/webpack").loader);
 
-  const cssInJS = await new Promise((resolve, reject) => {
+  const cssInJS = await new Promise<string>((resolve, reject) => {
     loader.call(
       // Abusing styled-jsx's webpack API just to get the CSS we need
       {
         query: "?type=global",
         addDependency: () => {},
-        callback: (err, data) => {
+        callback: (err: Error | null, data: string) => {
           if (err) {
             reject(err);
             return;
@@ -40,14 +38,12 @@ async function loadCSS(filename) /*: Promise<string> */ {
   return cssInJS;
 }
 
-/*::
 type Manifest = Array<{
-  cssIn: string,
-  jsOut: string,
+  cssIn: string;
+  jsOut: string;
 }>;
- */
 
-async function processManifest(manifest /*: Manifest*/) {
+async function processManifest(manifest: Manifest) {
   for (var entry of manifest) {
     console.log(`Processing CSS of ${entry.cssIn}`);
     const result = await loadCSS(entry.cssIn);
@@ -60,11 +56,11 @@ async function processManifest(manifest /*: Manifest*/) {
 var manifest = [
   {
     cssIn: require.resolve("@blueprintjs/core/lib/css/blueprint.css"),
-    jsOut: path.join(__dirname, "..", "src/vendor/blueprint.css.js")
+    jsOut: path.join(__dirname, "..", "src/vendor/blueprint-css.ts")
   },
   {
     cssIn: require.resolve("@blueprintjs/select/lib/css/blueprint-select.css"),
-    jsOut: path.join(__dirname, "..", "src/vendor/blueprint-select.css.js")
+    jsOut: path.join(__dirname, "..", "src/vendor/blueprint-select-css.ts")
   }
 ];
 

--- a/packages/styled-blueprintjsx/src/index.js
+++ b/packages/styled-blueprintjsx/src/index.js
@@ -1,5 +1,0 @@
-// @flow
-import blueprintCSS from "./vendor/blueprint.css.js";
-import blueprintSelectCSS from "./vendor/blueprint-select.css.js";
-
-export { blueprintCSS, blueprintSelectCSS };

--- a/packages/styled-blueprintjsx/src/index.js.flow
+++ b/packages/styled-blueprintjsx/src/index.js.flow
@@ -1,0 +1,3 @@
+// @flow
+declare export var blueprintCSS: string;
+declare export var blueprintSelectCSS: string;

--- a/packages/styled-blueprintjsx/src/index.ts
+++ b/packages/styled-blueprintjsx/src/index.ts
@@ -1,0 +1,5 @@
+// @flow
+import blueprintCSS from "./vendor/blueprint-css";
+import blueprintSelectCSS from "./vendor/blueprint-select-css";
+
+export { blueprintCSS, blueprintSelectCSS };

--- a/packages/styled-blueprintjsx/src/vendor/blueprint-css.ts
+++ b/packages/styled-blueprintjsx/src/vendor/blueprint-css.ts
@@ -1,4 +1,4 @@
-import css from "styled-jsx/css";
+import css from 'styled-jsx/css';
 
 export default css.global`@charset "UTF-8";
 /*!
@@ -17,15 +17,14 @@ html{
   -webkit-box-sizing:inherit;
           box-sizing:inherit; }
 
-/*
 body{
   text-transform:none;
   line-height:1.28581;
   letter-spacing:0;
-  font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif;
   font-size:14px;
   font-weight:400;
-  color:#182026; }
+  color:#182026;
+  font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif; }
 
 p{
   margin-top:0;
@@ -42,15 +41,11 @@ strong{
 
 ::selection{
   background:rgba(125, 188, 255, 0.6); }
-
-  */
-
 .bp3-heading{
   color:#182026;
   font-weight:600;
   margin:0 0 10px;
   padding:0; }
-
   .bp3-dark .bp3-heading{
     color:#f5f8fa; }
 
@@ -81,7 +76,6 @@ h6.bp3-heading, .bp3-running-text h6{
   text-transform:none;
   line-height:1.28581;
   letter-spacing:0;
-  font-family:-apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", "Icons16", sans-serif;
   font-size:14px;
   font-weight:400; }
 
@@ -387,7 +381,8 @@ a{
   border-radius:3px;
   background:#ced9e0;
   cursor:pointer;
-  padding:1px 5px; }
+  padding:1px 5px;
+  vertical-align:text-bottom; }
   .bp3-breadcrumbs-collapsed::before{
     display:block;
     background:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cg fill='%235C7080'%3e%3ccircle cx='2' cy='8.03' r='2'/%3e%3ccircle cx='14' cy='8.03' r='2'/%3e%3ccircle cx='8' cy='8.03' r='2'/%3e%3c/g%3e%3c/svg%3e") center no-repeat;
@@ -1877,7 +1872,7 @@ a.bp3-button{
         -ms-user-select:none;
             user-select:none; }
     .bp3-control .bp3-control-indicator::before{
-      display:inline-block;
+      display:block;
       width:1em;
       height:1em;
       content:""; }
@@ -3523,7 +3518,8 @@ table.bp3-html-table.bp3-interactive tbody tr:active td{
   display:inline-block;
   -webkit-box-flex:0;
       -ms-flex:0 0 auto;
-          flex:0 0 auto; }
+          flex:0 0 auto;
+  vertical-align:text-bottom; }
   .bp3-icon:not(:empty)::before{
     content:"" !important;
     content:unset !important; }
@@ -3785,6 +3781,9 @@ span.bp3-icon:empty{
 
 .bp3-icon-citation::before{
   content:""; }
+
+.bp3-icon-clean::before{
+  content:""; }
 
 .bp3-icon-clipboard::before{
   content:""; }
@@ -5303,9 +5302,6 @@ button.bp3-menu-item{
     top:0;
     right:0;
     left:0; }
-  .bp3-navbar .bp3-logo{
-    margin-right:15px;
-    width:20px; }
 
 .bp3-navbar-heading{
   margin-right:15px;
@@ -6380,6 +6376,7 @@ span.bp3-popover-target{
   max-width:100%;
   min-height:20px;
   padding:2px 6px;
+  line-height:16px;
   color:#f5f8fa;
   font-size:12px; }
   .bp3-tag.bp3-interactive{
@@ -6432,6 +6429,7 @@ span.bp3-popover-target{
     min-width:30px;
     min-height:30px;
     padding:0 10px;
+    line-height:20px;
     font-size:14px; }
     .bp3-tag.bp3-large::before,
     .bp3-tag.bp3-large > *,
@@ -7306,4 +7304,4 @@ span.bp3-popover-target{
 
 .bp3-dark .bp3-tree-node.bp3-tree-node-selected > .bp3-tree-node-content{
   background-color:#137cbd; }
-/*# sourceMappingURL=blueprint.css.map */`;
+/*# sourceMappingURL=blueprint.css.map */`

--- a/packages/styled-blueprintjsx/src/vendor/blueprint-select-css.ts
+++ b/packages/styled-blueprintjsx/src/vendor/blueprint-select-css.ts
@@ -1,6 +1,11 @@
 import css from "styled-jsx/css";
 
-export default css.global`
+export default css.global`/*!
+
+Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+Licensed under the terms of the LICENSE file distributed with this project.
+
+*/
 .bp3-omnibar{
   -webkit-filter:blur(0);
           filter:blur(0);
@@ -107,4 +112,4 @@ export default css.global`
   padding:0; }
   .bp3-select-popover .bp3-menu:not(:first-child){
     padding-top:5px; }
-`;
+/*# sourceMappingURL=blueprint-select.css.map */`;

--- a/packages/styled-blueprintjsx/tsconfig.json
+++ b/packages/styled-blueprintjsx/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
In addition to doing the migration for `@nteract/styled-blueprintjsx`, this:

* adds `ts-node` for us to use for dev scripts
* changes the vendorized css paths to not end as `.css.ts`, instead using `-css.ts`

Since this re-vendors blueprint, this also includes some changes from them to match the current component suite.