### PR TITLE
build all pkgs and apps with `tsc -b` at root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,9 @@ jobs:
 
       # run tests!
       - run: yarn run test:lint
-      - run: yarn run build:packages:ci
+      # build all packages and applications
+      - run: yarn build:all:ci
       - run: yarn run test --maxWorkers 1
-
-      # Check types for non-emitting TypeScript builds (applications)
-      - run: yarn report:desktop
-      - run: yarn report:jext
 
       - run:
           name: Build Docs

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:ts": "tslint --config tslint.json --project tsconfig.base.json",
     "lint:ts:fix": "tslint --config tslint.json --project tsconfig.base.json --fix",
     "build:all": "tsc -b",
+    "build:all:ci": "tsc -b --verbose",
     "build": "NODE_ENV=production npm run build:packages",
     "build:clean": "npm run build:packages -- --clean",
     "build:apps": "lerna run build --scope nteract --scope nteract-on-jupyter --parallel --stream",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "files": [],
   "references": [
     { "path": "packages" },
-    { "path": "applications/desktop" }
-    // Enable this once reporting passes
-    // { "path": "applications/jupyter-extension"}
+    { "path": "applications/desktop" },
+    { "path": "applications/jupyter-extension"}
   ]
 }


### PR DESCRIPTION
This moves our root level `tsc` build to handle all apps and packages. I've also switched up the Circle CI order so that we get the benefit of building all at once (since we're fully on project references).