### PR TITLE
Fix catchAndRetry parameter types

### DIFF
--- a/applications/desktop/src/notebook/epics/index.ts
+++ b/applications/desktop/src/notebook/epics/index.ts
@@ -1,3 +1,4 @@
+import { Observable } from "rxjs";
 import { catchError, startWith } from "rxjs/operators";
 import { epics as coreEpics } from "@nteract/core";
 import { DesktopNotebookAppState } from "../state";
@@ -26,10 +27,7 @@ import { closeNotebookEpic } from "./close-notebook";
 
 import { Actions } from "../actions";
 
-export function retryAndEmitError(
-  err: Error,
-  source: ActionsObservable<Actions>
-) {
+export function retryAndEmitError(err: Error, source: Observable<Actions>) {
   console.error(err);
   return source.pipe(startWith({ type: "ERROR", payload: err, error: true }));
 }


### PR DESCRIPTION
Ended up chasing a lot of red herrings with this one but the problem ended up being that the type on `catchAndRetry` didn't match up with the type definitions for `catchError`.