### PR TITLE
[perf] take codemirror options as direct props

### DIFF
--- a/packages/editor/__tests__/editor.spec.tsx
+++ b/packages/editor/__tests__/editor.spec.tsx
@@ -141,11 +141,11 @@ describe("editor.hint CodeMirror callback", () => {
 
 describe("Editor", () => {
   it("handles cursor blinkery changes", () => {
-    const editorWrapper = mount(<Editor options={{ cursorBlinkRate: 530 }} />);
+    const editorWrapper = mount(<Editor cursorBlinkRate={530} />);
     const instance = editorWrapper.instance();
     const cm = instance.cm;
     expect(cm.options.cursorBlinkRate).toBe(530);
-    editorWrapper.setProps({ options: { cursorBlinkRate: 0 } });
+    editorWrapper.setProps({ cursorBlinkRate: 0 });
     expect(cm.options.cursorBlinkRate).toBe(0);
   });
 });

--- a/packages/editor/src/configurable.ts
+++ b/packages/editor/src/configurable.ts
@@ -1,0 +1,75 @@
+import { EditorConfiguration } from "codemirror";
+
+// For some reason the addon typings don't export options we need for
+// recomposition. Instead they add on to the EditorConfiguration interface.
+// As a result we have to import bare modules to get the additional properties
+// we want on the EditorConfiguration interface.
+// import "codemirror/codemirror-matchbrackets";
+// import "codemirror/codemirror-showhint";
+// However, if we import these they're on the wrong path for actual import and
+// webpack fails. Instead we'll encode our typings here...
+
+type FullEditorConfiguration = EditorConfiguration & {
+  showHint?: boolean;
+  hintOptions?: any;
+  matchBrackets?: boolean;
+};
+
+export { FullEditorConfiguration };
+
+// Declare which options we allow being configured
+export const configurableCodeMirrorOptions: {
+  // Ensure we capture each of the editor configuration options
+  [k in keyof FullEditorConfiguration]: boolean
+} = {
+  // Do nothing with value, we handle it in a separately managed way
+  value: false,
+  mode: true,
+  // We don't allow overriding the theme as we use this to help theme codemirror
+  theme: false,
+  indentUnit: true,
+  smartIndent: true,
+  tabSize: true,
+  indentWithTabs: true,
+  electricChars: true,
+  rtlMoveVisually: true,
+  keyMap: true,
+  // We're in control of `extraKeys` since we need to bind them to our events
+  extraKeys: false,
+  lineWrapping: true,
+  lineNumbers: true,
+  firstLineNumber: true,
+  lineNumberFormatter: true,
+  gutters: true,
+  fixedGutter: true,
+  readOnly: true,
+  showCursorWhenSelecting: true,
+  undoDepth: true,
+  historyEventDelay: true,
+  tabindex: true,
+  autofocus: true,
+  dragDrop: true,
+  onDragEvent: true,
+  onKeyEvent: true,
+  cursorBlinkRate: true,
+  cursorHeight: true,
+  workTime: true,
+  workDelay: true,
+  pollInterval: true,
+  flattenSpans: true,
+  maxHighlightLength: true,
+  viewportMargin: true,
+  lint: true,
+  placeholder: true,
+
+  // CodeMirror addon configurations
+  showHint: true,
+  // We don't want overriding of the hint behavior
+  hintOptions: false
+};
+
+export function isConfigurable(
+  option: any
+): option is keyof EditorConfiguration {
+  return !!(configurableCodeMirrorOptions as { [s: string]: boolean })[option];
+}


### PR DESCRIPTION
Reopening of #4032 with a fresh look.

This is now a semi-clean wrapper on top of Codemirror where you can do this:

```jsx
<Editor tabSize={8} />
```

directly instead of passing in an options object for the codemirror options. _However_, not every option is configurable because of the way we use the codemirror classes and set keys for notebook usage. For instance, `theme`, `hintOptions`, and `extraKeys` cannot be overridden since we need to be able to bind them to internal methods.