### PR TITLE
[jext] move blueprint css import to pure css

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
@@ -18,7 +18,6 @@ import {
 import { CodeMirrorCSS, ShowHintCSS } from "@nteract/editor";
 import { Media } from "@nteract/outputs";
 import { GlobalCSSVariables } from "@nteract/presentational-components";
-import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
 import { ContentRecord, HostRecord } from "@nteract/types";
 
 import { GlobalMenuStyle } from "@nteract/connected-components";
@@ -194,9 +193,6 @@ export async function main(config: JupyterConfigData, rootEl): Promise<void> {
       {/* Keep global styles out of the provider backed render cycle */}
       <GlobalAppStyle />
       <GlobalCSSVariables />
-
-      <BlueprintCSS />
-      <BlueprintSelectCSS />
 
       <CodeMirrorCSS />
       <ShowHintCSS />

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -4,6 +4,9 @@
 
 import { JupyterConfigData, readConfig } from "./config";
 
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/select/lib/css/blueprint-select.css";
+
 import urljoin from "url-join";
 
 const rootEl = document.querySelector("#root");


### PR DESCRIPTION
Let webpack do the dirty work of moving CSS assets. App loads much quicker in dev (and in general).
