### PR TITLE
Wire errorMiddleware in jupyter_extension similarly to how it's wired in desktop

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.js
@@ -2,7 +2,7 @@
 import { combineReducers, createStore, applyMiddleware, compose } from "redux";
 import { createEpicMiddleware, combineEpics } from "redux-observable";
 import type { AppState } from "@nteract/core";
-import { reducers, epics as coreEpics } from "@nteract/core";
+import { reducers, epics as coreEpics, middlewares as coreMiddlewares } from "@nteract/core";
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
@@ -17,15 +17,16 @@ export default function configureStore(initialState: AppState) {
   const rootEpic = combineEpics<AppState, redux$AnyAction, *>(
     ...coreEpics.allEpics
   );
-  const middlewares = createEpicMiddleware();
+  const epicMiddleware = createEpicMiddleware();
+  const middlewares = [epicMiddleware, coreMiddlewares.errorMiddleware];
 
   const store = createStore(
     rootReducer,
     initialState,
-    composeEnhancers(applyMiddleware(middlewares))
+    composeEnhancers(applyMiddleware(...middlewares))
   );
 
-  middlewares.run(rootEpic);
+  epicMiddleware.run(rootEpic);
 
   return store;
 }


### PR DESCRIPTION
Possibly related to #2387.

On macOS I'm seeing occasional errors in the UI. I had to add some
logging manually to track down that they're coming from saveContentEpic.
With this change they are reported to the console, albeit TWICE.
First first logging happens the the errorMiddleware itself here - https://github.com/nteract/nteract/blob/6d9e66cd78395a395b9e80a346b4d73a58261422/packages/core/src/middlewares.ts#L21
The message is then propagated to the notifactionSystem, which also logs
here - https://github.com/nteract/nteract/blob/255761ed1f9d640e47740da6fbe3fd035f4bd7bc/packages/types/src/index.ts#L143

Any thoughts on further sanitizing this? I'm happy to leave it double-
reporting; better that than not at all.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [ ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
