### PR TITLE
Fix regression in tab completion

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -234,7 +234,7 @@ export default class CodeMirrorEditor extends React.PureComponent<
 
     // Initiate code completion in response to some keystrokes *other than* "Ctrl-Space" (which is bound in extraKeys, above)
     this.keyupEventsSubscriber = keyupEvents
-      .pipe(switchMap<EditorKeyEvent, EditorKeyEvent>(of))
+      .pipe(switchMap<EditorKeyEvent, EditorKeyEvent>(i => of(i)))
       .subscribe(({ editor, ev }) => {
         if (
           completion &&


### PR DESCRIPTION
`switchMap` sends 4 arguments on each item passed through. We only want the first and don't care about the rest. Without this, the `of` gets all the arguments which ends up turning each of the arguments into new items in the stream, causing the whole stream to fail later.

We probably should disable `no-unnecessary-callback-wrapper` for our codebase because
it makes an assumption about the number of arguments.

This came from:

https://github.com/nteract/nteract/pull/4083/files#r249873790

Which, applied as part of our tsconfig made sense. We have to be careful about this rule though, and I think it's an area where a human reviewer around unnecessary callback wrappers would be better.
