### PR TITLE
import from ts files by name

### DIFF
--- a/applications/desktop/src/main/index.ts
+++ b/applications/desktop/src/main/index.ts
@@ -32,7 +32,7 @@ import {
 } from "fs-observable";
 
 import { launch, launchNewNotebook } from "./launch";
-import { initAutoUpdater } from "./auto-updater.js";
+import { initAutoUpdater } from "./auto-updater";
 import { loadFullMenu, loadTrayMenu } from "./menu";
 import prepareEnv from "./prepare-env";
 import initializeKernelSpecs from "./kernel-specs";

--- a/applications/desktop/src/main/store.ts
+++ b/applications/desktop/src/main/store.ts
@@ -2,7 +2,7 @@ import { createStore, applyMiddleware, compose, Middleware } from "redux";
 import { electronEnhancer } from "redux-electron-store";
 import { middlewares as coreMiddlewares } from "@nteract/core";
 
-import reducers from "./reducers.js";
+import reducers from "./reducers";
 
 const middlewares: Middleware[] = [];
 


### PR DESCRIPTION
This fixes the desktop build process. Our build is quick enough now (after packages are built) that we could add desktop's targeted `npm run build` to our CI config. For now, this'll at least make `master` reasonable to work with.