### PR TITLE
catch errors on output failures

### DIFF
--- a/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
+++ b/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
@@ -1073,9 +1073,9 @@ exports[`HTML renders direct HTML 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-htpNat",
+            "componentId": "sc-bxivhb",
             "isStatic": true,
-            "lastClassName": "eQWcRZ",
+            "lastClassName": "dCqVSe",
             "rules": Array [
               "
   ",
@@ -1205,7 +1205,7 @@ exports[`HTML renders direct HTML 1`] = `
           "displayName": "styled.div",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-htpNat",
+          "styledComponentId": "sc-bxivhb",
           "target": "div",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -1215,7 +1215,7 @@ exports[`HTML renders direct HTML 1`] = `
       forwardedRef={[Function]}
     >
       <div
-        className="sc-htpNat eQWcRZ"
+        className="sc-bxivhb dCqVSe"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<b>cats are best</b>",
@@ -1250,9 +1250,9 @@ exports[`HTML updates the underlying HTML when data changes 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-htpNat",
+            "componentId": "sc-bxivhb",
             "isStatic": true,
-            "lastClassName": "eQWcRZ",
+            "lastClassName": "dCqVSe",
             "rules": Array [
               "
   ",
@@ -1382,7 +1382,7 @@ exports[`HTML updates the underlying HTML when data changes 1`] = `
           "displayName": "styled.div",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-htpNat",
+          "styledComponentId": "sc-bxivhb",
           "target": "div",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -1392,7 +1392,7 @@ exports[`HTML updates the underlying HTML when data changes 1`] = `
       forwardedRef={[Function]}
     >
       <div
-        className="sc-htpNat eQWcRZ"
+        className="sc-bxivhb dCqVSe"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<b>squirrels are pretty great, too</b>",


### PR DESCRIPTION
I've noticed on `master` that data explorer has a bug or two causing a breakdown in the component tree. I've set up some `componentDidCatch` logic in our `<Output />` picker component so that it doesn't kill the app and so we can show information about the outputs as necessary.

![kapture 2019-01-25 at 8 37 24](https://user-images.githubusercontent.com/836375/51759266-ab17ad80-207c-11e9-8a99-41d1f1dd11c8.gif)

This got missed in the switch over to a connected rich media component. Now we're back to disallowing outputs from breaking the app.