### PR TITLE
Finalize typechecking on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,16 +36,7 @@ jobs:
 
       # Check types for non-emitting TypeScript builds (applications)
       - run: yarn report:desktop
-
-      # Until Jupyter extension has the last error fixed we can only report on it
-      - run:
-          name: Report on types for Jupyter Extension
-          shell: /bin/bash
-          command: |
-            set +e # Allow failure for now
-            echo '**** Reporting on types for Jupyter Extension ****'
-            yarn report:jext
-            echo '**** Application type reporting finished ****'
+      - run: yarn report:jext
 
       - run:
           name: Build Docs

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/headers.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/headers.tsx
@@ -39,7 +39,7 @@ export interface FileHeaderProps {
   baseDir: string;
   changeContentName: (value: actions.ChangeContentName["payload"]) => {};
   contentRef: ContentRef;
-  displayName?: string;
+  displayName: string;
   error?: object | null;
   loading: boolean;
   saving: boolean;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -12,10 +12,9 @@ import { default as File } from "./file";
 interface IContentsProps {
   appBase: string;
   baseDir: string;
-  changeContentName: (value: actions.ChangeContentName) => {};
   contentType: "dummy" | "notebook" | "directory" | "file";
   contentRef: ContentRef;
-  displayName?: string;
+  displayName: string;
   error?: object | null;
   lastSavedStatement: string;
   loading: boolean;
@@ -109,7 +108,7 @@ const makeMapStateToProps = (
       contentRef,
       baseDir: dirname(content.filepath),
       contentType: content.type,
-      displayName: content.filepath.split("/").pop(),
+      displayName: content.filepath.split("/").pop() || "",
       error: comms.error,
       lastSavedStatement: "recently",
       loading: comms.loading,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.ts
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.ts
@@ -30,7 +30,8 @@ export default function configureStore(initialState: Partial<AppState>) {
 
   const store = createStore(
     rootReducer,
-    initialState,
+    // TODO: Properly type redux store for jupyter-extension
+    (initialState as unknown) as any,
     composeEnhancers(applyMiddleware(...middlewares))
   );
 


### PR DESCRIPTION
* Addresses a couple new type errors in the jupyter extension
* Bypasses the error that was preventing us from reporting on type errors in jupyter extension
* Enables checking by default on CI