### PR TITLE
expose explicit usage api for kernels

### DIFF
--- a/packages/fs-kernels/src/kernel.ts
+++ b/packages/fs-kernels/src/kernel.ts
@@ -13,7 +13,7 @@ import { cleanup, launch, LaunchedKernel, launchSpec } from "./spawnteract";
 
 interface Usage {
   /**
-   * percentage (from 0 to 100*vcore)
+   * percentage (from 0 to 100*number of cores)
    */
   cpu: number;
 
@@ -23,27 +23,27 @@ interface Usage {
   memory: number;
 
   /**
-   * PPID
+   * PPID - Parent PID
    */
   ppid: number;
 
   /**
-   * PID
+   * PID - Process ID
    */
   pid: number;
 
   /**
-   * ms user + system time
+   * ms user + system time (in local time)
    */
   ctime: number;
 
   /**
-   * ms since the start of the process
+   * ms since the start of the process (local time)
    */
   elapsed: number;
 
   /**
-   * ms since epoch
+   * ms since epoch (local time)
    */
   timestamp: number;
 }

--- a/packages/fs-kernels/src/kernel.ts
+++ b/packages/fs-kernels/src/kernel.ts
@@ -11,6 +11,43 @@ import { JupyterConnectionInfo } from "enchannel-zmq-backend";
 import { KernelSpec } from "./kernelspecs";
 import { cleanup, launch, LaunchedKernel, launchSpec } from "./spawnteract";
 
+interface Usage {
+  /**
+   * percentage (from 0 to 100*vcore)
+   */
+  cpu: number;
+
+  /**
+   * bytes
+   */
+  memory: number;
+
+  /**
+   * PPID
+   */
+  ppid: number;
+
+  /**
+   * PID
+   */
+  pid: number;
+
+  /**
+   * ms user + system time
+   */
+  ctime: number;
+
+  /**
+   * ms since the start of the process
+   */
+  elapsed: number;
+
+  /**
+   * ms since epoch
+   */
+  timestamp: number;
+}
+
 export class Kernel {
   kernelSpec: KernelSpec;
   process: ExecaChildProcess;
@@ -34,7 +71,7 @@ export class Kernel {
     this.process.removeAllListeners();
   }
 
-  async getUsage() {
+  async getUsage(): Promise<Usage> {
     return await pidusage(this.process.pid);
   }
 }


### PR DESCRIPTION
Ran into this issue on `master`. The type return for `getUsage` is flaky for our end users because it depends on `@types/pidusage`. Our typescript config now errors on this so I had to export an interface. Luckily if the types change we'll know what's missing and what we're expecting to expose to our own users.