### PR TITLE
remove unnecessary babel and styled-jsx deps

### DIFF
--- a/packages/styled-blueprintjsx/package.json
+++ b/packages/styled-blueprintjsx/package.json
@@ -33,9 +33,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@babel/runtime-corejs2": "^7.0.0",
-    "babel-runtime": "^6.26.0",
-    "styled-jsx": "^3.1.0"
   },
   "devDependencies": {
     "@blueprintjs/core": "^3.7.0",


### PR DESCRIPTION
Noticed this while cleaning up packages, we don't need this anymore.