### PR TITLE
remove null state generic for tsx

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
@@ -55,7 +55,7 @@ const GlobalAppStyle = createGlobalStyle`
   }
 `;
 
-class App extends React.Component<{ contentRef: ContentRef }, null> {
+class App extends React.Component<{ contentRef: ContentRef }> {
   notificationSystem!: ReactNotificationSystem;
 
   shouldComponentUpdate(nextProps: { contentRef: ContentRef }) {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/components/last-saved.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/components/last-saved.tsx
@@ -32,7 +32,7 @@ const Pretext = styled(Span)`
   padding-right: 10px;
 `;
 
-class LastSaved extends React.PureComponent<LastSavedProps, null> {
+class LastSaved extends React.PureComponent<LastSavedProps> {
   intervalId!: number;
   isStillMounted: boolean;
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.tsx
@@ -44,7 +44,7 @@ type DirectoryProps = {
   }>
 };
 
-export class DirectoryApp extends React.PureComponent<DirectoryProps, null> {
+export class DirectoryApp extends React.PureComponent<DirectoryProps> {
   openNotebook = (ks: KernelspecRecord | KernelspecProps) => {
     openNotebook(this.props.host, ks, {
       appVersion: this.props.appVersion,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/text-file.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/text-file.tsx
@@ -34,7 +34,7 @@ type TextFileState = {
   Editor: React.ComponentType<MonacoEditorProps>
 };
 
-class EditorPlaceholder extends React.Component<MonacoEditorProps, null> {
+class EditorPlaceholder extends React.Component<MonacoEditorProps> {
   render() {
     // TODO: Show a little blocky placeholder
     return null;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -47,7 +47,7 @@ const mapStateToProps = (
   };
 };
 
-class Contents extends React.Component<ContentsProps, null> {
+class Contents extends React.Component<ContentsProps> {
   render() {
     const appBase = this.props.appBase;
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
@@ -45,7 +45,7 @@ const transforms = {
   "application/vnd.dataresource+json": NullTransform
 };
 
-class NotebookPlaceholder extends React.Component<Props, null> {
+class NotebookPlaceholder extends React.Component<Props> {
   render() {
     // TODO: Show an approximated notebook
     return null;

--- a/packages/host-cache/src/components/kernel.tsx
+++ b/packages/host-cache/src/components/kernel.tsx
@@ -109,7 +109,7 @@ type KernelProps = {
   cwd: string;
 };
 
-class Kernel extends React.Component<KernelProps, null> {
+class Kernel extends React.Component<KernelProps> {
   static Consumer = Consumer;
 
   static defaultProps = {

--- a/packages/jupyter-widgets/src/index.js.flow
+++ b/packages/jupyter-widgets/src/index.js.flow
@@ -6,4 +6,4 @@ type Props = {
   channels: Subject<*>
 };
 
-export type WidgetDisplay = React.Component<Props, null>;
+export type WidgetDisplay = React.Component<Props>;

--- a/packages/jupyter-widgets/src/index.tsx
+++ b/packages/jupyter-widgets/src/index.tsx
@@ -19,7 +19,7 @@ type Props = {
  * Even though it may appear to be pure, since it doesn't have react state, this
  * component's iframe maintains it's own state in communication with the kernel.
  */
-export class WidgetDisplay extends React.Component<Props, null> {
+export class WidgetDisplay extends React.Component<Props> {
   static MIMETYPE = "application/vnd.jupyter.widget-view+json";
 
   // TODO: Uncomment this and related code in a follow-up PR.

--- a/packages/transforms/src/text.tsx
+++ b/packages/transforms/src/text.tsx
@@ -6,7 +6,7 @@ type Props = {
   mediaType: "text/plain";
 };
 
-export default class TextDisplay extends React.PureComponent<Props, null> {
+export default class TextDisplay extends React.PureComponent<Props> {
   static MIMETYPE = "text/plain";
 
   static defaultProps = {


### PR DESCRIPTION
Since I've noticed `connect`ed components run into a problem with `null` being declared for a component's type of state frequently, I'm trying out removing all of them from our code base. This was a flow quirk that wanted the `null` at the end and we don't need it any more.