### PR TITLE
[WIP] start making a blueprint backed declarative react menu

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -19,7 +19,9 @@ import { ConnectedDirectory } from "./directory";
 import { default as File } from "./file";
 import { ConnectedFileHeader as FileHeader, DirectoryHeader } from "./headers";
 
-import { NotebookMenu } from "@nteract/connected-components";
+import { NotebookMenu as OldNotebookMenu } from "@nteract/connected-components";
+
+import { NotebookMenu } from "./notebook-menu";
 
 interface IContentsProps {
   appBase: string;
@@ -96,7 +98,10 @@ class Contents extends React.PureComponent<
                 saving={saving}
               >
                 {contentType === "notebook" ? (
-                  <NotebookMenu contentRef={this.props.contentRef} />
+                  <>
+                    <OldNotebookMenu contentRef={this.props.contentRef} />
+                    <NotebookMenu contentRef={this.props.contentRef} />
+                  </>
                 ) : null}
               </FileHeader>
               <File contentRef={contentRef} appBase={appBase} />

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -28,8 +28,13 @@ const popoverProps = {
   autofocus: false
 };
 
+/**
+ * Written to be a workaround for submenu bugs
+ * xref: https://github.com/palantir/blueprint/issues/3352
+ */
 const submenuPopoverProps = Object.assign({}, popoverProps, {
-  position: Position.RIGHT
+  position: Position.RIGHT,
+  autofocus: false
 });
 
 interface Props {
@@ -116,23 +121,26 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             />
             <MenuDivider />
             <MenuItem
-              text="Cell Type"
-              icon="code-block"
-              popoverProps={submenuPopoverProps}
-            >
-              <MenuItem
-                text="Code"
-                icon="code"
-                onClick={this.props.triggers.edit.cellType.code}
-              />
-              <MenuItem
-                text="Markdown"
-                icon="new-text-box"
-                onClick={this.props.triggers.edit.cellType.code}
-              />
-            </MenuItem>
+              text="Change Focused Cell to Code"
+              icon="code"
+              onClick={this.props.triggers.edit.cellType.code}
+            />
+            <MenuItem
+              text="Change Focused Cell to Markdown"
+              icon="new-text-box"
+              onClick={this.props.triggers.edit.cellType.markdown}
+            />
           </Menu>
         </Popover>
+        {/*
+          Until we have implemented themes to match up with blueprint, we
+          need to stick with only the light theme. As a result, we won't have a
+          "View" menu.
+
+          To implement dark mode for a blueprint app, specify `bp3-dark` as a
+          className on the top most component.
+        */}
+        {/*
         <Popover {...popoverProps}>
           <Button text={"View"} />
           <Menu>
@@ -153,26 +161,20 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
               />
             </MenuItem>
           </Menu>
-        </Popover>
+        </Popover> */}
         <Popover {...popoverProps}>
           <Button text={"Cell"} />
           <Menu>
             <MenuItem
-              text="New Cell"
-              icon="code-block"
-              popoverProps={submenuPopoverProps}
-            >
-              <MenuItem
-                text="Code"
-                icon="code"
-                onClick={this.props.triggers.cell.newCell.code}
-              />
-              <MenuItem
-                text="Markdown"
-                icon="new-text-box"
-                onClick={this.props.triggers.cell.newCell.markdown}
-              />
-            </MenuItem>
+              text="New Code Cell"
+              icon="code"
+              onClick={this.props.triggers.cell.newCell.code}
+            />
+            <MenuItem
+              text="New Markdown Cell"
+              icon="new-text-box"
+              onClick={this.props.triggers.cell.newCell.markdown}
+            />
           </Menu>
         </Popover>
         <Popover {...popoverProps}>
@@ -223,6 +225,7 @@ function makeMapDispatchToProps(
           },
           cellType: {
             markdown: () => {
+              console.log("change to markdown");
               dispatch(actions.changeCellType({ to: "markdown", contentRef }));
             },
             code: () => {
@@ -233,7 +236,6 @@ function makeMapDispatchToProps(
         view: {
           themes: {
             dark: () => {
-              console.log("go dark");
               dispatch(actions.setTheme("dark"));
             },
             light: () => {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -22,10 +22,10 @@ import { connect } from "react-redux";
 type MenuEntry = () => void | { [item: string]: MenuEntry };
 
 const popoverProps = {
-  position: Position.BOTTOM_LEFT,
-  minimal: true,
-  interactionKind: PopoverInteractionKind.HOVER,
-  autofocus: false
+  position: Position.BOTTOM_LEFT
+  // minimal: true,
+  // interactionKind: PopoverInteractionKind.HOVER,
+  // autofocus: false
 };
 
 /**
@@ -79,59 +79,53 @@ interface Props {
 export class PureNotebookMenu extends React.PureComponent<Props> {
   render() {
     return (
-      <ButtonGroup minimal>
-        <Popover {...popoverProps}>
-          <Button text={"File"} minimal />
-          <Menu>
-            <MenuItem
-              text="Open..."
-              icon="folder-shared"
-              onClick={this.props.triggers.file.open}
-            />
-            <MenuDivider />
-            <MenuItem
-              text="Save"
-              icon="floppy-disk"
-              onClick={this.props.triggers.file.save}
-            />
-            <MenuItem
-              text="Download (.ipynb)"
-              icon="cloud-download"
-              onClick={this.props.triggers.file.download}
-            />
-          </Menu>
-        </Popover>
-        <Popover {...popoverProps}>
-          <Button text={"Edit"} />
-          <Menu>
-            <MenuItem
-              text="Cut Cell"
-              icon="cut"
-              onClick={this.props.triggers.edit.cutCell}
-            />
-            <MenuItem
-              text="Copy Cell"
-              icon="clipboard"
-              onClick={this.props.triggers.edit.copyCell}
-            />
-            <MenuItem
-              text="Paste Cell Below"
-              icon="clipboard"
-              onClick={this.props.triggers.edit.pasteCell}
-            />
-            <MenuDivider />
-            <MenuItem
-              text="Change Focused Cell to Code"
-              icon="code"
-              onClick={this.props.triggers.edit.cellType.code}
-            />
-            <MenuItem
-              text="Change Focused Cell to Markdown"
-              icon="new-text-box"
-              onClick={this.props.triggers.edit.cellType.markdown}
-            />
-          </Menu>
-        </Popover>
+      <Menu className="bp3-button-group">
+        <MenuItem text={"File"} popoverProps={popoverProps}>
+          <MenuItem
+            text="Open..."
+            icon="folder-shared"
+            onClick={this.props.triggers.file.open}
+          />
+          <MenuDivider />
+          <MenuItem
+            text="Save"
+            icon="floppy-disk"
+            onClick={this.props.triggers.file.save}
+          />
+          <MenuItem
+            text="Download (.ipynb)"
+            icon="cloud-download"
+            onClick={this.props.triggers.file.download}
+          />
+        </MenuItem>
+        <MenuItem text={"Edit"} popoverProps={popoverProps}>
+          <MenuItem
+            text="Cut Cell"
+            icon="cut"
+            onClick={this.props.triggers.edit.cutCell}
+          />
+          <MenuItem
+            text="Copy Cell"
+            icon="clipboard"
+            onClick={this.props.triggers.edit.copyCell}
+          />
+          <MenuItem
+            text="Paste Cell Below"
+            icon="clipboard"
+            onClick={this.props.triggers.edit.pasteCell}
+          />
+          <MenuDivider />
+          <MenuItem
+            text="Change Focused Cell to Code"
+            icon="code"
+            onClick={this.props.triggers.edit.cellType.code}
+          />
+          <MenuItem
+            text="Change Focused Cell to Markdown"
+            icon="new-text-box"
+            onClick={this.props.triggers.edit.cellType.markdown}
+          />
+        </MenuItem>
         {/*
           Until we have implemented themes to match up with blueprint, we
           need to stick with only the light theme. As a result, we won't have a
@@ -162,30 +156,21 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             </MenuItem>
           </Menu>
         </Popover> */}
-        <Popover {...popoverProps}>
-          <Button text={"Insert"} />
-          <Menu>
-            <MenuItem
-              text="Code Cell"
-              icon="code"
-              onClick={this.props.triggers.cell.newCell.code}
-            />
-            <MenuItem
-              text="Markdown Cell"
-              icon="new-text-box"
-              onClick={this.props.triggers.cell.newCell.markdown}
-            />
-          </Menu>
-        </Popover>
-        <Popover {...popoverProps}>
-          <Button text={"Runtime"} />
-          <Menu />
-        </Popover>
-        <Popover {...popoverProps}>
-          <Button text={"Help"} />
-          <Menu />
-        </Popover>
-      </ButtonGroup>
+        <MenuItem text={"Insert"} popoverProps={popoverProps}>
+          <MenuItem
+            text="Code Cell"
+            icon="code"
+            onClick={this.props.triggers.cell.newCell.code}
+          />
+          <MenuItem
+            text="Markdown Cell"
+            icon="new-text-box"
+            onClick={this.props.triggers.cell.newCell.markdown}
+          />
+        </MenuItem>
+        <MenuItem text={"Runtime"} popoverProps={popoverProps} />
+        <MenuItem text={"Help"} popoverProps={popoverProps} />
+      </Menu>
     );
   }
 }

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -1,0 +1,102 @@
+/**
+ * Declarative menu to replace the rc-menu backed menu
+ */
+import React from "react";
+import ReactDOM from "react-dom";
+
+import {
+  Button,
+  ButtonGroup,
+  Menu,
+  MenuDivider,
+  MenuItem,
+  Popover,
+  Position
+} from "@blueprintjs/core";
+import { AppState, ContentRef } from "@nteract/core";
+import { Dispatch } from "redux";
+import { connect } from "react-redux";
+
+interface Props {
+  // Since we create the mapDispatchToProps only once (? should verify this)
+  // We can make a grab bag of actions nested by menu name
+  // tslint:disable-next-line:react-pure-components-have-simple-attributes
+  triggers: {
+    [menu: string]: {
+      [onClick: string]: () => void;
+    };
+  };
+}
+
+export class PureNotebookMenu extends React.PureComponent<Props> {
+  render() {
+    return (
+      <ButtonGroup minimal>
+        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+          <Button text={"File"} minimal />
+          <Menu>
+            <MenuItem
+              text="Open..."
+              icon="folder-shared"
+              onClick={this.props.triggers.file.open}
+            />
+            <MenuDivider />
+            <MenuItem
+              text="Save"
+              icon="floppy-disk"
+              onClick={this.props.triggers.file.save}
+            />
+            <MenuItem
+              text="Download (.ipynb)"
+              icon="cloud-download"
+              onClick={this.props.triggers.file.download}
+            />
+          </Menu>
+        </Popover>
+        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+          <Button text={"Edit"} />
+          <Menu>
+            <MenuItem
+              text="Cut Cell"
+              icon="cut"
+              onClick={this.props.triggers.edit.cut}
+            />
+          </Menu>
+        </Popover>
+      </ButtonGroup>
+    );
+  }
+}
+
+function makeMapDispatchToProps(
+  initialState: AppState,
+  initialProps: { contentRef: ContentRef }
+) {
+  const { contentRef } = initialProps;
+
+  function mapDispatchToProps(dispatch: Dispatch) {
+    return {
+      triggers: {
+        // each submenu has its own actions to map with
+        file: {
+          open: () => {
+            console.log("clicky");
+            dispatch({ type: "Clicky", payload: { contentRef } });
+          }
+        },
+        edit: {
+          cut: () => {
+            console.log("cut me");
+          }
+        }
+      }
+    };
+  }
+
+  return mapDispatchToProps;
+}
+
+export const NotebookMenu = connect(
+  null,
+  makeMapDispatchToProps
+)(PureNotebookMenu);

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -59,7 +59,12 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             />
           </Menu>
         </Popover>
-        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+        <Popover
+          position={Position.BOTTOM_LEFT}
+          minimal
+          usePortal
+          interactionKind={PopoverInteractionKind.HOVER}
+        >
           <Button text={"Edit"} />
           <Menu>
             <MenuItem
@@ -85,19 +90,39 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             />
           </Menu>
         </Popover>
-        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+        <Popover
+          position={Position.BOTTOM_LEFT}
+          minimal
+          usePortal
+          interactionKind={PopoverInteractionKind.HOVER}
+        >
           <Button text={"View"} />
           <Menu />
         </Popover>
-        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+        <Popover
+          position={Position.BOTTOM_LEFT}
+          minimal
+          usePortal
+          interactionKind={PopoverInteractionKind.HOVER}
+        >
           <Button text={"Cell"} />
           <Menu />
         </Popover>
-        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+        <Popover
+          position={Position.BOTTOM_LEFT}
+          minimal
+          usePortal
+          interactionKind={PopoverInteractionKind.HOVER}
+        >
           <Button text={"Runtime"} />
           <Menu />
         </Popover>
-        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+        <Popover
+          position={Position.BOTTOM_LEFT}
+          minimal
+          usePortal
+          interactionKind={PopoverInteractionKind.HOVER}
+        >
           <Button text={"Help"} />
           <Menu />
         </Popover>

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -1,3 +1,4 @@
+// tslint:disable:object-literal-sort-keys
 /**
  * Declarative menu to replace the rc-menu backed menu
  */
@@ -14,17 +15,47 @@ import {
   Position,
   PopoverInteractionKind
 } from "@blueprintjs/core";
-import { AppState, ContentRef } from "@nteract/core";
+import { actions, AppState, ContentRef } from "@nteract/core";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
+
+type MenuEntry = () => void | { [item: string]: MenuEntry };
 
 interface Props {
   // Since we create the mapDispatchToProps only once (? should verify this)
   // We can make a grab bag of actions nested by menu name
   // tslint:disable-next-line:react-pure-components-have-simple-attributes
   triggers: {
-    [menu: string]: {
-      [onClick: string]: () => void;
+    // each submenu has its own actions to map with
+    file: {
+      open: () => void;
+      save: () => void;
+      download: () => void;
+    };
+    edit: {
+      cutCell: () => void;
+      copyCell: () => void;
+      pasteCell: () => void;
+      cellType: {
+        markdown: () => void;
+        code: () => void;
+      };
+    };
+    view: {
+      themes: {
+        dark: () => void;
+        light: () => void;
+      };
+    };
+    cell: {
+      runAll: () => void;
+      runAllBelow: () => void;
+      newCell: {
+        markdown: () => void;
+        code: () => void;
+      };
+      clearAllOutputs: () => void;
+      unhideAllInputAndOutput: () => void;
     };
   };
 }
@@ -36,7 +67,6 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          usePortal
           interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"File"} minimal />
@@ -62,47 +92,61 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          usePortal
-          interactionKind={PopoverInteractionKind.HOVER}
+
+          // interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Edit"} />
           <Menu>
             <MenuItem
               text="Cut Cell"
               icon="cut"
-              onClick={this.props.triggers.edit.cut}
+              onClick={this.props.triggers.edit.cutCell}
             />
             <MenuItem
               text="Copy Cell"
               icon="clipboard"
-              onClick={this.props.triggers.edit.copy}
+              onClick={this.props.triggers.edit.copyCell}
             />
             <MenuItem
               text="Paste Cell Below"
               icon="clipboard"
-              onClick={this.props.triggers.edit.paste}
+              onClick={this.props.triggers.edit.pasteCell}
             />
             <MenuDivider />
-            <MenuItem
-              text="Cell Type"
-              icon="code-block"
-              onClick={this.props.triggers.edit.paste}
-            />
+            <MenuItem text="Cell Type" icon="code-block">
+              <MenuItem
+                text="Code"
+                icon="code"
+                onClick={this.props.triggers.edit.cellType.code}
+              />
+              <MenuItem
+                text="Markdown"
+                icon="new-text-box"
+                onClick={this.props.triggers.edit.cellType.code}
+              />
+            </MenuItem>
+          </Menu>
+        </Popover>
+        <Popover position={Position.BOTTOM_LEFT} minimal>
+          <Button text={"View"} />
+          <Menu>
+            <MenuItem text="Themes" icon="cog">
+              <MenuItem
+                text="light"
+                icon="flash"
+                onClick={this.props.triggers.view.themes.light}
+              />
+              <MenuItem
+                text="dark"
+                icon="moon"
+                onClick={this.props.triggers.view.themes.dark}
+              />
+            </MenuItem>
           </Menu>
         </Popover>
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          usePortal
-          interactionKind={PopoverInteractionKind.HOVER}
-        >
-          <Button text={"View"} />
-          <Menu />
-        </Popover>
-        <Popover
-          position={Position.BOTTOM_LEFT}
-          minimal
-          usePortal
           interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Cell"} />
@@ -111,7 +155,6 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          usePortal
           interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Runtime"} />
@@ -120,7 +163,6 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          usePortal
           interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Help"} />
@@ -137,19 +179,91 @@ function makeMapDispatchToProps(
 ) {
   const { contentRef } = initialProps;
 
+  const payload = { contentRef };
+
   function mapDispatchToProps(dispatch: Dispatch) {
     return {
       triggers: {
         // each submenu has its own actions to map with
         file: {
           open: () => {
-            console.log("clicky");
-            dispatch({ type: "Clicky", payload: { contentRef } });
+            // Special case -- redirect to /tree
+          },
+          save: () => {
+            dispatch(actions.save(payload));
+          },
+          download: () => {
+            dispatch(actions.downloadContent(payload));
           }
         },
         edit: {
-          cut: () => {
-            console.log("cut me");
+          cutCell: () => {
+            dispatch(actions.cutCell(payload));
+          },
+          copyCell: () => {
+            dispatch(actions.copyCell(payload));
+          },
+          pasteCell: () => {
+            dispatch(actions.pasteCell(payload));
+          },
+          cellType: {
+            markdown: () => {
+              dispatch(actions.changeCellType({ to: "markdown", contentRef }));
+            },
+            code: () => {
+              dispatch(actions.changeCellType({ to: "code", contentRef }));
+            }
+          }
+        },
+        view: {
+          themes: {
+            dark: () => {
+              console.log("go dark");
+              dispatch(actions.setTheme("dark"));
+            },
+            light: () => {
+              dispatch(actions.setTheme("light"));
+            }
+          }
+        },
+        cell: {
+          runAll: () => {
+            dispatch(actions.executeAllCells(payload));
+          },
+          runAllBelow: () => {
+            dispatch(actions.executeAllCellsBelow(payload));
+          },
+          newCell: {
+            markdown: () => {
+              dispatch(
+                actions.createCellBelow({
+                  contentRef,
+                  cellType: "markdown",
+                  source: ""
+                })
+              );
+            },
+            code: () => {
+              dispatch(
+                actions.createCellBelow({
+                  contentRef,
+                  cellType: "code",
+                  source: ""
+                })
+              );
+            }
+          },
+          clearAllOutputs: () => {
+            dispatch(actions.clearAllOutputs(payload));
+          },
+          unhideAllInputAndOutput: () => {
+            dispatch(
+              actions.unhideAll({
+                outputHidden: false,
+                inputHidden: false,
+                contentRef
+              })
+            );
           }
         }
       }

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -11,7 +11,8 @@ import {
   MenuDivider,
   MenuItem,
   Popover,
-  Position
+  Position,
+  PopoverInteractionKind
 } from "@blueprintjs/core";
 import { AppState, ContentRef } from "@nteract/core";
 import { Dispatch } from "redux";
@@ -32,7 +33,12 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
   render() {
     return (
       <ButtonGroup minimal>
-        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+        <Popover
+          position={Position.BOTTOM_LEFT}
+          minimal
+          usePortal
+          interactionKind={PopoverInteractionKind.HOVER}
+        >
           <Button text={"File"} minimal />
           <Menu>
             <MenuItem
@@ -61,7 +67,39 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
               icon="cut"
               onClick={this.props.triggers.edit.cut}
             />
+            <MenuItem
+              text="Copy Cell"
+              icon="clipboard"
+              onClick={this.props.triggers.edit.copy}
+            />
+            <MenuItem
+              text="Paste Cell Below"
+              icon="clipboard"
+              onClick={this.props.triggers.edit.paste}
+            />
+            <MenuDivider />
+            <MenuItem
+              text="Cell Type"
+              icon="code-block"
+              onClick={this.props.triggers.edit.paste}
+            />
           </Menu>
+        </Popover>
+        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+          <Button text={"View"} />
+          <Menu />
+        </Popover>
+        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+          <Button text={"Cell"} />
+          <Menu />
+        </Popover>
+        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+          <Button text={"Runtime"} />
+          <Menu />
+        </Popover>
+        <Popover position={Position.BOTTOM_LEFT} minimal usePortal>
+          <Button text={"Help"} />
+          <Menu />
         </Popover>
       </ButtonGroup>
     );

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -21,6 +21,17 @@ import { connect } from "react-redux";
 
 type MenuEntry = () => void | { [item: string]: MenuEntry };
 
+const popoverProps = {
+  position: Position.BOTTOM_LEFT,
+  minimal: true,
+  interactionKind: PopoverInteractionKind.HOVER,
+  autofocus: false
+};
+
+const submenuPopoverProps = Object.assign({}, popoverProps, {
+  position: Position.RIGHT
+});
+
 interface Props {
   // Since we create the mapDispatchToProps only once (? should verify this)
   // We can make a grab bag of actions nested by menu name
@@ -64,11 +75,7 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
   render() {
     return (
       <ButtonGroup minimal>
-        <Popover
-          position={Position.BOTTOM_LEFT}
-          minimal
-          // interactionKind={PopoverInteractionKind.HOVER}
-        >
+        <Popover {...popoverProps}>
           <Button text={"File"} minimal />
           <Menu>
             <MenuItem
@@ -89,12 +96,7 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             />
           </Menu>
         </Popover>
-        <Popover
-          position={Position.BOTTOM_LEFT}
-          minimal
-
-          // interactionKind={PopoverInteractionKind.HOVER}
-        >
+        <Popover {...popoverProps}>
           <Button text={"Edit"} />
           <Menu>
             <MenuItem
@@ -113,7 +115,11 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
               onClick={this.props.triggers.edit.pasteCell}
             />
             <MenuDivider />
-            <MenuItem text="Cell Type" icon="code-block">
+            <MenuItem
+              text="Cell Type"
+              icon="code-block"
+              popoverProps={submenuPopoverProps}
+            >
               <MenuItem
                 text="Code"
                 icon="code"
@@ -127,10 +133,14 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             </MenuItem>
           </Menu>
         </Popover>
-        <Popover position={Position.BOTTOM_LEFT} minimal>
+        <Popover {...popoverProps}>
           <Button text={"View"} />
           <Menu>
-            <MenuItem text="Themes" icon="cog">
+            <MenuItem
+              text="Themes"
+              icon="cog"
+              popoverProps={submenuPopoverProps}
+            >
               <MenuItem
                 text="light"
                 icon="flash"
@@ -144,14 +154,14 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             </MenuItem>
           </Menu>
         </Popover>
-        <Popover
-          position={Position.BOTTOM_LEFT}
-          minimal
-          // interactionKind={PopoverInteractionKind.HOVER}
-        >
+        <Popover {...popoverProps}>
           <Button text={"Cell"} />
           <Menu>
-            <MenuItem text="New Cell" icon="code-block">
+            <MenuItem
+              text="New Cell"
+              icon="code-block"
+              popoverProps={submenuPopoverProps}
+            >
               <MenuItem
                 text="Code"
                 icon="code"
@@ -165,19 +175,11 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
             </MenuItem>
           </Menu>
         </Popover>
-        <Popover
-          position={Position.BOTTOM_LEFT}
-          minimal
-          // interactionKind={PopoverInteractionKind.HOVER}
-        >
+        <Popover {...popoverProps}>
           <Button text={"Runtime"} />
           <Menu />
         </Popover>
-        <Popover
-          position={Position.BOTTOM_LEFT}
-          minimal
-          // interactionKind={PopoverInteractionKind.HOVER}
-        >
+        <Popover {...popoverProps}>
           <Button text={"Help"} />
           <Menu />
         </Popover>

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -163,15 +163,15 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
           </Menu>
         </Popover> */}
         <Popover {...popoverProps}>
-          <Button text={"Cell"} />
+          <Button text={"Insert"} />
           <Menu>
             <MenuItem
-              text="New Code Cell"
+              text="Code Cell"
               icon="code"
               onClick={this.props.triggers.cell.newCell.code}
             />
             <MenuItem
-              text="New Markdown Cell"
+              text="Markdown Cell"
               icon="new-text-box"
               onClick={this.props.triggers.cell.newCell.markdown}
             />

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook-menu.tsx
@@ -67,7 +67,7 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          interactionKind={PopoverInteractionKind.HOVER}
+          // interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"File"} minimal />
           <Menu>
@@ -147,15 +147,28 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          interactionKind={PopoverInteractionKind.HOVER}
+          // interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Cell"} />
-          <Menu />
+          <Menu>
+            <MenuItem text="New Cell" icon="code-block">
+              <MenuItem
+                text="Code"
+                icon="code"
+                onClick={this.props.triggers.cell.newCell.code}
+              />
+              <MenuItem
+                text="Markdown"
+                icon="new-text-box"
+                onClick={this.props.triggers.cell.newCell.markdown}
+              />
+            </MenuItem>
+          </Menu>
         </Popover>
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          interactionKind={PopoverInteractionKind.HOVER}
+          // interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Runtime"} />
           <Menu />
@@ -163,7 +176,7 @@ export class PureNotebookMenu extends React.PureComponent<Props> {
         <Popover
           position={Position.BOTTOM_LEFT}
           minimal
-          interactionKind={PopoverInteractionKind.HOVER}
+          // interactionKind={PopoverInteractionKind.HOVER}
         >
           <Button text={"Help"} />
           <Menu />

--- a/packages/connected-components/src/notebook-menu/index.tsx
+++ b/packages/connected-components/src/notebook-menu/index.tsx
@@ -1,3 +1,4 @@
+/* tslint:disable */
 import { CellType } from "@nteract/commutable";
 import { actions, selectors } from "@nteract/core";
 import {


### PR DESCRIPTION
Slightly kicking off this menu re-write so that we're all-in on blueprint for the UI components, to reduce our overall dependencies (streamlining our build, reducing load times) as well as unify our UI direction.

![image](https://user-images.githubusercontent.com/836375/52154765-1e4c9100-2634-11e9-9a75-f218775ccd88.png)

This will end up being a pretty straightforward PR to rip out our old menu with this now that I've done the start of it. A lot of indirection should get cleaned up as a result. The new setup will end up being a declarative React structure for the menu with some bound dispatch on nested keys. The old setup was 
declarative JSON structure getting re-hydrated into a React structure, along with a lot of key + constant redirection. It was not code I liked touching.

Since I want a more rapid way of developing on this, I'm going to put this PR on hold while I rip out the rest of the global style components (moving blueprint up already was a big win).