### PR TITLE
perf: switch connected components to makeMapStateToProps

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
@@ -82,40 +82,50 @@ export class File extends React.PureComponent<FileProps> {
   }
 }
 
-const mapStateToProps = (
-  state: AppState,
-  ownProps: {
-    contentRef: ContentRef;
-    appBase: string;
-  }
-) => {
-  const content = selectors.content(state, ownProps);
-
-  if (!content || content.type === "directory") {
-    throw new Error(
-      "The file component should only be used with files and notebooks"
-    );
-  }
-
-  const comms = selectors.communication(state, ownProps);
-  if (!comms) {
-    throw new Error("CommunicationByRef information not found");
-  }
-
-  return {
-    appBase: ownProps.appBase,
-    baseDir: dirname(content.filepath),
-    contentRef: ownProps.contentRef,
-    displayName: content.filepath.split("/").pop(),
-    error: comms.error,
-    lastSavedStatement: "recently",
-    loading: comms.loading,
-    mimetype: content.mimetype,
-    saving: comms.saving,
-    type: content.type
-  };
+type InitialProps = {
+  contentRef: ContentRef;
+  appBase: string;
 };
 
-export const ConnectedFile = connect(mapStateToProps)(File);
+// Since the contentRef stays unique for the duration of this file,
+// we use the makeMapStateToProps pattern to optimize re-render
+const makeMapStateToProps = (
+  initialState: AppState,
+  initialProps: InitialProps
+) => {
+  const { contentRef, appBase } = initialProps;
+
+  const mapStateToProps = (state: AppState) => {
+    const content = selectors.content(state, initialProps);
+
+    if (!content || content.type === "directory") {
+      throw new Error(
+        "The file component should only be used with files and notebooks"
+      );
+    }
+
+    const comms = selectors.communication(state, initialProps);
+    if (!comms) {
+      throw new Error("CommunicationByRef information not found");
+    }
+
+    return {
+      appBase,
+      contentRef,
+      baseDir: dirname(content.filepath),
+      displayName: content.filepath.split("/").pop(),
+      error: comms.error,
+      lastSavedStatement: "recently",
+      loading: comms.loading,
+      mimetype: content.mimetype,
+      saving: comms.saving,
+      type: content.type
+    };
+  };
+
+  return mapStateToProps;
+};
+
+export const ConnectedFile = connect(makeMapStateToProps)(File);
 
 export default ConnectedFile;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -76,44 +76,48 @@ class Contents extends React.PureComponent<IContentsProps, IContentsState> {
   }
 }
 
-const mapStateToProps = (
-  state: AppState,
-  ownProps: { contentRef: ContentRef }
+const makeMapStateToProps = (
+  initialState: AppState,
+  initialProps: { contentRef: ContentRef }
 ) => {
-  const contentRef = ownProps.contentRef;
-  const host = state.app.host;
-  const comms = selectors.communication(state, ownProps);
-
-  if (!comms) {
-    throw new Error("CommunicationByRef information not found");
-  }
-
+  const host = initialState.app.host;
   if (host.type !== "jupyter") {
     throw new Error("this component only works with jupyter apps");
   }
+  const appBase = urljoin(host.basePath, "/nteract/edit");
 
-  if (!contentRef) {
-    throw new Error("cant display without a contentRef");
-  }
+  const mapStateToProps = (state: AppState) => {
+    const contentRef = initialProps.contentRef;
+    const comms = selectors.communication(state, initialProps);
 
-  const content = selectors.content(state, { contentRef });
+    if (!comms) {
+      throw new Error("CommunicationByRef information not found");
+    }
 
-  if (!content) {
-    throw new Error("need content to view content, check your contentRefs");
-  }
+    if (!contentRef) {
+      throw new Error("cant display without a contentRef");
+    }
 
-  return {
-    appBase: urljoin(host.basePath, "/nteract/edit"),
-    baseDir: dirname(content.filepath),
-    contentRef,
-    contentType: content.type,
-    displayName: content.filepath.split("/").pop(),
-    error: comms.error,
-    lastSavedStatement: "recently",
-    loading: comms.loading,
-    mimetype: content.mimetype,
-    saving: comms.saving
+    const content = selectors.content(state, { contentRef });
+
+    if (!content) {
+      throw new Error("need content to view content, check your contentRefs");
+    }
+
+    return {
+      appBase,
+      contentRef,
+      baseDir: dirname(content.filepath),
+      contentType: content.type,
+      displayName: content.filepath.split("/").pop(),
+      error: comms.error,
+      lastSavedStatement: "recently",
+      loading: comms.loading,
+      mimetype: content.mimetype,
+      saving: comms.saving
+    };
   };
+  return mapStateToProps;
 };
 
-export default connect(mapStateToProps)(Contents);
+export default connect(makeMapStateToProps)(Contents);


### PR DESCRIPTION
Flow was preventing us from being able to switch to `makeMapStateToProps`. Now that we're on typescript it's an easy switch over. This will include a _lot_ of fixes for #3434.

* [x] jext's `contents/file`
* [x] jext's `contents/index`

General pattern here is:

* Move `mapStateToProps` into a function called `makeMapStateToProps`:

```js
const makeMapStateToProps = (initialState: AppState, initialProps: InitialProps) => {
  const mapStateToProps = (state: AppState) => {
    // can use initialProps in a closure here
  }
  return mapStateToProps;
}

connect(makeMapStateToProps, mapDispatchToProps)(Component);
```

Note that `mapDispatchToProps` also needs to move away from having `ownProps` as well.


