### PR TITLE
Remove icon not supported warning and add todo

### DIFF
--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -118,7 +118,8 @@ const getIcon = (title: string) => {
   if (title === "X" || title === "Y" || title === "Size" || title === "Color") {
     return iconHash[title];
   } else {
-    console.warn("Icon title not supported");
+    // TODO: Verify if we are handling icon title properly
+    // console.warn("Icon title not supported");
     return title as IconName;
   }
 };


### PR DESCRIPTION
This line generates warnings the user doesn't need to see in production. I thought I'd add a todo though, since I'm not 100% sure if we are handling properly.