### PR TITLE
correct the tsconfig for jupyter extension

### DIFF
--- a/applications/jupyter-extension/tsconfig.json
+++ b/applications/jupyter-extension/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "composite": true 
+    "composite": false
   },
-  "include": ["nteract_on_jupyter/app/app"]
+  "include": ["nteract_on_jupyter/app"]
 }


### PR DESCRIPTION
This sets up the right path for the jupyter extension. However, type checking will fail now (even though we don't hook it up to CI yet). To run it, do:

```
npx tsc -b applications/jupyter-extension
```

41 errors, we can take them one at a time with new PRs. 😄 