### PR TITLE
[WIP] try another approach for ts setup

### DIFF
--- a/packages/commutable/tsconfig.json
+++ b/packages/commutable/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "lib"
   },
-  "include": ["src"]
+  "include": ["src", "src/*.ts"]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "ansi-to-react" }, { "path": "messaging" }]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "files": [],
-  "references": [{ "path": "ansi-to-react" }, { "path": "messaging" }]
+  "references": [
+    { "path": "ansi-to-react" },
+    { "path": "messaging" },
+    { "path": "types" },
+    { "path": "commutable" }
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,22 +4,16 @@
   "compilerOptions": {
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "composite": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"],
     "target": "es2017",
     "module": "commonjs",
     "jsx": "react",
     "typeRoots": ["./node_modules/@types", "types"],
-    "baseUrl": ".",
-    "moduleResolution": "node",
-    "paths": {
-      // Attempt to allow our namespace packages to get resolved
-      "@nteract/*": ["./packages/*/src"],
-      "@mybinder/*": ["./packages/*/src"],
-      "rx-jupyter": ["./packages/rx-jupyter/src"],
-      "rx-binder": ["./packages/rx-binder/src"],
-      "enchannel-zmq-backend": ["./packages/enchannel-zmq-backend/src"],
-      "fs-observable": ["./packages/fs-observable/src"]
-    }
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
Attempting to follow the lead in https://github.com/RyanCavanaugh/learn-a for building our packages.

To build with this setup, use:

```
npx tsc -b packages
```

Make sure to run `yarn` first when you clone this branch.

## Goal

Get package builds and package build watches to be able to be run as one singular `tsc` command under the hood:

```
tsc -b packages --watch
```
