### PR TITLE
Bug: Fixes cell toolbar not displaying

### DIFF
--- a/packages/notebook-app-component/src/toolbar.tsx
+++ b/packages/notebook-app-component/src/toolbar.tsx
@@ -89,7 +89,7 @@ export const CellToolbar = styled.div`
 export const CellToolbarMask = styled.div.attrs(
   (props: { sourceHidden?: boolean }) => ({
     style: {
-      display: props.sourceHidden ? "block" : "none"
+      display: !props.sourceHidden ? "block" : "none"
     }
   })
 )`

--- a/packages/presentational-components/src/components/cell.tsx
+++ b/packages/presentational-components/src/components/cell.tsx
@@ -62,9 +62,9 @@ export const Cell = styled.div.attrs<CellProps>(props => ({
   }
 
   /*
-  Our cells conditionally style the prompt contained within based on if the cell is
-  selected or hovered. To do this with styled-components we use their method of
-  referring to other components:
+  Our cells conditionally style the prompt contained within based on if the 
+  cell is selected or hovered. To do this with styled-components we use their 
+  method of referring to other components:
 
   https://www.styled-components.com/docs/advanced#referring-to-other-components
 


### PR DESCRIPTION
The cell toolbar was not showing. I fixed the logic around `sourceHidden` in the `Toolbar` component to get the toolbar back.

Closes #4154.