### PR TITLE
Add Keyboard Shortcuts, Documention, and Kernel Doc links to Help menu

### DIFF
--- a/applications/desktop/src/main/menu.ts
+++ b/applications/desktop/src/main/menu.ts
@@ -98,7 +98,19 @@ const helpDraft = {
   role: "help",
   submenu: [
     {
-      label: "Learn More",
+      label: "Documentation",
+      click: () => {
+        shell.openExternal("https://docs.nteract.io");
+      }
+    },
+    {
+      label: "Keyboard Shortcuts",
+      click: () => {
+        shell.openExternal("https://docs.nteract.io/#/desktop/shortcut-keys");
+      }
+    },
+    {
+      label: "View nteract on GitHub",
       click: () => {
         shell.openExternal("http://github.com/nteract/nteract");
       }
@@ -114,9 +126,7 @@ const helpDraft = {
     {
       label: "Install Additional Kernels",
       click: () => {
-        shell.openExternal(
-          "https://ipython.readthedocs.io/en/latest/install/kernel_install.html"
-        );
+        shell.openExternal("https://nteract.io/kernels");
       }
     }
   ] as any[]


### PR DESCRIPTION
This resolves #3863. Rather than adding an additional 'kernel help' link to the menu, I replaced the existing link (which previously pointed to the iPython docs) with the nteract kernels page (https://nteract.io/kernels) - which covers more languages.