### PR TITLE
Fix grid breaking if no primary keys are passed

### DIFF
--- a/packages/data-explorer/src/charts/grid.tsx
+++ b/packages/data-explorer/src/charts/grid.tsx
@@ -168,6 +168,8 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
 
     const { filters, showFilters } = this.state;
 
+    const { primaryKey = [] } = schema;
+
     const tableColumns = schema.fields.map((field: Dx.Field) => {
       if (
         field.type === "string" ||
@@ -177,7 +179,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
         return {
           Header: field.name,
           accessor: field.name,
-          fixed: schema.primaryKey.indexOf(field.name) !== -1 && "left",
+          fixed: primaryKey.indexOf(field.name) !== -1 && "left",
           filterMethod: (filter: Dx.JSONObject, row: Dx.JSONObject) => {
             if (
               field.type === "string" ||
@@ -200,7 +202,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
         return {
           Header: field.name,
           accessor: field.name,
-          fixed: schema.primaryKey.indexOf(field.name) !== -1 && "left"
+          fixed: primaryKey.indexOf(field.name) !== -1 && "left"
         };
       }
     });


### PR DESCRIPTION
Simple two-line fix for when the grid breaks if you don't have primary keys at all in your schema.