### PR TITLE
Adds browser-cache-circumvention to rx-jupyter.

### DIFF
--- a/packages/rx-jupyter/__tests__/contents-spec.ts
+++ b/packages/rx-jupyter/__tests__/contents-spec.ts
@@ -25,9 +25,9 @@ describe("contents", () => {
         "/walla/walla/bingbang.ipynb"
       ) as AjaxObservable;
       const request = content$.request;
-      expect(request.url).toBe(
-        "http://localhost:8888/api/contents/walla/walla/bingbang.ipynb"
-      );
+      expect(request.url).toEqual(expect.stringContaining(
+        "http://localhost:8888/api/contents/walla/walla/bingbang.ipynb?_="
+      ));
       expect(request.method).toBe("GET");
       expect(request.crossDomain).toBe(true);
       expect(request.responseType).toBe("json");
@@ -37,9 +37,9 @@ describe("contents", () => {
         type: "directory"
       }) as AjaxObservable;
       const request = content$.request;
-      expect(request.url).toBe(
-        "http://localhost:8888/api/contents/walla/walla?type=directory"
-      );
+      expect(request.url).toEqual(expect.stringContaining(
+        "http://localhost:8888/api/contents/walla/walla?type=directory&_="
+      ));
       expect(request.method).toBe("GET");
       expect(request.crossDomain).toBe(true);
       expect(request.responseType).toBe("json");
@@ -107,9 +107,9 @@ describe("contents", () => {
         "/path/to/content"
       );
       const request = (create$ as AjaxObservable).request;
-      expect(request.url).toBe(
-        "http://localhost:8888/api/contents/path/to/content/checkpoints"
-      );
+      expect(request.url).toEqual(expect.stringContaining(
+        "http://localhost:8888/api/contents/path/to/content/checkpoints?_="
+      ));
       expect(request.method).toBe("GET");
       expect(request.crossDomain).toBe(true);
       expect(request.responseType).toBe("json");

--- a/packages/rx-jupyter/__tests__/kernel-spec.ts
+++ b/packages/rx-jupyter/__tests__/kernel-spec.ts
@@ -13,7 +13,7 @@ describe("kernels", () => {
       const id = "0000-1111-2222-3333";
       const kernel$ = kernels.get(serverConfig, id) as AjaxObservable;
       const request = kernel$.request;
-      expect(request.url).toBe(`http://localhost:8888/api/kernels/${id}`);
+      expect(request.url).toEqual(expect.stringContaining(`http://localhost:8888/api/kernels/${id}?_=`));
       expect(request.method).toBe("GET");
     });
   });
