### PR TITLE
pluck kernelRef from content model

### DIFF
--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -370,18 +370,10 @@ export const ConnectedCell = connect(
 
 type NotebookProps = NotebookStateProps & NotebookDispatchProps;
 
-interface PureNotebookProps {
-  cellOrder?: Immutable.List<any>;
-  theme?: string;
-  contentRef: ContentRef;
-  kernelRef?: KernelRef;
-}
-
 interface NotebookStateProps {
   cellOrder: Immutable.List<any>;
   theme: string;
   contentRef: ContentRef;
-  kernelRef?: KernelRef | null;
 }
 
 interface NotebookDispatchProps {
@@ -439,7 +431,6 @@ const makeMapStateToProps = (
       return {
         cellOrder: Immutable.List(),
         contentRef,
-        kernelRef: null,
         theme
       };
     }
@@ -450,12 +441,9 @@ const makeMapStateToProps = (
       );
     }
 
-    const kernelRef = model.kernelRef;
-
     return {
       cellOrder: model.notebook.cellOrder,
       contentRef,
-      kernelRef,
       theme
     };
   };
@@ -591,10 +579,7 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
           />
           {this.props.cellOrder.map(this.createCellElement)}
         </Cells>
-        <StatusBar
-          contentRef={this.props.contentRef}
-          kernelRef={this.props.kernelRef}
-        />
+        <StatusBar contentRef={this.props.contentRef} />
         {getTheme(this.props.theme)}
       </React.Fragment>
     );

--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -71,17 +71,26 @@ export class StatusBar extends React.Component<Props> {
 
 interface InitialProps {
   contentRef: ContentRef;
-  kernelRef?: KernelRef | null;
 }
 
 const makeMapStateToProps = (
   initialState: AppState,
   initialProps: InitialProps
 ): ((state: AppState) => Props) => {
-  const { contentRef, kernelRef } = initialProps;
+  const { contentRef } = initialProps;
 
   const mapStateToProps = (state: AppState) => {
     const content = selectors.content(state, { contentRef });
+
+    if (!content || content.type !== "notebook") {
+      return {
+        kernelStatus: NOT_CONNECTED,
+        kernelSpecDisplayName: "no kernel",
+        lastSaved: null
+      };
+    }
+
+    const kernelRef = content.model.kernelRef;
     let kernel = null;
     if (kernelRef) {
       kernel = selectors.kernel(state, { kernelRef });


### PR DESCRIPTION
Hopefully this is the last vestige of the old global kernel setup. Any `contentRef` that identifies a notebook should pluck the kernel from the notebook model directly.

This fixes the status bar on desktop.