### PR TITLE
lock down content(s) record types

### DIFF
--- a/packages/reducers/src/core/entities/index.ts
+++ b/packages/reducers/src/core/entities/index.ts
@@ -1,6 +1,12 @@
 import { combineReducers } from "redux-immutable";
 
-import { makeEntitiesRecord } from "@nteract/types";
+import {
+  makeEntitiesRecord,
+  EntitiesRecord,
+  EntitiesRecordProps
+} from "@nteract/types";
+
+import { Action } from "redux";
 
 import { contents } from "./contents";
 import { hosts } from "./hosts";

--- a/packages/types/src/entities/contents/index.ts
+++ b/packages/types/src/entities/contents/index.ts
@@ -29,5 +29,7 @@ export type ContentsRecordProps = {
 };
 
 export const makeContentsRecord = Immutable.Record<ContentsRecordProps>({
-  byRef: Immutable.Map()
+  byRef: Immutable.Map<ContentRef, ContentRecord>()
 });
+
+export type ContentsRecord = Immutable.RecordOf<ContentsRecordProps>;


### PR DESCRIPTION
Even more type declaring in reducers and types. This tackles the _contents_ reducer, which is just `byRef[ContentRef]` and needed some more generics sprinkled in. `combineReducers` from `redux-immutable` turned into a huge pain to deal with for types so I did this tiny reducer by hand.