### PR TITLE
Blueprint as css for desktop

### DIFF
--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -5,8 +5,10 @@
 import * as MathJax from "@nteract/mathjax";
 
 import { GlobalCSSVariables } from "@nteract/presentational-components";
-import { BlueprintCSS, BlueprintSelectCSS } from "@nteract/styled-blueprintjsx";
 import { createGlobalStyle } from "styled-components";
+
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/select/lib/css/blueprint-select.css";
 
 import { CodeMirrorCSS, ShowHintCSS } from "@nteract/editor";
 
@@ -183,9 +185,6 @@ export default class App extends React.PureComponent {
       <React.Fragment>
         <AppStyle />
         <GlobalCSSVariables />
-
-        <BlueprintCSS />
-        <BlueprintSelectCSS />
 
         <CodeMirrorCSS />
         <ShowHintCSS />

--- a/applications/desktop/webpack.common.js
+++ b/applications/desktop/webpack.common.js
@@ -57,6 +57,10 @@ const rendererConfig = {
   module: {
     rules: [
       {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"]
+      },
+      {
         test: /\.tsx?$/,
         use: [configurator.tsLoaderConfig]
       }
@@ -67,11 +71,7 @@ const rendererConfig = {
     extensions: [".js", ".jsx", ".ts", ".tsx"],
     alias: configurator.mergeDefaultAliases()
   },
-  plugins: [
-    // No external CSS should get side-loaded by js
-    // I'm looking at you vega-tooltip
-    new webpack.IgnorePlugin(/\.(css|less)$/)
-  ]
+  plugins: []
 };
 
 module.exports = {

--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -26,6 +26,7 @@ export const RightStatus = styled.div`
 `;
 
 export const Bar = styled.div`
+  padding-top: 8px;
   position: fixed;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
This turns the style loader on for desktop and allows us to load the base CSS directly instead of these global styles.