### PR TITLE
target es2017 for compilation

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
+    "target": "es2017",
     "jsx": "react",
     "typeRoots": ["./node_modules/@types", "types"],
     "baseUrl": ".",


### PR DESCRIPTION
We were defaulting to producing ES3 output (since this wasn't set) when we can be on ES2017 (for node 8+, current browsers).