### PR TITLE
switch over button groups to styled components

### DIFF
--- a/packages/transform-dataresource/package.json
+++ b/packages/transform-dataresource/package.json
@@ -47,7 +47,7 @@
     "react-table": "^6.8.6",
     "react-table-hoc-fixed-columns": "1.0.2",
     "semiotic": "^1.16.0",
-    "styled-jsx": "^3.1.0",
+    "styled-components": "^4.1.3",
     "tv4": "^1.3.0"
   }
 }

--- a/packages/transform-dataresource/src/ParallelCoordinatesController.js
+++ b/packages/transform-dataresource/src/ParallelCoordinatesController.js
@@ -6,7 +6,7 @@ import { ResponsiveOrdinalFrame, Axis } from "semiotic";
 
 import HTMLLegend from "./HTMLLegend";
 import { numeralFormatting } from "./utilities";
-import buttonGroupStyle from "./css/button-group";
+import { StyledButtonGroup, StyledButton } from "./components/button-group";
 import TooltipContent from "./tooltip-content";
 
 type State = {
@@ -218,20 +218,20 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
 
     return (
       <div>
-        <div className="button-group">
-          <button
+        <StyledButtonGroup>
+          <StyledButton
             className={`button-text ${filterMode ? "selected" : ""}`}
             onClick={() => this.setState({ filterMode: true })}
           >
             Filter
-          </button>
-          <button
+          </StyledButton>
+          <StyledButton
             className={`button-text ${filterMode ? "" : "selected"}`}
             onClick={() => this.setState({ filterMode: false })}
           >
             Explore
-          </button>
-        </div>
+          </StyledButton>
+        </StyledButtonGroup>
         <ResponsiveOrdinalFrame
           data={this.state.data}
           oAccessor="metric"
@@ -339,7 +339,6 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
           )}
           {...additionalSettings}
         />
-        <style jsx>{buttonGroupStyle}</style>
       </div>
     );
   }

--- a/packages/transform-dataresource/src/VizControls.js
+++ b/packages/transform-dataresource/src/VizControls.js
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { Select } from "@blueprintjs/select";
-import { Button, ButtonGroup, MenuItem, Code } from "@blueprintjs/core";
+import { Button, MenuItem, Code } from "@blueprintjs/core";
 import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
 
-import buttonGroupStyle from "./css/button-group";
+import { StyledButtonGroup, StyledButton } from "./components/button-group";
 import chartUIStyle from "./css/viz-controls";
 import { controlHelpText } from "./docs/chart-docs";
 
@@ -350,9 +350,9 @@ export default ({
             <div>
               <Code>Chart Type</Code>
             </div>
-            <ButtonGroup vertical={true}>
+            <StyledButtonGroup vertical={true}>
               {availableLineTypes.map(lineTypeOption => (
-                <Button
+                <StyledButton
                   key={lineTypeOption.type}
                   className={`button-text ${lineType === lineTypeOption.type &&
                     "selected"}`}
@@ -360,9 +360,9 @@ export default ({
                   onClick={() => setLineType(lineTypeOption.type)}
                 >
                   {lineTypeOption.label}
-                </Button>
+                </StyledButton>
               ))}
-            </ButtonGroup>
+            </StyledButtonGroup>
           </div>
         )}
         {view === "hexbin" && (
@@ -370,9 +370,9 @@ export default ({
             <div>
               <Code>Chart Type</Code>
             </div>
-            <ButtonGroup vertical={true}>
+            <StyledButtonGroup vertical={true}>
               {availableAreaTypes.map(areaTypeOption => (
-                <Button
+                <StyledButton
                   className={`button-text ${areaType === areaTypeOption.type &&
                     "selected"}`}
                   key={areaTypeOption.type}
@@ -380,9 +380,9 @@ export default ({
                   active={areaType === areaTypeOption.type}
                 >
                   {areaTypeOption.label}
-                </Button>
+                </StyledButton>
               ))}
-            </ButtonGroup>
+            </StyledButtonGroup>
           </div>
         )}
         {view === "hierarchy" && (
@@ -406,9 +406,9 @@ export default ({
             <div>
               <Code>Categories</Code>
             </div>
-            <ButtonGroup vertical={true}>
+            <StyledButtonGroup vertical={true}>
               {dimensions.map(dim => (
-                <Button
+                <StyledButton
                   key={`dimensions-select-${dim.name}`}
                   className={`button-text ${selectedDimensions.indexOf(
                     dim.name
@@ -417,9 +417,9 @@ export default ({
                   active={selectedDimensions.indexOf(dim.name) !== -1}
                 >
                   {dim.name}
-                </Button>
+                </StyledButton>
               ))}
-            </ButtonGroup>
+            </StyledButtonGroup>
           </div>
         )}
         {view === "line" && (
@@ -430,9 +430,9 @@ export default ({
             <div>
               <Code>Metrics</Code>
             </div>
-            <ButtonGroup vertical={true}>
+            <StyledButtonGroup vertical={true}>
               {metrics.map(metric => (
-                <Button
+                <StyledButton
                   key={`metrics-select-${metric.name}`}
                   className={`button-text ${selectedMetrics.indexOf(
                     metric.name
@@ -441,14 +441,13 @@ export default ({
                   active={selectedMetrics.indexOf(metric.name) !== -1}
                 >
                   {metric.name}
-                </Button>
+                </StyledButton>
               ))}
-            </ButtonGroup>
+            </StyledButtonGroup>
           </div>
         )}
       </div>
       <style jsx>{chartUIStyle}</style>
-      <style jsx>{buttonGroupStyle}</style>
       <BlueprintCSS />
       <BlueprintSelectCSS />
     </React.Fragment>

--- a/packages/transform-dataresource/src/components/button-group.js
+++ b/packages/transform-dataresource/src/components/button-group.js
@@ -1,6 +1,12 @@
-import css from "styled-jsx/css";
+// @flow
+import styled from "styled-components";
+import { ButtonGroup, Button } from "@blueprintjs/core";
 
-export default css`
+/**
+ * This ports over some of the overridden styles within the data
+ * explorer from the migration away from styled-jsx.
+ */
+export const StyledButtonGroup = styled(ButtonGroup)`
   .button-text {
     margin: 0 10px 10px 0;
     -webkit-appearance: none;
@@ -15,22 +21,24 @@ export default css`
     border-color: #1d8bf1;
     color: #1d8bf1;
   }
-  .button-group .button-text {
+  .button-text {
     margin-right: -1px;
     border-radius: 0;
   }
-  .button-group .button-text:first-child {
+  .button-text:first-child {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-  .button-group .button-text:last-child {
+  .button-text:last-child {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-  .button-group .button-text.selected {
+  .button-text.selected {
     background: white;
     color: #1d8bf1;
     z-index: 1;
     position: relative;
   }
 `;
+
+export const StyledButton = styled(Button);


### PR DESCRIPTION
This switches over the button groups and buttons that were in place for the data explorer to styled-components. I _could_ further optimize some of this, but buttons were being handled in two distinct cases here. I'd love to be able to rely on styled-components' generated class names more here rather than having generic `button-text` class names. The `selected` logic we could do as a prop to the styled-component as well, which should make it more declarative (and type-safe) to use from the outside.