### PR TITLE
bring back positive lookahead regex for newline splitting

### DIFF
--- a/packages/commutable/__tests__/primitive.spec.ts
+++ b/packages/commutable/__tests__/primitive.spec.ts
@@ -4,6 +4,6 @@ describe("remultiline", () => {
     it("correctly splits strings by newline", () => {
         const testString = "this\nis\na\ntest\n";
         const multilined = remultiline(testString);
-        expect(multilined).toBe(["this", "is", "a", "test"]);
+        expect(multilined).toEqual(["this\n", "is\n", "a\n", "test\n"]);
     })
 })

--- a/packages/commutable/__tests__/primitive.spec.ts
+++ b/packages/commutable/__tests__/primitive.spec.ts
@@ -1,0 +1,9 @@
+import { remultiline } from "../src/primitives";
+
+describe("remultiline", () => {
+    it("correctly splits strings by newline", () => {
+        const testString = "this\nis\na\ntest\n";
+        const multilined = remultiline(testString);
+        expect(multilined).toBe(["this ", " is ", " a ", " test "]);
+    })
+})

--- a/packages/commutable/__tests__/primitive.spec.ts
+++ b/packages/commutable/__tests__/primitive.spec.ts
@@ -4,6 +4,6 @@ describe("remultiline", () => {
     it("correctly splits strings by newline", () => {
         const testString = "this\nis\na\ntest\n";
         const multilined = remultiline(testString);
-        expect(multilined).toBe(["this ", " is ", " a ", " test "]);
+        expect(multilined).toBe(["this", "is", "a", "test"]);
     })
 })

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -116,7 +116,7 @@ export function remultiline(s: string | string[]): string[] {
     return s;
   }
   // Use positive lookahead regex to split on newline and retain newline char
-  return s.split(/(.+(:\r\n|\n))/g).filter(x => x !== "");
+  return s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== "");
 }
 
 function isJSONKey(key: string) {


### PR DESCRIPTION
A regression worked its way into `remultiline` during the last weeks' refactor. All the `?` got deleted, making this not a positive lookahead regex with a non-matching group...

cc @stormpython @captainsafia 