### PR TITLE
Reducer refactoring

### DIFF
--- a/packages/reducers/src/app.ts
+++ b/packages/reducers/src/app.ts
@@ -46,7 +46,7 @@ export default function handleApp(
     | Save
     | SaveFulfilled
     | SaveFailed
-) {
+): RecordOf<AppRecordProps> {
   switch (action.type) {
     case actions.SAVE:
       return save(state);

--- a/packages/reducers/src/app.ts
+++ b/packages/reducers/src/app.ts
@@ -1,3 +1,4 @@
+// Vendor modules
 import * as actions from "@nteract/actions";
 import {
   Save,

--- a/packages/reducers/src/app.ts
+++ b/packages/reducers/src/app.ts
@@ -6,28 +6,32 @@ import {
   SetGithubTokenAction,
   SetNotificationSystemAction
 } from "@nteract/actions";
-import { AppRecord, makeAppRecord } from "@nteract/types";
+import { AppRecord, AppRecordProps, makeAppRecord } from "@nteract/types";
+import { RecordOf } from "immutable";
 
-function setGithubToken(state: AppRecord, action: SetGithubTokenAction) {
+function setGithubToken(
+  state: AppRecord,
+  action: SetGithubTokenAction
+): RecordOf<AppRecordProps> {
   return state.set("githubToken", action.payload.githubToken);
 }
 
-function save(state: AppRecord) {
+function save(state: AppRecord): RecordOf<AppRecordProps> {
   return state.set("isSaving", true);
 }
 
-function saveFailed(state: AppRecord) {
+function saveFailed(state: AppRecord): RecordOf<AppRecordProps> {
   return state.set("isSaving", false);
 }
 
-function saveFulfilled(state: AppRecord) {
+function saveFulfilled(state: AppRecord): RecordOf<AppRecordProps> {
   return state.set("isSaving", false).set("lastSaved", new Date());
 }
 
 function setNotificationsSystem(
   state: AppRecord,
   action: SetNotificationSystemAction
-) {
+): RecordOf<AppRecordProps> {
   if (!action.payload || !action.payload.notificationSystem) {
     return state;
   }

--- a/packages/reducers/src/comms.ts
+++ b/packages/reducers/src/comms.ts
@@ -1,11 +1,11 @@
-import { fromJS } from "immutable";
-
+// Vendor modules
 import {
   CommMessageAction,
   CommOpenAction,
   RegisterCommTargetAction
 } from "@nteract/actions";
 import { CommsRecord, makeCommsRecord } from "@nteract/types";
+import { fromJS } from "immutable";
 
 function registerCommTarget(
   state: CommsRecord,
@@ -60,7 +60,7 @@ type CommAction = RegisterCommTargetAction | CommMessageAction | CommOpenAction;
 export default function(
   state: CommsRecord = makeCommsRecord(),
   action: CommAction
-) {
+): CommsRecord {
   switch (action.type) {
     case "REGISTER_COMM_TARGET":
       return registerCommTarget(state, action);

--- a/packages/reducers/src/config.ts
+++ b/packages/reducers/src/config.ts
@@ -1,19 +1,22 @@
-import { Map } from "immutable";
-
+// Vendor modules
 import { MergeConfigAction, SetConfigAction } from "@nteract/actions";
 import { ConfigState } from "@nteract/types";
+import { Map } from "immutable";
 
 type ConfigAction = SetConfigAction<any> | MergeConfigAction;
 
 export function setConfigAtKey(
   state: ConfigState,
   action: SetConfigAction<any>
-) {
+): Map<string, any> {
   const { key, value } = action.payload;
   return state.set(key, value);
 }
 
-export function mergeConfig(state: ConfigState, action: MergeConfigAction) {
+export function mergeConfig(
+  state: ConfigState,
+  action: MergeConfigAction
+): Map<string, any> {
   const { config } = action.payload;
   return state.merge(config);
 }
@@ -21,7 +24,7 @@ export function mergeConfig(state: ConfigState, action: MergeConfigAction) {
 export default function handleConfig(
   state: ConfigState = Map(),
   action: ConfigAction
-) {
+): Map<string, any> {
   switch (action.type) {
     case "SET_CONFIG_AT_KEY":
       return setConfigAtKey(state, action);

--- a/packages/reducers/src/core/entities/contents/file.ts
+++ b/packages/reducers/src/core/entities/contents/file.ts
@@ -1,14 +1,19 @@
+// Vendor modules
 import * as actions from "@nteract/actions";
-import { FileModelRecord } from "@nteract/types";
+import { FileModelRecord, FileModelRecordProps } from "@nteract/types";
+import { RecordOf } from "immutable";
 
 function updateFileText(
   state: FileModelRecord,
   action: actions.UpdateFileText
-) {
+): RecordOf<FileModelRecordProps> {
   return state.set("text", action.payload.text);
 }
 
-export function file(state: FileModelRecord, action: actions.UpdateFileText) {
+export function file(
+  state: FileModelRecord,
+  action: actions.UpdateFileText
+): RecordOf<FileModelRecordProps> {
   switch (action.type) {
     case actions.UPDATE_FILE_TEXT:
       return updateFileText(state, action);

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -1,8 +1,6 @@
-import { fromJS } from "@nteract/commutable";
-import { List, Map, RecordOf } from "immutable";
-import { Action } from "redux";
-
+// Vendor modules
 import * as actionTypes from "@nteract/actions";
+import { fromJS } from "@nteract/commutable";
 import {
   ContentModel,
   ContentRecord,
@@ -19,7 +17,10 @@ import {
   makeFileModelRecord,
   makeNotebookContentRecord
 } from "@nteract/types";
+import { List, Map, RecordOf } from "immutable";
+import { Action } from "redux";
 
+// Local modules
 import { file } from "./file";
 import { notebook } from "./notebook";
 
@@ -195,8 +196,9 @@ const byRef = (
         .updateIn(
           [saveFulfilledAction.payload.contentRef, "model"],
           (model: ContentModel) => {
-            // Notebook ends up needing this because we store a last saved version of the notebook
-            // Alternatively, we could be storing a hash of the content to compare 🤔
+            // Notebook ends up needing this because we store a last
+            // saved version of the notebook Alternatively, we could
+            // be storing a hash of the content to compare 🤔
             if (model && model.type === "notebook") {
               return notebook(model, saveFulfilledAction);
             }

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -2,25 +2,24 @@
 import * as actionTypes from "@nteract/actions";
 import {
   CellId,
-  ImmutableCell,
-  ImmutableCodeCell,
-  ImmutableMarkdownCell,
-  ImmutableNotebook,
-  ImmutableOutput,
-  OnDiskOutput
-} from "@nteract/commutable";
-import {
   createFrozenMediaBundle,
   createImmutableOutput,
   deleteCell,
   emptyCodeCell,
   emptyMarkdownCell,
   emptyNotebook,
+  ImmutableCell,
+  ImmutableCodeCell,
+  ImmutableMarkdownCell,
+  ImmutableNotebook,
+  ImmutableOutput,
   insertCellAfter,
   insertCellAt,
   makeCodeCell,
   makeMarkdownCell,
-  makeRawCell
+  makeRawCell,
+  OnDiskOutput,
+  OnDiskStreamOutput
 } from "@nteract/commutable";
 import {
   DocumentRecordProps,
@@ -65,7 +64,7 @@ export function reduceOutputs(
     return outputs.push(createImmutableOutput(output));
   }
 
-  const streamOutput = output;
+  const streamOutput: OnDiskStreamOutput = output;
 
   if (typeof streamOutput.name === "undefined") {
     return outputs.push(createImmutableOutput(streamOutput));

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -1,3 +1,5 @@
+// Vendor modules
+import * as actionTypes from "@nteract/actions";
 import {
   CellId,
   ImmutableCell,
@@ -5,8 +7,7 @@ import {
   ImmutableMarkdownCell,
   ImmutableNotebook,
   ImmutableOutput,
-  OnDiskOutput,
-  OnDiskStreamOutput
+  OnDiskOutput
 } from "@nteract/commutable";
 import {
   createFrozenMediaBundle,
@@ -21,14 +22,16 @@ import {
   makeMarkdownCell,
   makeRawCell
 } from "@nteract/commutable";
+import {
+  DocumentRecordProps,
+  makeDocumentRecord,
+  NotebookModel,
+  PayloadMessage
+} from "@nteract/types";
 import { escapeCarriageReturnSafe } from "escape-carriage";
-import { fromJS, List, Map, Set } from "immutable";
+import { fromJS, List, Map, RecordOf, Set } from "immutable";
 import { has } from "lodash";
 import uuid from "uuid/v4";
-
-import * as actionTypes from "@nteract/actions";
-import { makeDocumentRecord, PayloadMessage } from "@nteract/types";
-import { NotebookModel } from "@nteract/types";
 
 type KeyPath = List<string | number>;
 type KeyPaths = List<KeyPath>;
@@ -45,7 +48,7 @@ type KeyPaths = List<KeyPath>;
 export function reduceOutputs(
   outputs: List<ImmutableOutput> = List(),
   output: OnDiskOutput
-) {
+): List<ImmutableOutput> {
   // Find the last output to see if it's a stream type
   // If we don't find one, default to null
   const last = outputs.last(null);
@@ -57,7 +60,8 @@ export function reduceOutputs(
   if (output.output_type !== "stream" || last.output_type !== "stream") {
     // If the last output type or the incoming output type isn't a stream
     // we just add it to the outputs
-    // This is kind of like a "break" between streams if we get error, display_data, execute_result, etc.
+    // This is kind of like a "break" between streams if we get error,
+    // display_data, execute_result, etc.
     return outputs.push(createImmutableOutput(output));
   }
 
@@ -93,7 +97,10 @@ export function reduceOutputs(
   return outputs.push(createImmutableOutput(streamOutput));
 }
 
-export function cleanCellTransient(state: NotebookModel, id: string) {
+export function cleanCellTransient(
+  state: NotebookModel,
+  id: string
+): RecordOf<DocumentRecordProps> {
   // Clear out key paths that should no longer be referenced
   return state
     .setIn(["cellPagers", id], List())
@@ -107,16 +114,24 @@ export function cleanCellTransient(state: NotebookModel, id: string) {
     .setIn(["transient", "cellMap", id], Map());
 }
 
-function setNotebookCheckpoint(state: NotebookModel) {
+function setNotebookCheckpoint(
+  state: NotebookModel
+): RecordOf<DocumentRecordProps> {
   // Use the current version of the notebook document
   return state.set("savedNotebook", state.get("notebook"));
 }
 
-function focusCell(state: NotebookModel, action: actionTypes.FocusCell) {
+function focusCell(
+  state: NotebookModel,
+  action: actionTypes.FocusCell
+): RecordOf<DocumentRecordProps> {
   return state.set("cellFocused", action.payload.id);
 }
 
-function clearOutputs(state: NotebookModel, action: actionTypes.ClearOutputs) {
+function clearOutputs(
+  state: NotebookModel,
+  action: actionTypes.ClearOutputs
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -137,7 +152,7 @@ function clearOutputs(state: NotebookModel, action: actionTypes.ClearOutputs) {
 function toggleTagInCell(
   state: NotebookModel,
   action: actionTypes.ToggleTagInCell
-): NotebookModel {
+): RecordOf<DocumentRecordProps> {
   const { id, tag } = action.payload;
 
   return state.updateIn(
@@ -155,7 +170,7 @@ function toggleTagInCell(
 function clearAllOutputs(
   state: NotebookModel,
   action: actionTypes.ClearAllOutputs | actionTypes.RestartKernel
-) {
+): RecordOf<DocumentRecordProps> {
   // If we get a restart kernel action that said to clear outputs, we'll
   // handle it
   if (
@@ -190,7 +205,10 @@ function clearAllOutputs(
     .set("transient", transient);
 }
 
-function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
+function appendOutput(
+  state: NotebookModel,
+  action: actionTypes.AppendOutput
+): RecordOf<DocumentRecordProps> {
   const output = action.payload.output;
   const cellId = action.payload.id;
 
@@ -257,7 +275,7 @@ function appendOutput(state: NotebookModel, action: actionTypes.AppendOutput) {
 function updateDisplay(
   state: NotebookModel,
   action: actionTypes.UpdateDisplay
-) {
+): RecordOf<DocumentRecordProps> {
   const { content } = action.payload;
   if (!(content && content.transient && content.transient.display_id)) {
     return state;
@@ -287,7 +305,7 @@ function updateDisplay(
 function focusNextCell(
   state: NotebookModel,
   action: actionTypes.FocusNextCell
-) {
+): RecordOf<DocumentRecordProps> {
   const cellOrder = state.getIn(["notebook", "cellOrder"]);
 
   const id = action.payload.id ? action.payload.id : state.get("cellFocused");
@@ -325,7 +343,7 @@ function focusNextCell(
 function focusPreviousCell(
   state: NotebookModel,
   action: actionTypes.FocusPreviousCell
-): NotebookModel {
+): RecordOf<DocumentRecordProps> {
   const cellOrder = state.getIn(["notebook", "cellOrder"]);
   const curIndex = cellOrder.findIndex(
     (id: CellId) => id === action.payload.id
@@ -338,14 +356,14 @@ function focusPreviousCell(
 function focusCellEditor(
   state: NotebookModel,
   action: actionTypes.FocusCellEditor
-) {
+): RecordOf<DocumentRecordProps> {
   return state.set("editorFocused", action.payload.id);
 }
 
 function focusNextCellEditor(
   state: NotebookModel,
   action: actionTypes.FocusNextCellEditor
-) {
+): RecordOf<DocumentRecordProps> {
   const cellOrder: List<CellId> = state.getIn(["notebook", "cellOrder"]);
 
   const id = action.payload.id ? action.payload.id : state.get("editorFocused");
@@ -365,7 +383,7 @@ function focusNextCellEditor(
 function focusPreviousCellEditor(
   state: NotebookModel,
   action: actionTypes.FocusPreviousCellEditor
-) {
+): RecordOf<DocumentRecordProps> {
   const cellOrder: List<CellId> = state.getIn(["notebook", "cellOrder"]);
   const curIndex = cellOrder.findIndex(
     (id: CellId) => id === action.payload.id
@@ -375,7 +393,10 @@ function focusPreviousCellEditor(
   return state.set("editorFocused", cellOrder.get(nextIndex));
 }
 
-function moveCell(state: NotebookModel, action: actionTypes.MoveCell) {
+function moveCell(
+  state: NotebookModel,
+  action: actionTypes.MoveCell
+): RecordOf<DocumentRecordProps> {
   return state.updateIn(
     ["notebook", "cellOrder"],
     (cellOrder: List<CellId>) => {
@@ -400,7 +421,7 @@ function moveCell(state: NotebookModel, action: actionTypes.MoveCell) {
 function deleteCellFromState(
   state: NotebookModel,
   action: actionTypes.DeleteCell | actionTypes.RemoveCell
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -416,7 +437,7 @@ function deleteCellFromState(
 function createCellBelow(
   state: NotebookModel,
   action: actionTypes.CreateCellBelow
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -439,7 +460,7 @@ function createCellBelow(
 function createCellAbove(
   state: NotebookModel,
   action: actionTypes.CreateCellAbove
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -458,7 +479,7 @@ function createCellAbove(
 function createCellAfter(
   state: NotebookModel,
   action: actionTypes.CreateCellAfter
-) {
+): RecordOf<DocumentRecordProps> {
   console.log(
     "DEPRECATION WARNING: This function is being deprecated. Please use createCellBelow() instead"
   );
@@ -484,7 +505,7 @@ function createCellAfter(
 function createCellBefore(
   state: NotebookModel,
   action: actionTypes.CreateCellBefore
-) {
+): RecordOf<DocumentRecordProps> {
   console.log(
     "DEPRECATION WARNING: This function is being deprecated. Please use createCellAbove() instead"
   );
@@ -506,7 +527,7 @@ function createCellBefore(
 function createCellAppend(
   state: NotebookModel,
   action: actionTypes.CreateCellAppend
-) {
+): RecordOf<DocumentRecordProps> {
   const { cellType } = action.payload;
   const notebook: ImmutableNotebook = state.get("notebook");
   const cellOrder: List<CellId> = notebook.get("cellOrder", List());
@@ -558,7 +579,7 @@ function acceptPayloadMessage(
 function sendExecuteRequest(
   state: NotebookModel,
   action: actionTypes.SendExecuteRequest
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   const contentRef = action.payload.contentRef;
   if (!id) {
@@ -584,7 +605,7 @@ function sendExecuteRequest(
 function setInCell(
   state: NotebookModel,
   action: actionTypes.SetInCell<string>
-) {
+): RecordOf<DocumentRecordProps> {
   return state.setIn(
     ["notebook", "cellMap", action.payload.id].concat(action.payload.path),
     action.payload.value
@@ -594,7 +615,7 @@ function setInCell(
 function toggleCellOutputVisibility(
   state: NotebookModel,
   action: actionTypes.ToggleCellOutputVisibility
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -606,12 +627,16 @@ function toggleCellOutputVisibility(
   );
 }
 
-function unhideAll(state: NotebookModel, action: actionTypes.UnhideAll) {
+function unhideAll(
+  state: NotebookModel,
+  action: actionTypes.UnhideAll
+): RecordOf<DocumentRecordProps> {
   return state.updateIn(["notebook", "cellMap"], cellMap =>
     cellMap.map((cell: ImmutableCell) => {
       if ((cell as any).get("cell_type") === "code") {
         return cell.mergeIn(["metadata"], {
-          // TODO: Verify that we convert to one namespace for hidden input/output
+          // TODO: Verify that we convert to one namespace
+          // for hidden input/output
           outputHidden: action.payload.outputHidden,
           inputHidden: action.payload.inputHidden
         });
@@ -624,7 +649,7 @@ function unhideAll(state: NotebookModel, action: actionTypes.UnhideAll) {
 function toggleCellInputVisibility(
   state: NotebookModel,
   action: actionTypes.ToggleCellInputVisibility
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -639,7 +664,7 @@ function toggleCellInputVisibility(
 function updateCellStatus(
   state: NotebookModel,
   action: actionTypes.UpdateCellStatus
-) {
+): RecordOf<DocumentRecordProps> {
   const { id, status } = action.payload;
   return state.setIn(["transient", "cellMap", id, "status"], status);
 }
@@ -647,7 +672,7 @@ function updateCellStatus(
 function updateOutputMetadata(
   state: NotebookModel,
   action: actionTypes.UpdateOutputMetadata
-) {
+): RecordOf<DocumentRecordProps> {
   const { id, metadata, index, mediaType } = action.payload;
   const currentOutputs = state.getIn(["notebook", "cellMap", id, "outputs"]);
 
@@ -666,7 +691,7 @@ function updateOutputMetadata(
 function setLanguageInfo(
   state: NotebookModel,
   action: actionTypes.SetLanguageInfo
-) {
+): RecordOf<DocumentRecordProps> {
   const langInfo = fromJS(action.payload.langInfo);
   return state.setIn(["notebook", "metadata", "language_info"], langInfo);
 }
@@ -674,7 +699,7 @@ function setLanguageInfo(
 function setKernelspecInfo(
   state: NotebookModel,
   action: actionTypes.SetKernelspecInfo
-) {
+): RecordOf<DocumentRecordProps> {
   const { kernelInfo } = action.payload;
   return state
     .setIn(
@@ -691,19 +716,22 @@ function setKernelspecInfo(
 function overwriteMetadataField(
   state: NotebookModel,
   action: actionTypes.OverwriteMetadataField
-) {
+): RecordOf<DocumentRecordProps> {
   const { field, value } = action.payload;
   return state.setIn(["notebook", "metadata", field], fromJS(value));
 }
 function deleteMetadataField(
   state: NotebookModel,
   action: actionTypes.DeleteMetadataField
-) {
+): RecordOf<DocumentRecordProps> {
   const { field } = action.payload;
   return state.deleteIn(["notebook", "metadata", field]);
 }
 
-function copyCell(state: NotebookModel, action: actionTypes.CopyCell) {
+function copyCell(
+  state: NotebookModel,
+  action: actionTypes.CopyCell
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id || state.cellFocused;
 
   const cell = state.getIn(["notebook", "cellMap", id]);
@@ -713,7 +741,10 @@ function copyCell(state: NotebookModel, action: actionTypes.CopyCell) {
   return state.set("copied", cell);
 }
 
-function cutCell(state: NotebookModel, action: actionTypes.CutCell) {
+function cutCell(
+  state: NotebookModel,
+  action: actionTypes.CutCell
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -733,7 +764,7 @@ function cutCell(state: NotebookModel, action: actionTypes.CutCell) {
     );
 }
 
-function pasteCell(state: NotebookModel) {
+function pasteCell(state: NotebookModel): RecordOf<DocumentRecordProps> {
   const copiedCell = state.get("copied");
 
   const pasteAfter = state.cellFocused;
@@ -754,7 +785,7 @@ function pasteCell(state: NotebookModel) {
 function changeCellType(
   state: NotebookModel,
   action: actionTypes.ChangeCellType
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -815,7 +846,7 @@ function changeCellType(
 function toggleOutputExpansion(
   state: NotebookModel,
   action: actionTypes.ToggleCellExpansion
-) {
+): RecordOf<DocumentRecordProps> {
   const id = action.payload.id ? action.payload.id : state.cellFocused;
   if (!id) {
     return state;
@@ -879,7 +910,7 @@ const defaultDocument: NotebookModel = makeDocumentRecord({
 export function notebook(
   state: NotebookModel = defaultDocument,
   action: DocumentAction
-) {
+): RecordOf<DocumentRecordProps> {
   switch (action.type) {
     case actionTypes.TOGGLE_TAG_IN_CELL:
       return toggleTagInCell(state, action);

--- a/packages/reducers/src/core/entities/hosts.ts
+++ b/packages/reducers/src/core/entities/hosts.ts
@@ -1,6 +1,7 @@
 // Vendor modules
 import * as actions from "@nteract/actions";
 import {
+  HostRecord,
   makeHostsRecord,
   makeJupyterHostRecord,
   makeLocalHostRecord
@@ -9,7 +10,10 @@ import { List, Map } from "immutable";
 import { Action, Reducer } from "redux";
 import { combineReducers } from "redux-immutable";
 
-const byRef = (state = Map(), action: Action): Map<{}, {}> => {
+const byRef = (
+  state = Map() as Map<string, HostRecord>,
+  action: Action
+): Map<string, HostRecord> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_HOST:
@@ -50,7 +54,7 @@ const refs = (state = List(), action: Action): List<string> => {
 
 export const hosts: Reducer<
   {
-    byRef: Map<{}, {}>;
+    byRef: Map<string, HostRecord>;
     refs: List<string>;
   },
   Action<any>

--- a/packages/reducers/src/core/entities/hosts.ts
+++ b/packages/reducers/src/core/entities/hosts.ts
@@ -1,15 +1,15 @@
-import { List, Map } from "immutable";
-import { Action } from "redux";
-import { combineReducers } from "redux-immutable";
-
+// Vendor modules
 import * as actions from "@nteract/actions";
 import {
   makeHostsRecord,
   makeJupyterHostRecord,
   makeLocalHostRecord
 } from "@nteract/types";
+import { List, Map } from "immutable";
+import { Action, Reducer } from "redux";
+import { combineReducers } from "redux-immutable";
 
-const byRef = (state = Map(), action: Action) => {
+const byRef = (state = Map(), action: Action): Map<{}, {}> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_HOST:
@@ -37,7 +37,7 @@ const byRef = (state = Map(), action: Action) => {
   }
 };
 
-const refs = (state = List(), action: Action) => {
+const refs = (state = List(), action: Action): List<any> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_HOST:
@@ -48,4 +48,10 @@ const refs = (state = List(), action: Action) => {
   }
 };
 
-export const hosts = combineReducers({ byRef, refs }, makeHostsRecord as any);
+export const hosts: Reducer<
+  {
+    byRef: Map<{}, {}>;
+    refs: List<any>;
+  },
+  Action<any>
+> = combineReducers({ byRef, refs }, makeHostsRecord as any);

--- a/packages/reducers/src/core/entities/hosts.ts
+++ b/packages/reducers/src/core/entities/hosts.ts
@@ -37,7 +37,7 @@ const byRef = (state = Map(), action: Action): Map<{}, {}> => {
   }
 };
 
-const refs = (state = List(), action: Action): List<any> => {
+const refs = (state = List(), action: Action): List<string> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_HOST:
@@ -51,7 +51,7 @@ const refs = (state = List(), action: Action): List<any> => {
 export const hosts: Reducer<
   {
     byRef: Map<{}, {}>;
-    refs: List<any>;
+    refs: List<string>;
   },
   Action<any>
 > = combineReducers({ byRef, refs }, makeHostsRecord as any);

--- a/packages/reducers/src/core/entities/index.ts
+++ b/packages/reducers/src/core/entities/index.ts
@@ -1,11 +1,8 @@
+// Vendor modules
+import { makeEntitiesRecord } from "@nteract/types";
 import { combineReducers } from "redux-immutable";
 
-import {
-  EntitiesRecord,
-  EntitiesRecordProps,
-  makeEntitiesRecord
-} from "@nteract/types";
-
+// Local modules
 import { contents } from "./contents";
 import { hosts } from "./hosts";
 import { kernels } from "./kernels";

--- a/packages/reducers/src/core/entities/kernels.ts
+++ b/packages/reducers/src/core/entities/kernels.ts
@@ -1,25 +1,23 @@
-import { List, Map } from "immutable";
-import { Action } from "redux";
-import { combineReducers } from "redux-immutable";
-
+// Vendor modules
 import * as actionTypes from "@nteract/actions";
-import { JSONObject } from "@nteract/commutable/src";
+import { JSONObject } from "@nteract/commutable";
 import {
+  HelpLink,
+  makeHelpLinkRecord,
+  makeKernelInfoRecord,
   makeKernelNotStartedRecord,
   makeKernelsRecord,
   makeLocalKernelRecord,
   makeRemoteKernelRecord
 } from "@nteract/types";
-import {
-  HelpLink,
-  makeHelpLinkRecord,
-  makeKernelInfoRecord
-} from "@nteract/types";
+import { List, Map } from "immutable";
+import { Action, Reducer } from "redux";
+import { combineReducers } from "redux-immutable";
 
 // TODO: we need to clean up references to old kernels at some point. Listening
 // for KILL_KERNEL_SUCCESSFUL seems like a good candidate, but I think you can
 // also end up with a dead kernel if that fails and you hit KILL_KERNEL_FAILED.
-const byRef = (state = Map(), action: Action) => {
+const byRef = (state = Map(), action: Action): Map<{}, {}> => {
   let typedAction;
   switch (action.type) {
     case actionTypes.SET_LANGUAGE_INFO:
@@ -127,4 +125,9 @@ const byRef = (state = Map(), action: Action) => {
   }
 };
 
-export const kernels = combineReducers({ byRef }, makeKernelsRecord as any);
+export const kernels: Reducer<
+  {
+    byRef: Map<{}, {}>;
+  },
+  Action<any>
+> = combineReducers({ byRef }, makeKernelsRecord as any);

--- a/packages/reducers/src/core/entities/kernelspecs.ts
+++ b/packages/reducers/src/core/entities/kernelspecs.ts
@@ -1,16 +1,15 @@
-import { List, Map } from "immutable";
-import { Action } from "redux";
-import { combineReducers } from "redux-immutable";
-
+// Vendor modules
 import * as actionTypes from "@nteract/actions";
 import {
-  KernelspecProps,
   makeKernelspec,
   makeKernelspecsByRefRecord,
   makeKernelspecsRecord
 } from "@nteract/types";
+import { List, Map } from "immutable";
+import { Action, Reducer } from "redux";
+import { combineReducers } from "redux-immutable";
 
-const byRef = (state = Map(), action: Action) => {
+const byRef = (state = Map(), action: Action): Map<{}, {}> => {
   const typedAction = action as actionTypes.FetchKernelspecsFulfilled;
   switch (action.type) {
     case actionTypes.FETCH_KERNELSPECS_FULFILLED:
@@ -32,7 +31,7 @@ const byRef = (state = Map(), action: Action) => {
   }
 };
 
-const refs = (state = List(), action: Action) => {
+const refs = (state = List(), action: Action): List<any> => {
   let typedAction;
   switch (action.type) {
     case actionTypes.FETCH_KERNELSPECS_FULFILLED:
@@ -45,7 +44,10 @@ const refs = (state = List(), action: Action) => {
   }
 };
 
-export const kernelspecs = combineReducers(
-  { byRef, refs },
-  makeKernelspecsRecord as any
-);
+export const kernelspecs: Reducer<
+  {
+    byRef: Map<{}, {}>;
+    refs: List<any>;
+  },
+  Action<any>
+> = combineReducers({ byRef, refs }, makeKernelspecsRecord as any);

--- a/packages/reducers/src/core/entities/modals.ts
+++ b/packages/reducers/src/core/entities/modals.ts
@@ -1,12 +1,13 @@
-import { combineReducers } from "redux-immutable";
-
+// Vendor modules
 import * as actions from "@nteract/actions";
 import { makeModalsRecord } from "@nteract/types";
+import { Action, Reducer } from "redux";
+import { combineReducers } from "redux-immutable";
 
 const modalType = (
-  state = "",
+  state: string = "",
   action: actions.OpenModal | actions.CloseModal
-) => {
+): string => {
   switch (action.type) {
     case actions.OPEN_MODAL:
       return action.payload.modalType;
@@ -17,4 +18,9 @@ const modalType = (
   }
 };
 
-export const modals = combineReducers({ modalType }, makeModalsRecord as any);
+export const modals: Reducer<
+  {
+    modalType: string;
+  },
+  Action<any>
+> = combineReducers({ modalType }, makeModalsRecord as any);

--- a/packages/reducers/src/core/entities/transforms.ts
+++ b/packages/reducers/src/core/entities/transforms.ts
@@ -22,7 +22,7 @@ const byId = (state = Map(), action: Action): Map<{}, {}> => {
   }
 };
 
-const displayOrder = (state = List(), action: Action): List<any> => {
+const displayOrder = (state = List(), action: Action): List<string> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_TRANSFORM:

--- a/packages/reducers/src/core/entities/transforms.ts
+++ b/packages/reducers/src/core/entities/transforms.ts
@@ -5,7 +5,10 @@ import { List, Map } from "immutable";
 import { Action, Reducer } from "redux";
 import { combineReducers } from "redux-immutable";
 
-const byId = (state = Map(), action: Action): Map<{}, {}> => {
+const byId = (
+  state = Map() as Map<string, React.ComponentClass>,
+  action: Action
+): Map<string, React.ComponentClass> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_TRANSFORM:
@@ -22,7 +25,10 @@ const byId = (state = Map(), action: Action): Map<{}, {}> => {
   }
 };
 
-const displayOrder = (state = List(), action: Action): List<string> => {
+const displayOrder = (
+  state = List() as List<string>,
+  action: Action
+): List<string> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_TRANSFORM:
@@ -38,7 +44,7 @@ const displayOrder = (state = List(), action: Action): List<string> => {
 
 export const transforms: Reducer<
   {
-    byId: Map<{}, {}>;
+    byId: Map<string, React.ComponentClass>;
     displayOrder: List<any>;
   },
   Action<any>

--- a/packages/reducers/src/core/entities/transforms.ts
+++ b/packages/reducers/src/core/entities/transforms.ts
@@ -1,11 +1,11 @@
-import { List, Map } from "immutable";
-import { Action } from "redux";
-import { combineReducers } from "redux-immutable";
-
+// Vendor modules
 import * as actions from "@nteract/actions";
 import { makeTransformsRecord } from "@nteract/types";
+import { List, Map } from "immutable";
+import { Action, Reducer } from "redux";
+import { combineReducers } from "redux-immutable";
 
-const byId = (state = Map(), action: Action) => {
+const byId = (state = Map(), action: Action): Map<{}, {}> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_TRANSFORM:
@@ -22,7 +22,7 @@ const byId = (state = Map(), action: Action) => {
   }
 };
 
-const displayOrder = (state = List(), action: Action) => {
+const displayOrder = (state = List(), action: Action): List<any> => {
   let typedAction;
   switch (action.type) {
     case actions.ADD_TRANSFORM:
@@ -36,7 +36,10 @@ const displayOrder = (state = List(), action: Action) => {
   }
 };
 
-export const transforms = combineReducers(
-  { byId, displayOrder },
-  makeTransformsRecord as any
-);
+export const transforms: Reducer<
+  {
+    byId: Map<{}, {}>;
+    displayOrder: List<any>;
+  },
+  Action<any>
+> = combineReducers({ byId, displayOrder }, makeTransformsRecord as any);

--- a/packages/reducers/src/core/index.ts
+++ b/packages/reducers/src/core/index.ts
@@ -1,13 +1,12 @@
+// Vendor modules
+import * as actions from "@nteract/actions";
+import { makeStateRecord } from "@nteract/types";
 import { Action } from "redux";
 import { combineReducers } from "redux-immutable";
 
-import * as actions from "@nteract/actions";
-
-import { makeStateRecord } from "@nteract/types";
-
+// Local modules
 import { entities } from "./entities";
 
-// TODO: #2618: This should at a minimum be moved into a contents entry.
 // TODO: This is temporary until we have sessions in place. Ideally, we point to
 // a document, which knows about its session and that session knows about its
 // kernel. For now, we need to keep a reference to the currently targeted kernel


### PR DESCRIPTION
Added return `types` for all the reducer files. 

It helps to see the types of what is being returned, so that we can compare implementations.