### PR TITLE
Adds styling back to kernel cards

### DIFF
--- a/packages/connected-components/__tests__/__snapshots__/new-notebook-navigation.spec.tsx.snap
+++ b/packages/connected-components/__tests__/__snapshots__/new-notebook-navigation.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`NewNotebookNavigation snapshots 1`] = `
       tabIndex={0}
     >
       <div
-        className="sc-htpNat jvwiWg"
+        className="sc-htpNat cBWZXY"
       >
         <div
           className="logo"
@@ -65,7 +65,7 @@ exports[`NewNotebookNavigation snapshots 1`] = `
         </div>
       </div>
       <div
-        className="sc-bxivhb ctacXM"
+        className="sc-bxivhb deNLLN"
       >
         <p
           className="sc-ifAKCX bbZDsL"
@@ -87,7 +87,7 @@ exports[`NewNotebookNavigation snapshots 1`] = `
       tabIndex={0}
     >
       <div
-        className="sc-htpNat jvwiWg"
+        className="sc-htpNat cBWZXY"
       >
         <div
           className="logo"
@@ -136,7 +136,7 @@ exports[`NewNotebookNavigation snapshots 1`] = `
         </div>
       </div>
       <div
-        className="sc-bxivhb ctacXM"
+        className="sc-bxivhb deNLLN"
       >
         <p
           className="sc-ifAKCX bbZDsL"
@@ -158,7 +158,7 @@ exports[`NewNotebookNavigation snapshots 1`] = `
       tabIndex={0}
     >
       <div
-        className="sc-htpNat jvwiWg"
+        className="sc-htpNat cBWZXY"
       >
         <div
           className="logo"
@@ -207,7 +207,7 @@ exports[`NewNotebookNavigation snapshots 1`] = `
         </div>
       </div>
       <div
-        className="sc-bxivhb ctacXM"
+        className="sc-bxivhb deNLLN"
       >
         <p
           className="sc-ifAKCX bbZDsL"

--- a/packages/connected-components/src/new-notebook-navigation/index.tsx
+++ b/packages/connected-components/src/new-notebook-navigation/index.tsx
@@ -16,7 +16,7 @@ import { AppState, KernelspecProps, KernelspecRecord } from "@nteract/types";
 import * as Immutable from "immutable";
 import * as React from "react";
 import { connect } from "react-redux";
-import styled from "styled-components";
+import styled, { StyledComponent } from "styled-components";
 
 import { default as Logo } from "./logos";
 
@@ -78,7 +78,7 @@ const LogoBox = styled.div`
   justify-content: center;
   align-items: center;
   font-size: 30px;
-  background-color: var(--theme-app-bg);
+  background-color: var(--theme-app-bg, white);
   flex: 1;
 
   .logo {
@@ -93,7 +93,7 @@ const TextBox = styled.div`
   font-size: 0.8em;
   width: 100px;
   box-sizing: border-box;
-  background-color: var(--theme-primary-bg);
+  background-color: var(--theme-primary-bg, hsl(0, 0%, 98%));
   border-top: 1px solid var(--theme-app-border);
 `;
 


### PR DESCRIPTION
Kernel card styles were missing. This PR adds the styles back. The issue is that the global style variables were not being injected into the `Directory` component. This PR is a work around until we add global styles back to all components.

Closes #4153.
