### PR TITLE
GraphQL: lay foundation for rx-backed messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@types/execa": "^0.9.0",
     "@types/file-saver": "^2.0.0",
     "@types/graphql": "^14.0.3",
+    "@types/graphql-type-json": "^0.1.3",
     "@types/jest": "^23.3.8",
     "@types/jsonfile": "^5.0.0",
     "@types/leaflet": "^1.2.14",

--- a/packages/fs-kernels/package.json
+++ b/packages/fs-kernels/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/nteract/nteract/issues"
   },
   "dependencies": {
+    "@nteract/messaging": "^5.0.0-alpha.0",
     "enchannel-zmq-backend": "^8.0.0-alpha.0",
     "execa": "^1.0.0",
     "jsonfile": "^5.0.0",

--- a/packages/fs-kernels/src/kernel.ts
+++ b/packages/fs-kernels/src/kernel.ts
@@ -4,6 +4,8 @@
 import { ExecaChildProcess } from "execa";
 import pidusage from "pidusage";
 
+import { Channels } from "@nteract/messaging";
+
 import { JupyterConnectionInfo } from "enchannel-zmq-backend";
 
 import { launch, launchSpec, LaunchedKernel, cleanup } from "./spawnteract";
@@ -14,12 +16,14 @@ export class Kernel {
   process: ExecaChildProcess;
   connectionInfo: JupyterConnectionInfo;
   connectionFile: string;
+  channels: Channels;
 
   constructor(launchedKernel: LaunchedKernel) {
     this.process = launchedKernel.spawn;
     this.connectionInfo = launchedKernel.config;
     this.kernelSpec = launchedKernel.kernelSpec;
     this.connectionFile = launchedKernel.connectionFile;
+    this.channels = launchedKernel.channels;
   }
 
   async shutdown() {

--- a/packages/fs-kernels/tsconfig.json
+++ b/packages/fs-kernels/tsconfig.json
@@ -5,5 +5,8 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../enchannel-zmq-backend" }]
+  "references": [
+    { "path": "../enchannel-zmq-backend" },
+    { "path": "../messaging" }
+  ]
 }

--- a/packages/kernel-relay/package.json
+++ b/packages/kernel-relay/package.json
@@ -19,6 +19,8 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "@nteract/fs-kernels": "^1.0.0",
+    "@nteract/messaging": "^5.0.0-alpha.0",
+    "enchannel-zmq-backend": "^8.0.0-alpha.0",
     "apollo-server": "^2.3.1",
     "graphql": "^14.0.2",
     "graphql-type-json": "^0.2.1"

--- a/packages/kernel-relay/tsconfig.json
+++ b/packages/kernel-relay/tsconfig.json
@@ -5,5 +5,9 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../fs-kernels" }]
+  "references": [
+    { "path": "../fs-kernels" },
+    { "path": "../enchannel-zmq-backend" },
+    { "path": "../messaging" }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,7 +1776,14 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/graphql@^14.0.3":
+"@types/graphql-type-json@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@types/graphql-type-json/-/graphql-type-json-0.1.3.tgz#c4e6c0caccd907bf22baa73e76584433d7a0469b"
+  integrity sha512-H/RVUQKL/W5+msmG/+DpYkljDgqE4ibzWm9B6RV/jHdE7dOU+fqmLHb8Ol9JFzbD+ZsIITPuNMYVmaw6FjuyDA==
+  dependencies:
+    "@types/graphql" "*"
+
+"@types/graphql@*", "@types/graphql@^14.0.3":
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.3.tgz#389e2e5b83ecdb376d9f98fae2094297bc112c1c"
   integrity sha512-TcFkpEjcQK7w8OcrQcd7iIBPjU0rdyi3ldj6d0iJ4PPSzbWqPBvXj9KSwO14hTOX2dm9RoiH7VuxksJLNYdXUQ==


### PR DESCRIPTION
Extracted from #3891 so we can start using it in other contexts (@captainsafia is using it for shutdown message logic).

* provide channels on kernel object
* include JSON scalars for untyped jupyter payloads