### PR TITLE
Cleanup asset paths

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -14,13 +14,12 @@ if (!rootEl || !dataEl) {
 } else {
   const config: JupyterConfigData = readConfig(rootEl, dataEl);
 
+  const webpackPublicPath = urljoin(config.assetUrl, "nteract/static/dist/");
   // Allow chunks from webpack to load from their built location
   // NOTE: This _must_ run synchronously before webpack tries to load other
-  // chunks
-  ((window as unknown) as any).__webpack_public_path__ = urljoin(
-    config.assetUrl,
-    "nteract/static/dist/"
-  );
+  // chunks, and must be a free variable
+  // @ts-ignore
+  __webpack_public_path__ = webpackPublicPath;
 
   import("./bootstrap").then(module => {
     module.main(config, rootEl);

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -6,7 +6,19 @@ const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const nodeEnv = process.env.NODE_ENV || "development";
 const isProd = nodeEnv === "production";
 
-const ASSET_PATH = process.env.ASSET_PATH || "/nteract/static/dist/";
+const plugins = [
+  new MonacoWebpackPlugin(),
+  new webpack.IgnorePlugin(
+    /^((fs)|(path)|(os)|(crypto)|(source-map-support))$/,
+    /vs\/language\/typescript\/lib/
+  )
+];
+
+if (isProd) {
+  plugins.push(new LodashModuleReplacementPlugin());
+} else {
+  plugins.push(new webpack.HotModuleReplacementPlugin());
+}
 
 module.exports = {
   externals: ["canvas"],
@@ -18,14 +30,12 @@ module.exports = {
   devServer: isProd
     ? {}
     : {
+        publicPath: "/nteract/static/dist/",
         hot: true,
         headers: { "Access-Control-Allow-Origin": "*" }
       },
   target: "web",
   output: {
-    // Note: this gets overriden by our use of __webpack_public_path__ later
-    // to allow serving the notebook at e.g. /user/c/nteract/edit
-    publicPath: ASSET_PATH,
     chunkFilename: "[name]-[chunkhash].bundle.js"
   },
   module: {
@@ -55,17 +65,5 @@ module.exports = {
     extensions: [".ts", ".tsx", ".js"],
     alias: configurator.mergeDefaultAliases()
   },
-  plugins: [
-    new LodashModuleReplacementPlugin(),
-    new webpack.DefinePlugin({
-      "process.env.ASSET_PATH": JSON.stringify(ASSET_PATH)
-    }),
-    //new webpack.IgnorePlugin(/\.(css|less)$/),
-    new MonacoWebpackPlugin(),
-
-    new webpack.IgnorePlugin(
-      /^((fs)|(path)|(os)|(crypto)|(source-map-support))$/,
-      /vs\/language\/typescript\/lib/
-    )
-  ]
+  plugins
 };

--- a/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
+++ b/applications/jupyter-extension/nteract_on_jupyter/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
       },
   target: "web",
   output: {
-    chunkFilename: "[name]-[chunkhash].bundle.js"
+    chunkFilename: isProd ? "[name]-[chunkhash].bundle.js" : "[name].bundle.js"
   },
   module: {
     rules: [


### PR DESCRIPTION
Fixes #4169, bringing `jupyter nteract --dev` back to working.

Turns out that we were kind of _over-configuring_ the webpack setup here. When in dev mode, setting `publicPath` to a default asset path was causing `/nteract/static/dist` to be set for `__webpack_require__.p` (computed by webpack later on) regardless of `__webpack_public_path__` being set to what we needed. By setting the webpack dev server to host its `publicPath` at `/nteract/static/dist` explicitly while _not_ setting `publicPath` for our main `output`, we've finally got the right setup.

If I recall correctly, I had set this default asset path so that the app would work without the setting of `__webpack_public_path__` in the simple case of no `--NotebookApp.base_url`. That ended up causing more issue than it was worth.

I've also verified this works when the dev server is not running with `yarn build:asap` followed by a plain `jupyter nteract`.