### PR TITLE
Keybindings: Edit cells

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -46,8 +46,12 @@ class Contents extends React.PureComponent<
   private keyMap: KeyMap = {
     CHANGE_CELL_TYPE: ["ctrl+shift+y", "ctrl+shift+m"],
     COPY_CELL: "ctrl+shift+c",
+    CREATE_CELL_ABOVE: "ctrl+shift+a",
+    CREATE_CELL_BELOW: "ctrl+shift+b",
     CUT_CELL: "ctrl+shift+x",
     DELETE_CELL: "ctrl+shift+d",
+    EXECUTE_ALL_CELLS: "alt+r a",
+    EXECUTE_CELL: "ctrl+enter",
     PASTE_CELL: "ctrl+shift+v",
     SAVE: "ctrl+s"
   };
@@ -169,10 +173,24 @@ const mapDispatchToProps = (
     },
     COPY_CELL: () =>
       dispatch(actions.copyCell({ contentRef: initialProps.contentRef })),
+    CREATE_CELL_ABOVE: () =>
+      dispatch(
+        actions.createCellAbove({ contentRef: initialProps.contentRef })
+      ),
+    CREATE_CELL_BELOW: () =>
+      dispatch(
+        actions.createCellBelow({ contentRef: initialProps.contentRef })
+      ),
     CUT_CELL: () =>
       dispatch(actions.cutCell({ contentRef: initialProps.contentRef })),
     DELETE_CELL: () =>
       dispatch(actions.deleteCell({ contentRef: initialProps.contentRef })),
+    EXECUTE_ALL_CELLS: dispatch(
+      actions.executeAllCells({ contentRef: initialProps.contentRef })
+    ),
+    EXECUTE_CELL: dispatch(
+      actions.executeCell({ contentRef: initialProps.contentRef })
+    ),
     PASTE_CELL: () =>
       dispatch(actions.pasteCell({ contentRef: initialProps.contentRef })),
     SAVE: () => dispatch(actions.save({ contentRef: initialProps.contentRef }))

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -45,6 +45,7 @@ class Contents extends React.PureComponent<
   private keyMap: KeyMap = {
     COPY_CELL: "ctrl+shift+c",
     CUT_CELL: "ctrl+shift+x",
+    DELETE_CELL: "ctrl+shift+d",
     PASTE_CELL: "ctrl+shift+v",
     SAVE: "ctrl+s"
   };
