### PR TITLE
Fix remultiline for consecutive newlines

### DIFF
--- a/packages/commutable/__tests__/primitive.spec.ts
+++ b/packages/commutable/__tests__/primitive.spec.ts
@@ -21,8 +21,6 @@ describe("remultiline", () => {
     expect(
       remultiline("test\n\n\nthis\n\nout\n\n\n\n\n\nwhat").map(flagNewlines)
     ).toEqual(
-      // This shows the super weird case with ours which is a bunch of
-      // newlines before the last line...
       ["test\n", "\n", "\n", "this\n", "\n", "out\n", "\n", "\n", "\n", "\n", "\n", "what"].map(
         flagNewlines
       )

--- a/packages/commutable/__tests__/primitive.spec.ts
+++ b/packages/commutable/__tests__/primitive.spec.ts
@@ -15,7 +15,7 @@ describe("remultiline", () => {
 
   it("can handle repeated newlines", () => {
     expect(remultiline("test\n\n\nthis\n\nout").map(flagNewlines)).toEqual(
-      ["test\n", "\n\n", "this\n", "\nout"].map(flagNewlines)
+      ["test\n", "\n", "\n", "this\n", "\n", "out"].map(flagNewlines)
     );
 
     expect(
@@ -23,7 +23,7 @@ describe("remultiline", () => {
     ).toEqual(
       // This shows the super weird case with ours which is a bunch of
       // newlines before the last line...
-      ["test\n", "\n\n", "this\n", "\n", "out\n", "\n\n\n\n\nwhat"].map(
+      ["test\n", "\n", "\n", "this\n", "\n", "out\n", "\n", "\n", "\n", "\n", "\n", "what"].map(
         flagNewlines
       )
     );

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -115,8 +115,8 @@ export function remultiline(s: string | string[]): string[] {
     // Assume already multiline string
     return s;
   }
-  // Use positive lookahead regex to split on newline and retain newline char
-  return s.split(/(.+?(?:\r\n|\n))/g).filter(x => x !== "");
+  // Split on newline and retain newline char
+  return s.split(/(.*?(?:\r\n|\n))/g).filter(x => x !== "");
 }
 
 function isJSONKey(key: string) {


### PR DESCRIPTION
As [mentioned here](https://github.com/nteract/nteract/commit/4445a69a18cdb96e570734bd183fbd272a035afb#r32423015) the current `remultiline` acts differently than Jupyter notebook does when converting a cell source string to multiple lines when there are consecutive newlines in the string.

With this change, 
```
test


this

out
```
is converted to
```js
["test\n", "\n", "\n", "this\n", "\n", "out"]
```
with no preceding newlines. 

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I was expecting code to be auto-formatted as a commit hook. Do I have to run prettier myself?

Fixes: https://github.com/nteract/hydrogen/issues/1552