### PR TITLE
include a root level tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages" }
+  ]
+}


### PR DESCRIPTION
Lets us run:

```
tsc -b
```

at the root. I've also noticed some various auditing tools like `rxjs-operator-counter` will use `tsconfig.json` at the root to do its thing, so this is here for ease of detection.