### PR TITLE
Add missing nteractDesktop fields

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -4,6 +4,7 @@
   "description": "A collection of actions",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "nteractDesktop": "src/index.ts",
   "scripts": {
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",

--- a/packages/epics/package.json
+++ b/packages/epics/package.json
@@ -11,6 +11,8 @@
   "homepage": "https://github.com/nteract/nteract/tree/master/packages/epics#readme",
   "license": "BSD-3-Clause",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "nteractDesktop": "src/index.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/reducers/package.json
+++ b/packages/reducers/package.json
@@ -4,6 +4,7 @@
   "description": "A set of reducers for use in nteract applications",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "nteractDesktop": "src/index.ts",
   "scripts": {
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
The `nteractDesktop` main field is used by babel/webpack to resolve modules to `src` instead of requiring a from `lib`. This means we can hack on the apps without needing to constantly run typescript compilation.

This fixes the webpack build of the desktop app.
