### PR TITLE
Adds tsconfig.json file to jupyter-extension

### DIFF
--- a/applications/jupyter-extension/tsconfig.json
+++ b/applications/jupyter-extension/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": true 
+  },
+  "include": ["nteract_on_jupyter/app/app"]
+}


### PR DESCRIPTION
Adds `tsconfig.json` file to `jupyter-extension`. This PR is apart of the Typescript conversion, started with PR #3914.