### PR TITLE
report on TS in apps without failing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,20 @@ jobs:
       - run: yarn run test:lint
       - run: yarn run build:packages:ci
       - run: yarn run test --maxWorkers 1
+
+      - run:
+          name: Report on types for Applications
+          shell: /bin/bash
+          command: |
+            set +e # Allow failure for now
+            echo '**** Reporting on types for Jupyter Extension ****'
+            yarn report:jext
+            echo '**** Reporting on types for Desktop ****'
+            yarn report:desktop
+            echo '**** Reporting on types for Play ****'
+            yarn report:play
+            echo '**** Application type reporting finished ****'
+
       - run: yarn run test:flow
 
       - run:

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     "pack": "lerna run pack --scope nteract --stream",
     "dist": "lerna run dist --scope nteract --stream",
     "dist:all": "lerna run dist:all --scope nteract --stream",
+    "report:jext": "tsc -b applications/jupyter-extension",
+    "report:desktop": "tsc -b applications/desktop",
+    "report:play": "tsc -b applications/play",
     "clean": "lerna clean --yes && npm run build:clean && rimraf node_modules"
   },
   "jest": {


### PR DESCRIPTION
This adds a command for both desktop and jupyter extension (e.g. `npm run report:desktop`) command which runs our `noEmit` typescript checks. It's enabled on CI while allowing failure (using `set +e`).