### PR TITLE
[WIP] Surface bookstore

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/config.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/config.py
@@ -5,27 +5,22 @@ class NteractConfig(Configurable):
     """The nteract application configuration object
     """
     name = Unicode('nteract',
-        help='The name of nteract, which is configurable for some reason')
+        help='The name of nteract, configurable so it can be set dynamically').tag(config=True)
 
     page_url = Unicode('/nteract',
-        help='The base URL for nteract web')
+        help='The base URL for nteract web').tag(config=True)
 
     version = Unicode('',
-        help='The version of nteract web')
+        help='The version of nteract web').tag(config=True)
 
     settings_dir = Unicode('',
-        help='The settings directory')
+        help='The settings directory').tag(config=True)
 
     assets_dir = Unicode('',
-        help='The assets directory')
-
-    dev_mode = Bool(False,
-        help='Whether the application is in dev mode')
+        help='The assets directory').tag(config=True)
 
     asset_url = Unicode('',
-        config=True,
-        help='Remote URL for loading assets')
+        help='Remote URL for loading assets').tag(config=True)
 
     ga_code = Unicode('',
-        config=True,
-        help="Google Analytics tracking code")
+        help="Google Analytics tracking code").tag(config=True)

--- a/applications/jupyter-extension/nteract_on_jupyter/extension.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/extension.py
@@ -25,14 +25,13 @@ def load_jupyter_server_extension(nbapp):
     app_dir = here  # bundle is part of the python package
 
     web_app = nbapp.web_app
-    config = NteractConfig(parent=nbapp)
-
+    config = nbapp.config
+    
     # original
-    # config.assets_dir = os.path.join(app_dir, 'static')
-    config.assets_dir = app_dir
+    # config.NteractConfig.assets_dir = os.path.join(app_dir, 'static')
+    config.NteractConfig.assets_dir = app_dir
 
-    config.page_url = '/nteract'
-    config.dev_mode = False
+    config.NteractConfig.page_url = '/nteract'
 
     # Check for core mode.
     core_mode = ''
@@ -42,13 +41,14 @@ def load_jupyter_server_extension(nbapp):
     # Check for an app dir that is local.
     if app_dir == here or app_dir == os.path.join(here, 'build'):
         core_mode = True
-        config.settings_dir = ''
+        config.NteractConfig.settings_dir = ''
 
     web_app.settings.setdefault('page_config_data', dict())
     web_app.settings['page_config_data']['token'] = nbapp.token
-    web_app.settings['page_config_data']['ga_code'] = config.ga_code
-    web_app.settings['page_config_data']['asset_url'] = config.asset_url
+    web_app.settings['page_config_data']['ga_code'] = config.NteractConfig.ga_code
+    web_app.settings['page_config_data']['asset_url'] = config.NteractConfig.asset_url
 
-    web_app.settings['nteract_config'] = config
+    web_app.settings['config'] = config
 
-    add_handlers(web_app, config)
+    # add_handlers(web_app, nbapp.config)
+    add_handlers(web_app)

--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -61,6 +61,15 @@ class NAppHandler(IPythonHandler):
             page_title = '{filename} - nteract'.format(filename=filename)
         else:
             page_title = 'nteract'
+            
+        try:
+            from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
+            bookstore_settings = BookstoreSettings(config=config)
+            bookstore_enabled = validate_bookstore(bookstore_settings)
+
+        except ImportError:
+            print("Bookstore module not installed.")
+            bookstore_enabled = False
 
         config = dict(
             ga_code=config.ga_code,
@@ -72,6 +81,7 @@ class NAppHandler(IPythonHandler):
             public_url=url,
             contents_path=path,
             page=self.page,
+            bookstore_enabled=bookstore_enabled,
         )
         self.write(self.render_template('index.html', **config))
 

--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -20,34 +20,35 @@ from notebook.utils import url_path_join as ujoin
 from traitlets import HasTraits, Unicode, Bool
 
 from . import PACKAGE_DIR
+from .config import NteractConfig
 
 FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 
 class NAppHandler(IPythonHandler):
     """Render the nteract view"""
     def initialize(self, config, page):
-        self.nteract_config = config
+        self.nbconfig = config
         self.page = page
 
     @web.authenticated
     def get(self, path="/"):
-        config = self.nteract_config
-        settings_dir = config.settings_dir
-        assets_dir = config.assets_dir
+        nteract_config = NteractConfig(config=self.nbconfig)
+        settings_dir = nteract_config.settings_dir
+        assets_dir = nteract_config.assets_dir
 
         base_url = self.settings['base_url']
-        url = ujoin(base_url, config.page_url, '/static/')
+        url = ujoin(base_url, nteract_config.page_url, '/static/')
 
         # Handle page config data.
         page_config = dict()
         page_config.update(self.settings.get('page_config_data', {}))
