### PR TITLE
Remove blueprint styled-component from data-explorer

### DIFF
--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -23,7 +23,6 @@
     "@blueprintjs/core": "^3.7.0",
     "@blueprintjs/select": "^3.2.0",
     "@nteract/octicons": "^1.0.4-alpha.0",
-    "@nteract/styled-blueprintjsx": "^1.1.5-alpha.0",
     "d3-collection": "^1.0.7",
     "d3-scale": "^2.1.2",
     "d3-shape": "^1.2.2",

--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -1,6 +1,5 @@
 import { Button, Code, IconName, MenuItem } from "@blueprintjs/core";
 import { Select } from "@blueprintjs/select";
-import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
 import * as React from "react";
 
 import { StyledButtonGroup } from "./components/button-group";
@@ -558,8 +557,6 @@ export default ({
           </div>
         )}
       </Wrapper>
-      <BlueprintCSS />
-      <BlueprintSelectCSS />
     </React.Fragment>
   );
 };

--- a/packages/data-explorer/src/charts/grid.tsx
+++ b/packages/data-explorer/src/charts/grid.tsx
@@ -1,5 +1,4 @@
 import { Button, InputGroup, Tooltip } from "@blueprintjs/core";
-import { BlueprintCSS } from "@nteract/styled-blueprintjsx";
 import * as React from "react";
 import ReactTable from "react-table";
 import withFixedColumns from "react-table-hoc-fixed-columns";
@@ -218,7 +217,6 @@ class DataResourceTransformGrid extends React.Component<Props, State> {
           filterable={showFilters}
         />
         <ReactTableStyles />
-        <BlueprintCSS />
       </div>
     );
   }


### PR DESCRIPTION
Based on the discussion at today's weekly meeting, and #4019 

This would require docs to explain how to load blueprint stylesheets with a css loader (or other method) [Here is an example using the component from a project bootstrapped with create-react-app](https://github.com/BenRussert/data-explorer-web/blob/fe0ec69024c982f50bba31fd0b2f820d8129037b/src/App.tsx#L5-L9)

Here are some more [docs on this from blueprint](https://blueprintjs.com/docs/#blueprint.quick-start)