### PR TITLE
expose bookstore validation info to front-end via settings dict

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -68,7 +68,9 @@ class NAppHandler(IPythonHandler):
             public_url=url,
             contents_path=path,
             page=self.page,
+            bookstore_validation=json.dumps(self.settings.get('bookstore_validation', {}))
         )
+
         self.write(self.render_template('index.html', **config))
 
     def get_template(self, name):

--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -58,6 +58,9 @@ class NAppHandler(IPythonHandler):
         else:
             page_title = 'nteract'
 
+        bookstore_settings =  self.settings.get("bookstore", {})
+        bookstore_settings['enabled'] = all(value for value in bookstore_settings.get("validation", {}).values())
+
         config = dict(
             ga_code=config.ga_code,
             asset_url=asset_url,
@@ -68,7 +71,7 @@ class NAppHandler(IPythonHandler):
             public_url=url,
             contents_path=path,
             page=self.page,
-            bookstore_validation=json.dumps(self.settings.get('bookstore_validation', {}))
+            bookstore=bookstore_settings
         )
 
         self.write(self.render_template('index.html', **config))

--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -22,7 +22,7 @@ Distributed under the terms of the Modified BSD License.
     "contentsPath": "{{ contents_path }}",
     "assetUrl": "{{ asset_url }}",
     "page": "{{ page }}",
-    "bookstoreValidation": {{ bookstore_validation | safe }}
+    "bookstore": {{ bookstore | tojson(indent=2) }}
   }</script>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico">{% endblock %}

--- a/applications/jupyter-extension/nteract_on_jupyter/index.html
+++ b/applications/jupyter-extension/nteract_on_jupyter/index.html
@@ -21,7 +21,8 @@ Distributed under the terms of the Modified BSD License.
     "publicUrl": "{{ public_url }}",
     "contentsPath": "{{ contents_path }}",
     "assetUrl": "{{ asset_url }}",
-    "page": "{{ page }}"
+    "page": "{{ page }}",
+    "bookstoreValidation": {{ bookstore_validation | safe }}
   }</script>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico">{% endblock %}


### PR DESCRIPTION
This makes #4144 irrelevant. 

This relies on the webapp.settings object as a means of communication between the server extensions.

All of the load_server_extensions should be run by the time this handler can respond to the request.

This avoids all of the strange config finagling that we had to do in #4144. 

I still think as @willingc suggested we should reevaluate how we're using config in the jupyter-extension but for now at least this doesn't require changing any of that.

- need to declare that the content is safe for quotes to be not escaped 
(which is necessary for it to be read as JSON)