### PR TITLE
Fix style guide

### DIFF
--- a/packages/directory-listing/src/components/entry.md
+++ b/packages/directory-listing/src/components/entry.md
@@ -7,6 +7,8 @@ This component is used to create individual entries in a directory. It is not me
 In the example below, we use the `Entry` component to display an icon, name, and time since last save of an entry in a directory.
 
 ```jsx
+const { Listing, Icon, Name, LastSaved } = require("..");
+
 <Listing>
   <Entry>
     <Icon fileType="notebook" />
@@ -15,5 +17,5 @@ In the example below, we use the `Entry` component to display an icon, name, and
     </Name>
     <LastSaved lastModified={new Date("2018-07-04")} />
   </Entry>
-</Listing>
+</Listing>;
 ```

--- a/packages/directory-listing/src/components/entry.tsx
+++ b/packages/directory-listing/src/components/entry.tsx
@@ -58,3 +58,5 @@ export class Entry extends React.PureComponent<EntryProps> {
     );
   }
 }
+
+export default Entry;

--- a/packages/directory-listing/src/components/icon.tsx
+++ b/packages/directory-listing/src/components/icon.tsx
@@ -49,3 +49,5 @@ export class Icon extends React.PureComponent<IconProps> {
     return <IconWrapper>{icon}</IconWrapper>;
   }
 }
+
+export default Icon;

--- a/packages/directory-listing/src/components/lastsaved.tsx
+++ b/packages/directory-listing/src/components/lastsaved.tsx
@@ -51,3 +51,5 @@ export class LastSaved extends React.PureComponent<LastSavedProps> {
     );
   }
 }
+
+export default LastSaved;

--- a/packages/directory-listing/src/components/listing.md
+++ b/packages/directory-listing/src/components/listing.md
@@ -11,6 +11,8 @@ import {
 The `Listing` component is a container component to show any listing of directories and files in a tabular layout for users. This component works best with `<Entry>` for each item in a content listing.
 
 ```jsx
+const { Entry, Name, Icon, LastSaved } = require("..");
+
 <Listing>
   <Entry>
     <Icon fileType="notebook" />
@@ -42,5 +44,5 @@ The `Listing` component is a container component to show any listing of director
     </Name>
     <LastSaved lastModified={new Date("2018-05-27T16:21:25.354Z")} />
   </Entry>
-</Listing>
+</Listing>;
 ```

--- a/packages/directory-listing/src/components/listing.tsx
+++ b/packages/directory-listing/src/components/listing.tsx
@@ -29,3 +29,5 @@ export class Listing extends React.PureComponent<ListingProps> {
     );
   }
 }
+
+export default Listing;

--- a/packages/directory-listing/src/components/name.tsx
+++ b/packages/directory-listing/src/components/name.tsx
@@ -14,3 +14,5 @@ export const Name = styled.span`
 `;
 
 Name.displayName = "Name";
+
+export default Name;

--- a/packages/outputs/src/components/display-data.tsx
+++ b/packages/outputs/src/components/display-data.tsx
@@ -33,3 +33,5 @@ DisplayData.defaultProps = {
   output_type: "display_data",
   output: null
 };
+
+export default DisplayData;

--- a/packages/outputs/src/components/execute-result.tsx
+++ b/packages/outputs/src/components/execute-result.tsx
@@ -33,3 +33,5 @@ ExecuteResult.defaultProps = {
   output: null,
   output_type: "execute_result"
 };
+
+export default ExecuteResult;

--- a/packages/outputs/src/components/kernel-output-error.tsx
+++ b/packages/outputs/src/components/kernel-output-error.tsx
@@ -48,3 +48,5 @@ KernelOutputError.defaultProps = {
 };
 
 KernelOutputError.displayName = "KernelOutputError";
+
+export default KernelOutputError;

--- a/packages/outputs/src/components/media/html.tsx
+++ b/packages/outputs/src/components/media/html.tsx
@@ -79,3 +79,5 @@ export class HTML extends React.PureComponent<Props> {
     );
   }
 }
+
+export default HTML;

--- a/packages/outputs/src/components/media/image.tsx
+++ b/packages/outputs/src/components/media/image.tsx
@@ -33,3 +33,5 @@ Image.defaultProps = {
   data: "",
   mediaType: "image/jpeg"
 };
