### PR TITLE
Include some install instructions for data explorer

### DIFF
--- a/packages/transform-dataresource/README.md
+++ b/packages/transform-dataresource/README.md
@@ -2,7 +2,19 @@
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/nteract/examples/master?urlpath=%2Fnteract%2Fedit%2Fpython%2Fhappiness.ipynb)
 # nteract Data Explorer
 
-[Read](https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897) @emeeks's post on designing the data explorer.
+[Read @emeek's post on designing the data explorer](https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897).
+
+## Using the Data Explorer
+
+```
+yarn install @nteract/transform-dataresource
+```
+
+```jsx
+import DataExplorer from "@nteract/transform-dataresource";
+
+<DataExplorer />
+```
 
 ## Hacking on the nteract Data Explorer
 For expedited development, we recommend using the [Jupyter Extension](https://github.com/nteract/nteract/tree/master/applications/jupyter-extension) to contribute.


### PR DESCRIPTION
Just noticed that data explorer didn't have install / usage instructions.  CC @emeeks @stormpython @BenRussert 

...I did this from the GitHub UI without checking the interface, please correct if wrong. 😅 
