### PR TITLE
correct the kernel status bar logic

### DIFF
--- a/applications/desktop/src/notebook/epics/zeromq-kernels.ts
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.ts
@@ -358,12 +358,12 @@ export const killKernelEpic = (
     ofType(actions.KILL_KERNEL),
     concatMap((action: actions.KillKernelAction) => {
       const kernelRef = action.payload.kernelRef;
-      const kernel = selectors.kernel(state$.value, { kernelRef });
-
       if (!kernelRef) {
         console.warn("tried to kill a kernel without a kernelRef");
         return empty();
       }
+
+      const kernel = selectors.kernel(state$.value, { kernelRef });
 
       if (!kernel) {
         // tslint:disable-next-line:no-console

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -206,11 +206,22 @@ export const restartKernelEpic = (
     ofType(actions.RESTART_KERNEL),
     concatMap((action: actions.RestartKernel | actions.NewKernelAction) => {
       const state = state$.value;
-
       const oldKernelRef = action.payload.kernelRef;
+      const notificationSystem = selectors.notificationSystem(state);
+
+      if (!oldKernelRef) {
+        notificationSystem.addNotification({
+          title: "Failure to Restart",
+          message: `Unable to restart kernel, please select a new kernel.`,
+          dismissible: true,
+          position: "tr",
+          level: "error"
+        });
+        return empty();
+      }
+
       const oldKernel = selectors.kernel(state, { kernelRef: oldKernelRef });
 
-      const notificationSystem = selectors.notificationSystem(state);
       if (!oldKernelRef || !oldKernel) {
         notificationSystem.addNotification({
           title: "Failure to Restart",

--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -82,9 +82,7 @@ const makeMapStateToProps = (
 
   const mapStateToProps = (state: AppState) => {
     const content = selectors.content(state, { contentRef });
-    const kernel =
-      // check for undefined or null kernelRef (using double equal)
-      kernelRef == null ? selectors.kernel(state, { kernelRef }) : null;
+    const kernel = selectors.kernel(state, { kernelRef });
 
     const lastSaved = content && content.lastSaved ? content.lastSaved : null;
 
@@ -104,9 +102,9 @@ const makeMapStateToProps = (
     }
 
     return {
-      lastSaved,
+      kernelSpecDisplayName,
       kernelStatus,
-      kernelSpecDisplayName
+      lastSaved
     };
   };
 

--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -82,7 +82,10 @@ const makeMapStateToProps = (
 
   const mapStateToProps = (state: AppState) => {
     const content = selectors.content(state, { contentRef });
-    const kernel = selectors.kernel(state, { kernelRef });
+    let kernel = null;
+    if (kernelRef) {
+      kernel = selectors.kernel(state, { kernelRef });
+    }
 
     const lastSaved = content && content.lastSaved ? content.lastSaved : null;
 

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -201,8 +201,10 @@ export const kernelsByRef = (state: AppState) =>
  */
 export const kernel = (
   state: AppState,
-  { kernelRef }: { kernelRef?: KernelRef | null }
-) => (kernelRef ? kernelsByRef(state).get(kernelRef) : null);
+  { kernelRef }: { kernelRef?: KernelRef }
+) => {
+  return kernelRef ? kernelsByRef(state).get(kernelRef) : null;
+};
 
 /**
  * Returns the KernelRef for the kernel the nteract application is currently

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -203,7 +203,7 @@ export const kernel = (
   state: AppState,
   { kernelRef }: { kernelRef?: KernelRef }
 ) => {
-  return kernelRef ? kernelsByRef(state).get(kernelRef) : null;
+  return kernelRef ? kernelsByRef(state).get(kernelRef, null) : null;
 };
 
 /**


### PR DESCRIPTION
On `master` I noticed (really a while ago, during the typescript conversion) that the status bar isn't reporting the kernel properly. It looks like the `null` check was reversed. We're back to having good status:

![screen shot 2019-01-18 at 6 12 17 am](https://user-images.githubusercontent.com/836375/51391845-0af3de80-1ae8-11e9-85b2-0c1c8c12fbeb.png)
