### PR TITLE
yarn dev on kernel-relay now watches ts src

### DIFF
--- a/packages/kernel-relay/package.json
+++ b/packages/kernel-relay/package.json
@@ -6,7 +6,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "start": "node lib/index.js",
-    "dev": "nodemon lib/index.js"
+    "dev": "concurrently \"nodemon lib/index.js\" \"tsc -b . --watch\""
   },
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Now when hacking on `kernel-relay` you can run:

```
yarn dev
```

within the kernel-relay package to run both the typescript build in watch mode and the server in auto-reload.