### PR TITLE
tslint disable interface-name

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
   ],
   "jsRules": {},
   "rules": {
+    "interface-name": false,
     "no-unnecessary-type-assertion": true,
     "no-debugger": true,
     "no-duplicate-variable": true,


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

Disable tslint rule **interface-name**