### PR TITLE
optimize styling of <Cell /> in notebook app

### DIFF
--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -60,16 +60,15 @@ function getTheme(theme: string) {
   }
 }
 
-const Cell = styled(PlainCell)`
+const Cell = styled(PlainCell).attrs((props: { isSelected: boolean }) => ({
+  className: props.isSelected ? "selected" : ""
+}))`
   /*
    * Show the cell-toolbar-mask if hovering on cell,
-   * cell was the last clicked (has .focused class).
+   * cell was the last clicked
    */
-  &:hover ${CellToolbarMask} {
+  &:hover ${CellToolbarMask}, &.selected ${CellToolbarMask} {
     display: block;
-  }
-  & ${CellToolbarMask} {
-    ${props => (props.isSelected ? `display: block;` : ``)}
   }
 `;
 


### PR DESCRIPTION
Another styled-components optimization. Fun thing I learned here is that `attrs` goes after the `styled(SomeComponent)` bit when it's a component you're (re)-styling. This one feels a little redundant since we also set this class on selected otherwise, but I feel like we have to ensure it for the cell toolbar. Working well in the app at least. 🤷‍♂️ 

## What's this perf enhancement all about?

Summary from https://github.com/nteract/nteract/pull/4036:

> Apparently we were creating lots of new entries in the `<head>` of our document on each render of a component. With issues listed in #3434 still in effect, this all causes a cascade of performance issues. Folks started noticing a huge performance regression after we introduced styled-components so here we take the liberty of optimizing the way folks suggest in styled-components/styled-components#134 