### PR TITLE
bump required engine to match electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "yargs": "^12.0.0"
   },
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=8.12.0"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
With the new electron builder in place, it appears the required node version is higher. Our repo should follow suit.