### PR TITLE
clean up base types

### DIFF
--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -25,7 +25,8 @@ import {
   makeEntitiesRecord,
   makeStateRecord,
   createContentRef,
-  createKernelRef
+  createKernelRef,
+  AppState
 } from "@nteract/types";
 
 export { fixtureCommutable, fixture, fixtureJSON } from "./fixture-nb";
@@ -99,7 +100,7 @@ export function fixtureStore(config: JSONObject) {
   const kernelRef = createKernelRef();
   const contentRef = createContentRef();
 
-  return createStore(rootReducer, {
+  const initialAppState: AppState = {
     core: makeStateRecord({
       kernelRef,
       entities: makeEntitiesRecord({
@@ -132,7 +133,7 @@ export function fixtureStore(config: JSONObject) {
           })
         })
       })
-    }) as any,
+    }),
     app: makeAppRecord({
       notificationSystem: {
         addNotification: () => {} // most of the time you'll want to mock this
@@ -143,5 +144,7 @@ export function fixtureStore(config: JSONObject) {
       theme: "light"
     }),
     comms: makeCommsRecord()
-  });
+  };
+
+  return createStore(rootReducer, initialAppState as any);
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -100,7 +100,7 @@ export type CommsRecordProps = {
 
 export type CommsRecord = Immutable.RecordOf<CommsRecordProps>;
 
-export const makeCommsRecord = Immutable.Record({
+export const makeCommsRecord = Immutable.Record<CommsRecordProps>({
   targets: Immutable.Map(),
   info: Immutable.Map(),
   models: Immutable.Map()
@@ -112,7 +112,7 @@ const version: string = require("../package.json").version;
 export type ConfigState = Immutable.Map<string, any>;
 
 export type StateRecordProps = {
-  kernelRef?: KernelRef | null;
+  kernelRef: KernelRef | null;
   currentKernelspecsRef?: KernelspecsRef | null;
   communication: Immutable.RecordOf<CommunicationRecordProps>;
   entities: Immutable.RecordOf<EntitiesRecordProps>;
@@ -124,6 +124,7 @@ export const makeStateRecord = Immutable.Record<StateRecordProps>({
   communication: makeCommunicationRecord(),
   entities: makeEntitiesRecord()
 });
+export type CoreRecord = Immutable.RecordOf<StateRecordProps>;
 
 export type AppRecordProps = {
   host: HostRecord;
@@ -162,10 +163,9 @@ export const makeAppRecord = Immutable.Record<AppRecordProps>({
   error: null,
   // set the default version to @nteract/core's version
   version: `@nteract/core@${version}`
-} );
+});
 
 export type AppRecord = Immutable.RecordOf<AppRecordProps>;
-export type CoreRecord = Immutable.RecordOf<StateRecordProps>;
 
 export type AppState = {
   app: AppRecord;
@@ -173,3 +173,12 @@ export type AppState = {
   config: ConfigState;
   core: CoreRecord;
 };
+
+export type AppStateRecord = Immutable.RecordOf<AppState>;
+
+export const makeAppStateRecord = Immutable.Record<AppState>({
+  app: makeAppRecord(),
+  comms: makeCommsRecord(),
+  config: Immutable.Map<string, any>(),
+  core: makeStateRecord()
+});


### PR DESCRIPTION
I noticed that more of our types could be cleaned up (and moved away from `any`) so I'm taking a stab at cleaning up `types`, `reducers`, and `fixtures`. Wish me luck!