### PR TITLE
remove excessively protective tslint typedef rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -55,16 +55,12 @@
       "severity": "warn"
     },
     "strict-type-predicates": true,
-    "typedef": {
-      "options": [
-        "call-signature",
-        "member-variable-declaration",
-        "parameter",
-        "property-declaration",
-        "variable-declaration"
-      ],
-      "severity": "warn"
-    },
+    "typedef": [
+      true,
+      "call-signature",
+      "parameter",
+      "member-variable-declaration"
+    ],
     "variable-name": [true, "ban-keywords"]
   }
 }


### PR DESCRIPTION
The `typedef` rule has been bugging me across the codebase. We shouldn't have to declare types that should be able to be inferred:

![image](https://user-images.githubusercontent.com/836375/52085997-aa8a8580-255a-11e9-9d1b-e8eac85680ff.png)

Now, we don't have to. We can write `const y = "something"` and it will let us leave `y` as a string there. .______.