### PR TITLE
Fixes Kernel Keybindings

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/app.tsx
@@ -1,4 +1,4 @@
-import { ContentRef } from "@nteract/core";
+import { ContentRef, KernelRef } from "@nteract/core";
 import * as React from "react";
 import NotificationSystem, {
   System as ReactNotificationSystem
@@ -6,17 +6,28 @@ import NotificationSystem, {
 
 import { default as Contents } from "./contents";
 
-class App extends React.Component<{ contentRef: ContentRef }> {
+class App extends React.Component<{
+  contentRef: ContentRef;
+  kernelRef: KernelRef;
+}> {
   notificationSystem!: ReactNotificationSystem;
 
-  shouldComponentUpdate(nextProps: { contentRef: ContentRef }): boolean {
-    return nextProps.contentRef !== this.props.contentRef;
+  shouldComponentUpdate(nextProps: {
+    contentRef: ContentRef;
+    kernelRef: KernelRef;
+  }): boolean {
+    return (
+      nextProps.contentRef !== this.props.contentRef ||
+      nextProps.kernelRef !== this.props.kernelRef
+    );
   }
 
   render(): JSX.Element {
+    const { contentRef, kernelRef } = this.props;
+
     return (
       <React.Fragment>
-        <Contents contentRef={this.props.contentRef} />
+        <Contents contentRef={contentRef} kernelRef={kernelRef} />
         <NotificationSystem
           ref={(notificationSystem: ReactNotificationSystem) => {
             this.notificationSystem = notificationSystem;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
@@ -147,7 +147,7 @@ export async function main(config: JupyterConfigData, rootEl): Promise<void> {
   ReactDOM.render(
     <React.Fragment>
       <Provider store={store}>
-        <App contentRef={contentRef} />
+        <App contentRef={contentRef} kernelRef={kernelRef} />
       </Provider>
     </React.Fragment>,
     rootEl

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
@@ -41,15 +41,16 @@ export class File extends React.PureComponent<FileProps> {
 
     // notebooks don't report a mimetype so we'll use the content.type
     if (this.props.type === "notebook") {
-      choice = <Notebook contentRef={this.props.contentRef} />;
+      const { contentRef } = this.props;
+      choice = <Notebook contentRef={contentRef} />;
     } else if (this.props.type === "dummy") {
       choice = null;
     } else if (
       this.props.mimetype == null ||
       !TextFile.handles(this.props.mimetype)
     ) {
-      // TODO: Redirect to /files/ endpoint for them to download the file or view
-      //       as is
+      // TODO: Redirect to /files/ endpoint for them to download
+      // the file or view as is
       choice = (
         <PaddedContainer>
           <pre>Can not render this file type</pre>
@@ -62,7 +63,7 @@ export class File extends React.PureComponent<FileProps> {
     return choice;
   };
 
-  render() {
+  render(): JSX.Element {
     const choice = this.getChoice();
 
     // Right now we only handle one kind of editor

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
@@ -1,4 +1,4 @@
-import { AppState, ContentRef, selectors } from "@nteract/core";
+import { AppState, ContentRef, KernelRef, selectors } from "@nteract/core";
 import { dirname } from "path";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -32,6 +32,7 @@ interface FileProps {
   appBase: string;
   displayName?: string;
   mimetype?: string | null;
+  kernelRef: KernelRef | null;
   lastSavedStatement: string;
 }
 
@@ -41,7 +42,12 @@ export class File extends React.PureComponent<FileProps> {
 
     // notebooks don't report a mimetype so we'll use the content.type
     if (this.props.type === "notebook") {
-      choice = <Notebook contentRef={this.props.contentRef} />;
+      choice = (
+        <Notebook
+          contentRef={this.props.contentRef}
+          kernelRef={this.props.kernelRef}
+        />
+      );
     } else if (this.props.type === "dummy") {
       choice = null;
     } else if (

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/file/index.tsx
@@ -41,8 +41,7 @@ export class File extends React.PureComponent<FileProps> {
 
     // notebooks don't report a mimetype so we'll use the content.type
     if (this.props.type === "notebook") {
-      const { contentRef } = this.props;
-      choice = <Notebook contentRef={contentRef} />;
+      choice = <Notebook contentRef={this.props.contentRef} />;
     } else if (this.props.type === "dummy") {
       choice = null;
     } else if (

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/headers.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/headers.tsx
@@ -51,7 +51,7 @@ export interface State {
 }
 
 class FileHeader extends React.PureComponent<FileHeaderProps, State> {
-  static defaultProps: { children: any } = {
+  static defaultProps: { children: React.ReactNode } = {
     children: null
   };
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/headers.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/headers.tsx
@@ -1,7 +1,7 @@
 import { H4 } from "@blueprintjs/core";
 import * as actions from "@nteract/actions";
 
-import { ContentRef } from "@nteract/core";
+import { ContentRef, KernelRef } from "@nteract/core";
 import { ErrorIcon, LoadingIcon, SavingIcon } from "@nteract/iron-icons";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -51,9 +51,10 @@ export interface State {
 }
 
 class FileHeader extends React.PureComponent<FileHeaderProps, State> {
-  static defaultProps = {
+  static defaultProps: { children: any } = {
     children: null
   };
+
   constructor(props: FileHeaderProps) {
     super(props);
 

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -34,14 +34,7 @@ interface IContentsProps {
 interface IContentsState {
   isDialogOpen: boolean;
 }
-interface IDispatchFromProps {
-  handlers: any;
-}
-
-class Contents extends React.PureComponent<
-  IContentsProps & IDispatchFromProps,
-  IContentsState
-> {
+class Contents extends React.PureComponent<IContentsProps, IContentsState> {
   render(): JSX.Element {
     const {
       appBase,
@@ -50,7 +43,6 @@ class Contents extends React.PureComponent<
       contentType,
       displayName,
       error,
-      handlers,
       loading,
       saving
     } = this.props;

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -130,8 +130,6 @@ const makeMapStateToProps = (
   initialProps: { appBase: string; contentRef: ContentRef }
 ) => {
   const host: HostRecord = initialState.app.host;
-  const kernelRef: KernelRef = initialState.core.currentKernelspecsRef;
-  console.log("kernelRef... ", kernelRef);
 
   if (host.type !== "jupyter") {
     throw new Error("this component only works with jupyter apps");
@@ -157,6 +155,8 @@ const makeMapStateToProps = (
       throw new Error("need content to view content, check your contentRefs");
     }
 
+    const kernelRef = content.model.kernelRef;
+
     return {
       appBase,
       baseDir: dirname(content.filepath),
@@ -177,7 +177,6 @@ const makeMapStateToProps = (
 };
 
 const mapDispatchToProps = (dispatch: Dispatch, ownProps: IContentsProps) => {
-  console.log("ownProps... ", ownProps);
   const { contentRef, kernelRef } = ownProps;
 
   return {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/index.tsx
@@ -3,6 +3,7 @@ import {
   DirectoryContentRecordProps,
   DummyContentRecordProps,
   FileContentRecordProps,
+  KernelRef,
   NotebookContentRecordProps
 } from "@nteract/types";
 import { RecordOf } from "immutable";
@@ -25,6 +26,7 @@ interface IContentsProps {
   displayName: string;
   error?: object | null;
   filepath: string | undefined;
+  kernelRef: KernelRef;
   lastSavedStatement: string;
   loading: boolean;
   mimetype?: string | null;
@@ -43,6 +45,7 @@ class Contents extends React.PureComponent<IContentsProps, IContentsState> {
       contentType,
       displayName,
       error,
+      kernelRef,
       loading,
       saving
     } = this.props;
@@ -66,7 +69,11 @@ class Contents extends React.PureComponent<IContentsProps, IContentsState> {
                 <NotebookMenu contentRef={this.props.contentRef} />
               ) : null}
             </FileHeader>
-            <File contentRef={contentRef} appBase={appBase} />
+            <File
+              contentRef={contentRef}
+              kernelRef={kernelRef}
+              appBase={appBase}
+            />
           </React.Fragment>
         );
       case "directory":

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
@@ -1,8 +1,10 @@
+import { CellType } from "@nteract/commutable";
+import { actions, ContentRef } from "@nteract/core";
 import * as React from "react";
+import { HotKeys, KeyMap } from "react-hotkeys";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-
-import { actions, ContentRef } from "@nteract/core";
+import urljoin from "url-join";
 
 // Show nothing while loading the notebook app
 const NotebookPlaceholder = (props: any) => null;
@@ -17,6 +19,26 @@ interface Props {
 }
 
 class Notebook extends React.PureComponent<Props, State> {
+  private keyMap: KeyMap = {
+    CHANGE_CELL_TYPE: [
+      "ctrl+shift+y",
+      "ctrl+shift+m",
+      "meta+shift+y",
+      "meta+shift+m"
+    ],
+    COPY_CELL: ["ctrl+shift+c", "meta+shift+c"],
+    CREATE_CELL_ABOVE: ["ctrl+shift+a", "meta+shift+a"],
+    CREATE_CELL_BELOW: ["ctrl+shift+b", "meta+shift+b"],
+    CUT_CELL: ["ctrl+shift+x", "meta+shift+x"],
+    DELETE_CELL: ["ctrl+shift+d", "meta+shift+d"],
+    EXECUTE_ALL_CELLS: ["alt+r a"],
+    INTERRUPT_KERNEL: ["alt+r i"],
+    KILL_KERNEL: ["alt+r k"],
+    PASTE_CELL: ["ctrl+shift+v", "meta+shift+v"],
+    RESTART_KERNEL: ["alt+r r", "alt+r c", "alt+r a"],
+    SAVE: ["ctrl+s", "ctrl+shift+s", "meta+s", "meta+shift+s"]
+  };
+
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -24,60 +46,60 @@ class Notebook extends React.PureComponent<Props, State> {
     };
   }
 
-  loadApp() {
-    import(/* webpackChunkName: "notebook-app-component" */ "@nteract/notebook-app-component").then(
-      module => {
-        this.setState({ App: module.default });
-      }
-    );
+  loadApp(): void {
+    import(/* webpackChunkName: "notebook-app-component" */
+    "@nteract/notebook-app-component").then(module => {
+      this.setState({ App: module.default });
+    });
   }
 
-  loadTransforms() {
-    import(/* webpackChunkName: "plotly" */ "@nteract/transform-plotly").then(
-      module => {
-        this.props.addTransform(module.default);
-        this.props.addTransform(module.PlotlyNullTransform);
-      }
-    );
+  loadTransforms(): void {
+    import(/* webpackChunkName: "plotly" */
+    "@nteract/transform-plotly").then(module => {
+      this.props.addTransform(module.default);
+      this.props.addTransform(module.PlotlyNullTransform);
+    });
 
-    import(/* webpackChunkName: "tabular-dataresource" */ "@nteract/data-explorer").then(
-      module => {
-        this.props.addTransform(module.default);
-      }
-    );
+    import(/* webpackChunkName: "tabular-dataresource" */
+    "@nteract/data-explorer").then(module => {
+      this.props.addTransform(module.default);
+    });
 
-    import(/* webpackChunkName: "jupyter-widgets" */ "@nteract/jupyter-widgets").then(
-      module => {
-        this.props.addTransform(module.WidgetDisplay);
-      }
-    );
+    import(/* webpackChunkName: "jupyter-widgets" */
+    "@nteract/jupyter-widgets").then(module => {
+      this.props.addTransform(module.WidgetDisplay);
+    });
 
     import("@nteract/transform-model-debug").then(module => {
       this.props.addTransform(module.default);
     });
 
-    import(/* webpackChunkName: "vega-transform" */ "@nteract/transform-vega").then(
-      module => {
-        this.props.addTransform(module.VegaLite1);
-        this.props.addTransform(module.VegaLite2);
-        this.props.addTransform(module.Vega2);
-        this.props.addTransform(module.Vega3);
-      }
-    );
+    import(/* webpackChunkName: "vega-transform" */
+    "@nteract/transform-vega").then(module => {
+      this.props.addTransform(module.VegaLite1);
+      this.props.addTransform(module.VegaLite2);
+      this.props.addTransform(module.Vega2);
+      this.props.addTransform(module.Vega3);
+    });
 
-    // TODO: The geojson transform will likely need some work because of the basemap URL(s)
+    // TODO: The geojson transform will likely need some work
+    // because of the basemap URL(s)
     // import GeoJSONTransform from "@nteract/transform-geojson";
   }
 
-  componentDidMount() {
+  componentDidMount(): void {
     this.loadApp();
     this.loadTransforms();
   }
 
-  render() {
+  render(): JSX.Element {
     const App = this.state.App;
 
-    return <App contentRef={this.props.contentRef} />;
+    return (
+      <HotKeys keyMap={this.keyMap} handlers={handlers}>
+        <App contentRef={this.props.contentRef} />
+      </HotKeys>
+    );
   }
 }
 
@@ -85,23 +107,72 @@ interface InitialProps {
   contentRef: ContentRef;
 }
 
-const makeMapDispatchToProps = (
-  initialDispatch: Dispatch,
-  initialProps: InitialProps
-) => {
-  const mapDispatchToProps = (dispatch: Dispatch) => {
-    return {
-      addTransform: (transform: React.ComponentType & { MIMETYPE: string }) => {
-        return dispatch(
-          actions.addTransform({
-            mediaType: transform.MIMETYPE,
-            component: transform
+const makeMapDispatchToProps = (dispatch: Dispatch, ownProps: InitialProps) => {
+  const { contentRef } = ownProps;
+  return {
+    addTransform: (transform: React.ComponentType & { MIMETYPE: string }) => {
+      return dispatch(
+        actions.addTransform({
+          mediaType: transform.MIMETYPE,
+          component: transform
+        })
+      );
+    },
+    // `HotKeys` handlers object
+    // see: https://github.com/greena13/react-hotkeys#defining-handlers
+    handlers: {
+      CHANGE_CELL_TYPE: (event: KeyboardEvent) => {
+        const type: CellType = event.key === "Y" ? "code" : "markdown";
+        return dispatch(actions.changeCellType({ to: type, contentRef }));
+      },
+      COPY_CELL: () => dispatch(actions.copyCell({ contentRef })),
+      CREATE_CELL_ABOVE: () =>
+        dispatch(actions.createCellAbove({ cellType: "code", contentRef })),
+      CREATE_CELL_BELOW: () =>
+        dispatch(
+          actions.createCellBelow({
+            cellType: "code",
+            source: "",
+            contentRef
           })
-        );
-      }
-    };
+        ),
+      CUT_CELL: () => dispatch(actions.cutCell({ contentRef })),
+      DELETE_CELL: () => dispatch(actions.deleteCell({ contentRef })),
+      EXECUTE_ALL_CELLS: () =>
+        dispatch(actions.executeAllCells({ contentRef })),
+      INTERRUPT_KERNEL: () => {
+        if (kernelRef) {
+          dispatch(actions.interruptKernel({ kernelRef }));
+        }
+      },
+      KILL_KERNEL: () => {
+        if (kernelRef) {
+          dispatch(
+            actions.killKernel({
+              kernelRef,
+              restarting: false
+            })
+          );
+        }
+      },
+      PASTE_CELL: () => dispatch(actions.pasteCell({ contentRef })),
+      RESTART_KERNEL: (event: KeyboardEvent) => {
+        const outputHandling: "None" | "Clear All" | "Run All" =
+          event.key === "r"
+            ? "None"
+            : event.key === "a"
+            ? "Run All"
+            : "Clear All";
+
+        if (kernelRef) {
+          return dispatch(
+            actions.restartKernel({ outputHandling, contentRef, kernelRef })
+          );
+        }
+      },
+      SAVE: () => dispatch(actions.save({ contentRef }))
+    }
   };
-  return mapDispatchToProps;
 };
 
 export default connect(

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
@@ -1,6 +1,5 @@
 import { CellType } from "@nteract/commutable";
-import { actions, AppState, ContentRef, selectors } from "@nteract/core";
-import { createKernelRef, KernelRef } from "@nteract/types";
+import { actions, ContentRef, KernelRef } from "@nteract/core";
 import * as React from "react";
 import { HotKeys, KeyMap } from "react-hotkeys";
 import { connect } from "react-redux";
@@ -15,6 +14,7 @@ interface State {
 
 interface Props {
   contentRef: ContentRef;
+  kernelRef: KernelRef;
   addTransform?(component: any): void;
 }
 
@@ -112,10 +112,9 @@ class Notebook extends React.PureComponent<NotebookProps, State> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch, ownProps: NotebookProps) => {
-  const { contentRef } = ownProps;
-  // Creates a fake kernelRef for kernel actions that allow
-  // for interrupt, restart, and kill behaviors.
-  const kernelRef = createKernelRef();
+  const { contentRef, kernelRef } = ownProps;
+
+  console.log(kernelRef);
 
   return {
     addTransform: (transform: React.ComponentType & { MIMETYPE: string }) => {

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
@@ -1,18 +1,10 @@
 import { CellType } from "@nteract/commutable";
 import { actions, AppState, ContentRef, selectors } from "@nteract/core";
-import {
-  DirectoryContentRecordProps,
-  DummyContentRecordProps,
-  FileContentRecordProps,
-  KernelRef,
-  NotebookContentRecordProps
-} from "@nteract/types";
-import { RecordOf } from "immutable";
+import { createKernelRef, KernelRef } from "@nteract/types";
 import * as React from "react";
 import { HotKeys, KeyMap } from "react-hotkeys";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import urljoin from "url-join";
 
 // Show nothing while loading the notebook app
 const NotebookPlaceholder = (props: any) => null;
@@ -23,12 +15,11 @@ interface State {
 
 interface Props {
   contentRef: ContentRef;
-  kernelRef?: KernelRef;
-  addTransform(component: any): void;
+  addTransform?(component: any): void;
 }
 
 interface IDispatchFromProps {
-  handlers: any;
+  handlers?: any;
 }
 
 interface InitialProps {
@@ -124,36 +115,11 @@ class Notebook extends React.PureComponent<NotebookProps, State> {
   }
 }
 
-const makeMapStateToProps = (
-  initialState: AppState,
-  initialProps: NotebookProps
-) => {
-  const contentRef: ContentRef = initialProps.contentRef;
-
-  const mapStateToProps = (state: AppState) => {
-    if (!contentRef) {
-      throw new Error("cant display without a contentRef");
-    }
-
-    const content: any = selectors.content(state, { contentRef });
-
-    if (!content) {
-      throw new Error("need content to view content, check your contentRefs");
-    }
-
-    const kernelRef: KernelRef = content.model.kernelRef;
-
-    return {
-      contentRef,
-      kernelRef
-    };
-  };
-
-  return mapStateToProps;
-};
-
-const mapDispatchToProps = (dispatch: Dispatch, ownProps: Props) => {
-  const { contentRef, kernelRef } = ownProps;
+const mapDispatchToProps = (dispatch: Dispatch, ownProps: NotebookProps) => {
+  const { contentRef } = ownProps;
+  // Creates a fake kernelRef for kernel actions that allow
+  // for interrupt, restart, and kill behaviors.
+  const kernelRef = createKernelRef();
 
   return {
     addTransform: (transform: React.ComponentType & { MIMETYPE: string }) => {
@@ -214,6 +180,6 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: Props) => {
 };
 
 export default connect(
-  makeMapStateToProps,
+  null,
   mapDispatchToProps
 )(Notebook);

--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/notebook.tsx
@@ -91,10 +91,6 @@ class Notebook extends React.PureComponent<NotebookProps, State> {
       this.props.addTransform(module.Vega2);
       this.props.addTransform(module.Vega3);
     });
-
-    // TODO: The geojson transform will likely need some work
-    // because of the basemap URL(s)
-    // import GeoJSONTransform from "@nteract/transform-geojson";
   }
 
   componentDidMount(): void {

--- a/packages/connected-components/__tests__/__snapshots__/notebook-menu.spec.tsx.snap
+++ b/packages/connected-components/__tests__/__snapshots__/notebook-menu.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PureNotebookMenu  snapshots renders the default 1`] = `
 <ul
   aria-activedescendant=""
-  className="rc-menu sc-htpNat iSedcs rc-menu-root rc-menu-horizontal"
+  className="rc-menu sc-bxivhb lcjtud rc-menu-root rc-menu-horizontal"
   onKeyDown={[Function]}
   role="menu"
   style={Object {}}

--- a/packages/connected-components/src/notebook-menu/index.tsx
+++ b/packages/connected-components/src/notebook-menu/index.tsx
@@ -42,7 +42,6 @@ interface Props {
   persistAfterClick?: boolean;
   defaultOpenKeys?: string[];
   openKeys?: string[];
-  kernelRef: KernelRef | null;
   currentKernelRef?: KernelRef | null;
   saveNotebook?: (payload: { contentRef: string }) => void;
   downloadNotebook?: (payload: { contentRef: string }) => void;
@@ -128,8 +127,7 @@ class PureNotebookMenu extends React.PureComponent<Props, State> {
       restartKernelAndRunAllOutputs,
       killKernel,
       interruptKernel,
-      currentContentRef,
-      kernelRef
+      currentContentRef
     } = this.props;
     const [action, ...args] = parseActionKey(key);
     switch (action) {
@@ -233,14 +231,14 @@ class PureNotebookMenu extends React.PureComponent<Props, State> {
         break;
       case MENU_ITEM_ACTIONS.INTERRUPT_KERNEL:
         if (interruptKernel) {
-          interruptKernel({ kernelRef });
+          interruptKernel({ kernelRef: currentKernelRef });
         }
         break;
       case MENU_ITEM_ACTIONS.RESTART_KERNEL:
         if (restartKernel) {
           restartKernel({
             outputHandling: "None",
-            kernelRef,
+            kernelRef: currentKernelRef,
             contentRef: currentContentRef
           });
         }
@@ -248,7 +246,7 @@ class PureNotebookMenu extends React.PureComponent<Props, State> {
       case MENU_ITEM_ACTIONS.RESTART_AND_CLEAR_OUTPUTS:
         if (restartKernelAndClearOutputs) {
           restartKernelAndClearOutputs({
-            kernelRef,
+            kernelRef: currentKernelRef,
             contentRef: currentContentRef
           });
         }
@@ -256,20 +254,20 @@ class PureNotebookMenu extends React.PureComponent<Props, State> {
       case MENU_ITEM_ACTIONS.RESTART_AND_RUN_ALL_OUTPUTS:
         if (restartKernelAndRunAllOutputs) {
           restartKernelAndRunAllOutputs({
-            kernelRef,
+            kernelRef: currentKernelRef,
             contentRef: currentContentRef
           });
         }
         break;
       case MENU_ITEM_ACTIONS.KILL_KERNEL:
         if (killKernel) {
-          killKernel({ restarting: false, kernelRef });
+          killKernel({ restarting: false, kernelRef: currentKernelRef });
         }
         break;
       case MENU_ITEM_ACTIONS.CHANGE_KERNEL:
         if (changeKernelByName) {
           changeKernelByName({
-            oldKernelRef: kernelRef,
+            oldKernelRef: currentKernelRef,
             contentRef: currentContentRef,
             kernelSpecName: args[0]
           });


### PR DESCRIPTION
Currently, the keybindings for kernel actions does not work. This PR address this bug by passing a `faked` kernelRef to the kernel `actions`.

Closes #4176.