### PR TITLE
move global styles further up the tree

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -24,6 +24,8 @@ import { GlobalCSSVariables } from "@nteract/presentational-components";
 import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
 import { ContentRecord, HostRecord } from "@nteract/types";
 
+import { GlobalMenuStyle } from "@nteract/connected-components";
+
 import * as Immutable from "immutable";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -134,7 +136,6 @@ function main(rootEl: Element, dataEl: Node | null) {
   const initialState: AppState = {
     app: makeAppRecord({
       version: `nteract-on-jupyter@${config.appVersion}`,
-      // TODO: Move into core as a "current" host
       host: jupyterHostRecord
     }),
     comms: makeCommsRecord(),
@@ -227,6 +228,7 @@ function main(rootEl: Element, dataEl: Node | null) {
 
   ReactDOM.render(
     <React.Fragment>
+      {/* Keep global styles out of the provider backed render cycle */}
       <GlobalAppStyle />
       <GlobalCSSVariables />
 
@@ -235,6 +237,8 @@ function main(rootEl: Element, dataEl: Node | null) {
 
       <CodeMirrorCSS />
       <ShowHintCSS />
+
+      <GlobalMenuStyle />
 
       <Provider store={store}>
         <App contentRef={contentRef} />

--- a/packages/connected-components/src/index.tsx
+++ b/packages/connected-components/src/index.tsx
@@ -6,3 +6,5 @@ export {
 export { default as HeaderEditor } from "./header-editor";
 export { default as NotebookMenu } from "./notebook-menu";
 export { default as ModalController } from "./modal-controller";
+
+export { GlobalMenuStyle } from "./notebook-menu/styles";

--- a/packages/connected-components/src/notebook-menu/index.tsx
+++ b/packages/connected-components/src/notebook-menu/index.tsx
@@ -7,7 +7,6 @@ import {
   KernelspecsByRefRecord,
   KernelspecsRef
 } from "@nteract/types";
-import * as Immutable from "immutable";
 import Menu, { Divider, MenuItem, SubMenu } from "rc-menu";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -16,7 +15,6 @@ import styled from "styled-components";
 import { MODAL_TYPES } from "../modal-controller";
 
 import { MENU_ITEM_ACTIONS, MENUS } from "./constants";
-import { GlobalMenuStyle } from "./styles";
 
 // To allow actions that can take dynamic arguments (like selecting a kernel
 // based on the host's kernelspecs), we have some simple utility functions to
@@ -42,62 +40,49 @@ interface Props {
   executeAllCells?: (payload: { contentRef: string }) => void;
   executeAllCellsBelow?: (payload: { contentRef: string }) => void;
   clearAllOutputs?: (payload: { contentRef: string }) => void;
-  unhideAll?: (
-    payload: {
-      outputHidden: boolean;
-      inputHidden: boolean;
-      contentRef: string;
-    }
-  ) => void;
+  unhideAll?: (payload: {
+    outputHidden: boolean;
+    inputHidden: boolean;
+    contentRef: string;
+  }) => void;
   cutCell?: (payload: { id?: string; contentRef: string }) => void;
   copyCell?: (payload: { id?: string; contentRef: string }) => void;
   pasteCell?: (payload: { contentRef: string }) => void;
-  createCellBelow?: (
-    payload: {
-      id?: string | undefined;
-      cellType: CellType;
-      source: string;
-      contentRef: string;
-    }
-  ) => void;
-  changeCellType?: (
-    payload: {
-      id?: string | undefined;
-      to: CellType;
-      contentRef: string;
-    }
-  ) => void;
+  createCellBelow?: (payload: {
+    id?: string | undefined;
+    cellType: CellType;
+    source: string;
+    contentRef: string;
+  }) => void;
+  changeCellType?: (payload: {
+    id?: string | undefined;
+    to: CellType;
+    contentRef: string;
+  }) => void;
   setTheme?: (theme: string) => void;
   openAboutModal?: () => void;
-  changeKernelByName?: (
-    payload: {
-      kernelSpecName: string;
-      oldKernelRef?: KernelRef | null;
-      contentRef: ContentRef;
-    }
-  ) => void;
-  restartKernel?: (
-    payload: {
-      outputHandling: actions.RestartKernelOutputHandling;
-      kernelRef?: string | null;
-      contentRef: string;
-    }
-  ) => void;
-  restartKernelAndClearOutputs?: (
-    payload: {
-      kernelRef?: string | null;
-      contentRef: string;
-    }
-  ) => void;
-  restartKernelAndRunAllOutputs?: (
-    payload: {
-      kernelRef?: string | null;
-      contentRef: string;
-    }
-  ) => void;
-  killKernel?: (
-    payload: { restarting: boolean; kernelRef?: string | null }
-  ) => void;
+  changeKernelByName?: (payload: {
+    kernelSpecName: string;
+    oldKernelRef?: KernelRef | null;
+    contentRef: ContentRef;
+  }) => void;
+  restartKernel?: (payload: {
+    outputHandling: actions.RestartKernelOutputHandling;
+    kernelRef?: string | null;
+    contentRef: string;
+  }) => void;
+  restartKernelAndClearOutputs?: (payload: {
+    kernelRef?: string | null;
+    contentRef: string;
+  }) => void;
+  restartKernelAndRunAllOutputs?: (payload: {
+    kernelRef?: string | null;
+    contentRef: string;
+  }) => void;
+  killKernel?: (payload: {
+    restarting: boolean;
+    kernelRef?: string | null;
+  }) => void;
   interruptKernel?: (payload: { kernelRef?: string | null }) => void;
   currentContentRef: ContentRef;
   currentKernelspecsRef?: KernelspecsRef | null;
@@ -471,7 +456,6 @@ class PureNotebookMenu extends React.Component<Props, State> {
             </MenuItem>
           </SubMenu>
         </StickyMenu>
-        <GlobalMenuStyle />
       </React.Fragment>
     );
   }

--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -41,7 +41,7 @@ import StatusBar from "./status-bar";
 import Toolbar, { CellToolbarMask } from "./toolbar";
 import TransformMedia from "./transform-media";
 
-import styled, { createGlobalStyle, StyledComponent } from "styled-components";
+import styled from "styled-components";
 
 function getTheme(theme: string) {
   switch (theme) {


### PR DESCRIPTION
As we noticed with PRs like #4093, `createGlobalStyle`'s returned react classes aren't a no-op on re-render even though effectively static.

Sprinkled some extra cleanups around global styles in as well.