+
+export default Image;

--- a/packages/outputs/src/components/media/javascript.md
+++ b/packages/outputs/src/components/media/javascript.md
@@ -1,7 +1,6 @@
 The Media.JavaScript component allows you to execute JavaScript in the context of the current document.
 
-```
-const JavaScript = require("./javascript").JavaScript;
+```jsx
 <JavaScript
   data={`
 console.log('%cWelcome to the nteract.io component docs!', "color: #3d3d3d; font-size: 24px;");
@@ -16,7 +15,6 @@ window.el = element;
 Because of this, you can declare variables in the scope of the current window context. For example, view the source code for the component below.
 
 ```
-const JavaScript = require("./javascript").JavaScript;
 <JavaScript data={"window.this_is_our_special_variable = 10;"}/>
 ```
 
@@ -32,7 +30,6 @@ If you're familiar with the Jupyter ecosystem, note that this component executes
 The `Media.JavaScript` component can also help you when things go wrong by printing an error trace. For example, here's what happens when you attempt to log invoke an undefined function.
 
 ```
-const JavaScript = require("./javascript").JavaScript;
 <JavaScript data={"there_is_no_way_this_function_exists_right_now(and_takes_this_parameter)"}/>
 ```
 

--- a/packages/outputs/src/components/media/javascript.tsx
+++ b/packages/outputs/src/components/media/javascript.tsx
@@ -60,3 +60,5 @@ export class JavaScript extends React.PureComponent<Props> {
     );
   }
 }
+
+export default JavaScript;

--- a/packages/outputs/src/components/media/json.tsx
+++ b/packages/outputs/src/components/media/json.tsx
@@ -59,3 +59,5 @@ export class Json extends React.PureComponent<Props> {
     );
   }
 }
+
+export default Json;

--- a/packages/outputs/src/components/media/latex.tsx
+++ b/packages/outputs/src/components/media/latex.tsx
@@ -16,3 +16,5 @@ export class LaTeX extends React.PureComponent<Props> {
     return <MathJax.Text>{this.props.data}</MathJax.Text>;
   }
 }
+
+export default LaTeX;

--- a/packages/outputs/src/components/media/markdown.tsx
+++ b/packages/outputs/src/components/media/markdown.tsx
@@ -23,3 +23,5 @@ export class Markdown extends React.PureComponent<Props> {
     return <MarkdownComponent source={this.props.data} />;
   }
 }
+
+export default Markdown;

--- a/packages/outputs/src/components/media/plain.md
+++ b/packages/outputs/src/components/media/plain.md
@@ -1,15 +1,11 @@
 Plain text is....plain. It contains no formatting, images, or interactivity. Its lack of richness doesn't mean there isn't a component for it in the nteract space! You can use the `Media.Plain` component to render plain text. All you'll need to do is pass the contents of the text to the `data` prop of the component.
 
 ```jsx
-const { Plain } = require("./");
-
-<Plain data={"This text is as plain as can be."} />;
+<Plain data={"This text is as plain as can be."} />
 ```
 
 As it tuns out, although plain text does not contain any formatting. The `Media.Plain` component will let you format your content using [ANSI escape codes]((https://en.wikipedia.org/wiki/ANSI_escape_code). Here's an example of a piece of text formatted using the escape code for a red color.
 
 ```jsx
-const { Plain } = require("./");
-
-<Plain data={"\u001b[31msome red text\u001b[0m"} />;
+<Plain data={"\u001b[31msome red text\u001b[0m"} />
 ```

--- a/packages/outputs/src/components/media/plain.md
+++ b/packages/outputs/src/components/media/plain.md
@@ -1,11 +1,13 @@
 Plain text is....plain. It contains no formatting, images, or interactivity. Its lack of richness doesn't mean there isn't a component for it in the nteract space! You can use the `Media.Plain` component to render plain text. All you'll need to do is pass the contents of the text to the `data` prop of the component.
 
 ```jsx
-<Plain data={"This text is as plain as can be."} />
+const { Plain } = require("./plain");
+<Plain data={"This text is as plain as can be."} />;
 ```
 
 As it tuns out, although plain text does not contain any formatting. The `Media.Plain` component will let you format your content using [ANSI escape codes]((https://en.wikipedia.org/wiki/ANSI_escape_code). Here's an example of a piece of text formatted using the escape code for a red color.
 
 ```jsx
-<Plain data={"\u001b[31msome red text\u001b[0m"} />
+const { Plain } = require("./plain");
+<Plain data={"\u001b[31msome red text\u001b[0m"} />;
 ```

--- a/packages/outputs/src/components/media/plain.tsx
+++ b/packages/outputs/src/components/media/plain.tsx
@@ -18,3 +18,5 @@ Plain.defaultProps = {
 };
 
 Plain.displayName = "Plaintext";
+
+export default Plain;

--- a/packages/outputs/src/components/media/svg.md
+++ b/packages/outputs/src/components/media/svg.md
@@ -9,10 +9,11 @@ SVG, or Scalable Vector Graphics, is an image format for two-dimensional graphic
 
 That's right! Under the hood, SVG images are just plain-text. Their scalability and responsiveness makes them great for rendering charts and graphs. The media type used to refer to SVGs in the Jupyter ecosystem, and elsewhere on the web, is `image/svg+xml`. To render SVGs, you can use the `Media.SVG` component. You'll need to pass a `data` prop that contains the plain-text contents of the SVG.
 
-```
-const SVG = require("./svg").SVG;
-<SVG data={`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+```jsx
+<SVG
+  data={`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
 <circle cx="250" cy="250" r="210" fill="#fff" stroke="#000" stroke-width="8"/>
-</svg>`}/>
+</svg>`}
+/>
 ```

--- a/packages/outputs/src/components/media/svg.tsx
+++ b/packages/outputs/src/components/media/svg.tsx
@@ -40,3 +40,5 @@ export class SVG extends React.PureComponent<Props> {
     );
   }
 }
