### PR TITLE
propagate ts errors in apps to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,8 @@ jobs:
       - run: yarn run test --maxWorkers 1
 
       - run:
-          name: Report on types for Applications
-          shell: /bin/bash
+          name: Check Types For Applications
           command: |
-            set +e # Allow failure for now
             echo '**** Reporting on types for Jupyter Extension ****'
             yarn report:jext
             echo '**** Reporting on types for Desktop ****'


### PR DESCRIPTION
Opening this branch to showcase where we're at with types for apps on CI. Should only be 5 errors at this point. I'll keep this up to date with master + this one change so we know when we're good to commit to this in CI.