@@ -158,6 +159,8 @@ const mapDispatchToProps = (
       dispatch(actions.copyCell({ contentRef: initialProps.contentRef })),
     CUT_CELL: () =>
       dispatch(actions.cutCell({ contentRef: initialProps.contentRef })),
+    DELETE_CELL: () =>
+      dispatch(actions.deleteCell({ contentRef: initialProps.contentRef })),
     PASTE_CELL: () =>
       dispatch(actions.pasteCell({ contentRef: initialProps.contentRef })),
     SAVE: () => dispatch(actions.save({ contentRef: initialProps.contentRef }))

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -1,4 +1,5 @@
 import * as actions from "@nteract/actions";
+import { CellType } from "@nteract/commutable";
 import { AppState, ContentRef, HostRecord, selectors } from "@nteract/core";
 import {
   DirectoryContentRecordProps,
@@ -43,6 +44,7 @@ class Contents extends React.PureComponent<
   IContentsState
 > {
   private keyMap: KeyMap = {
+    CHANGE_CELL_TYPE: ["ctrl+shift+y", "ctrl+shift+m"],
     COPY_CELL: "ctrl+shift+c",
     CUT_CELL: "ctrl+shift+x",
     DELETE_CELL: "ctrl+shift+d",
@@ -155,6 +157,16 @@ const mapDispatchToProps = (
   // `HotKeys` handlers object
   // see: https://github.com/greena13/react-hotkeys#defining-handlers
   handlers: {
+    CHANGE_CELL_TYPE: (event: KeyboardEvent) => {
+      const type: CellType = event.key === "Y" ? "code" : "markdown";
+
+      return dispatch(
+        actions.changeCellType({
+          to: type,
+          contentRef: initialProps.contentRef
+        })
+      );
+    },
     COPY_CELL: () =>
       dispatch(actions.copyCell({ contentRef: initialProps.contentRef })),
     CUT_CELL: () =>

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -174,11 +174,18 @@ const mapDispatchToProps = (
       dispatch(actions.copyCell({ contentRef: initialProps.contentRef })),
     CREATE_CELL_ABOVE: () =>
       dispatch(
-        actions.createCellAbove({ contentRef: initialProps.contentRef })
+        actions.createCellAbove({
+          cellType: "code",
+          contentRef: initialProps.contentRef
+        })
       ),
     CREATE_CELL_BELOW: () =>
       dispatch(
-        actions.createCellBelow({ contentRef: initialProps.contentRef })
+        actions.createCellBelow({
+          cellType: "code",
+          source: "",
+          contentRef: initialProps.contentRef
+        })
       ),
     CUT_CELL: () =>
       dispatch(actions.cutCell({ contentRef: initialProps.contentRef })),

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -43,6 +43,9 @@ class Contents extends React.PureComponent<
   IContentsState
 > {
   private keyMap: KeyMap = {
+    COPY_CELL: "ctrl+shift+c",
+    CUT_CELL: "ctrl+shift+x",
+    PASTE_CELL: "ctrl+shift+v",
     SAVE: "ctrl+s"
   };
 
@@ -151,6 +154,12 @@ const mapDispatchToProps = (
   // `HotKeys` handlers object
   // see: https://github.com/greena13/react-hotkeys#defining-handlers
   handlers: {
+    COPY_CELL: () =>
+      dispatch(actions.copyCell({ contentRef: initialProps.contentRef })),
+    CUT_CELL: () =>
+      dispatch(actions.cutCell({ contentRef: initialProps.contentRef })),
+    PASTE_CELL: () =>
+      dispatch(actions.pasteCell({ contentRef: initialProps.contentRef })),
     SAVE: () => dispatch(actions.save({ contentRef: initialProps.contentRef }))
   }
 });

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -51,7 +51,6 @@ class Contents extends React.PureComponent<
     CUT_CELL: "ctrl+shift+x",
     DELETE_CELL: "ctrl+shift+d",
     EXECUTE_ALL_CELLS: "alt+r a",
-    EXECUTE_CELL: "ctrl+enter",
     PASTE_CELL: "ctrl+shift+v",
     SAVE: "ctrl+s"
   };
@@ -185,12 +184,10 @@ const mapDispatchToProps = (
       dispatch(actions.cutCell({ contentRef: initialProps.contentRef })),
     DELETE_CELL: () =>
       dispatch(actions.deleteCell({ contentRef: initialProps.contentRef })),
-    EXECUTE_ALL_CELLS: dispatch(
-      actions.executeAllCells({ contentRef: initialProps.contentRef })
-    ),
-    EXECUTE_CELL: dispatch(
-      actions.executeCell({ contentRef: initialProps.contentRef })
-    ),
+    EXECUTE_ALL_CELLS: () =>
+      dispatch(
+        actions.executeAllCells({ contentRef: initialProps.contentRef })
+      ),
     PASTE_CELL: () =>
       dispatch(actions.pasteCell({ contentRef: initialProps.contentRef })),
     SAVE: () => dispatch(actions.save({ contentRef: initialProps.contentRef }))


### PR DESCRIPTION
This adds notebook keybinding shortcuts except for `notebook: run-cell`.

- [x] notebook: copy-cell  => `ctrl+shift+c`
- [x] notebook: cut-cell => `ctrl+shift+x`
- [x] notebook: delete-cell => `ctrl+shift+d`
- [x] notebook: change-cell-to-code => `ctrl+shift+y`
- [x] notebook: change-cell-to-markdown => `ctrl+shift+m`
- [x] notebook: move-cursor-down-1 => `ArrowDown`
- [x] notebook: move-cursor-up-1 => `ArrowUp`
- [ ] notebook: run-cell => `ctrl+enter`
- [x] notebook: insert-cell-above => `ctrl+shift+a`
- [x] notebook: insert-cell-below => `ctrl+shift+b`
- [x] Run Cell and Select Next => `shift+enter`
- [x] Cell Menu: run-all => `alt+r,a`

This closes #4105.