### PR TITLE
clean up all errors and warnings in styleguide

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/contents/directory.tsx
@@ -80,6 +80,7 @@ export class DirectoryApp extends React.PureComponent<DirectoryProps> {
               <Entry>
                 <Icon fileType={"directory"} />
                 <Name>{dotdotlink}</Name>
+                <LastSaved lastModified={null} />
               </Entry>
             )}
             {this.props.contents.map((entry, index) => {

--- a/packages/directory-listing/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/directory-listing/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,16 +2,26 @@
 
 exports[`Entry accepts props and renders entries in directory 1`] = `
 <DirectoryEntry>
-  <Icon
-    color="#0366d6"
-    fileType="directory"
+  <td
     key=".0"
-  />
-  <Name
+    style={
+      Object {
+        "width": "25px",
+      }
+    }
+  >
+    <Icon
+      color="#0366d6"
+      fileType="directory"
+    />
+  </td>
+  <td
     key=".1"
   >
-    linky jr
-  </Name>
+    <Name>
+      linky jr
+    </Name>
+  </td>
   <td
     key=".2"
   >

--- a/packages/directory-listing/src/components/entry.tsx
+++ b/packages/directory-listing/src/components/entry.tsx
@@ -1,14 +1,9 @@
 import * as React from "react";
-// react-hot-loader uses proxies to the original elements so we need to use
-// their comparison function in case a consumer of these components is
-// using hot module reloading
-import { areComponentsEqual } from "react-hot-loader";
 import styled from "styled-components";
 
-import { Icon } from "./icon";
-import { LastSaved } from "./lastsaved";
-import { Name } from "./name";
+import { areComponentsEqual } from "react-hot-loader";
 
+import { Icon } from "./icon";
 interface EntryProps {
   children: React.ReactNode;
 }
@@ -16,17 +11,27 @@ interface EntryProps {
 const DirectoryEntry = styled.tr`
   border-top: 1px solid #eaecef;
 
-  :hover {
+  &:first-child {
+    border-top: none;
+  }
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
     background-color: #f6f8fa;
     transition: background-color 0.1s ease-out;
   }
 
-  & td:first-child {
-    border-top: none;
+  & td {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    vertical-align: middle;
+    width: auto;
+    padding-left: 8px;
   }
 
   & td:last-child {
-    border-bottom: none;
     text-align: right;
     padding-right: 10px;
   }
@@ -42,22 +47,12 @@ export class Entry extends React.PureComponent<EntryProps> {
   render() {
     return (
       <DirectoryEntry>
-        {React.Children.map(this.props.children, (child, index: number) => {
-          const childElement = child as React.ReactElement<any>;
-          if (
-            areComponentsEqual(
-              childElement.type as React.ComponentType<any>,
-              Icon
-            ) ||
-            areComponentsEqual(
-              childElement.type as React.ComponentType<any>,
-              Name
-            )
-          ) {
-            return childElement;
-          } else {
-            return <td>{child}</td>;
+        {/* Wrap each child in a `<td>` */}
+        {React.Children.map(this.props.children, child => {
+          if (child && areComponentsEqual((child as any).type, Icon)) {
+            return <td style={{ width: "25px" }}>{child}</td>;
           }
+          return <td>{child}</td>;
         })}
       </DirectoryEntry>
     );

--- a/packages/directory-listing/src/components/icon.tsx
+++ b/packages/directory-listing/src/components/icon.tsx
@@ -7,22 +7,19 @@ interface IconProps {
   fileType: "unknown" | "notebook" | "directory" | "file" | "dummy";
 }
 
-const IconTD = styled.td.attrs(props => ({
+const IconWrapper = styled.span.attrs(props => ({
   style: {
     color: props.color
   }
 }))`
-  padding-right: 2px;
-  padding-left: 10px;
-  width: 17px;
   vertical-align: middle;
   text-align: center;
   opacity: 0.95;
   color: "#0366d6";
 `;
 
-IconTD.displayName = "IconTD";
-IconTD.defaultProps = {
+IconWrapper.displayName = "IconWrapper";
+IconWrapper.defaultProps = {
   color: "#0366d6"
 };
 
@@ -49,6 +46,6 @@ export class Icon extends React.PureComponent<IconProps> {
         icon = <FileText />;
     }
 
-    return <IconTD>{icon}</IconTD>;
+    return <IconWrapper>{icon}</IconWrapper>;
   }
 }

--- a/packages/directory-listing/src/components/listing.tsx
+++ b/packages/directory-listing/src/components/listing.tsx
@@ -11,6 +11,7 @@ const ListingRoot = styled.table`
   border-collapse: collapse;
   border-radius: 2px;
   border-spacing: 0;
+  table-layout: auto;
 `;
 
 ListingRoot.displayName = "ListingRoot";

--- a/packages/directory-listing/src/components/name.tsx
+++ b/packages/directory-listing/src/components/name.tsx
@@ -1,9 +1,7 @@
 import styled from "styled-components";
 
-export const Name = styled.td`
+export const Name = styled.span`
   vertical-align: middle;
-  font-size: 0.9em;
-  padding: 8px;
 
   a {
     text-decoration: none;

--- a/packages/outputs/src/components/media/plain.md
+++ b/packages/outputs/src/components/media/plain.md
@@ -1,11 +1,15 @@
 Plain text is....plain. It contains no formatting, images, or interactivity. Its lack of richness doesn't mean there isn't a component for it in the nteract space! You can use the `Media.Plain` component to render plain text. All you'll need to do is pass the contents of the text to the `data` prop of the component.
 
-```
-<Plain data={"This text is as plain as can be."}/>
+```jsx
+const { Plain } = require("./");
+
+<Plain data={"This text is as plain as can be."} />;
 ```
 
 As it tuns out, although plain text does not contain any formatting. The `Media.Plain` component will let you format your content using [ANSI escape codes]((https://en.wikipedia.org/wiki/ANSI_escape_code). Here's an example of a piece of text formatted using the escape code for a red color.
 
-```
-<Plain data={'\u001b[31msome red text\u001b[0m'}/>
+```jsx
+const { Plain } = require("./");
+
+<Plain data={"\u001b[31msome red text\u001b[0m"} />;
 ```

--- a/packages/outputs/src/components/rich-media.md
+++ b/packages/outputs/src/components/rich-media.md
@@ -86,7 +86,7 @@ const Media = require('./media')
 
 <RichMedia data={{ "text/plain": "SparkContext ⚡️" }}>
   <Media.HTML />
-  <Plain />
+  <Media.Plain />
 </RichMedia>
 ```
 
@@ -95,14 +95,9 @@ The `<RichMedia />` component will pass the appropriate data from the media bund
 ```jsx
 const Media = require("./media");
 
-const Plain = props => <pre>{props.data}</pre>;
-Plain.defaultProps = {
-  mediaType: "text/plain"
-};
-
 <RichMedia data={{ "text/plain": "SparkContext ⚡️" }}>
   <Media.HTML />
-  <Plain />
+  <Media.Plain />
 </RichMedia>;
 ```
 
@@ -111,11 +106,6 @@ Whereas this output has a richer HTML output:
 ```jsx
 const Media = require("./media");
 
-const Plain = props => <pre>{props.data}</pre>;
-Plain.defaultProps = {
-  mediaType: "text/plain"
-};
-
 <RichMedia
   data={{
     "text/plain": "plain was richer",
@@ -123,7 +113,7 @@ Plain.defaultProps = {
   }}
 >
   <Media.HTML />
-  <Plain />
+  <Media.Plain />
 </RichMedia>;
 ```
 
@@ -180,11 +170,6 @@ Which means that you can customize outputs as props!
 ```jsx
 const Media = require("./media");
 
-const Plain = props => <pre>{props.data}</pre>;
-Plain.defaultProps = {
-  mediaType: "text/plain"
-};
-
 // Pretend this is the data explorer :)
 const FancyTable = props => (
   <table style={{ border: `2px solid ${props.color}` }}>
@@ -233,7 +218,7 @@ class Output extends React.Component {
         >
           <FancyTable color={this.state.color} />
           <Media.HTML />
-          <Plain />
+          <Media.Plain />
         </RichMedia>
       </div>
     );

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -74,17 +74,18 @@ module.exports = {
         </script>`
     }
   },
-  dangerouslyUpdateWebpackConfig(webpackConfig, env) {
-    webpackConfig.node = {
+  webpackConfig: {
+    node: {
       fs: "empty",
       child_process: "empty",
       net: "empty",
       canvas: "empty"
-    };
-    webpackConfig.resolve.extensions = [".ts", ".tsx", ".js", ".jsx", ".json"];
-    webpackConfig.externals = ["canvas"];
-    webpackConfig.module = {
-      ...webpackConfig.module,
+    },
+    resolve: {
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".json"]
+    },
+    externals: ["canvas"],
+    module: {
       rules: [
         {
           test: /\.tsx?$/,
@@ -100,7 +101,6 @@ module.exports = {
           }
         }
       ]
-    };
-    return webpackConfig;
+    }
   }
 };


### PR DESCRIPTION
# Style guide cleanup!

`yarn docs` for everyone!

I went after cleaning up every single error currently present in the style guide, from `webpackConfig` to the use of `<Media.Plain >` to dangling `<td>`s.

## Migrate to `webpackConfig` key in style guide config

Before:

```
$ yarn docs
yarn run v1.13.0
$ styleguidist server
Warning: No webpack config found. You may need to specify "webpackConfig" option in your style guide config:
https://react-styleguidist.js.org/docs/webpack.html

You can now view your style guide in the browser:

  Local:            http://localhost:6060/
  On your network:  http://192.168.113.55:6060/

 DONE  Compiled successfully!
```

After:

```
$ yarn docs
yarn run v1.13.0
$ styleguidist server
You can now view your style guide in the browser:

  Local:            http://localhost:6060/
  On your network:  http://192.168.113.55:6060/

 DONE  Compiled successfully!
```

## Use `<Media.Plain />` wherever possible instead of assuming `<Plain />`

There were errors for `<Plain />` not being found

## Clean up the `<td>` errors in the component style guide

Make each of the leaf node elements for Directory Listing (Name, Icon, Last Saved) not have to be `<td>`.