### PR TITLE
Dx add features

### DIFF
--- a/packages/data-explorer/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/data-explorer/__tests__/__snapshots__/index.spec.tsx.snap
@@ -129,15 +129,6 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
               },
             }
           }
-          areaStyle={[Function]}
-          areaType={
-            Object {
-              "bins": 10,
-              "thresholds": 6,
-              "type": "scatterplot",
-            }
-          }
-          areas={false}
           axes={
             Array [
               Object {
@@ -166,7 +157,7 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
             Object {
               "bottom": 50,
               "left": 75,
-              "right": 150,
+              "right": 30,
               "top": 30,
             }
           }
@@ -313,16 +304,18 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
           responsiveWidth={false}
           size={
             Array [
-              575,
+              455,
               430,
             ]
           }
+          summaryStyle={[Function]}
           tooltipContent={[Function]}
           xAccessor="Happiness Rank"
           yAccessor="Standard Error"
         />
         <Component
           areaType="hexbin"
+          barGrouping="Clustered"
           chart={
             Object {
               "dim1": "Region",
@@ -488,6 +481,7 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
           }
           hierarchyType="dendrogram"
           lineType="line"
+          marginalGraphics="none"
           metrics={
             Array [
               Object {
@@ -538,6 +532,7 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
           setAreaType={[Function]}
           setLineType={[Function]}
           summaryType="violin"
+          trendLine="none"
           updateChart={[Function]}
           updateDimensions={[Function]}
           updateMetrics={[Function]}

--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -33,7 +33,7 @@
     "react-hot-loader": "^4.1.2",
     "react-table": "^6.8.6",
     "react-table-hoc-fixed-columns": "2.0.1",
-    "semiotic": "^1.19.0",
+    "semiotic": "^1.19.1",
     "styled-components": "^4.1.3"
   },
   "devDependencies": {

--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -33,7 +33,7 @@
     "react-hot-loader": "^4.1.2",
     "react-table": "^6.8.6",
     "react-table-hoc-fixed-columns": "2.0.1",
-    "semiotic": "^1.16.3",
+    "semiotic": "^1.19.0",
     "styled-components": "^4.1.3"
   },
   "devDependencies": {

--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -259,6 +259,9 @@ interface VizControlParams {
   areaType: Dx.AreaType;
   setAreaType: (label: Dx.AreaType) => void;
   data: Dx.Datapoint[];
+  trendLine: Dx.TrendLineType;
+  marginalGraphics: Dx.SummaryType;
+  barGrouping: Dx.BarGroupingType;
 }
 export default ({
   view,
@@ -269,6 +272,9 @@ export default ({
   selectedDimensions,
   selectedMetrics,
   hierarchyType,
+  trendLine,
+  marginalGraphics,
+  barGrouping,
   summaryType,
   networkType,
   setLineType,
@@ -341,6 +347,46 @@ export default ({
             false,
             chart.metric3,
             getControlHelpText(view, "metric3")
+          )}
+        {view === "bar" &&
+          metricDimSelector(
+            metricNames,
+            updateChartGenerator("metric4"),
+            "Error Bars",
+            false,
+            chart.metric4,
+            getControlHelpText(view, "metric4")
+          )}
+        {view === "bar" &&
+          metricDimSelector(
+            ["Clustered", "Stacked"],
+            selectedBarGrouping =>
+              updateChart({ barGrouping: selectedBarGrouping }),
+            "Stack or Cluster",
+            true,
+            barGrouping,
+            controlHelpText.barGrouping as string
+          )}
+        {view === "scatter" &&
+          metricDimSelector(
+            ["boxplot", "violin", "heatmap", "ridgeline", "histogram"],
+            selectedMarginalGraphics =>
+              updateChart({ marginalGraphics: selectedMarginalGraphics }),
+            "Marginal Graphics",
+            false,
+            marginalGraphics,
+            controlHelpText.marginalGraphics as string
+          )}
+
+        {view === "scatter" &&
+          metricDimSelector(
+            ["linear", "polynomial", "power", "exponential", "logarithmic"],
+            selectedRegressionType =>
+              updateChart({ trendLine: selectedRegressionType }),
+            "Trendline",
+            false,
+            trendLine,
+            controlHelpText.trendLine as string
           )}
         {(view === "summary" ||
           view === "scatter" ||

--- a/packages/data-explorer/src/charts/bar.tsx
+++ b/packages/data-explorer/src/charts/bar.tsx
@@ -13,6 +13,8 @@ interface BarOptions {
   colors: string[];
   setColor: (color: string[]) => void;
   barGrouping: Dx.BarGroupingType;
+  dimensions: object[];
+  metrics: object[];
 }
 
 export const semioticBarChart = (
@@ -36,6 +38,7 @@ export const semioticBarChart = (
   const additionalSettings: {
     afterElements?: JSX.Element;
     dynamicColumnWidth?: string;
+    rExtent?: number[];
     tooltipContent?: (hoveredDataPoint: {
       x: number;
       y: number;
@@ -63,7 +66,16 @@ export const semioticBarChart = (
       Math.max(...data.map(d => d[metric1] + d[metric4]))
     ];
 
-    errorBarAnnotations = (d: object, i: number, xy: object) => {
+    errorBarAnnotations = (
+      d: Dx.Datapoint,
+      i: number,
+      xy: {
+        width: number;
+        height: number;
+        styleFn: (args: object) => object;
+        rScale: (args: object) => number;
+      }
+    ) => {
       const errorBarSize = Math.abs(
         xy.rScale(d[metric1]) - xy.rScale(d[metric1] + d[metric4])
       );
@@ -129,13 +141,17 @@ export const semioticBarChart = (
       (selectedDimensions.length > 0 && selectedDimensions.join(",") !== dim1)
     ) {
       additionalSettings.pieceHoverAnnotation = true;
+      const combinedOptions = [
+        ...options.dimensions,
+        ...options.metrics
+      ] as Array<{ name: string }>;
       additionalSettings.tooltipContent = hoveredDatapoint => {
         return (
           <TooltipContent x={hoveredDatapoint.x} y={hoveredDatapoint.y}>
             <div
               style={{ heightMax: "300px", display: "flex", flexWrap: "wrap" }}
             >
-              {[...options.dimensions, ...options.metrics].map((dim, index) => (
+              {combinedOptions.map((dim: { name: string }, index: number) => (
                 <div
                   style={{
                     margin: "2px 5px 0",

--- a/packages/data-explorer/src/charts/bar.tsx
+++ b/packages/data-explorer/src/charts/bar.tsx
@@ -12,6 +12,7 @@ interface BarOptions {
   chart: Dx.Chart;
   colors: string[];
   setColor: (color: string[]) => void;
+  barGrouping: Dx.BarGroupingType;
 }
 
 export const semioticBarChart = (
@@ -19,8 +20,8 @@ export const semioticBarChart = (
   schema: Dx.Schema,
   options: BarOptions
 ) => {
-  const { selectedDimensions, chart, colors, setColor } = options;
-  const { dim1, metric1, metric3 } = chart;
+  const { selectedDimensions, chart, colors, setColor, barGrouping } = options;
+  const { dim1, metric1, metric3, metric4 } = chart;
 
   const oAccessor =
     selectedDimensions.length === 0
@@ -55,6 +56,47 @@ export const semioticBarChart = (
   if (metric3 && metric3 !== "none") {
     additionalSettings.dynamicColumnWidth = metric3;
   }
+  let errorBarAnnotations;
+  if (barGrouping === "Clustered" && metric4 && metric4 !== "none") {
+    additionalSettings.rExtent = [
+      Math.min(...data.map(d => d[metric1] - d[metric4])),
+      Math.max(...data.map(d => d[metric1] + d[metric4]))
+    ];
+
+    errorBarAnnotations = (d: object, i: number, xy: object) => {
+      const errorBarSize = Math.abs(
+        xy.rScale(d[metric1]) - xy.rScale(d[metric1] + d[metric4])
+      );
+
+      return (
+        <g>
+          <rect width={xy.width} height={xy.height} style={xy.styleFn(d)} />
+          <g
+            transform={`translate(${xy.width / 2},${
+              d.negative ? xy.height : 0
+            })`}
+            stroke="#333"
+            strokeWidth="1"
+            opacity="0.75"
+          >
+            <line
+              y1={-errorBarSize}
+              y2={-errorBarSize}
+              x1={Math.min(0, -xy.width / 2 + 2)}
+              x2={Math.max(0, xy.width / 2 - 2)}
+            />
+            <line x1={0} x2={0} y1={-errorBarSize} y2={errorBarSize} />
+            <line
+              y1={errorBarSize}
+              y2={errorBarSize}
+              x1={Math.min(0, -xy.width / 2 + 2)}
+              x2={Math.max(0, xy.width / 2 - 2)}
+            />
+          </g>
+        </g>
+      );
+    };
+  }
 
   const uniqueValues = sortedData.reduce(
     (uniques, datapoint) =>
@@ -83,27 +125,30 @@ export const semioticBarChart = (
     );
 
     if (
-      selectedDimensions.length > 0 &&
-      selectedDimensions.join(",") !== dim1
+      barGrouping === "Clustered" ||
+      (selectedDimensions.length > 0 && selectedDimensions.join(",") !== dim1)
     ) {
       additionalSettings.pieceHoverAnnotation = true;
       additionalSettings.tooltipContent = hoveredDatapoint => {
         return (
           <TooltipContent x={hoveredDatapoint.x} y={hoveredDatapoint.y}>
-            {dim1 && dim1 !== "none" && <p>{hoveredDatapoint[dim1]}</p>}
-            <p>
-              {typeof oAccessor === "function"
-                ? oAccessor(hoveredDatapoint)
-                : hoveredDatapoint[oAccessor]}
-            </p>
-            <p>
-              {rAccessor}: {hoveredDatapoint[rAccessor]}
-            </p>
-            {metric3 && metric3 !== "none" && (
-              <p>
-                {metric3}: {hoveredDatapoint[metric3]}
-              </p>
-            )}
+            <div
+              style={{ heightMax: "300px", display: "flex", flexWrap: "wrap" }}
+            >
+              {[...options.dimensions, ...options.metrics].map((dim, index) => (
+                <div
+                  style={{
+                    margin: "2px 5px 0",
+                    display: "inline-block",
+                    minWidth: "100px"
+                  }}
+                  key={`dim-${index}`}
+                >
+                  <span style={{ fontWeight: 600 }}>{dim.name}</span>:{" "}
+                  {hoveredDatapoint[dim.name]}
+                </div>
+              ))}
+            </div>
           </TooltipContent>
         );
       };
@@ -126,7 +171,10 @@ export const semioticBarChart = (
     0;
 
   const barSettings = {
-    type: cardinality > 4 ? "clusterbar" : "bar",
+    type:
+      barGrouping === "Clustered"
+        ? { type: "clusterbar", customMark: errorBarAnnotations }
+        : { type: "bar", customMark: errorBarAnnotations },
     data: sortedData,
     oAccessor,
     rAccessor,
@@ -177,6 +225,7 @@ export const semioticBarChart = (
       );
     },
     baseMarkProps: { forceUpdate: true },
+    size: [500, 600],
     ...additionalSettings
   };
 

--- a/packages/data-explorer/src/charts/xyplot.tsx
+++ b/packages/data-explorer/src/charts/xyplot.tsx
@@ -385,7 +385,7 @@ export const semioticScatterplot = (
     };
   }
 
-  const xyPlotSettings = {
+  const xyPlotSettings: { [key: string]: any } = {
     xAccessor: type === "hexbin" || type === "heatmap" ? "x" : metric1,
     yAccessor: type === "hexbin" || type === "heatmap" ? "y" : metric2,
     axes: [

--- a/packages/data-explorer/src/docs/chart-docs.ts
+++ b/packages/data-explorer/src/docs/chart-docs.ts
@@ -21,6 +21,7 @@ export type ChartOptionTypes =
   | "metric1"
   | "metric2"
   | "metric3"
+  | "metric4"
   | "dim1"
   | "dim2"
   | "dim3"
@@ -36,8 +37,10 @@ export type ExplorationTypes =
   | "summaryType"
   | "hierarchyType"
   | "nestingDimensions"
-  | "barDimensions";
-
+  | "barDimensions"
+  | "trendLine"
+  | "barGrouping"
+  | "marginalGraphics";
 export const controlHelpText: {
   [key in ExplorationTypes]?: { [key: string]: string } | string
 } = {
@@ -53,6 +56,7 @@ export const controlHelpText: {
     default: "Size the width of bars (Marimekko style) based on this metric",
     scatter: "Size the radius of points based on this metric"
   },
+  metric4: "Error bars according to this value",
   dim1: {
     default: "Color items by this dimension",
     summary: "Group items into this category",
@@ -75,5 +79,10 @@ export const controlHelpText: {
     "Represent your data using a line chart, stacked area chart or ranked area chart",
   areaType: "Represent as a heatmap, hexbin or contour plot",
   lineDimensions:
-    "Only plot the selected dimensions (or all if none are selected)"
+    "Only plot the selected dimensions (or all if none are selected)",
+  trendLine: "Select the kind of trend line you want to display on the chart",
+  barGrouping:
+    "Choose between a clustered or a stacked bar chart when there are multiple pieces in the same category",
+  marginalGraphics:
+    "Choose the kind of marginal summary you want to see for summarizing density along the axes"
 };

--- a/packages/data-explorer/src/index.tsx
+++ b/packages/data-explorer/src/index.tsx
@@ -34,6 +34,9 @@ interface dxMetaProps {
   summaryType?: SummaryType;
   networkType?: NetworkType;
   hierarchyType?: HierarchyType;
+  trendLine?: Dx.TrendLineType;
+  marginalGraphics?: SummaryType;
+  barGrouping?: Dx.BarGroupingType;
   colors?: string[];
   chart?: Chart;
 }
@@ -75,6 +78,9 @@ interface State {
   displayChart: DisplayChart;
   primaryKey: string[];
   data: Dx.Datapoint[];
+  trendLine: Dx.TrendLineType;
+  marginalGraphics: Dx.SummaryType;
+  barGrouping: Dx.BarGroupingType;
 }
 
 const generateChartKey = ({
@@ -87,6 +93,9 @@ const generateChartKey = ({
   summaryType,
   networkType,
   hierarchyType,
+  trendLine,
+  marginalGraphics,
+  barGrouping,
   chart
 }: {
   view: View;
@@ -98,13 +107,16 @@ const generateChartKey = ({
   summaryType: SummaryType;
   networkType: NetworkType;
   hierarchyType: HierarchyType;
+  trendLine: Dx.TrendLineType;
+  marginalGraphics: SummaryType;
+  barGrouping: Dx.BarGroupingType;
   chart: Chart;
 }) =>
   `${view}-${lineType}-${areaType}-${selectedDimensions.join(
     ","
   )}-${selectedMetrics.join(
     ","
-  )}-${pieceType}-${summaryType}-${networkType}-${hierarchyType}-${JSON.stringify(
+  )}-${pieceType}-${summaryType}-${networkType}-${hierarchyType}-${trendLine}-${marginalGraphics}-${barGrouping}-${JSON.stringify(
     chart
   )}`;
 
@@ -234,7 +246,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
     // Provide a default primaryKey if none provided
     if (primaryKey.length === 0) {
       primaryKey = [Dx.defaultPrimaryKey];
-      fields.push({ name: Dx.defaultPrimaryKey, type: "integer" });
+      fields = [...fields, { name: Dx.defaultPrimaryKey, type: "integer" }];
     }
 
     const dimensions = fields.filter(
@@ -276,6 +288,9 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
       view: initialView,
       lineType: "line",
       areaType: "hexbin",
+      trendLine: "none",
+      marginalGraphics: "none",
+      barGrouping: "Clustered",
       selectedDimensions: [],
       selectedMetrics: [],
       pieceType: "bar",
@@ -290,6 +305,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
         metric1: (metrics[0] && metrics[0].name) || "none",
         metric2: (metrics[1] && metrics[1].name) || "none",
         metric3: "none",
+        metric4: "none",
         dim1: (dimensions[0] && dimensions[0].name) || "none",
         dim2: (dimensions[1] && dimensions[1].name) || "none",
         dim3: "none",
@@ -325,6 +341,9 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
       summaryType,
       networkType,
       hierarchyType,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
       colors,
       primaryKey,
       data: stateData
@@ -348,7 +367,10 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
       summaryType,
       networkType,
       hierarchyType,
-      chart
+      chart,
+      trendLine,
+      marginalGraphics,
+      barGrouping
     });
 
     const frameSettings = chartGenerator(stateData, data!.schema, {
@@ -366,6 +388,9 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
       networkType,
       hierarchyType,
       primaryKey,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
       setColor: this.setColor
     });
 
@@ -388,6 +413,9 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
             hierarchyType,
             summaryType,
             networkType,
+            trendLine,
+            marginalGraphics,
+            barGrouping,
             updateChart: this.updateChart,
             updateDimensions: this.updateDimensions,
             setLineType: this.setLineType,
@@ -416,6 +444,9 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
             summaryType,
             networkType,
             hierarchyType,
+            trendLine,
+            marginalGraphics,
+            barGrouping,
             colors,
             chart
           }
@@ -485,7 +516,10 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
       pieceType,
       summaryType,
       networkType,
-      hierarchyType
+      hierarchyType,
+      trendLine,
+      marginalGraphics,
+      barGrouping
     } = this.state;
 
     let display: React.ReactNode = null;
@@ -514,7 +548,10 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
         summaryType,
         networkType,
         hierarchyType,
-        chart
+        chart,
+        trendLine,
+        marginalGraphics,
+        barGrouping
       });
 
       display = this.state.displayChart[chartKey];

--- a/packages/data-explorer/src/tooltip-content.tsx
+++ b/packages/data-explorer/src/tooltip-content.tsx
@@ -9,10 +9,10 @@ interface Props {
 
 // A little "mixin" for picking the :before on a tooltip
 const beforeContent = (props: Props) => {
-  if (props.x < 100) {
+  if (props.x < 200) {
     return null;
   }
-  if (props.y < 100) {
+  if (props.y < 200) {
     return `
       border-left: inherit;
       border-top: inherit;
@@ -48,8 +48,8 @@ const beforeContent = (props: Props) => {
 const TooltipContent = styled.div.attrs((props: Props) => ({
   style: {
     transform: `translate(
-      ${props.x < 100 ? "0px" : "calc(-50% + 7px)"},
-      ${props.y < 100 ? "10px" : "calc(-100% - 10px)"}
+      ${props.x < 200 ? "0px" : "calc(-50% + 7px)"},
+      ${props.y < 200 ? "10px" : "calc(-100% - 10px)"}
     )`
   }
 }))`

--- a/packages/data-explorer/src/types.ts
+++ b/packages/data-explorer/src/types.ts
@@ -66,6 +66,7 @@ export interface Chart {
   metric1: string;
   metric2: string;
   metric3: string;
+  metric4: string;
   dim1: string;
   dim2: string;
   dim3: string;
@@ -75,7 +76,18 @@ export interface Chart {
 export type LineType = "line" | "stackedarea" | "bumparea" | "stackedpercent";
 export type AreaType = "hexbin" | "heatmap" | "contour";
 
+export type BarGroupingType = "Stacked" | "Clustered";
+
+export type TrendLineType =
+  | "none"
+  | "linear"
+  | "polynomial"
+  | "logarithmic"
+  | "exponential"
+  | "power";
+
 export type SummaryType =
+  | "none"
   | "violin"
   | "joy"
   | "histogram"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11717,10 +11717,10 @@ semiotic-mark@0.3.1:
     prop-types "^15.6.0"
     roughjs-es5 "0.1.0"
 
-semiotic@^1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.19.0.tgz#ec24959b32856cf085e459e29370531eefa01dc9"
-  integrity sha512-2ewgUwOGgfBan5uj2JHCyBl2xHGd04gmw5RfVesKJaoLsVLRHUGSmHSTQTCXR4MLNp0SySd+c39uSBiHprA/lw==
+semiotic@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.19.1.tgz#1d1c93b737cfb5aa51f4cce96c13779f0b5aaefb"
+  integrity sha512-xDTMLXCtbqDRWvG2vwQsgdVuXeR98IJ6rncMitmLpcJ31tj4JFCb47WsyYeUNUHHsYlu7yQNWxCxBGVvSuSGeA==
   dependencies:
     "@mapbox/polylabel" "1"
     d3-array "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3601,7 +3601,7 @@ d3-bboxCollide@^1.0.3:
   dependencies:
     d3-quadtree "1.0.1"
 
-d3-brush@^1.0.4:
+d3-brush@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.6.tgz#33691f2032d9db6c5d8cb684ff255a9883629e21"
   integrity sha512-lGSiF5SoSqO5/mYGD5FAeGKKS62JdA1EV7HPrU2b5rTX4qEJJtpjaGLJngjnkewQy7UnGstnFd3168wpf5z76w==
@@ -11285,6 +11285,11 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
+regression@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regression/-/regression-2.0.1.tgz#8d29c3e8224a10850c35e337e85a8b2fac3b0c87"
+  integrity sha1-jSnD6CJKEIUMNeM36FqLL6w7DIc=
+
 remark-parse@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
@@ -11712,15 +11717,15 @@ semiotic-mark@0.3.1:
     prop-types "^15.6.0"
     roughjs-es5 "0.1.0"
 
-semiotic@^1.16.3:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.16.4.tgz#b4a9728d72322e768705b376c1a04d07412d62af"
-  integrity sha512-ZWWH+ehpHGyc4KVrhC+Vuuthodt71nCgv0ChRjQLrqaKm5z3yi+2yTA/zwuUi05YD+XhLNkcKC6w1Q/vnXP8GQ==
+semiotic@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.19.0.tgz#ec24959b32856cf085e459e29370531eefa01dc9"
+  integrity sha512-2ewgUwOGgfBan5uj2JHCyBl2xHGd04gmw5RfVesKJaoLsVLRHUGSmHSTQTCXR4MLNp0SySd+c39uSBiHprA/lw==
   dependencies:
     "@mapbox/polylabel" "1"
     d3-array "^1.2.0"
     d3-bboxCollide "^1.0.3"
-    d3-brush "^1.0.4"
+    d3-brush "^1.0.6"
     d3-chord "^1.0.4"
     d3-collection "^1.0.1"
     d3-contour "^1.1.1"
@@ -11743,6 +11748,7 @@ semiotic@^1.16.3:
     promise "8.0.1"
     prop-types "15.6.0"
     react-annotation "2.1.5"
+    regression "^2.0.1"
     roughjs-es5 "0.1.0"
     semiotic-mark "0.3.1"
     svg-path-bounding-box "1.0.4"


### PR DESCRIPTION
Adds a few new features to the Data Explorer:

* Error bars in bar chart
There's now an option to display error bars on the bar chart based on a metric. Only works with Clustered Bar Charts (because stacked error bars is nonsensical)

![Screen Shot 2019-03-20 at 1 51 59 PM](https://user-images.githubusercontent.com/495634/54718365-905f3380-4b17-11e9-91ec-7436130157ee.png)

* Explicit stacked/cluster button
Previously Data Explorer tried to smartly select between clustering and stacking items when there were multiple items in a category. This wasn't a great experience so now it's an option to switch between Clustered and Stacked

* Trend line in scatterplot
There's an option to display a trend line in the scatterplot. It has the standard options (note: this currently isn't updating unless you then change a metric because of a bug in Semiotic, so this will be fixed with the next release of Semiotic)

* Marginal Graphics in scatterplot
You can display summary graphics in the margins of various types (like boxplots or histograms) to show the density along the axes.
![Screen Shot 2019-03-20 at 1 51 43 PM](https://user-images.githubusercontent.com/495634/54718475-da481980-4b17-11e9-8486-e1e43589767b.png)
