### PR TITLE
optimize styling of <CellToolbarMask />

### DIFF
--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
@@ -9,17 +9,16 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
       forwardedComponent={
         Object {
           "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
+          "attrs": Array [
+            [Function],
+          ],
           "componentStyle": ComponentStyle {
             "componentId": "sc-ifAKCX",
             "isStatic": false,
-            "lastClassName": "bfbVaH",
+            "lastClassName": "jozPvG",
             "rules": Array [
               "
   z-index: 9999;
-  display: ",
-              [Function],
-              ";
   position: absolute;
   top: 0px;
   right: 0px;
@@ -45,7 +44,12 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
       forwardedRef={null}
     >
       <div
-        className="sc-ifAKCX bfbVaH"
+        className="sc-ifAKCX jozPvG"
+        style={
+          Object {
+            "display": "none",
+          }
+        }
       >
         <styled.div>
           <StyledComponent
@@ -348,17 +352,16 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
       forwardedComponent={
         Object {
           "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
+          "attrs": Array [
+            [Function],
+          ],
           "componentStyle": ComponentStyle {
             "componentId": "sc-ifAKCX",
             "isStatic": false,
-            "lastClassName": "bfbVaH",
+            "lastClassName": "jozPvG",
             "rules": Array [
               "
   z-index: 9999;
-  display: ",
-              [Function],
-              ";
   position: absolute;
   top: 0px;
   right: 0px;
@@ -384,7 +387,12 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
       forwardedRef={null}
     >
       <div
-        className="sc-ifAKCX bfbVaH"
+        className="sc-ifAKCX jozPvG"
+        style={
+          Object {
+            "display": "none",
+          }
+        }
       >
         <styled.div>
           <StyledComponent

--- a/packages/notebook-app-component/src/toolbar.tsx
+++ b/packages/notebook-app-component/src/toolbar.tsx
@@ -21,7 +21,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
-import styled from "styled-components";
+import styled, { StyledComponent } from "styled-components";
 
 export interface PureToolbarProps {
   type: "markdown" | "code" | "raw";
@@ -86,10 +86,14 @@ export const CellToolbar = styled.div`
   }
 `;
 
-export const CellToolbarMask = styled.div`
+export const CellToolbarMask = styled.div.attrs(
+  (props: { sourceHidden?: boolean }) => ({
+    style: {
+      display: props.sourceHidden ? "block" : "none"
+    }
+  })
+)`
   z-index: 9999;
-  display: ${(props: { sourceHidden?: boolean }) =>
-    props.sourceHidden ? "block" : "none"};
   position: absolute;
   top: 0px;
   right: 0px;
@@ -99,7 +103,7 @@ export const CellToolbarMask = styled.div`
               mouse to the toolbar without causing the cell to go out of focus and thus
               hide the toolbar before they get there. */
   padding: 0px 0px 0px 50px;
-`;
+` as StyledComponent<"div", any, { sourceHidden?: boolean }, never>;
 
 export class PureToolbar extends React.PureComponent<PureToolbarProps> {
   static defaultProps: Partial<PureToolbarProps> = {


### PR DESCRIPTION
Another styled-components perf enhancement for our regularly rendering components.

## What's this perf enhancement all about?

Summary from https://github.com/nteract/nteract/pull/4036:

> Apparently we were creating lots of new entries in the `<head>` of our document on each render of a component. With issues listed in #3434 still in effect, this all causes a cascade of performance issues. Folks started noticing a huge performance regression after we introduced styled-components so here we take the liberty of optimizing the way folks suggest in styled-components/styled-components#134 