### PR TITLE
build a minimal server for deployment using ncc

### DIFF
--- a/packages/kernel-relay/get-prebuilt.js
+++ b/packages/kernel-relay/get-prebuilt.js
@@ -1,0 +1,18 @@
+/**
+ * This module exists entirely to assist with getting the right
+ * version of zeromq for the target platform on postinstall.
+ *
+ * To ease this setup, we'll keep this as a plain js file.
+ */
+
+const path = require("path");
+const fs = require("fs");
+
+const placementDir = path.join("lib", "build", "Release");
+fs.mkdirSync(placementDir, { recursive: true });
+const placement = path.join(placementDir, "zmq.node");
+
+const zmqDir = path.dirname(require.resolve("zeromq"));
+const builtModule = path.join(zmqDir, "build", "Release", "zmq.node");
+
+fs.copyFileSync(builtModule, placement);

--- a/packages/kernel-relay/package.json
+++ b/packages/kernel-relay/package.json
@@ -2,16 +2,29 @@
   "name": "@nteract/kernel-relay",
   "version": "2.0.0",
   "description": "This package provides a GraphQL API for managing communication between a Jupyter kernel and clients. The package allows users to launch kernels, subscribe to the status of a kernel, send Jupyter messages from a client to a kernel, and more.",
+  "bin": {
+    "kernel-relay": "lib/index.js"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "start": "node lib/index.js",
-    "dev": "concurrently \"nodemon lib/index.js\" \"tsc -b . --watch\""
+    "postinstall": "npm run get-zeromq",
+    "get-zeromq": "node get-prebuilt.js",
+    "prepublishOnly": "npm run build:prod && rm lib/build/Release/zmq.node",
+    "build": "ncc build src/index.ts -o lib",
+    "build:prod": "npm run build -- -m -s",
+    "build:watch": "npm run build -- --watch",
+    "start": "ncc start src/index.ts",
+    "dev": "concurrently \"nodemon lib/index.js\" \"npm run build:watch\""
   },
   "keywords": [
     "jupyter",
     "graphql",
     "server"
+  ],
+  "files": [
+    "lib",
+    "get-prebuilt.js"
   ],
   "publishConfig": {
     "access": "public"
@@ -19,14 +32,16 @@
   "author": "nteract Contributors",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "zeromq": "^5.1.0"
+  },
+  "devDependencies": {
+    "@zeit/ncc": "^0.13.0",
     "@nteract/fs-kernels": "^2.0.0",
     "@nteract/messaging": "^6.0.0",
     "apollo-server": "^2.3.1",
     "enchannel-zmq-backend": "^9.0.0",
     "graphql": "^14.0.2",
-    "graphql-type-json": "^0.2.1"
-  },
-  "devDependencies": {
+    "graphql-type-json": "^0.2.1",
     "apollo-server-testing": "^2.3.1",
     "nodemon": "^1.18.9"
   }

--- a/packages/kernel-relay/tsconfig.json
+++ b/packages/kernel-relay/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "target": "es2015",
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,6 +1674,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
+"@zeit/ncc@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.13.0.tgz#90611c7cf15a26ddaa2521b106ca0f021cd83408"
+  integrity sha512-I2pLWVzdq2f4U6jxeu2EV7Q7dMsnXkgf+Jq9vhgYWzPzfMcCLhomPatBuvR3VpNZilqIXePZThlPuGrmA3ReFw==
+
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -15069,7 +15074,7 @@ zen-observable@^0.8.0:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.11.tgz#d3415885eeeb42ee5abb9821c95bb518fcd6d199"
   integrity sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ==
 
-zeromq@5:
+zeromq@5, zeromq@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/zeromq/-/zeromq-5.1.0.tgz#e96508f8babe851c1ea07c0edcedf8e7715947f6"
   integrity sha512-wBEwnWaC1BQgcVoC4ZcERuIf+F0LdW12rblcwFNQANUGjJqQB1Ty3D59+WhvBJU9EliQw9Qc6V914gYXMzO6jw==


### PR DESCRIPTION
This packages up the `kernel-relay` as a single\*  webpacked file for ease of deployment across clusters, by way of [`ncc`](https://github.com/zeit/ncc#readme).

What I said with "single" is a bit of a lie because we still have our zeromq native dependency and this also emits typescript bindings. Pretty tidy though.

```
$ tree -h lib
lib
├── [  96]  build
│   └── [  96]  Release
│       └── [1.1M]  zmq.node
├── [  11]  index.d.ts
├── [2.8M]  index.js
├── [6.7M]  index.js.map
└── [ 263]  server.d.ts
```

Note: we don't _have_ to include the sourcemap. It seemed like a wise idea while we're still building on top of our initial prototype though.