### PR TITLE
remove redundancies in action creator

### DIFF
--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -9,12 +9,9 @@ import { contents } from "rx-jupyter";
 
 // NOTE: de-any this file
 
-export const fetchContent = (payload: {
-  filepath: string;
-  params: Object;
-  kernelRef: KernelRef;
-  contentRef: ContentRef;
-}): actionTypes.FetchContent => ({
+export const fetchContent = (
+  payload: actionTypes.FetchContent["payload"]
+): actionTypes.FetchContent => ({
   type: actionTypes.FETCH_CONTENT,
   payload
 });


### PR DESCRIPTION
@stormpython and I just noticed that we can write simpler action creators (and work with action types) more simply by plucking off properties:

```ts
export const fetchContent = (
  payload: actionTypes.FetchContent["payload"]
): actionTypes.FetchContent => ({
  type: actionTypes.FETCH_CONTENT,
  payload
});
```

Posting this to point out a simplification here. Upon further glance, there are some [nice helpers in the community for typesafe actions](https://github.com/piotrwitek/typesafe-actions#typesafe-actions) that reduce all the boilerplate currently sitting here.
