### PR TITLE
keep ts loader config consistent across apps

### DIFF
--- a/applications/desktop/webpack.common.js
+++ b/applications/desktop/webpack.common.js
@@ -3,16 +3,6 @@ const path = require("path");
 const webpack = require("webpack");
 const configurator = require("@nteract/webpack-configurator");
 
-const tsLoaderConfig = {
-  loader: "ts-loader",
-  options: {
-    transpileOnly: true,
-    compilerOptions: {
-      noEmit: false
-    }
-  }
-};
-
 const nodeModules = {
   jmp: "commonjs jmp",
   canvas: "commonjs canvas",
@@ -40,7 +30,7 @@ const mainConfig = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: [tsLoaderConfig]
+        use: [configurator.tsLoaderConfig]
       }
     ]
   },
@@ -68,7 +58,7 @@ const rendererConfig = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: [tsLoaderConfig]
+        use: [configurator.tsLoaderConfig]
       }
     ]
   },

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -8,16 +8,6 @@ const isProd = nodeEnv === "production";
 
 const ASSET_PATH = process.env.ASSET_PATH || "/nteract/static/dist";
 
-const tsLoaderConfig = {
-  loader: "ts-loader",
-  options: {
-    transpileOnly: true,
-    compilerOptions: {
-      noEmit: false
-    }
-  }
-};
-
 module.exports = {
   externals: ["canvas"],
   mode: isProd ? "production" : "development",
@@ -34,6 +24,7 @@ module.exports = {
   target: "web",
   output: {
     // Note: this gets overriden by our use of __webpack_public_path__ later
+    // to allow serving the notebook at e.g. /user/c/nteract/edit
     publicPath: ASSET_PATH,
     chunkFilename: "[name]-[chunkhash].bundle.js"
   },
@@ -45,7 +36,7 @@ module.exports = {
       },
       {
         test: /\.tsx?$/,
-        use: [tsLoaderConfig]
+        use: [configurator.tsLoaderConfig]
       }
     ]
   },

--- a/packages/webpack-configurator/index.js
+++ b/packages/webpack-configurator/index.js
@@ -1,15 +1,9 @@
-// @flow
-
 // Since this has to be loaded at the stage of use by webpack and won't be
-// transpiled, all flow in this file uses the "comment style".
+// transpiled, all types use flow's "comment style".
 
-/*::
-opaque type Aliases = {[string]: string }
-*/
+// From https://github.com/ReactiveX/rxjs/blob/01a09789a0a9484c368b7bd6ed37f94d25490a00/doc/pipeable-operators.md#build-and-treeshaking
+const rxAliases = require("rxjs/_esm5/path-mapping")();
 
-const rxAliases /* : Aliases */ = require("rxjs/_esm5/path-mapping")();
-
-const babelTypescriptConfig = require("./config/babel.typescript.config");
 const { aliases } = require("./aliases");
 
 // We don't transpile packages in node_modules, unless it's _our_ package
@@ -28,41 +22,18 @@ function mergeDefaultAliases(originalAlias /*: ?Aliases */) /*: Aliases */ {
   };
 }
 
-// We will follow the next.js universal webpack configuration signature
-// https://zeit.co/blog/next5#universal-webpack-and-next-plugins
-
-/*::
-type NextWebPackOptions = {
-  dev: boolean,
-  isServer: boolean,
-  defaultLoaders: {
-  // the babel-loader configuration for Next.js.
-    babel: Object,
-    // the hot-self-accept-loader configuration.
-    // This loader should only be used for advanced use cases.
-    // For example @zeit/next-typescript adds it for top-level typescript pages.
-    hotSelfAccept: Object
-}
-}
-
-// Semi-hokey webpack type just to have some localized semi-sanity
-type WebpackConfig = {
-  externals: Array<string>,
-  resolve?: {
-    mainFields?: Array<string>,
-    extensions?: Array<string>,
-    alias?: { [string]: string }
-  },
-  module: {
-    rules: Array<{
-      test: RegExp,
-      exclude?: RegExp,
-      loader?: string,
-      use?: { loader?: string, options?: Object } | "string" | Array<*>
-    }>
+const tsLoaderConfig = {
+  loader: "ts-loader",
+  options: {
+    transpileOnly: true,
+    compilerOptions: {
+      noEmit: false
+    }
   }
 };
-*/
+
+// We will follow the next.js universal webpack configuration signature
+// https://zeit.co/blog/next5#universal-webpack-and-next-plugins
 
 function nextWebpack(config /*: WebpackConfig */) /*: WebpackConfig */ {
   config.externals = ["canvas", ...config.externals];
@@ -78,10 +49,7 @@ function nextWebpack(config /*: WebpackConfig */) /*: WebpackConfig */ {
   });
 
   config.module.rules.push({
-    test: /\.tsx?$/,
-    exclude: exclude,
-    loader: "babel-loader",
-    options: babelTypescriptConfig()
+    tsLoaderConfig
   });
 
   config.resolve = Object.assign({}, config.resolve, {
@@ -98,5 +66,6 @@ module.exports = {
   exclude,
   aliases,
   mergeDefaultAliases,
-  nextWebpack
+  nextWebpack,
+  tsLoaderConfig
 };


### PR DESCRIPTION
Make one common ts loader config as part of our webpack configurator package, that is used across jext and desktop.