### PR TITLE
Remove vendor chunk from desktop app

### DIFF
--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -320,7 +320,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script src="../lib/vendor.js"></script>
     <script src="../lib/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The current webpack config doesn't generate a vendor chunk anymore.
This prevents the desktop app from throwing `ERR_FILE_NOT_FOUND`.