### PR TITLE
Fixed win32 related bugs in tests

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/loading.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/loading.spec.ts
@@ -97,7 +97,10 @@ describe("newNotebookEpic", () => {
             ),
             writable: true,
             name: "Untitled.ipynb",
-            path: "/home/whatever/Untitled.ipynb",
+            path:
+              process.platform === "win32"
+                ? "\\home\\whatever\\Untitled.ipynb"
+                : "/home/whatever/Untitled.ipynb",
             created: expect.any(String),
             last_modified: expect.any(String)
           }

--- a/applications/desktop/__tests__/renderer/menu.spec.ts
+++ b/applications/desktop/__tests__/renderer/menu.spec.ts
@@ -383,7 +383,7 @@ describe("dispatchInterruptKernel", () => {
     const store = {
       dispatch: jest.fn(),
       getState: () => ({
-        app: Immutable.Map(notificationSystem),
+        app: Immutable.Map({ notificationSystem }),
         core: {
           entities: {
             contents: {


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

- Fixed path returned by windows
- Fixed map entry was not in curly braces