### PR TITLE
Move global styles to root for perf

### DIFF
--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -8,6 +8,8 @@ import { GlobalCSSVariables } from "@nteract/presentational-components";
 import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
 import { createGlobalStyle } from "styled-components";
 
+import { CodeMirrorCSS, ShowHintCSS } from "@nteract/editor";
+
 import DataExplorer from "@nteract/data-explorer";
 import { WidgetDisplay } from "@nteract/jupyter-widgets";
 import GeoJSONTransform from "@nteract/transform-geojson";
@@ -179,10 +181,14 @@ export default class App extends React.PureComponent {
   render() {
     return (
       <React.Fragment>
+        <AppStyle />
         <GlobalCSSVariables />
+
         <BlueprintCSS />
         <BlueprintSelectCSS />
-        <AppStyle />
+
+        <CodeMirrorCSS />
+        <ShowHintCSS />
 
         <Provider store={store}>
           <MathJax.Provider src={mathJaxPath} input="tex">

--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -197,13 +197,12 @@ export default class App extends React.PureComponent {
               contentRef={contentRef}
             />
           </MathJax.Provider>
-
-          <NotificationSystem
-            ref={(notificationSystem: ReactNotificationSystem) => {
-              this.notificationSystem = notificationSystem;
-            }}
-          />
         </Provider>
+        <NotificationSystem
+          ref={(notificationSystem: ReactNotificationSystem) => {
+            this.notificationSystem = notificationSystem;
+          }}
+        />
       </React.Fragment>
     );
   }

--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -1,5 +1,12 @@
+/**
+ * Main entry point for the desktop notebook UI
+ */
+
 import * as MathJax from "@nteract/mathjax";
+
 import { GlobalCSSVariables } from "@nteract/presentational-components";
+import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
+import { createGlobalStyle } from "styled-components";
 
 import DataExplorer from "@nteract/data-explorer";
 import { WidgetDisplay } from "@nteract/jupyter-widgets";
@@ -42,8 +49,6 @@ import { initMenuHandlers } from "./menu";
 import { initNativeHandlers } from "./native-window";
 import { makeDesktopNotebookRecord } from "./state";
 import configureStore, { DesktopStore } from "./store";
-
-import { createGlobalStyle } from "styled-components";
 
 // Load the nteract fonts
 require("./fonts");
@@ -173,23 +178,27 @@ export default class App extends React.PureComponent {
 
   render() {
     return (
-      <Provider store={store}>
-        <MathJax.Provider src={mathJaxPath} input="tex">
-          <NotebookApp
-            // The desktop app always keeps the same contentRef in a browser window
-            contentRef={contentRef}
-          />
-        </MathJax.Provider>
-
-        <NotificationSystem
-          ref={(notificationSystem: ReactNotificationSystem) => {
-            this.notificationSystem = notificationSystem;
-          }}
-        />
-
+      <React.Fragment>
         <GlobalCSSVariables />
+        <BlueprintCSS />
+        <BlueprintSelectCSS />
         <AppStyle />
-      </Provider>
+
+        <Provider store={store}>
+          <MathJax.Provider src={mathJaxPath} input="tex">
+            <NotebookApp
+              // The desktop app always keeps the same contentRef in a browser window
+              contentRef={contentRef}
+            />
+          </MathJax.Provider>
+
+          <NotificationSystem
+            ref={(notificationSystem: ReactNotificationSystem) => {
+              this.notificationSystem = notificationSystem;
+            }}
+          />
+        </Provider>
+      </React.Fragment>
     );
   }
 }

--- a/applications/desktop/src/notebook/native-window.ts
+++ b/applications/desktop/src/notebook/native-window.ts
@@ -149,9 +149,12 @@ export function initNativeHandlers(
   contentRef: ContentRef,
   store: Store<AppState, Actions>
 ) {
-  const state$ = from((store as unknown) as ObservableInput<AppState>).pipe(
-    share()
-  );
+  const state$ = new Observable<AppState>(observer => {
+    const unsubscribe = store.subscribe(() => {
+      observer.next(store.getState());
+    });
+    return unsubscribe;
+  });
 
   return createTitleFeed(contentRef, state$).subscribe(
     setTitleFromAttributes,

--- a/applications/desktop/tsconfig.json
+++ b/applications/desktop/tsconfig.json
@@ -7,6 +7,7 @@
   "references": [
     { "path": "../../packages/core" },
     { "path": "../../packages/types" },
+    { "path": "../../packages/editor" },
     { "path": "../../packages/notebook-app-component" },
     { "path": "../../packages/presentational-components" },
     { "path": "../../packages/fs-observable" },

--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
@@ -1,54 +1,10 @@
 import { ContentRef } from "@nteract/core";
-import { GlobalCSSVariables } from "@nteract/presentational-components";
-import { BlueprintCSS } from "@nteract/styled-blueprintjsx";
 import * as React from "react";
 import NotificationSystem, {
   System as ReactNotificationSystem
 } from "react-notification-system";
-import { createGlobalStyle } from "styled-components";
 
 import { default as Contents } from "./contents";
-
-const GlobalAppStyle = createGlobalStyle`
-  html {
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
-  }
-
-  *,
-  *::before,
-  *::after {
-    -webkit-box-sizing: inherit;
-    box-sizing: inherit;
-  }
-
-  body {
-    font-family: "Source Sans Pro";
-    font-size: 16px;
-    background-color: var(--theme-app-bg);
-    color: var(--theme-app-fg);
-    margin: 0;
-  }
-
-  #app {
-    padding-top: 20px;
-  }
-
-  @keyframes fadeOut {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 0;
-    }
-  }
-
-  div#loading {
-    animation-name: fadeOut;
-    animation-duration: 0.25s;
-    animation-fill-mode: forwards;
-  }
-`;
 
 class App extends React.Component<{ contentRef: ContentRef }> {
   notificationSystem!: ReactNotificationSystem;
@@ -60,10 +16,6 @@ class App extends React.Component<{ contentRef: ContentRef }> {
   render() {
     return (
       <React.Fragment>
-        <BlueprintCSS />
-        <GlobalCSSVariables />
-        <GlobalAppStyle />
-
         <Contents contentRef={this.props.contentRef} />
         <NotificationSystem
           ref={(notificationSystem: ReactNotificationSystem) => {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -1,3 +1,6 @@
+/**
+ * Main entry point for the web notebook UI
+ */
 import {
   actions,
   createContentRef,
@@ -18,6 +21,10 @@ import { AppState } from "@nteract/core";
 import { Media } from "@nteract/outputs";
 import { ContentRecord, HostRecord } from "@nteract/types";
 
+import { GlobalCSSVariables } from "@nteract/presentational-components";
+import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
+import { createGlobalStyle } from "styled-components";
+
 import * as Immutable from "immutable";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -29,6 +36,47 @@ import configureStore from "./store";
 const urljoin = require("url-join");
 
 require("./fonts");
+
+const GlobalAppStyle = createGlobalStyle`
+  html {
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+
+  *,
+  *::before,
+  *::after {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+  }
+
+  body {
+    font-family: "Source Sans Pro";
+    font-size: 16px;
+    background-color: var(--theme-app-bg);
+    color: var(--theme-app-fg);
+    margin: 0;
+  }
+
+  #app {
+    padding-top: 20px;
+  }
+
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  div#loading {
+    animation-name: fadeOut;
+    animation-duration: 0.25s;
+    animation-fill-mode: forwards;
+  }
+`;
 
 export interface JupyterConfigData {
   token: string;
@@ -178,9 +226,15 @@ function main(rootEl: Element, dataEl: Node | null) {
   store.dispatch(actions.fetchKernelspecs({ hostRef, kernelspecsRef }));
 
   ReactDOM.render(
-    <Provider store={store}>
-      <App contentRef={contentRef} />
-    </Provider>,
+    <React.Fragment>
+      <GlobalAppStyle />
+      <GlobalCSSVariables />
+      <BlueprintCSS />
+      <BlueprintSelectCSS />
+      <Provider store={store}>
+        <App contentRef={contentRef} />
+      </Provider>
+    </React.Fragment>,
     rootEl
   );
 }

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -23,6 +23,7 @@ import { ContentRecord, HostRecord } from "@nteract/types";
 
 import { GlobalCSSVariables } from "@nteract/presentational-components";
 import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
+import { CodeMirrorCSS, ShowHintCSS } from "@nteract/editor";
 import { createGlobalStyle } from "styled-components";
 
 import * as Immutable from "immutable";
@@ -229,8 +230,13 @@ function main(rootEl: Element, dataEl: Node | null) {
     <React.Fragment>
       <GlobalAppStyle />
       <GlobalCSSVariables />
+
       <BlueprintCSS />
       <BlueprintSelectCSS />
+
+      <CodeMirrorCSS />
+      <ShowHintCSS />
+
       <Provider store={store}>
         <App contentRef={contentRef} />
       </Provider>

--- a/packages/data-explorer/tsconfig.json
+++ b/packages/data-explorer/tsconfig.json
@@ -8,7 +8,6 @@
   "references": [
     { "path": "../commutable" },
     { "path": "../types" },
-    { "path": "../octicons" },
-    { "path": "../styled-blueprintjsx" }
+    { "path": "../octicons" }
   ]
 }

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -37,10 +37,12 @@ import { tool } from "./jupyter/tooltip";
 
 import { InitialTextArea } from "./components/initial-text-area";
 
-import styled, { StyledComponent } from "styled-components";
-
 import CodeMirrorCSS from "./vendored/codemirror";
 import ShowHintCSS from "./vendored/show-hint";
+
+export { CodeMirrorCSS, ShowHintCSS };
+
+import styled, { StyledComponent } from "styled-components";
 
 const TipButton: StyledComponent<"button", never> = styled.button`
   float: right;
@@ -478,8 +480,6 @@ export default class CodeMirrorEditor extends React.PureComponent<
     return (
       <React.Fragment>
         {/* Global CodeMirror CSS packaged up by styled-components */}
-        <CodeMirrorCSS />
-        <ShowHintCSS />
 
         <div className="tip-holder" />
         <InitialTextArea


### PR DESCRIPTION
This moves a bunch of the `createGlobalStyle` styles up to the root. Apparently re-rendering a global style is _not_ a no-op and ends up causing a significant lag. Since this basically made the app entirely non-useful, I've refactored a few of these to require the styles to be placed at the root.