### PR TITLE
cache the computed kernelspecs listing for view

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -132,6 +132,7 @@ function main(rootEl: Element, dataEl: Node | null) {
   const hostRef = createHostRef();
   const contentRef = createContentRef();
   const NullTransform = () => null;
+  const kernelspecsRef = createKernelspecsRef();
 
   const initialState: AppState = {
     app: makeAppRecord({
@@ -143,6 +144,7 @@ function main(rootEl: Element, dataEl: Node | null) {
       theme: "light"
     }),
     core: makeStateRecord({
+      currentKernelspecsRef: kernelspecsRef,
       entities: makeEntitiesRecord({
         hosts: makeHostsRecord({
           byRef: Immutable.Map<string, HostRecord>().set(
@@ -211,7 +213,6 @@ function main(rootEl: Element, dataEl: Node | null) {
   };
 
   const kernelRef = createKernelRef();
-  const kernelspecsRef = createKernelspecsRef();
 
   const store = configureStore(initialState);
   (window as any).store = store;


### PR DESCRIPTION
Optimized our little notebook selector to only recompute data if the kernelspecs have changed.