### PR TITLE
include more tests for remultiline

### DIFF
--- a/packages/commutable/__tests__/primitive.spec.ts
+++ b/packages/commutable/__tests__/primitive.spec.ts
@@ -1,9 +1,35 @@
 import { remultiline } from "../src/primitives";
 
+// In order to make jest output read well, show 🇳🇱 instead of newlines
+function flagNewlines(s: string) {
+  // NOTE: This function can be thought of mentally as Netherlines
+  return s.replace(/\n/g, "🇳🇱");
+}
+
 describe("remultiline", () => {
-    it("correctly splits strings by newline", () => {
-        const testString = "this\nis\na\ntest\n";
-        const multilined = remultiline(testString);
-        expect(multilined).toEqual(["this\n", "is\n", "a\n", "test\n"]);
-    })
-})
+  it("correctly splits strings by newline", () => {
+    const testString = "this\nis\na\ntest\n";
+    const multilined = remultiline(testString);
+    expect(multilined).toEqual(["this\n", "is\n", "a\n", "test\n"]);
+  });
+
+  it("can handle repeated newlines", () => {
+    expect(remultiline("test\n\n\nthis\n\nout").map(flagNewlines)).toEqual(
+      ["test\n", "\n\n", "this\n", "\nout"].map(flagNewlines)
+    );
+
+    expect(
+      remultiline("test\n\n\nthis\n\nout\n\n\n\n\n\nwhat").map(flagNewlines)
+    ).toEqual(
+      // This shows the super weird case with ours which is a bunch of
+      // newlines before the last line...
+      ["test\n", "\n\n", "this\n", "\n", "out\n", "\n\n\n\n\nwhat"].map(
+        flagNewlines
+      )
+    );
+  });
+
+  it("keeps multiline arrays the same", () => {
+    expect(remultiline(["test\n", "this"])).toEqual(["test\n", "this"]);
+  });
+});

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -112,7 +112,7 @@ export function demultiline(s: string | string[]): string {
  */
 export function remultiline(s: string | string[]): string[] {
   if (Array.isArray(s)) {
-    // Assume
+    // Assume already multiline string
     return s;
   }
   // Use positive lookahead regex to split on newline and retain newline char


### PR DESCRIPTION
As @captainsafia and I noticed... there are no tests for commutable, even though there [_used to be_](https://github.com/nteract/commutable/tree/ae3edf1dfd7fbb344585667b7361984d70949926/test).

Since this is much of the backbone of our entire notebook app state, I'm going to make at least one new test a day for `commutable`. We test some of this via our reducers, but a lot of little functions are missed for the trees as a result.