### PR TITLE
specify that outerProps is React.SVGAttributes

### DIFF
--- a/packages/octicons/src/index.tsx
+++ b/packages/octicons/src/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 interface WrapperProps {
   children: React.ReactNode;
-  outerProps: any;
+  outerProps: React.SVGAttributes<any>;
   width: number;
   height: number;
   viewBox: string;


### PR DESCRIPTION
Noticed I could do this while working on the data explorer typescript migration.