### PR TITLE
[WIP] switch styleguide to an exclusively typescripted setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "style-loader": "^0.23.0",
     "styled-jsx": "^3.1.0",
     "ts-jest": "^23.10.4",
+    "ts-loader": "^5.3.2",
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-react": "^3.6.0",

--- a/styleguide/logo.tsx
+++ b/styleguide/logo.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
 import * as React from "react";
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 const GitHubLogo = () => (
   <svg width="17" height="17" viewBox="0 0 17 17">

--- a/styleguide/styleguide.config.js
+++ b/styleguide/styleguide.config.js
@@ -3,15 +3,10 @@
 const path = require("path");
 
 const reactDocgenTypescript = require("react-docgen-typescript").withCustomConfig(
-  "./tsconfig.base.json"
+  "../tsconfig.json"
 );
 
-const babelFlowConfig = require("./babel.flow.config");
-const babelTypescriptConfig = require("./babel.typescript.config");
-var {
-  exclude,
-  mergeDefaultAliases
-} = require("./packages/webpack-configurator");
+console.log("wtf mate");
 
 const typescriptPropsParser = reactDocgenTypescript.parse;
 
@@ -21,53 +16,56 @@ module.exports = {
   sections: [
     {
       name: "Introduction",
-      content: "doc/components.md"
+      content: "../doc/components.md"
     },
     {
       name: "@nteract/presentational-components",
-      components: "packages/presentational-components/src/components/*.tsx",
+      components: "../packages/presentational-components/src/components/*.tsx",
       propsParser: typescriptPropsParser
     },
     {
       name: "@nteract/outputs",
-      components: "packages/outputs/src/components/*.tsx",
+      components: "../packages/outputs/src/components/*.tsx",
       propsParser: typescriptPropsParser
     },
     {
       name: "@nteract/outputs/media",
-      components: "packages/outputs/src/components/media/*.tsx",
-      content: "packages/outputs/src/components/media/index.md",
-      ignore: "packages/outputs/src/components/media/index.tsx",
+      components: "../packages/outputs/src/components/media/*.tsx",
+      content: "../packages/outputs/src/components/media/index.md",
+      ignore: "../packages/outputs/src/components/media/index.tsx",
       propsParser: typescriptPropsParser
     },
     {
       name: "@mybinder/host-cache",
-      components: "packages/host-cache/src/components/*.tsx",
+      components: "../packages/host-cache/src/components/*.tsx",
       propsParser: typescriptPropsParser
     },
     {
       name: "@nteract/directory-listing",
-      components: "packages/directory-listing/src/components/*.tsx",
+      components: "../packages/directory-listing/src/components/*.tsx",
       propsParser: typescriptPropsParser
     },
     {
       name: "@nteract/markdown",
-      content: "packages/markdown/examples.md"
+      content: "../packages/markdown/examples.md"
     },
     {
       name: "@nteract/mathjax",
-      content: "packages/mathjax/examples.md"
+      content: "../packages/mathjax/examples.md"
     }
   ],
   // For overriding the components styleguidist uses
   styleguideComponents: {
     LogoRenderer: path.join(
       __dirname,
+      "..",
       "packages",
       "styleguide-components",
       "logo.js"
     )
   },
+  resolver: require("react-docgen").resolver.findAllComponentDefinitions,
+  propsParser: typescriptPropsParser,
   compilerConfig: {
     // Allow us to use {...props}
     objectAssign: "Object.assign",
@@ -87,34 +85,6 @@ module.exports = {
           gtag('js', new Date());
           gtag('config', 'UA-129108362-2');
         </script>`
-    }
-  },
-  webpackConfig: {
-    node: {
-      fs: "empty",
-      child_process: "empty",
-      net: "empty"
-    },
-    resolve: {
-      mainFields: ["nteractDesktop", "es2015", "jsnext:main", "module", "main"],
-      extensions: [".js", ".jsx", ".ts", ".tsx"],
-      alias: mergeDefaultAliases()
-    },
-    module: {
-      rules: [
-        {
-          test: /\.jsx?$/,
-          exclude,
-          loader: "babel-loader",
-          options: babelFlowConfig()
-        },
-        {
-          test: /\.tsx?$/,
-          exclude,
-          loader: "babel-loader",
-          options: babelTypescriptConfig()
-        }
-      ]
     }
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "composite": true,
+    "lib": ["esnext", "dom"],
+    "target": "es2017",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "preserveWatchOutput": true,
+    "jsx": "react",
+    "typeRoots": ["./node_modules/@types", "types"]
+  },
+  "files": [],
+  "references": [{ "path": "packages" }]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6010,7 +6010,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   integrity sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==
@@ -13709,7 +13709,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -15098,6 +15098,17 @@ ts-jest@^23.10.4:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+ts-loader@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.2.tgz#31d10be522bedfac8ee4c20c735e05a9bd772faf"
+  integrity sha512-TPeXFkdPjOrVEawY4xUgRnzlHEmKQF1DclJghPGq67jKnroVvs6mEGHWYtbUczgeWTvTaqUjSSaMmp1k5do4vw==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^3.1.4"
+    semver "^5.0.1"
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.2:
   version "1.9.3"


### PR DESCRIPTION
Experimenting with trimming down our styleguide config. It's a bit of a mess here. If anyone wants to try this they have to, assuming they've also ran `yarn` at the root level, run `npx styleguidist server` inside the styleguide directory.