### PR TITLE
take out forced hot(module) setups

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
@@ -1,4 +1,3 @@
-import { hot } from "react-hot-loader";
 import * as React from "react";
 import NotificationSystem, {
   System as ReactNotificationSystem
@@ -79,4 +78,4 @@ class App extends React.Component<{ contentRef: ContentRef }> {
   }
 }
 
-export default hot(module)(App);
+export default App;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -1,8 +1,4 @@
-// NOTE: We can safely install and use react-hot-loader as a regular dependency
-// instead of a dev dependency as it automatically ensures it is not executed
-// in production and the footprint is minimal.
 import * as React from "react";
-import { hot } from "react-hot-loader";
 import { connect } from "react-redux";
 import { dirname } from "path";
 import * as actions from "@nteract/actions";
@@ -120,4 +116,4 @@ const mapStateToProps = (
   };
 };
 
-export default connect(mapStateToProps)(hot(module)(Contents));
+export default connect(mapStateToProps)(Contents);

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -1,6 +1,3 @@
-// NOTE: We _must_ load hot _before_ React, even though we don't use it in this file
-// eslint-disable-next-line no-unused-vars
-import { hot } from "react-hot-loader";
 import * as React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";

--- a/packages/directory-listing/src/components/entry.tsx
+++ b/packages/directory-listing/src/components/entry.tsx
@@ -1,4 +1,7 @@
 import * as React from "react";
+// react-hot-loader uses proxies to the original elements so we need to use
+// their comparison function in case a consumer of these components is
+// using hot module reloading
 import { areComponentsEqual } from "react-hot-loader";
 import styled from "styled-components";
 

--- a/packages/notebook-app-component/src/index.tsx
+++ b/packages/notebook-app-component/src/index.tsx
@@ -1,5 +1,3 @@
-import { hot } from "react-hot-loader";
-
 import NotebookApp from "./notebook-app";
 
-export default hot(module)(NotebookApp);
+export default NotebookApp;


### PR DESCRIPTION
For the time being (until #4004 is addressed), this makes things more stable -- the page fully reloads instead of trying to hot swap out components.