### PR TITLE
Add The Option to Use Classes [pkg:ansi-to-react]

### DIFF
--- a/packages/ansi-to-react/README.md
+++ b/packages/ansi-to-react/README.md
@@ -13,7 +13,7 @@ $ npm install --save @nteract/ansi-to-react
 ```
 
 ## Usage
-
+### Basic
 The example below shows how we can use this package to render a string with ANSI escape codes.
 
 ```javascript
@@ -21,10 +21,42 @@ import Ansi from "@nteract/ansi-to-react";
 
 export function () => {
   return <Ansi>
-    {'\u001b[34mnode_modules\u001b[m\u001b[m'}
+    {'\u001b[34mhello world'}
   </Ansi>;
 };
 ```
+Will render
+```javascript
+<code>
+    <span style="color:rgb(0, 0, 187)">hello world</span>
+</code>
+```
+
+### Classes
+Style with classes instead of `style` attribute.
+```javascript
+<Ansi useClasses>
+    {'\u001b[34mhello world'}
+</Ansi>;
+```
+Will render
+```javascript
+<code>
+    <span class="ansi-blue">hello world</span>
+</code>
+```
+
+#### Class Names
+|Font color| Background Color
+|---|---|
+|ansi-black|ansi-bright-black
+|ansi-red|ansi-bright-red
+ansi-green|ansi-bright-green
+ansi-yellow|ansi-bright-yellow
+ansi-blue|ansi-bright-blue
+ansi-magenta|ansi-bright-magenta
+ansi-cyan|ansi-bright-cyan
+ansi-white|ansi-bright-white
 
 ## Documentation
 

--- a/packages/ansi-to-react/__tests__/index.spec.ts
+++ b/packages/ansi-to-react/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import { shallow } from "enzyme";
+import { shallow, render } from "enzyme";
 import * as React from "react";
 
 import Ansi from "../src/index";
@@ -102,5 +102,67 @@ describe("Ansi", () => {
     expect(el.text()).toBe(
       "<module 'something' from '/usr/local/lib/python2.7/dist-packages/something/__init__.pyc'>"
     );
+  });
+
+  describe("use classes", () => {
+    test("color only background", () => {
+      const el = shallow(
+        React.createElement(
+          Ansi,
+          { useClasses: true },
+          `hello ${GREEN_FG}world`
+        )
+      );
+      expect(el).not.toBeNull();
+      expect(el.text()).toBe("hello world");
+      expect(el.html()).toBe(
+        "<code><span>hello </span><span class=\"ansi-green\">world</span></code>"
+      );
+    });
+
+    test("useClasses option", () => {
+      const el = shallow(
+        React.createElement(
+          Ansi,
+          { useClasses: true },
+          `hello ${YELLOW_BG}world`
+        )
+      );
+      expect(el).not.toBeNull();
+      expect(el.text()).toBe("hello world");
+      expect(el.html()).toBe(
+        "<code><span>hello </span><span class=\"ansi-yellow\">world</span></code>"
+      );
+    });
+
+    test("color text and background", () => {
+      const el = shallow(
+        React.createElement(
+          Ansi,
+          { useClasses: true },
+          `hello ${GREEN_FG}${YELLOW_BG}world`
+        )
+      );
+      expect(el).not.toBeNull();
+      expect(el.text()).toBe("hello world");
+      expect(el.html()).toBe(
+        "<code><span>hello </span><span class=\"ansi-yellow ansi-green\">world</span></code>"
+      );
+    });
+
+    test("useClasses with linkify", () => {
+      const el = shallow(
+        React.createElement(
+          Ansi,
+          { linkify: true, useClasses: true },
+          `${GREEN_FG}this is a link: https://nteract.io/`
+        )
+      );
+      expect(el).not.toBeNull();
+      expect(el.text()).toBe("this is a link: https://nteract.io/");
+      expect(el.html()).toBe(
+        "<code><span class=\"ansi-green\">this is a link: <a href=\"https://nteract.io/\" target=\"_blank\">https://nteract.io/</a></span></code>"
+      );
+    });
   });
 });

--- a/packages/ansi-to-react/__tests__/index.spec.ts
+++ b/packages/ansi-to-react/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import { shallow, render } from "enzyme";
+import { shallow } from "enzyme";
 import * as React from "react";
 
 import Ansi from "../src/index";

--- a/packages/ansi-to-react/__tests__/index.spec.ts
+++ b/packages/ansi-to-react/__tests__/index.spec.ts
@@ -104,8 +104,8 @@ describe("Ansi", () => {
     );
   });
 
-  describe("use classes", () => {
-    test("color only background", () => {
+  describe("useClasses options", () => {
+    test("can add the font color class", () => {
       const el = shallow(
         React.createElement(
           Ansi,
@@ -120,7 +120,7 @@ describe("Ansi", () => {
       );
     });
 
-    test("useClasses option", () => {
+    test("can add the background color class", () => {
       const el = shallow(
         React.createElement(
           Ansi,
@@ -135,7 +135,7 @@ describe("Ansi", () => {
       );
     });
 
-    test("color text and background", () => {
+    test("can add font and background color classes", () => {
       const el = shallow(
         React.createElement(
           Ansi,
@@ -150,7 +150,7 @@ describe("Ansi", () => {
       );
     });
 
-    test("useClasses with linkify", () => {
+    test("can use useClasses with linkify", () => {
       const el = shallow(
         React.createElement(
           Ansi,

--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -130,7 +130,7 @@ export default function Ansi(props: Props) {
   return React.createElement(
     "code",
     { className },
-    ansiToJSON(children, useClasses).map(
+    ansiToJSON(children, !!useClasses).map(
       convertBundleIntoReact.bind(null, linkify, useClasses)
     )
   );

--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -131,7 +131,7 @@ export default function Ansi(props: Props) {
     "code",
     { className },
     ansiToJSON(children, !!useClasses).map(
-      convertBundleIntoReact.bind(null, linkify, useClasses)
+      convertBundleIntoReact.bind(null, linkify, !!useClasses)
     )
   );
 }

--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -28,7 +28,7 @@ function ansiToJSON(input: string, use_classes = false) {
  * @return {String} class name(s)
  */
 function createClass(bundle: AnserJsonEntry) {
-  let classNames: String = "";
+  let classNames: string = "";
 
   if (!bundle.bg && !bundle.fg) {
     return null;

--- a/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
+++ b/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
@@ -1497,6 +1497,7 @@ exports[`Plain Should render markdown 1`] = `
     >
       <code>
         <span
+          className={null}
           key="0"
           style={Object {}}
         >


### PR DESCRIPTION
# Background
The `anser` returns the rgb value.
There is an option to return class names instead, making the component more configurable. 

# How
Pass the option `use_classes` to `ansiToJson()`
```javascript
function ansiToJSON(input: string, use_classes = false) {
  input = escapeCarriageReturn(input);
  return ansiToJson(input, {
    json: true,
    remove_empty: true,
    use_classes
  });
}
```
and then, render the span with the class(es)
```javascript
const style = useClasses ? null : createStyle(bundle);
const className = useClasses ? createClass(bundle) : null;

  if (!linkify) {
    return React.createElement(
      "span",
      { style, key, className },
      bundle.content
    );
  }
```

# Example
```javascript
<Ansi useClasses>
    {'\u001b[34mhello world'}
</Ansi>;
```
Will render 
```javascript
<code>
    <span class="ansi-blue">hello world</span>
</code>
```

Feel free to provide me with feedback, changes.

Barak