### PR TITLE
partially switch to ts-jest for transforming ts(x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,9 +111,19 @@
       "/__tests__/.*types\\.tsx?"
     ],
     "transform": {
-      "^.+\\.tsx?$": "ts-jest"
+      ".*": "babel-jest"
     }
   },
+  "comment:jest": [
+    "when all the test's types are fixed, the transform field can be",
+    {
+      "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+      }
+    },
+    "until then, if you want to check types to see how close we are, replace",
+    "the transform field directly with the above"
+  ],
   "lint-staged": {
     "*.tsx,*.ts,*.js,!*js.snap": [
       "prettier --write",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     "clean": "lerna clean --yes && npm run build:clean && rimraf node_modules"
   },
   "jest": {
+    "preset": "ts-jest",
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.base.json"
+      }
+    },
     "reporters": [
       "default",
       "jest-junit"
@@ -105,7 +111,7 @@
       "/__tests__/.*types\\.tsx?"
     ],
     "transform": {
-      ".*": "babel-jest"
+      "^.+\\.tsx?$": "ts-jest"
     }
   },
   "lint-staged": {
@@ -141,7 +147,7 @@
     "@types/file-saver": "^2.0.0",
     "@types/graphql": "^14.0.3",
     "@types/graphql-type-json": "^0.1.3",
-    "@types/jest": "^23.3.8",
+    "@types/jest": "^23.3.11",
     "@types/jsonfile": "^5.0.0",
     "@types/leaflet": "^1.2.14",
     "@types/lodash": "^4.14.117",
@@ -189,7 +195,7 @@
     "eslint-plugin-react-perf": "^2.0.9",
     "husky": "^1.1.3",
     "immutable": "^4.0.0-rc.12",
-    "jest": "^23.0.1",
+    "jest": "^23.6.0",
     "jest-junit": "^5.0.0",
     "jupyter-paths": "^2.0.0",
     "kernelspecs": "^2.0.0",
@@ -223,7 +229,7 @@
     "spawnteract": "^5.0.0",
     "style-loader": "^0.23.0",
     "styled-jsx": "^3.1.0",
-    "ts-jest": "^23.10.4",
+    "ts-jest": "^23.10.5",
     "ts-loader": "^5.3.2",
     "ts-node": "^7.0.1",
     "tslint": "^5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1747,10 +1747,10 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
   integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
-"@types/jest@^23.3.8":
-  version "23.3.10"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
-  integrity sha512-DC8xTuW/6TYgvEg3HEXS7cu9OijFqprVDXXiOcdOKZCU/5PJNLZU37VVvmZHdtMiGOa8wAA/We+JzbdxFzQTRQ==
+"@types/jest@^23.3.11":
+  version "23.3.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.11.tgz#d3a936ae753d9e484965f5cbd19027c2b8af2551"
+  integrity sha512-eroF85PoG87XjCwzxey7yBsQNkIY/TV5myKKSG/022A0FW25afdu/uub6JDMS5eT68zBBt82S+w/MFOTjeLM3Q==
 
 "@types/js-cookie@^2.2.0":
   version "2.2.0"
@@ -8580,7 +8580,7 @@ jest-worker@^23.2.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^23.0.1:
+jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
   integrity sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==
@@ -14319,7 +14319,7 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
-ts-jest@^23.10.4:
+ts-jest@^23.10.5:
   version "23.10.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
   integrity sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==


### PR DESCRIPTION
We can't fully switch to ts-jest yet because of mismatched types between the spec files and our source files. However, we can lay the foundations for it and allow others to help us get to completion.

If you want to help, after this is merged:

* Replace the transforms in the jest config with the ones in this `comment:jest` field
* Fix a test (or 2 or 3)
* Only commit the changes to the test files
* Make a PR

Once we have it fully working with the transforms applied, we can switch completely over to `ts-jest`.