### PR TITLE
clean up directory listing components

### DIFF
--- a/packages/directory-listing/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/directory-listing/__tests__/__snapshots__/index.spec.tsx.snap
@@ -3,23 +3,23 @@
 exports[`Entry accepts props and renders entries in directory 1`] = `
 <DirectoryEntry>
   <Icon
-    className="directory-entry-field"
     color="#0366d6"
     fileType="directory"
     key=".0"
   />
   <Name
-    className="directory-entry-field"
     key=".1"
   >
     linky jr
   </Name>
-  <LastSaved
-    className="directory-entry-field"
+  <td
     key=".2"
-    lastModified={null}
-    last_modified="Fri Jun 22 2018 00:15:55 GMT-0400 (Eastern Daylight Time)"
-  />
+  >
+    <LastSaved
+      lastModified={null}
+      last_modified="Fri Jun 22 2018 00:15:55 GMT-0400 (Eastern Daylight Time)"
+    />
+  </td>
 </DirectoryEntry>
 `;
 

--- a/packages/directory-listing/src/components/entry.tsx
+++ b/packages/directory-listing/src/components/entry.tsx
@@ -21,12 +21,14 @@ const DirectoryEntry = styled.tr`
     transition: background-color 0.1s ease-out;
   }
 
-  :first-child {
+  & td:first-child {
     border-top: none;
   }
 
-  :last-child {
+  & td:last-child {
     border-bottom: none;
+    text-align: right;
+    padding-right: 10px;
   }
 `;
 
@@ -40,7 +42,7 @@ export class Entry extends React.PureComponent<EntryProps> {
   render() {
     return (
       <DirectoryEntry>
-        {React.Children.map(this.props.children, child => {
+        {React.Children.map(this.props.children, (child, index: number) => {
           const childElement = child as React.ReactElement<any>;
           if (
             areComponentsEqual(
@@ -50,21 +52,11 @@ export class Entry extends React.PureComponent<EntryProps> {
             areComponentsEqual(
               childElement.type as React.ComponentType<any>,
               Name
-            ) ||
-            areComponentsEqual(
-              childElement.type as React.ComponentType<any>,
-              LastSaved
             )
           ) {
-            return React.cloneElement(childElement, {
-              className:
-                typeof childElement.props.className === "string" &&
-                childElement.props.className !== ""
-                  ? `${childElement.props.className} directory-entry-field`
-                  : "directory-entry-field"
-            });
+            return childElement;
           } else {
-            return <td className="directory-entry-field">{child}</td>;
+            return <td>{child}</td>;
           }
         })}
       </DirectoryEntry>

--- a/packages/directory-listing/src/components/lastsaved.tsx
+++ b/packages/directory-listing/src/components/lastsaved.tsx
@@ -1,16 +1,35 @@
 import * as React from "react";
-import TimeAgo from "react-timeago";
+import TimeAgo, { Formatter, Unit, Suffix } from "react-timeago";
 import styled from "styled-components";
 
 interface LastSavedProps {
   lastModified?: Date | null;
 }
 
-const TimeAgoTD = styled.td`
-  text-align: right;
+const TimeAgoTD = styled.span`
   color: #6a737d;
-  padding-right: 10px;
 `;
+
+// Rather than showing a continual counter like "0 seconds ago"
+// followed by "1 seconds ago", and so on, just show "less than a minute"
+const slowDownFormatter: Formatter = (
+  value: number,
+  unit: Unit,
+  suffix: Suffix,
+  epochMiliseconds: number,
+  nextFormatter?: Formatter
+) => {
+  if (unit === "second") {
+    return "less than a minute";
+  }
+
+  // This should be defined but we'll play it safe given the type definition
+  if (!nextFormatter) {
+    return `${value} ${unit} ${suffix}`;
+  }
+
+  return nextFormatter(value, unit, suffix, epochMiliseconds);
+};
 
 TimeAgoTD.displayName = "TimeAgoTD";
 
@@ -23,7 +42,10 @@ export class LastSaved extends React.PureComponent<LastSavedProps> {
     return (
       <TimeAgoTD>
         {this.props.lastModified != null && (
-          <TimeAgo date={this.props.lastModified} />
+          <TimeAgo
+            date={this.props.lastModified}
+            formatter={slowDownFormatter}
+          />
         )}
       </TimeAgoTD>
     );


### PR DESCRIPTION
Tore out styles that were nested into components that should be done by the `<Entry>` container. Now the timeago component is reusable outside of the directory listing. This fixes the console error you'd sometimes see in the dev console about having a `td` inside of a non-table element.

While I was at it I made the ever incrementing counter for a new save not show "0 seconds ago", "1 seconds ago", ..., "59 seconds ago". Now it just says "less than a minute". 