### PR TITLE
override OutputWrapper type, set maxHeight in attrs

### DIFF
--- a/packages/presentational-components/__tests__/header-editor.spec.tsx
+++ b/packages/presentational-components/__tests__/header-editor.spec.tsx
@@ -2,7 +2,7 @@ import { shallow } from "enzyme";
 import * as React from "react";
 import renderer from "react-test-renderer";
 
-import { HeaderEditor } from "../src/";
+import { HeaderEditor } from "../src/components/header-editor";
 
 jest.mock("styled-components", () => {
   const styled = () => () => () => {};

--- a/packages/presentational-components/src/components/outputs.tsx
+++ b/packages/presentational-components/src/components/outputs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import styled from "styled-components";
+import styled, { StyledComponent } from "styled-components";
 
 interface OutputsProps {
   children?: React.ReactNode;
@@ -18,15 +18,17 @@ interface OutputWrapperProps {
   expanded?: boolean;
 }
 
-const OutputWrapper = styled.div<OutputWrapperProps>`
+const OutputWrapper = styled.div.attrs<OutputWrapperProps>(props => ({
+  style: {
+    maxHeight: props.expanded ? "100%" : null
+  }
+}))`
   padding: 10px 10px 10px calc(var(--prompt-width, 50px) + 10px);
   word-wrap: break-word;
   overflow-y: hidden;
   outline: none;
   /* When expanded, this is overtaken to 100% */
   text-overflow: ellipsis;
-
-  ${props => (props.expanded ? `max-height: 100%;` : null)}
 
   &:empty {
     display: none;
@@ -154,7 +156,7 @@ const OutputWrapper = styled.div<OutputWrapperProps>`
     padding-right: 20px;
     text-align: center;
   }
-`;
+` as StyledComponent<"div", any, OutputWrapperProps, never>;
 
 export class Outputs extends React.PureComponent<OutputsProps> {
   static defaultProps = {
@@ -169,7 +171,11 @@ export class Outputs extends React.PureComponent<OutputsProps> {
     }
 
     if (this.props.children) {
-      return <OutputWrapper>{this.props.children}</OutputWrapper>;
+      return (
+        <OutputWrapper expanded={this.props.expanded}>
+          {this.props.children}
+        </OutputWrapper>
+      );
     }
 
     return null;

--- a/packages/presentational-components/src/components/outputs.tsx
+++ b/packages/presentational-components/src/components/outputs.tsx
@@ -18,7 +18,7 @@ interface OutputWrapperProps {
   expanded?: boolean;
 }
 
-const OutputWrapper = styled.div.attrs<OutputWrapperProps>(props => ({
+const OutputWrapper = styled.div.attrs((props: OutputWrapperProps) => ({
   style: {
     maxHeight: props.expanded ? "100%" : null
   }

--- a/packages/presentational-components/src/components/outputs.tsx
+++ b/packages/presentational-components/src/components/outputs.tsx
@@ -18,7 +18,7 @@ interface OutputWrapperProps {
   expanded?: boolean;
 }
 
-const OutputWrapper = styled.div.attrs((props: OutputWrapperProps) => ({
+const OutputWrapper = styled.div.attrs<OutputWrapperProps>(props => ({
   style: {
     maxHeight: props.expanded ? "100%" : null
   }


### PR DESCRIPTION
Follow up to #4039 to ensure dynamic props end up in `attrs`.