+
+export default SVG;

--- a/packages/outputs/src/components/output.tsx
+++ b/packages/outputs/src/components/output.tsx
@@ -119,3 +119,5 @@ export class Output extends React.PureComponent<Props, State> {
     return React.cloneElement(chosenOne, { output: this.props.output });
   }
 }
+
+export default Output;

--- a/packages/outputs/src/components/rich-media.md
+++ b/packages/outputs/src/components/rich-media.md
@@ -132,18 +132,18 @@ Without any valid choices, it renders nothing!
 
 Since the children are React elements, we can pass custom props that will get rendered with the data:
 
-```
-const Special = props => props.big ? <h1>Big {props.data}</h1> : <p>Small {props.data}</p>
+```jsx
+const Special = props =>
+  props.big ? <h1>Big {props.data}</h1> : <p>Small {props.data}</p>;
 Special.defaultProps = {
   big: false,
   mediaType: "text/special"
-}
+};
 
 const Plain = props => <pre>{props.data}</pre>;
 Plain.defaultProps = {
   mediaType: "text/plain"
 };
-
 
 <div>
   <RichMedia
@@ -162,7 +162,7 @@ Plain.defaultProps = {
     <Special />
     <Plain />
   </RichMedia>
-</div>
+</div>;
 ```
 
 Which means that you can customize outputs as props!

--- a/packages/outputs/src/components/rich-media.tsx
+++ b/packages/outputs/src/components/rich-media.tsx
@@ -130,3 +130,5 @@ export class RichMedia extends React.PureComponent<RichMediaProps, State> {
     });
   }
 }
+
+export default RichMedia;

--- a/packages/outputs/src/components/stream-text.tsx
+++ b/packages/outputs/src/components/stream-text.tsx
@@ -27,3 +27,5 @@ export class StreamText extends React.PureComponent<Props> {
     );
   }
 }
+
+export default StreamText;

--- a/packages/presentational-components/src/components/cell.md
+++ b/packages/presentational-components/src/components/cell.md
@@ -8,6 +8,8 @@ based on hover and **selected** states.
 By moving a cursor over the component and hovering, styling can be changed.
 
 ```js
+var { Input, Prompt, Source, Outputs } = require("..");
+
 <Cell>
   <Input>
     <Prompt counter={1} />
@@ -52,12 +54,14 @@ By moving a cursor over the component and hovering, styling can be changed.
       </table>
     </div>
   </Outputs>
-</Cell>
+</Cell>;
 ```
 
 A `<Cell />` can be set as selected to **raise** it up.
 
 ```js
+var { Input, Prompt, Source, Outputs } = require("..");
+
 <Cell isSelected>
   <Input>
     <Prompt counter={2} />
@@ -66,7 +70,7 @@ A `<Cell />` can be set as selected to **raise** it up.
   <Outputs>
     <pre>Hello World</pre>
   </Outputs>
-</Cell>
+</Cell>;
 ```
 
 A cell can be in one of three levels, similar to raised cards:
@@ -77,6 +81,8 @@ A cell can be in one of three levels, similar to raised cards:
     the editor should be focused when this level is used
 
 ```js
+var { Input, Prompt, Source, Outputs, Cells } = require("..");
+
 <Cells>
   <Cell>
     <Input>
@@ -105,5 +111,5 @@ A cell can be in one of three levels, similar to raised cards:
       <pre>Output</pre>
     </Outputs>
   </Cell>
-</Cells>
+</Cells>;
 ```

--- a/packages/presentational-components/src/components/cell.tsx
+++ b/packages/presentational-components/src/components/cell.tsx
@@ -95,3 +95,5 @@ Cell.defaultProps = {
   _hovered: false,
   children: null
 };
+
+export default Cell;

--- a/packages/presentational-components/src/components/cells.md
+++ b/packages/presentational-components/src/components/cells.md
@@ -5,6 +5,8 @@ import { Cells } from "@nteract/presentational-components";
 `<Cells />` is a wrapper component to provide buffers between cells if you're building a notebook app.
 
 ```js
+var { Input, Prompt, Source, Outputs, Cell } = require("..");
+
 <Cells>
   <Cell>
     <Input>
@@ -65,5 +67,5 @@ import { Cells } from "@nteract/presentational-components";
     </Input>
     <Outputs />
   </Cell>
-</Cells>
+</Cells>;
 ```

--- a/packages/presentational-components/src/components/cells.tsx
+++ b/packages/presentational-components/src/components/cells.tsx
@@ -17,3 +17,5 @@ export const Cells = styled.div`
 `;
 
 Cells.displayName = "Cells";
+
+export default Cells;

--- a/packages/presentational-components/src/components/input.tsx
+++ b/packages/presentational-components/src/components/input.tsx
@@ -50,3 +50,5 @@ export const Input = styled(BareInput)`
 `;
 
 Input.displayName = "Input";
+
+export default Input;

--- a/packages/presentational-components/src/components/outputs.tsx
+++ b/packages/presentational-components/src/components/outputs.tsx
@@ -162,8 +162,9 @@ const OutputWrapper = styled.div.attrs<OutputWrapperProps>(props => ({
 export class Outputs extends React.PureComponent<OutputsProps> {
   static defaultProps = {
     children: null,
-    expanded: false,
-    hidden: false
+    className: "nteract-outputs",
+    hidden: false,
+    expanded: false
   };
 
   render() {
@@ -185,3 +186,5 @@ export class Outputs extends React.PureComponent<OutputsProps> {
     return null;
   }
 }
+
+export default Outputs;

--- a/packages/presentational-components/src/components/pagers.tsx
+++ b/packages/presentational-components/src/components/pagers.tsx
@@ -16,3 +16,5 @@ export const Pagers = styled(Outputs)`
 `;
 
 Pagers.displayName = "Pagers";
+
+export default Pagers;

--- a/packages/presentational-components/src/components/prompt.tsx
+++ b/packages/presentational-components/src/components/prompt.tsx
@@ -88,3 +88,5 @@ export const PromptBuffer = styled(Prompt)``;
 PromptBuffer.defaultProps = {
   blank: true
 };
+
+export default Prompt;

--- a/packages/presentational-components/src/components/source.tsx
+++ b/packages/presentational-components/src/components/source.tsx
@@ -50,3 +50,5 @@ Source.defaultProps = {
 };
 
 Source.displayName = "Source";
+
+export default Source;


### PR DESCRIPTION
Styleguidist 9.x had a whole suite of breaking changes that needed to be adapted to. I've gone ahead and done that here so we can use `yarn docs` again.