### PR TITLE
Remove moment.js from the webpack bundle

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/components/last-saved.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/components/last-saved.tsx
@@ -11,74 +11,13 @@
  *
  */
 
-import { AppState, ContentRef, selectors } from "@nteract/core";
-import moment from "moment";
+import { AppState, selectors } from "@nteract/core";
+import { LastSaved } from "@nteract/directory-listing";
 import * as React from "react";
 import { connect } from "react-redux";
-import styled from "styled-components";
 
 interface LastSavedProps {
-  date: string | number | Date | null;
-}
-
-const Span = styled.span`
-  margin: 0 auto;
-  font-size: 15px;
-  color: var(--nt-nav-dark);
-`;
-
-const Pretext = styled(Span)`
-  font-weight: var(--nt-font-weight-bolder);
-  padding-right: 10px;
-`;
-
-class LastSaved extends React.PureComponent<LastSavedProps> {
-  intervalId!: number;
-  isStillMounted: boolean;
-
-  constructor(props: LastSavedProps) {
-    super(props);
-    this.isStillMounted = false;
-  }
-
-  componentDidMount() {
-    this.isStillMounted = true;
-    this.intervalId = window.setInterval(() => {
-      if (this.isStillMounted && this.props.date !== null) {
-        // React Component method. Forces component to update.
-        // See https://reactjs.org/docs/react-component.html#forceupdate
-        this.forceUpdate();
-      }
-    }, 30 * 1000);
-  }
-
-  componentWillUnmount() {
-    this.isStillMounted = false;
-    clearInterval(this.intervalId);
-  }
-
-  render() {
-    if (this.props.date === null) {
-      return null;
-    }
-
-    const precious = moment(this.props.date);
-
-    let text = "just now";
-
-    if (moment().diff(precious) > 25000) {
-      text = precious.fromNow();
-    }
-
-    const title = precious.format("MMMM Do YYYY, h:mm:ss a");
-
-    return (
-      <React.Fragment>
-        <Pretext title={title}>Last Saved: </Pretext>
-        <Span title={title}>{text}</Span>
-      </React.Fragment>
-    );
-  }
+  lastModified?: Date | null;
 }
 
 interface OwnProps {
@@ -95,12 +34,12 @@ const makeMapStateToProps = (
 ) => {
   const { contentRef } = initialProps;
 
-  const mapStateToProps = (state: AppState): LastSavedProps => {
+  const mapStateToProps = (state: AppState) => {
     const content = selectors.contentByRef(state).get(contentRef);
     if (!content || !content.lastSaved) {
-      return { date: null };
+      return { lastModified: null };
     }
-    return { date: content.lastSaved };
+    return { lastModified: content.lastSaved };
   };
 
   return mapStateToProps;

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -39,7 +39,6 @@
     "@nteract/types": "^4.0.1",
     "@nteract/webpack-configurator": "^3.0.0",
     "jquery": "^3.2.1",
-    "moment": "^2.22.1",
     "monaco-editor-webpack-plugin": "^1.5.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -28,7 +28,6 @@
     "d3-shape": "^1.2.2",
     "d3-time-format": "^2.0.5",
     "lodash": "^4.17.4",
-    "moment": "^2.18.1",
     "numeral": "^2.0.6",
     "react-color": "^2.14.1",
     "react-hot-loader": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9365,11 +9365,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.18.1, moment@^2.22.1:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
-  integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
-
 monaco-editor-webpack-plugin@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz#920cbeecca25f15d70d568a7e11b0ba4daf1ae83"


### PR DESCRIPTION
This PR removes the last-saved display in the header of the jupyter extension. This information is already present in the status bar and in my optinion doesn't need to be duplicated in the UI.

This partially adresses #4160 by removing moment.js from the webpack bundle.