### PR TITLE
Update semiotic to not point to internal Netflix repo

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8125,7 +8125,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2csv@3.11.5:
+json2csv@^3.11.0:
   version "3.11.5"
   resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-3.11.5.tgz#088006c3b5c06425a48cb7326ca712a6f8661417"
   integrity sha512-ORsw84BuRKMLxfI+HFZuvxRDnsJps53D5fIGr6tLn4ZY+ymcG8XU00E+JJ2wfAiHx5w2QRNmOLE8xHiGAeSfuQ==
@@ -12256,9 +12256,9 @@ semiotic-mark@0.3.1:
     roughjs-es5 "0.1.0"
 
 semiotic@^1.16.3:
-  version "1.16.3"
-  resolved "https://artifacts.netflix.com/api/npm/npm-netflix/semiotic/-/semiotic-1.16.3.tgz#c879229190a8c8e4993efc45f964183e51d113dd"
-  integrity sha1-yHkikZCoyOSZPvxF+WQYPlHRE90=
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.16.4.tgz#b4a9728d72322e768705b376c1a04d07412d62af"
+  integrity sha512-ZWWH+ehpHGyc4KVrhC+Vuuthodt71nCgv0ChRjQLrqaKm5z3yi+2yTA/zwuUi05YD+XhLNkcKC6w1Q/vnXP8GQ==
   dependencies:
     "@mapbox/polylabel" "1"
     d3-array "^1.2.0"
@@ -12278,7 +12278,7 @@ semiotic@^1.16.3:
     d3-selection "^1.1.0"
     d3-shape "^1.2.0"
     d3-voronoi "^1.0.2"
-    json2csv "3.11.5"
+    json2csv "^3.11.0"
     labella "1.1.4"
     memoize-one "4.0.0"
     object-assign "4.1.1"


### PR DESCRIPTION
Somehow the yarn.lock got pointed at Netflix's internal NPM registry and it's breaking things. This points to the public registry.