### PR TITLE
Fix sending DX metadata to output

### DIFF
--- a/packages/notebook-app-component/src/transform-media.tsx
+++ b/packages/notebook-app-component/src/transform-media.tsx
@@ -43,7 +43,7 @@ const PureTransformMedia = (props: MappedProps & DispatchProps) => {
     <Media
       {...mediaActions}
       data={output.data[mediaType]}
-      metadata={output.metadata.get(mediaType)}
+      metadata={output.metadata.get(mediaType) || output.metadata.toJS()}
     />
   );
 };


### PR DESCRIPTION
Not sure what's changed upstream but this seems to expect metadata to be a map of media types and what's actually being passed is a map from the metadata object.

This minor change makes things work but I doubt it's the right change. If anyone has any context on what's happening upstream where this has changed let me know (or fix it :D )