@@ -22,7 +22,7 @@ describe("kernels", () => {
     test("creates an AjaxObservable configured for listing kernels", () => {
       const kernel$ = kernels.list(serverConfig) as AjaxObservable;
       const request = kernel$.request;
-      expect(request.url).toBe("http://localhost:8888/api/kernels");
+      expect(request.url).toEqual(expect.stringContaining("http://localhost:8888/api/kernels?_="));
       expect(request.method).toBe("GET");
       expect(request.crossDomain).toBe(true);
     });

--- a/packages/rx-jupyter/__tests__/kernelspecs-spec.ts
+++ b/packages/rx-jupyter/__tests__/kernelspecs-spec.ts
@@ -12,7 +12,7 @@ describe("kernelspecs", () => {
     test("creates an AjaxObservable for listing the kernelspecs", () => {
       const kernelSpec$ = kernelspecs.list(serverConfig) as AjaxObservable;
       const request = kernelSpec$.request;
-      expect(request.url).toBe("http://localhost:8888/api/kernelspecs");
+      expect(request.url).toEqual(expect.stringContaining("http://localhost:8888/api/kernelspecs?_="));
       expect(request.method).toBe("GET");
     });
   });
@@ -24,8 +24,8 @@ describe("kernelspecs", () => {
         "python3000"
       ) as AjaxObservable;
       const request = kernelSpec$.request;
-      expect(request.url).toBe(
-        "http://localhost:8888/api/kernelspecs/python3000"
+      expect(request.url).toEqual(
+          expect.stringContaining("http://localhost:8888/api/kernelspecs/python3000?_=")
       );
       expect(request.method).toBe("GET");
     });

--- a/packages/rx-jupyter/__tests__/sessions-spec.ts
+++ b/packages/rx-jupyter/__tests__/sessions-spec.ts
@@ -12,7 +12,7 @@ describe("sessions", () => {
     test("creates an AjaxObservable for listing the sessions", () => {
       const session$ = sessions.list(serverConfig) as AjaxObservable;
       const request = session$.request;
-      expect(request.url).toBe("http://localhost:8888/api/sessions");
+      expect(request.url).toEqual(expect.stringContaining("http://localhost:8888/api/sessions"));
       expect(request.method).toBe("GET");
       expect(request.crossDomain).toBe(true);
       expect(request.responseType).toBe("json");
@@ -23,7 +23,7 @@ describe("sessions", () => {
     test("creates an AjaxObservable for getting particular session info", () => {
       const session$ = sessions.get(serverConfig, "uuid") as AjaxObservable;
       const request = session$.request;
-      expect(request.url).toBe("http://localhost:8888/api/sessions/uuid");
+      expect(request.url).toEqual(expect.stringContaining("http://localhost:8888/api/sessions/uuid"));
       expect(request.method).toBe("GET");
       expect(request.crossDomain).toBe(true);
       expect(request.responseType).toBe("json");

--- a/packages/rx-jupyter/src/contents.ts
+++ b/packages/rx-jupyter/src/contents.ts
@@ -83,7 +83,7 @@ export const get = (
   if (query.length > 0) {
     uri = `${uri}?${query}`;
   }
-  return ajax(createAJAXSettings(serverConfig, uri));
+  return ajax(createAJAXSettings(serverConfig, uri, {cache: false}));
 };
 
 /**
@@ -170,7 +170,8 @@ export const save = (
 export const listCheckpoints = (serverConfig: ServerConfig, path: string) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, ""), {
-      method: "GET"
+      method: "GET",
+      cache: false
     })
   );
 

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -19,7 +19,7 @@ import { JupyterMessage } from "@nteract/messaging";
  * @returns An Observable with the request response
  */
 export const list = (serverConfig: ServerConfig) =>
-  ajax(createAJAXSettings(serverConfig, "/api/kernels"));
+  ajax(createAJAXSettings(serverConfig, "/api/kernels", {cache: false}));
 
 /**
  * Creates an AjaxObservable for getting info about a kernel.
@@ -30,7 +30,7 @@ export const list = (serverConfig: ServerConfig) =>
  * @returns An Observable with the request response
  */
 export const get = (serverConfig: ServerConfig, id: string) =>
-  ajax(createAJAXSettings(serverConfig, `/api/kernels/${id}`));
+  ajax(createAJAXSettings(serverConfig, `/api/kernels/${id}`, {cache: false}));
 
 /**
  * Creates an AjaxObservable for starting a kernel.

--- a/packages/rx-jupyter/src/kernelspecs.ts
+++ b/packages/rx-jupyter/src/kernelspecs.ts
@@ -13,7 +13,7 @@ import { createAJAXSettings, ServerConfig } from "./base";
  * @return An Observable with the request response
  */
 export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
-  ajax(createAJAXSettings(serverConfig, "/api/kernelspecs"));
+  ajax(createAJAXSettings(serverConfig, "/api/kernelspecs", {cache: false}));
 
   /**
    * Returns the specification of available kernels with the given
@@ -25,4 +25,4 @@ export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
    * @returns An Observable with the request reponse
    */
 export const get = (serverConfig: ServerConfig, name: string): Observable<AjaxResponse> =>
-  ajax(createAJAXSettings(serverConfig, `/api/kernelspecs/${name}`));
+  ajax(createAJAXSettings(serverConfig, `/api/kernelspecs/${name}`, {cache: false}));

--- a/packages/rx-jupyter/src/sessions.ts
+++ b/packages/rx-jupyter/src/sessions.ts
@@ -14,7 +14,7 @@ import { createAJAXSettings, ServerConfig } from "./base";
  * @returns An Observable with the request response
  */
 export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
-  ajax(createAJAXSettings(serverConfig, "/api/sessions"));
+  ajax(createAJAXSettings(serverConfig, "/api/sessions", {cache: false}));
 
 /**
  * Creates an AjaxObservable for getting a particular session's information.
@@ -25,7 +25,7 @@ export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
  * @returns An Observable with the request/response
  */
 export const get = (serverConfig: ServerConfig, sessionID: string): Observable<AjaxResponse> =>
-  ajax(createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`));
+  ajax(createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {cache: false}));
 
 /**
  * Creates an AjaxObservable for destroying a particular session.


### PR DESCRIPTION
This is one of several ways we might fix #3850.

In this case we assume that Jupyter server will not change its ways
regarding lack of Cache-control headers on APIs. So we augment the
querystring of GET and HEAD requests w/ a timestamp to ensure the
request makes it to the server. This is how Jupyter notebook does it.

I mechanically went through https://github.com/jupyter/notebook/tree/master/notebook/static/services
and found usages of jquery's ajax method w/ its `cache` option set to
false. Notably this was occurring on several PUT/POST/DELETE calls;
jquery docs say that doesn't make sense except for IE8, and their
code actually NOOPs these cases, so I've ommitted them.

I altered createAJAXSettings to behave much like jquery's ajax().
This creates a familiar API (for many), and centralizes the cache-
busting logic. It's notable however that in many cases we are now
assembling a URL string, only to pass it into createAJAXSettings
where it is parsed, the cache-busting query section added, before
a full string is finally rebuilt.