-        page_config.setdefault('appName', config.name)
-        page_config.setdefault('appVersion', config.version)
+        page_config.setdefault('appName', nteract_config.name)
+        page_config.setdefault('appVersion', nteract_config.version)
 
         mathjax_config = self.settings.get('mathjax_config',
                                            'TeX-AMS_HTML-full,Safe')
 
-        asset_url = config.asset_url
+        asset_url = nteract_config.asset_url
 
         if asset_url is "":
             asset_url = base_url
@@ -61,18 +62,18 @@ class NAppHandler(IPythonHandler):
             page_title = '{filename} - nteract'.format(filename=filename)
         else:
             page_title = 'nteract'
-            
+
         try:
             from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
-            bookstore_settings = BookstoreSettings(config=config)
+            bookstore_settings = BookstoreSettings(config=self.nbconfig)
             bookstore_enabled = validate_bookstore(bookstore_settings)
 
         except ImportError:
             print("Bookstore module not installed.")
             bookstore_enabled = False
 
-        config = dict(
-            ga_code=config.ga_code,
+        index_config = dict(
+            ga_code=nteract_config.ga_code,
             asset_url=asset_url,
             page_title=page_title,
             mathjax_url=self.mathjax_url,
@@ -83,26 +84,28 @@ class NAppHandler(IPythonHandler):
             page=self.page,
             bookstore_enabled=bookstore_enabled,
         )
-        self.write(self.render_template('index.html', **config))
+        self.write(self.render_template('index.html', **index_config))
 
     def get_template(self, name):
         return FILE_LOADER.load(self.settings['jinja2_env'], name)
 
 
-def add_handlers(web_app, config):
+def add_handlers(web_app):
+# def add_handlers(nbapp, nteract_config):
     """Add the appropriate handlers to the web app.
     """
     base_url = web_app.settings['base_url']
-    url = ujoin(base_url, config.page_url)
-    assets_dir = config.assets_dir
+    config = web_app.settings["config"]
+    nteract_config = config.NteractConfig
+
+    url = ujoin(base_url, nteract_config.page_url)
+    assets_dir = nteract_config.assets_dir
 
     package_file = os.path.join(assets_dir, 'package.json')
     with open(package_file) as fid:
         data = json.load(fid)
-
-    config.version = (config.version or
-                      data['version'])
-    config.name = config.name or data['name']
+    nteract_config.version = (nteract_config.version or data['version'])
+    nteract_config.name = nteract_config.name or data['name']
 
 
     handlers = [

--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -21,7 +21,8 @@ Distributed under the terms of the Modified BSD License.
     "publicUrl": "{{ public_url }}",
     "contentsPath": "{{ contents_path }}",
     "assetUrl": "{{ asset_url }}",
-    "page": "{{ page }}"
+    "page": "{{ page }}",
+    "bookstoreEnabled": "{{bookstore_enabled}}"
   }</script>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico">{% endblock %}


### PR DESCRIPTION
The purpose of this PR is to enable us to know on the front-end whether or not bookstore has been enabled.

This PR needs https://github.com/nteract/bookstore/pull/44 in order to be able to report `bookstoreEnabled: "True"`. 

However, a lot of decisions and refactoring needed to happen to enable this.

## Why did this require a refactor? 
It made the most sense (IMO) to put the check as locally as possible to the handler itself, because that is where much of the rest of the information being sent to the "jupyter-config-data" script.

In order for us to do that, we needed to have access to bookstore settings. Bookstore settings are defined via the BookstoreSettings Configurable object and set via traitlet configuration assignment.

Previously, we had been instantiating a `NteractConfig` object inside the `extension` module using the nbapp's config. We were assigning values to that object (post instantiation) and were passing it through to our `add_handlers` function that was defined in the `handlers` module. 

After some initial exploration, I discovered that we could not simply pass the `nbapp`'s config object to the `add_handlers` function, because the config values were only being assigned to the local `NteractConfig` object and were not propagated back to the `nbapp`'s config object. Values were also being assigned inside the `add_handlers` function (these also would not be propagated back to the `nbapp`'s config object.

Unfortunately, simply passing the global config object through was insufficient, because for traitlet values that had not been directly assigned and were not explicitly configured, when accessed on the global config object they had no value and were still treated as instances of LazyConfigValue (see https://github.com/ipython/traitlets/blob/d07d70d81e82f655ac36841415721d5246876538/traitlets/config/loader.py#L65-L73)

Solution:
In order to get access to the global config object later, we add it to the `webapp.settings` and then explicitly instantiate the NteractConfig and the BookstoreSettings inside the actual handler code.