### PR TITLE
[WIP] Use camelCase for values in commutable

### DIFF
--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -15,16 +15,16 @@ import {
 /* CodeCell Record Boilerplate */
 
 type CodeCellParams = {
-  cell_type: "code";
+  cellType: "code";
   // Sadly untyped and widely unspecced
   metadata: ImmutableMap<string, any>;
-  execution_count: ExecutionCount;
+  executionCount: ExecutionCount;
   source: string;
   outputs: ImmutableList<ImmutableOutput>;
 };
 export const makeCodeCell = Record<CodeCellParams>({
-  cell_type: "code",
-  execution_count: null,
+  cellType: "code",
+  executionCount: null,
   metadata: ImmutableMap({
     collapsed: false,
     outputHidden: false,
@@ -39,13 +39,13 @@ export type ImmutableCodeCell = RecordOf<CodeCellParams>;
 /* MarkdownCell Record Boilerplate */
 
 type MarkdownCellParams = {
-  cell_type: "markdown";
+  cellType: "markdown";
   source: string;
   metadata: ImmutableMap<string, any>;
 };
 
 export const makeMarkdownCell = Record<MarkdownCellParams>({
-  cell_type: "markdown",
+  cellType: "markdown",
   metadata: ImmutableMap(),
   source: ""
 });
@@ -55,13 +55,13 @@ export type ImmutableMarkdownCell = RecordOf<MarkdownCellParams>;
 /* RawCell Record Boilerplate */
 
 type RawCellParams = {
-  cell_type: "raw";
+  cellType: "raw";
   source: string;
   metadata: ImmutableMap<string, any>;
 };
 
 export const makeRawCell = Record<RawCellParams>({
-  cell_type: "raw",
+  cellType: "raw",
   metadata: ImmutableMap(),
   source: ""
 });

--- a/packages/commutable/src/notebook.ts
+++ b/packages/commutable/src/notebook.ts
@@ -18,7 +18,7 @@ import { JSONType, CellId } from "./primitives";
 export type NotebookRecordParams = {
   cellOrder: ImmutableList<CellId>;
   cellMap: ImmutableMap<CellId, ImmutableCell>;
-  nbformat_minor: number;
+  nbformatMinor: number;
   nbformat: number;
   metadata: ImmutableMap<string, any>;
 };
@@ -26,7 +26,7 @@ export type NotebookRecordParams = {
 export const makeNotebookRecord = Record<NotebookRecordParams>({
   cellOrder: ImmutableList(),
   cellMap: ImmutableMap(),
-  nbformat_minor: 0,
+  nbformatMinor: 0,
   nbformat: 4,
   metadata: ImmutableMap()
 });
@@ -41,9 +41,9 @@ export type Notebook = v4.Notebook | v3.Notebook;
 
 /**
  * Converts a string representation of a notebook into a JSON representation.
- * 
+ *
  * @param notebookString A string representation of a notebook.
- * 
+ *
  * @returns A JSON representation of the same notebook.
  */
 export const parseNotebook = (notebookString: string): Notebook =>
@@ -85,13 +85,13 @@ export const fromJS = (
 /**
  * Converts an immutable representation of a notebook to a JSON representation of the
  * notebook using the v4 of the nbformat specification.
- * 
+ *
  * @param immnb The immutable representation of a notebook.
- * 
+ *
  * @returns The JSON representation of a notebook.
  */
 export const toJS = (immnb: ImmutableNotebook): v4.Notebook => {
-  const minorVersion: null | number = immnb.get("nbformat_minor", null);
+  const minorVersion: null | number = immnb.get("nbformatMinor", null);
 
   if (
     immnb.get("nbformat") === 4 &&
@@ -105,9 +105,9 @@ export const toJS = (immnb: ImmutableNotebook): v4.Notebook => {
 
 /**
  * Converts a JSON representation of a notebook into a string representation.
- * 
+ *
  * @param notebook The JSON representation of a notebook.
- * 
+ *
  * @returns A string containing the notebook data.
  */
 export const stringifyNotebook = (notebook: v4.Notebook) =>

--- a/packages/commutable/src/outputs.ts
+++ b/packages/commutable/src/outputs.ts
@@ -106,15 +106,15 @@ export const isJSONKey = (key: string) =>
 
 /** ExecuteResult Record Boilerplate */
 type ExecuteResultParams = {
-  output_type: "execute_result";
-  execution_count: ExecutionCount;
+  outputType: "execute_result";
+  executionCount: ExecutionCount;
   data: ImmutableMimeBundle;
   metadata?: any;
 };
 
 export const makeExecuteResult = Record<ExecuteResultParams>({
-  output_type: "execute_result",
-  execution_count: null,
+  outputType: "execute_result",
+  executionCount: null,
   data: ImmutableMap(),
   metadata: ImmutableMap()
 });
@@ -124,13 +124,13 @@ type ImmutableExecuteResult = RecordOf<ExecuteResultParams>;
 /** DisplayData Record Boilerplate */
 
 type DisplayDataParams = {
-  output_type: "display_data";
+  outputType: "display_data";
   data: ImmutableMimeBundle;
   metadata?: any;
 };
 
 export const makeDisplayData = Record<DisplayDataParams>({
-  output_type: "display_data",
+  outputType: "display_data",
   data: ImmutableMap(),
   metadata: ImmutableMap()
 });
@@ -140,13 +140,13 @@ type ImmutableDisplayData = RecordOf<DisplayDataParams>;
 /** StreamOutput Record Boilerplate */
 
 type StreamOutputParams = {
-  output_type: "stream";
+  outputType: "stream";
   name: "stdout" | "stderr";
   text: string;
 };
 
 export const makeStreamOutput = Record<StreamOutputParams>({
-  output_type: "stream",
+  outputType: "stream",
   name: "stdout",
   text: ""
 });
@@ -156,14 +156,14 @@ type ImmutableStreamOutput = RecordOf<StreamOutputParams>;
 /** ErrorOutput Record Boilerplate */
 
 type ErrorOutputParams = {
-  output_type: "error";
+  outputType: "error";
   ename: string;
   evalue: string;
   traceback: ImmutableList<string>;
 };
 
 export const makeErrorOutput = Record<ErrorOutputParams>({
-  output_type: "error",
+  outputType: "error",
   ename: "",
   evalue: "",
   traceback: ImmutableList()

--- a/packages/commutable/src/v3.ts
+++ b/packages/commutable/src/v3.ts
@@ -100,7 +100,7 @@ const createImmutableMarkdownCell = (
   cell: MarkdownCell
 ): ImmutableMarkdownCell =>
   makeMarkdownCell({
-    cell_type: cell.cell_type,
+    cellType: cell.cell_type,
     source: demultiline(cell.source),
     metadata: immutableFromJS(cell.metadata)
   });
@@ -124,7 +124,7 @@ const createImmutableOutput = (output: Output): ImmutableOutput => {
   switch (output.output_type) {
     case "pyout":
       return makeExecuteResult({
-        execution_count: output.prompt_number,
+        executionCount: output.prompt_number,
         // Note strangeness with v4 API
         data: createImmutableMimeBundle(output),
         metadata: immutableFromJS(output.metadata)
@@ -155,16 +155,16 @@ const createImmutableOutput = (output: Output): ImmutableOutput => {
 
 const createImmutableCodeCell = (cell: CodeCell): ImmutableCodeCell =>
   makeCodeCell({
-    cell_type: cell.cell_type,
+    cellType: cell.cell_type,
     source: demultiline(cell.input),
     outputs: ImmutableList(cell.outputs.map(createImmutableOutput)),
-    execution_count: cell.prompt_number,
+    executionCount: cell.prompt_number,
     metadata: immutableFromJS(cell.metadata)
   });
 
 const createImmutableRawCell = (cell: RawCell): ImmutableRawCell =>
   makeRawCell({
-    cell_type: cell.cell_type,
+    cellType: cell.cell_type,
     source: demultiline(cell.source),
     metadata: immutableFromJS(cell.metadata)
   });
@@ -172,7 +172,7 @@ const createImmutableRawCell = (cell: RawCell): ImmutableRawCell =>
 const createImmutableHeadingCell = (cell: HeadingCell): ImmutableMarkdownCell =>
   // v3 heading cells are just markdown cells in v4+
   makeMarkdownCell({
-    cell_type: "markdown",
+    cellType: "markdown",
     source: Array.isArray(cell.source)
       ? demultiline(
           cell.source.map(line =>
@@ -227,7 +227,7 @@ export const fromJS = (notebook: Notebook) => {
   return makeNotebookRecord({
     cellOrder: cellStructure.cellOrder.asImmutable(),
     cellMap: cellStructure.cellMap.asImmutable(),
-    nbformat_minor: notebook.nbformat_minor,
+    nbformatMinor: notebook.nbformat_minor,
     nbformat: 4,
     metadata: immutableFromJS(notebook.metadata)
   });

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -132,7 +132,7 @@ export const createImmutableOutput = (output: Output): ImmutableOutput => {
   switch (output.output_type) {
     case "execute_result":
       return makeExecuteResult({
-        execution_count: output.execution_count,
+        executionCount: output.execution_count,
         data: createImmutableMimeBundle(output.data),
         metadata: immutableFromJS(output.metadata)
       });
@@ -148,7 +148,7 @@ export const createImmutableOutput = (output: Output): ImmutableOutput => {
       });
     case "error":
       return makeErrorOutput({
-        output_type: "error",
+        outputType: "error",
         ename: output.ename,
         evalue: output.evalue,
         // Note: this is one of the cases where the Array of strings (for
@@ -183,7 +183,7 @@ const createImmutableMetadata = (metadata: JSONObject) =>
 
 const createImmutableRawCell = (cell: RawCell): ImmutableRawCell =>
   makeRawCell({
-    cell_type: cell.cell_type,
+    cellType: cell.cell_type,
     source: demultiline(cell.source),
     metadata: createImmutableMetadata(cell.metadata)
   });
@@ -192,17 +192,17 @@ const createImmutableMarkdownCell = (
   cell: MarkdownCell
 ): ImmutableMarkdownCell =>
   makeMarkdownCell({
-    cell_type: cell.cell_type,
+    cellType: cell.cell_type,
     source: demultiline(cell.source),
     metadata: createImmutableMetadata(cell.metadata)
   });
 
 const createImmutableCodeCell = (cell: CodeCell): ImmutableCodeCell =>
   makeCodeCell({
-    cell_type: cell.cell_type,
+    cellType: cell.cell_type,
     source: demultiline(cell.source),
     outputs: ImmutableList(cell.outputs.map(createImmutableOutput)),
-    execution_count: cell.execution_count,
+    executionCount: cell.execution_count,
     metadata: createImmutableMetadata(cell.metadata)
   });
 
@@ -250,7 +250,7 @@ export const fromJS = (notebook: Notebook) => {
   return makeNotebookRecord({
     cellOrder: cellStructure.cellOrder.asImmutable(),
     cellMap: cellStructure.cellMap.asImmutable(),
-    nbformat_minor: notebook.nbformat_minor,
+    nbformatMinor: notebook.nbformat_minor,
     nbformat: 4,
     metadata: immutableFromJS(notebook.metadata)
   });
@@ -285,29 +285,29 @@ const mimeBundleToJS = (immMimeBundle: ImmutableMimeBundle): MimeBundle => {
 };
 
 const outputToJS = (output: ImmutableOutput): Output => {
-  switch (output.output_type) {
+  switch (output.outputType) {
     case "execute_result":
       return {
-        output_type: output.output_type,
-        execution_count: output.execution_count,
+        output_type: output.outputType,
+        execution_count: output.executionCount,
         data: mimeBundleToJS(output.data),
         metadata: output.metadata.toJS()
       };
     case "display_data":
       return {
-        output_type: output.output_type,
+        output_type: output.outputType,
         data: mimeBundleToJS(output.data),
         metadata: output.metadata.toJS()
       };
     case "stream":
       return {
-        output_type: output.output_type,
+        output_type: output.outputType,
         name: output.name,
         text: remultiline(output.text)
       };
     case "error":
       return {
-        output_type: output.output_type,
+        output_type: output.outputType,
         ename: output.ename,
         evalue: output.evalue,
         // Note: this is one of the cases where the Array of strings (for
@@ -335,7 +335,7 @@ const codeCellToJS = (immCell: ImmutableCodeCell): CodeCell => {
     cell_type: "code",
     source: remultiline(immCell.source),
     outputs: immCell.outputs.map(outputToJS).toArray(),
-    execution_count: immCell.execution_count,
+    execution_count: immCell.executionCount,
     metadata: metadataToJS(immCell.metadata)
   };
 };
@@ -363,7 +363,7 @@ const rawCellToJS = (immCell: ImmutableRawCell): RawCell => {
  * @returns A JSON representation of the same cell.
  */
 const cellToJS = (immCell: ImmutableCell): Cell => {
-  switch (immCell.cell_type) {
+  switch (immCell.cellType) {
     case "markdown":
       return markdownCellToJS(immCell);
     case "code":
@@ -397,6 +397,6 @@ export const toJS = (immnb: ImmutableNotebook): Notebook => {
     cells,
     metadata: plainNotebook.metadata.toJS(),
     nbformat: 4,
-    nbformat_minor: plainNotebook.nbformat_minor
+    nbformat_minor: plainNotebook.nbformatMinor
   };
 };

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -292,7 +292,7 @@ export function executeCellEpic(
           }
 
           // We only execute code cells
-          if ((cell as any).get("cell_type") === "code") {
+          if ((cell as any).get("cellType") === "code") {
             const source = cell.get("source", "");
 
             const message = createExecuteRequest(source);

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -75,7 +75,7 @@ function buildFixtureNotebook(config: JSONObject) {
       for (let i = 0; i < config.markdownCellCount; i++) {
         notebook = appendCellToNotebook(
           notebook,
-          emptyMarkdownCell.set("cell_type", "markdown")
+          emptyMarkdownCell.set("cellType", "markdown")
         );
       }
     }

--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -105,7 +105,7 @@ const mapStateToCellProps = (
     throw new Error("cell not found inside cell map");
   }
 
-  const cellType = (cell as any).get("cell_type");
+  const cellType = (cell as any).get("cellType");
   const outputs = cell.get("outputs", Immutable.List());
 
   const sourceHidden =
@@ -141,7 +141,7 @@ const mapStateToCellProps = (
     tags,
     source: cell.get("source", ""),
     theme: selectors.userTheme(state),
-    executionCount: (cell as ImmutableCodeCell).get("execution_count", null),
+    executionCount: (cell as ImmutableCodeCell).get("executionCount", null),
     outputs,
     models: selectors.models(state),
     pager,

--- a/packages/notebook-preview/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/notebook-preview/__tests__/__snapshots__/index.test.tsx.snap
@@ -102,7 +102,7 @@ print('hey')
                     "text/plain": "<IPython.core.display.HTML object>",
                   },
                   "metadata": Object {},
-                  "output_type": "display_data",
+                  "outputType": "display_data",
                 },
               ]
             }
@@ -349,7 +349,7 @@ print('hey')
                     "text/plain": "<IPython.core.display.HTML object>",
                   },
                   "metadata": Object {},
-                  "output_type": "display_data",
+                  "outputType": "display_data",
                 },
               ]
             }

--- a/packages/notebook-preview/src/index.tsx
+++ b/packages/notebook-preview/src/index.tsx
@@ -86,7 +86,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
           <Cells>
             {cellOrder.map((cellId: string) => {
               const cell = cellMap.get(cellId);
-              const cellType = cell.get("cell_type");
+              const cellType = cell.get("cellType");
               const source = cell.get("source");
 
               switch (cellType) {
@@ -110,7 +110,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
                       <PapermillView status={papermillStatus} />
                       <Input hidden={sourceHidden}>
                         <Prompt
-                          counter={cell.get("execution_count")}
+                          counter={cell.get("executionCount")}
                           running={papermillStatus === "running"}
                         />
                         <Source language={language} theme={this.props.theme}>
@@ -172,8 +172,7 @@ export class NotebookPreview extends React.PureComponent<Props, State> {
                   return (
                     <Cell key={cellId}>
                       <Outputs>
-                        <pre
-                        >{`Cell Type "${cellType}" is not implemented`}</pre>
+                        <pre>{`Cell Type "${cellType}" is not implemented`}</pre>
                       </Outputs>
                     </Cell>
                   );

--- a/packages/notebook-render/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/notebook-render/__tests__/__snapshots__/index.test.tsx.snap
@@ -108,7 +108,7 @@ print('hey')
                   "text/plain": "<IPython.core.display.HTML object>",
                 },
                 "metadata": Object {},
-                "output_type": "display_data",
+                "outputType": "display_data",
               },
             ]
           }
@@ -361,7 +361,7 @@ print('hey')
                   "text/plain": "<IPython.core.display.HTML object>",
                 },
                 "metadata": Object {},
-                "output_type": "display_data",
+                "outputType": "display_data",
               },
             ]
           }

--- a/packages/notebook-render/src/index.tsx
+++ b/packages/notebook-render/src/index.tsx
@@ -74,9 +74,12 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
     const allSourceHidden = notebook.getIn(["metadata", "hide_input"]) || false;
 
     const language =
-      notebook.getIn(
-        ["metadata", "language_info", "codemirror_mode", "name"]
-      ) ||
+      notebook.getIn([
+        "metadata",
+        "language_info",
+        "codemirror_mode",
+        "name"
+      ]) ||
       notebook.getIn(["metadata", "language_info", "codemirror_mode"]) ||
       notebook.getIn(["metadata", "language_info", "name"]) ||
       "text";
@@ -89,7 +92,7 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
         <Cells>
           {cellOrder.map((cellId: string) => {
             const cell = cellMap.get(cellId);
-            const cellType: string = cell!.get("cell_type");
+            const cellType: string = cell!.get("cellType");
             const source = cell!.get("source");
 
             switch (cellType) {
@@ -108,7 +111,7 @@ export default class NotebookRender extends React.PureComponent<Props, State> {
                     <Input hidden={sourceHidden}>
                       <Prompt
                         counter={(cell as ImmutableCodeCell).get(
-                          "execution_count"
+                          "executionCount"
                         )}
                       />
                       <Source language={language} theme={this.props.theme}>

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -30,9 +30,9 @@ const firstCellId = monocellDocument.getIn(["notebook", "cellOrder"]).first();
 describe("reduceOutputs", () => {
   test("puts new outputs at the end by default", () => {
     const outputs = Immutable.List([
-      Immutable.Map({ output_type: "stream", name: "stdout", text: "Woo" }),
+      Immutable.Map({ outputType: "stream", name: "stdout", text: "Woo" }),
       Immutable.Map({
-        output_type: "error",
+        outputType: "error",
         ename: "well",
         evalue: "actually",
         traceback: Immutable.List()
@@ -47,15 +47,15 @@ describe("reduceOutputs", () => {
     expect(JSON.stringify(newOutputs)).toEqual(
       JSON.stringify(
         Immutable.List([
-          Immutable.Map({ output_type: "stream", name: "stdout", text: "Woo" }),
+          Immutable.Map({ outputType: "stream", name: "stdout", text: "Woo" }),
           Immutable.Map({
-            output_type: "error",
+            outputType: "error",
             ename: "well",
             evalue: "actually",
             traceback: Immutable.List()
           }),
           Immutable.Map({
-            output_type: "display_data",
+            outputType: "display_data",
             data: Immutable.Map(),
             metadata: Immutable.Map()
           })
@@ -66,7 +66,7 @@ describe("reduceOutputs", () => {
 
   test("handles the case of a single stream output", () => {
     const outputs = Immutable.fromJS([
-      { name: "stdout", text: "hello", output_type: "stream" }
+      { name: "stdout", text: "hello", outputType: "stream" }
     ]);
     const newOutputs = reduceOutputs(outputs, {
       name: "stdout",
@@ -77,7 +77,7 @@ describe("reduceOutputs", () => {
     expect(JSON.stringify(newOutputs)).toBe(
       JSON.stringify(
         Immutable.fromJS([
-          { name: "stdout", text: "hello world", output_type: "stream" }
+          { name: "stdout", text: "hello world", outputType: "stream" }
         ])
       )
     );
@@ -103,6 +103,7 @@ describe("reduceOutputs", () => {
       text: " world",
       output_type: "stream"
     });
+    debugger;
     expect(
       Immutable.is(
         outputs,
@@ -115,8 +116,8 @@ describe("reduceOutputs", () => {
 
   test("keeps respective streams together", () => {
     const outputs = Immutable.fromJS([
-      { name: "stdout", text: "hello", output_type: "stream" },
-      { name: "stderr", text: "errors are", output_type: "stream" }
+      { name: "stdout", text: "hello", outputType: "stream" },
+      { name: "stderr", text: "errors are", outputType: "stream" }
     ]);
     const newOutputs = reduceOutputs(outputs, {
       name: "stdout",
@@ -127,8 +128,8 @@ describe("reduceOutputs", () => {
     expect(JSON.stringify(newOutputs)).toBe(
       JSON.stringify(
         Immutable.fromJS([
-          { name: "stdout", text: "hello world", output_type: "stream" },
-          { name: "stderr", text: "errors are", output_type: "stream" }
+          { name: "stdout", text: "hello world", outputType: "stream" },
+          { name: "stderr", text: "errors are", outputType: "stream" }
         ])
       )
     );
@@ -141,12 +142,12 @@ describe("reduceOutputs", () => {
     expect(JSON.stringify(evenNewerOutputs)).toBe(
       JSON.stringify(
         Immutable.fromJS([
-          { name: "stdout", text: "hello world", output_type: "stream" },
+          { name: "stdout", text: "hello world", outputType: "stream" },
           {
             name: "stderr",
 
             text: "errors are informative",
-            output_type: "stream"
+            outputType: "stream"
           }
         ])
       )
@@ -224,7 +225,7 @@ describe("focusNextCell", () => {
       "notebook",
       "cellMap",
       newCellId,
-      "cell_type"
+      "cellType"
     ]);
 
     expect(state.cellFocused).not.toBeNull();
@@ -247,7 +248,7 @@ describe("focusNextCell", () => {
       "notebook",
       "cellMap",
       newCellId,
-      "cell_type"
+      "cellType"
     ]);
 
     expect(state.cellFocused).not.toBeNull();
@@ -307,11 +308,9 @@ describe("updateExecutionCount", () => {
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
     const state = reducers(
       originalState,
-      actions.setInCell({ id, path: ["execution_count"], value: 42 })
+      actions.setInCell({ id, path: ["executionCount"], value: 42 })
     );
-    expect(state.getIn(["notebook", "cellMap", id, "execution_count"])).toBe(
-      42
-    );
+    expect(state.getIn(["notebook", "cellMap", id, "executionCount"])).toBe(42);
   });
 });
 
@@ -449,7 +448,7 @@ describe("createCellBelow", () => {
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
     const cellId = state.getIn(["notebook", "cellOrder"]).last();
     const cell = state.getIn(["notebook", "cellMap", cellId]);
-    expect(cell.get("cell_type")).toBe("markdown");
+    expect(cell.get("cellType")).toBe("markdown");
   });
 });
 
@@ -477,7 +476,7 @@ describe("createCellAfter", () => {
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(4);
     const cellId = state.getIn(["notebook", "cellOrder"]).last();
     const cell = state.getIn(["notebook", "cellMap", cellId]);
-    expect(cell.get("cell_type")).toBe("markdown");
+    expect(cell.get("cellType")).toBe("markdown");
   });
 });
 
@@ -732,7 +731,7 @@ describe("changeCellType", () => {
       originalState,
       actions.changeCellType({ id, to: "markdown" })
     );
-    expect(state.getIn(["notebook", "cellMap", id, "cell_type"])).toBe(
+    expect(state.getIn(["notebook", "cellMap", id, "cellType"])).toBe(
       "markdown"
     );
   });
@@ -746,7 +745,7 @@ describe("changeCellType", () => {
 
     const cell = state.getIn(["notebook", "cellMap", id]);
 
-    expect(cell.cell_type).toBe("code");
+    expect(cell.cellType).toBe("code");
     expect(cell.outputs).toEqual(Immutable.List());
   });
   test("does nothing if cell type is same", () => {

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -50,7 +50,7 @@ export function reduceOutputs(
   if (
     output.output_type !== "stream" ||
     !last ||
-    (outputs.size > 0 && last.get("output_type") !== "stream")
+    (outputs.size > 0 && last.get("outputType") !== "stream")
   ) {
     // If it's not a stream type, we just fold in the output
     return outputs.push(createImmutableOutput(output));
@@ -69,7 +69,7 @@ export function reduceOutputs(
     last &&
     outputs.size > 0 &&
     typeof streamOutput.name !== "undefined" &&
-    last.get("output_type") === "stream"
+    last.get("outputType") === "stream"
   ) {
     // Invariant: size > 0, outputs.last() exists
     if (last.get("name") === streamOutput.name) {
@@ -80,7 +80,7 @@ export function reduceOutputs(
       | undefined = outputs.butLast().last();
     if (
       nextToLast &&
-      nextToLast.get("output_type") === "stream" &&
+      nextToLast.get("outputType") === "stream" &&
       nextToLast.get("name") === streamOutput.name
     ) {
       return outputs.updateIn([outputs.size - 2, "text"], appendText);
@@ -119,14 +119,14 @@ function clearOutputs(state: NotebookModel, action: actionTypes.ClearOutputs) {
     return state;
   }
 
-  const type = state.getIn(["notebook", "cellMap", id, "cell_type"]);
+  const type = state.getIn(["notebook", "cellMap", id, "cellType"]);
 
   const cleanedState = cleanCellTransient(state, id);
 
   if (type === "code") {
     return cleanedState
       .setIn(["notebook", "cellMap", id, "outputs"], Immutable.List())
-      .setIn(["notebook", "cellMap", id, "execution_count"], null);
+      .setIn(["notebook", "cellMap", id, "executionCount"], null);
   }
   return cleanedState;
 }
@@ -160,10 +160,10 @@ function clearAllOutputs(
     .getIn(["notebook", "cellMap"])
     // NOTE: My kingdom for a mergeMap
     .map((cell: ImmutableCell) => {
-      if ((cell as any).get("cell_type") === "code") {
+      if ((cell as any).get("cellType") === "code") {
         return (cell as ImmutableCodeCell).merge({
           outputs: Immutable.List(),
-          execution_count: null
+          executionCount: null
         });
       }
       return cell;
@@ -293,7 +293,7 @@ function focusNextCell(
   }
 
   const curIndex = cellOrder.findIndex((foundId: CellId) => id === foundId);
-  const curCellType = state.getIn(["notebook", "cellMap", id, "cell_type"]);
+  const curCellType = state.getIn(["notebook", "cellMap", id, "cellType"]);
 
   const nextIndex = curIndex + 1;
 
@@ -622,7 +622,7 @@ function toggleCellOutputVisibility(
 function unhideAll(state: NotebookModel, action: actionTypes.UnhideAll) {
   return state.updateIn(["notebook", "cellMap"], cellMap =>
     cellMap.map((cell: ImmutableCell) => {
-      if ((cell as any).get("cell_type") === "code") {
+      if ((cell as any).get("cellType") === "code") {
         return cell.mergeIn(["metadata"], {
           // TODO: Verify that we convert to one namespace for hidden input/output
           outputHidden: action.payload.outputHidden,
@@ -758,7 +758,7 @@ function changeCellType(
   // $FlowFixMe: flow types in immutable need to be updated
   const cell = state.getIn(["notebook", "cellMap", id]);
 
-  const from = cell.cell_type;
+  const from = cell.cellType;
 
   // NOOP, since we're already that cell type
   if (from === to) {
@@ -771,7 +771,7 @@ function changeCellType(
   if (from === "code") {
     nextState = cleanCellTransient(
       state
-        .deleteIn(["notebook", "cellMap", id, "execution_count"])
+        .deleteIn(["notebook", "cellMap", id, "executionCount"])
         .deleteIn(["notebook", "cellMap", id, "outputs"]),
       id
     );

--- a/packages/selectors/src/notebook.ts
+++ b/packages/selectors/src/notebook.ts
@@ -88,7 +88,7 @@ export const codeCellIdsBelow = (
     .skip(index)
     .filter(
       (id: string) =>
-        model.notebook.getIn(["cellMap", id, "cell_type"]) === "code"
+        model.notebook.getIn(["cellMap", id, "cellType"]) === "code"
     );
 };
 
@@ -138,7 +138,7 @@ export const transientCellMap = (model: NotebookModel) =>
 export const codeCellIds = createSelector(
   [cellMap, cellOrder],
   (cellMap, cellOrder) => {
-    return cellOrder.filter(id => cellMap.getIn([id, "cell_type"]) === "code");
+    return cellOrder.filter(id => cellMap.getIn([id, "cellType"]) === "code");
   }
 );
 


### PR DESCRIPTION
(Effectively) reverts nteract/nteract#3845. There's more work to be done for switching to `camelCase` with commutable, as the outputs and many other areas have to handle it. Putting this PR up (and rebasing it to commit as @captainsafia) to continue the work. I merged a little too quickly on the earlier PRs.

