### PR TITLE
enable vdom by default in jext

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
@@ -18,6 +18,8 @@ import {
 import { Media } from "@nteract/outputs";
 import { ContentRecord, HostRecord } from "@nteract/types";
 
+import TransformVDOM from "@nteract/transform-vdom";
+
 import * as Immutable from "immutable";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -110,7 +112,7 @@ export async function main(config: JupyterConfigData, rootEl): Promise<void> {
             "application/vnd.vegalite.v2+json": NullTransform,
             "application/vnd.vega.v2+json": NullTransform,
             "application/vnd.vega.v3+json": NullTransform,
-            "application/vdom.v1+json": NullTransform,
+            "application/vdom.v1+json": TransformVDOM,
             "application/json": Media.Json,
             "application/javascript": Media.JavaScript,
             "text/html": Media.HTML,

--- a/packages/transform-vdom/src/index.tsx
+++ b/packages/transform-vdom/src/index.tsx
@@ -33,8 +33,8 @@ export default class VDOM extends React.PureComponent<Partial<Props>> {
 
   render(): React.ReactElement<any> {
     try {
-      // objectToReactElement is mutatitve so we'll clone our object
       if (this.props.data && this.props.onVDOMEvent) {
+        // objectToReactElement is mutatitve so we'll clone our object
         const obj = cloneDeep(this.props.data);
         return objectToReactElement(obj, this.props.onVDOMEvent);
       } else {


### PR DESCRIPTION
Looks like this got missed in the refactor of the jupyter extension -- vdom wasn't included in the default transforms when it should be.