### PR TITLE
Use single global comm for transform-vdom

### DIFF
--- a/packages/transform-vdom/src/index.tsx
+++ b/packages/transform-vdom/src/index.tsx
@@ -1,16 +1,21 @@
 import { cloneDeep } from "lodash";
 import * as React from "react";
 
-import { Attributes, objectToReactElement, SerializedEvent, VDOMEl } from "./object-to-react";
+import {
+  objectToReactElement,
+  VDOMEl,
+  Attributes,
+  EventPayload
+} from "./object-to-react";
 
 interface Props {
   mediaType: "application/vdom.v1+json";
   data: VDOMEl;
-  onVDOMEvent: (targetName: string, event: SerializedEvent<any>) => void;
+  onVDOMEvent: (event: EventPayload) => void;
 }
 
 // Provide object-to-react as an available helper on the library
-export { objectToReactElement, VDOMEl, Attributes, SerializedEvent };
+export { objectToReactElement, VDOMEl, Attributes, EventPayload };
 
 const mediaType = "application/vdom.v1+json";
 
@@ -20,7 +25,9 @@ export default class VDOM extends React.PureComponent<Props> {
   static defaultProps = {
     mediaType,
     onVDOMEvent: () => {
-      console.log("This app doesn't support vdom events ☹️ See @nteract/transform-vdom for more info: https://github.com/nteract/nteract/tree/master/packages/transform-vdom");
+      console.log(
+        "This app doesn't support vdom events ☹️ See @nteract/transform-vdom for more info: https://github.com/nteract/nteract/tree/master/packages/transform-vdom"
+      );
     }
   };
 


### PR DESCRIPTION
When using the new event handler feature in vdom, it's easy to run into the following issue:

```
[E 14:25:56.106 LabApp] Uncaught exception GET /api/kernels/9b07598f-f972-4154-ba02-24cb223a0891/channels?session_id=88cc0759-6744-4d7e-b503-a266628ea10b&token=4431ca05d2bf9e8fb5e2ad681db65b61716cf52fee8b2f8e (::1)
    HTTPServerRequest(protocol='http', host='localhost:8888', method='GET', uri='/api/kernels/9b07598f-f972-4154-ba02-24cb223a0891/channels?session_id=88cc0759-6744-4d7e-b503-a266628ea10b&token=4431ca05d2bf9e8fb5e2ad681db65b61716cf52fee8b2f8e', version='HTTP/1.1', remote_ip='::1')
    Traceback (most recent call last):
      File "/Users/grant/anaconda/lib/python3.6/site-packages/tornado/websocket.py", line 546, in _run_callback
        result = callback(*args, **kwargs)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/notebook/services/kernels/handlers.py", line 276, in open
        self.create_stream()
      File "/Users/grant/anaconda/lib/python3.6/site-packages/notebook/services/kernels/handlers.py", line 130, in create_stream
        self.channels[channel] = stream = meth(self.kernel_id, identity=identity)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/jupyter_client/multikernelmanager.py", line 33, in wrapped
        r = method(*args, **kwargs)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/jupyter_client/ioloop/manager.py", line 22, in wrapped
        socket = f(self, *args, **kwargs)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/jupyter_client/connect.py", line 563, in connect_stdin
        return self._create_connected_socket('stdin', identity=identity)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/jupyter_client/connect.py", line 543, in _create_connected_socket
        sock = self.context.socket(socket_type)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/zmq/sugar/context.py", line 146, in socket
        s = self._socket_class(self, socket_type, **kwargs)
      File "/Users/grant/anaconda/lib/python3.6/site-packages/zmq/sugar/socket.py", line 59, in __init__
        super(Socket, self).__init__(*a, **kw)
      File "zmq/backend/cython/socket.pyx", line 328, in zmq.backend.cython.socket.Socket.__init__
    zmq.error.ZMQError: Too many open files
```

as a result of connecting to too many comms. This is because each event handler was registering its own comm channel.

The simple solution is to register a single, global comm channel for all vdom components to use and include a unique id in the payloads. This PR makes the necessary changes in transform-vdom.

The only changes to transform-vdom involve including a `handler_id` key in the comm payload so that vdom (on the kernel) knows which handler function to call.