### PR TITLE
Remove Blueprint Controls

### DIFF
--- a/packages/data-explorer/README.md
+++ b/packages/data-explorer/README.md
@@ -42,10 +42,6 @@ Note: you also need to include the CSS for a few dependencies as well
 
 ```
 
-// Toolbars and other UI elements
-import "@blueprintjs/core/lib/css/blueprint.css";
-import "@blueprintjs/select/lib/css/blueprint-select.css";
-
 // CSS for the grid view on the data explorer
 import "react-table/react-table.css";
 ```

--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -20,8 +20,6 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@blueprintjs/core": "^3.7.0",
-    "@blueprintjs/select": "^3.2.0",
     "@nteract/octicons": "^2.0.0",
     "d3-collection": "^1.0.7",
     "d3-scale": "^2.1.2",

--- a/packages/data-explorer/src/ParallelCoordinatesController.tsx
+++ b/packages/data-explorer/src/ParallelCoordinatesController.tsx
@@ -2,7 +2,6 @@ import { scaleLinear, ScaleLinear } from "d3-scale";
 import * as React from "react";
 import { Axis, ResponsiveOrdinalFrame } from "semiotic";
 
-import { StyledButtonGroup } from "./components/button-group";
 import HTMLLegend from "./HTMLLegend";
 
 import TooltipContent from "./tooltip-content";
@@ -257,7 +256,7 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
 
     return (
       <div>
-        <StyledButtonGroup>
+        <div>
           <button
             className={`button-text ${filterMode ? "selected" : ""}`}
             onClick={() => this.setState({ filterMode: true })}
@@ -270,7 +269,7 @@ class ParallelCoordinatesController extends React.Component<Props, State> {
           >
             Explore
           </button>
-        </StyledButtonGroup>
+        </div>
         <ResponsiveOrdinalFrame
           data={this.state.data}
           oAccessor="metric"

--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -9,6 +9,7 @@ import styled, { css } from "styled-components";
 import * as Dx from "./types";
 
 // const NoResultsItem = <MenuItem disabled text="No results." />;
+/*
 
 const arrowHeadMarker = (
   <marker
@@ -123,6 +124,7 @@ const getIcon = (title: string) => {
     return title as IconName;
   }
 };
+*/
 
 const commonCSS = css`
   h2 {
@@ -192,13 +194,14 @@ const metricDimSelector = (
     */
     displayMetrics = (
       <select
-        onChange={(event?: React.SyntheticEvent<HTMLElement>): void => {
+        onChange={(event: { target: { value: string } }): void => {
           selectionFunction(event.target.value);
         }}
+        value={selectedValue}
       >
         {metricsList.map((metricName: string, i) => (
           <option
-            ariaSelected={metricName}
+            aria-selected={selectedValue === metricName}
             key={`display-metric-${i}`}
             label={metricName}
             value={metricName}
@@ -519,7 +522,6 @@ export default ({
                 key={lineTypeOption.type}
                 className={`button-text ${lineType === lineTypeOption.type &&
                   "selected"}`}
-                active={lineType === lineTypeOption.type}
                 onClick={() => setLineType(lineTypeOption.type)}
               >
                 {lineTypeOption.label}
@@ -572,7 +574,6 @@ export default ({
                       "selected"}`}
                     key={areaTypeOptionType}
                     onClick={() => setAreaType(areaTypeOptionType)}
-                    active={areaType === areaTypeOptionType}
                   >
                     {areaTypeOption.label}
                   </button>
@@ -646,7 +647,6 @@ export default ({
                   dim.name
                 ) !== -1 && "selected"}`}
                 onClick={() => updateDimensions(dim.name)}
-                active={selectedDimensions.indexOf(dim.name) !== -1}
               >
                 {dim.name}
               </button>
@@ -668,7 +668,6 @@ export default ({
                   metric.name
                 ) !== -1 && "selected"}`}
                 onClick={() => updateMetrics(metric.name)}
-                active={selectedMetrics.indexOf(metric.name) !== -1}
               >
                 {metric.name}
               </button>

--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -1,130 +1,9 @@
-// import { Button, Code, IconName, MenuItem } from "@blueprintjs/core";
-// import { Select } from "@blueprintjs/select";
 import * as React from "react";
 
-// import { StyledButtonGroup } from "./components/button-group";
 import { ChartOptionTypes, controlHelpText } from "./docs/chart-docs";
 
 import styled, { css } from "styled-components";
 import * as Dx from "./types";
-
-// const NoResultsItem = <MenuItem disabled text="No results." />;
-/*
-
-const arrowHeadMarker = (
-  <marker
-    id="arrow"
-    refX="3"
-    refY="3"
-    markerWidth="6"
-    markerHeight="6"
-    orient="auto-start-reverse"
-  >
-    <path fill="#5c7080" d="M 0 0 L 6 3 L 0 6 z" />
-  </marker>
-);
-
-const svgIconSettings = {
-  width: "16px",
-  height: "16px",
-  className: "bp3-icon"
-};
-
-const xAxisIcon = (
-  <svg {...svgIconSettings}>
-    <defs>{arrowHeadMarker}</defs>
-    <polyline
-      points="3,3 3,13 12,13"
-      fill="none"
-      stroke="#5c7080"
-      markerEnd="url(#arrow)"
-    />
-  </svg>
-);
-
-const yAxisIcon = (
-  <svg {...svgIconSettings}>
-    <defs>{arrowHeadMarker}</defs>
-    <polyline
-      points="3,3 3,13 12,13"
-      fill="none"
-      stroke="#5c7080"
-      markerStart="url(#arrow)"
-    />
-  </svg>
-);
-
-const sizeIcon = (
-  <svg {...svgIconSettings}>
-    <circle cx={3} cy={13} r={2} fill="none" stroke="#5c7080" />
-    <circle cx={6} cy={9} r={3} fill="none" stroke="#5c7080" />
-    <circle cx={9} cy={5} r={4} fill="none" stroke="#5c7080" />
-  </svg>
-);
-
-const colorIcon = (
-  <svg {...svgIconSettings}>
-    <circle cx={3} cy={11} r={3} fill="rgb(179, 51, 29)" />
-    <circle cx={13} cy={11} r={3} fill="rgb(87, 130, 220)" />
-    <circle cx={8} cy={5} r={3} fill="rgb(229, 194, 9)" />
-  </svg>
-);
-
-const iconHash: { [key in "Y" | "X" | "Size" | "Color"]: JSX.Element } = {
-  Y: yAxisIcon,
-  X: xAxisIcon,
-  Size: sizeIcon,
-  Color: colorIcon
-};
-
-interface MenuItemType {
-  label: string;
-}
-interface ModifiersType {
-  matchesPredicate: boolean;
-  active: boolean;
-  disabled: boolean;
-}
-
-const renderMenuItem = (
-  item: MenuItemType,
-  {
-    handleClick,
-    modifiers
-  }: {
-    handleClick: (event: React.MouseEvent<HTMLElement>) => void;
-    modifiers: ModifiersType;
-  }
-) => {
-  if (!modifiers.matchesPredicate) {
-    return null;
-  }
-  const text = `${item.label}`;
-  return (
-    <MenuItem
-      active={modifiers.active}
-      disabled={modifiers.disabled}
-      key={text}
-      onClick={handleClick}
-      text={text}
-    />
-  );
-};
-
-const filterItem = (query: string, item: MenuItemType) => {
-  return `${item.label.toLowerCase()}`.indexOf(query.toLowerCase()) >= 0;
-};
-
-const getIcon = (title: string) => {
-  if (title === "X" || title === "Y" || title === "Size" || title === "Color") {
-    return iconHash[title];
-  } else {
-    // TODO: Verify if we are handling icon title properly
-    // console.warn("Icon title not supported");
-    return title as IconName;
-  }
-};
-*/
 
 const commonCSS = css`
   h2 {
@@ -165,33 +44,6 @@ const metricDimSelector = (
   let displayMetrics;
 
   if (metricsList.length > 1) {
-    /*
-    displayMetrics = (
-      <Select
-        items={metricsList.map((metricName: string) => ({
-          value: metricName,
-          label: metricName
-        }))}
-        query={selectedValue}
-        noResults={NoResultsItem}
-        onItemSelect={(
-          item: { value: string; label: string },
-          event?: React.SyntheticEvent<HTMLElement>
-        ): void => {
-          selectionFunction(item.value);
-        }}
-        itemRenderer={renderMenuItem}
-        itemPredicate={filterItem}
-        resetOnClose
-      >
-        <Button
-          icon={getIcon(title)}
-          text={selectedValue}
-          rightIcon="double-caret-vertical"
-        />
-      </Select>
-    );
-    */
     displayMetrics = (
       <select
         onChange={(event: { target: { value: string } }): void => {
@@ -528,31 +380,7 @@ export default ({
               </button>
             ))}
           </div>
-        )
-        /*(
-          <div
-            title={controlHelpText.lineType as string}
-            style={{ display: "inline-block" }}
-          >
-            <div>
-              <Code>Chart Type</Code>
-            </div>
-            <StyledButtonGroup vertical>
-              {availableLineTypes.map(lineTypeOption => (
-                <Button
-                  key={lineTypeOption.type}
-                  className={`button-text ${lineType === lineTypeOption.type &&
-                    "selected"}`}
-                  active={lineType === lineTypeOption.type}
-                  onClick={() => setLineType(lineTypeOption.type)}
-                >
-                  {lineTypeOption.label}
-                </Button>
-              ))}
-            </StyledButtonGroup>
-          </div>
-                  ) */
-        }
+        )}
         {view === "hexbin" && (
           <div
             className="control-wrapper"
@@ -583,42 +411,7 @@ export default ({
               }
             })}
           </div>
-        )
-        /*(
-          <div
-            className="control-wrapper"
-            title={controlHelpText.areaType as string}
-          >
-            <div>
-              <Code>Chart Type</Code>
-            </div>
-            <StyledButtonGroup vertical>
-              {availableAreaTypes.map(areaTypeOption => {
-                const areaTypeOptionType = areaTypeOption.type;
-                if (
-                  areaTypeOptionType === "contour" ||
-                  areaTypeOptionType === "hexbin" ||
-                  areaTypeOptionType === "heatmap"
-                ) {
-                  return (
-                    <Button
-                      className={`button-text ${areaType ===
-                        areaTypeOptionType && "selected"}`}
-                      key={areaTypeOptionType}
-                      onClick={() => setAreaType(areaTypeOptionType)}
-                      active={areaType === areaTypeOptionType}
-                    >
-                      {areaTypeOption.label}
-                    </Button>
-                  );
-                } else {
-                  return <div />;
-                }
-              })}
-            </StyledButtonGroup>
-          </div>
-            )*/
-        }
+        )}
         {view === "hierarchy" && (
           <div
             className="control-wrapper"

--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -1,14 +1,14 @@
-import { Button, Code, IconName, MenuItem } from "@blueprintjs/core";
-import { Select } from "@blueprintjs/select";
+// import { Button, Code, IconName, MenuItem } from "@blueprintjs/core";
+// import { Select } from "@blueprintjs/select";
 import * as React from "react";
 
-import { StyledButtonGroup } from "./components/button-group";
+// import { StyledButtonGroup } from "./components/button-group";
 import { ChartOptionTypes, controlHelpText } from "./docs/chart-docs";
 
 import styled, { css } from "styled-components";
 import * as Dx from "./types";
 
-const NoResultsItem = <MenuItem disabled text="No results." />;
+// const NoResultsItem = <MenuItem disabled text="No results." />;
 
 const arrowHeadMarker = (
   <marker
@@ -163,6 +163,7 @@ const metricDimSelector = (
   let displayMetrics;
 
   if (metricsList.length > 1) {
+    /*
     displayMetrics = (
       <Select
         items={metricsList.map((metricName: string) => ({
@@ -188,6 +189,25 @@ const metricDimSelector = (
         />
       </Select>
     );
+    */
+    displayMetrics = (
+      <select
+        onChange={(event?: React.SyntheticEvent<HTMLElement>): void => {
+          selectionFunction(event.target.value);
+        }}
+      >
+        {metricsList.map((metricName: string, i) => (
+          <option
+            ariaSelected={metricName}
+            key={`display-metric-${i}`}
+            label={metricName}
+            value={metricName}
+          >
+            {metricName}
+          </option>
+        ))}
+      </select>
+    );
   } else {
     displayMetrics = <p style={{ margin: 0 }}>{metricsList[0]}</p>;
   }
@@ -195,7 +215,7 @@ const metricDimSelector = (
   return (
     <ControlWrapper title={contextTooltip}>
       <div>
-        <Code>{title}</Code>
+        <h3>{title}</h3>
       </div>
       {displayMetrics}
     </ControlWrapper>
@@ -492,6 +512,27 @@ export default ({
             style={{ display: "inline-block" }}
           >
             <div>
+              <h3>Chart Type</h3>
+            </div>
+            {availableLineTypes.map(lineTypeOption => (
+              <button
+                key={lineTypeOption.type}
+                className={`button-text ${lineType === lineTypeOption.type &&
+                  "selected"}`}
+                active={lineType === lineTypeOption.type}
+                onClick={() => setLineType(lineTypeOption.type)}
+              >
+                {lineTypeOption.label}
+              </button>
+            ))}
+          </div>
+        )
+        /*(
+          <div
+            title={controlHelpText.lineType as string}
+            style={{ display: "inline-block" }}
+          >
+            <div>
               <Code>Chart Type</Code>
             </div>
             <StyledButtonGroup vertical>
@@ -508,8 +549,41 @@ export default ({
               ))}
             </StyledButtonGroup>
           </div>
-        )}
+                  ) */
+        }
         {view === "hexbin" && (
+          <div
+            className="control-wrapper"
+            title={controlHelpText.areaType as string}
+          >
+            <div>
+              <h3>Chart Type</h3>
+            </div>
+            {availableAreaTypes.map(areaTypeOption => {
+              const areaTypeOptionType = areaTypeOption.type;
+              if (
+                areaTypeOptionType === "contour" ||
+                areaTypeOptionType === "hexbin" ||
+                areaTypeOptionType === "heatmap"
+              ) {
+                return (
+                  <button
+                    className={`button-text ${areaType === areaTypeOptionType &&
+                      "selected"}`}
+                    key={areaTypeOptionType}
+                    onClick={() => setAreaType(areaTypeOptionType)}
+                    active={areaType === areaTypeOptionType}
+                  >
+                    {areaTypeOption.label}
+                  </button>
+                );
+              } else {
+                return <div />;
+              }
+            })}
+          </div>
+        )
+        /*(
           <div
             className="control-wrapper"
             title={controlHelpText.areaType as string}
@@ -542,14 +616,15 @@ export default ({
               })}
             </StyledButtonGroup>
           </div>
-        )}
+            )*/
+        }
         {view === "hierarchy" && (
           <div
             className="control-wrapper"
             title={controlHelpText.nestingDimensions as string}
           >
             <div>
-              <Code>Nesting</Code>
+              <h3>Nesting</h3>
             </div>
             {selectedDimensions.length === 0
               ? "Select categories to nest"
@@ -562,22 +637,20 @@ export default ({
             title={controlHelpText.barDimensions as string}
           >
             <div>
-              <Code>Categories</Code>
+              <h3>Categories</h3>
             </div>
-            <StyledButtonGroup vertical>
-              {dimensions.map(dim => (
-                <Button
-                  key={`dimensions-select-${dim.name}`}
-                  className={`button-text ${selectedDimensions.indexOf(
-                    dim.name
-                  ) !== -1 && "selected"}`}
-                  onClick={() => updateDimensions(dim.name)}
-                  active={selectedDimensions.indexOf(dim.name) !== -1}
-                >
-                  {dim.name}
-                </Button>
-              ))}
-            </StyledButtonGroup>
+            {dimensions.map(dim => (
+              <button
+                key={`dimensions-select-${dim.name}`}
+                className={`button-text ${selectedDimensions.indexOf(
+                  dim.name
+                ) !== -1 && "selected"}`}
+                onClick={() => updateDimensions(dim.name)}
+                active={selectedDimensions.indexOf(dim.name) !== -1}
+              >
+                {dim.name}
+              </button>
+            ))}
           </div>
         )}
         {view === "line" && (
@@ -586,22 +659,20 @@ export default ({
             title={controlHelpText.lineDimensions as string}
           >
             <div>
-              <Code>Metrics</Code>
+              <h3>Metrics</h3>
             </div>
-            <StyledButtonGroup vertical>
-              {metrics.map(metric => (
-                <Button
-                  key={`metrics-select-${metric.name}`}
-                  className={`button-text ${selectedMetrics.indexOf(
-                    metric.name
-                  ) !== -1 && "selected"}`}
-                  onClick={() => updateMetrics(metric.name)}
-                  active={selectedMetrics.indexOf(metric.name) !== -1}
-                >
-                  {metric.name}
-                </Button>
-              ))}
-            </StyledButtonGroup>
+            {metrics.map(metric => (
+              <button
+                key={`metrics-select-${metric.name}`}
+                className={`button-text ${selectedMetrics.indexOf(
+                  metric.name
+                ) !== -1 && "selected"}`}
+                onClick={() => updateMetrics(metric.name)}
+                active={selectedMetrics.indexOf(metric.name) !== -1}
+              >
+                {metric.name}
+              </button>
+            ))}
           </div>
         )}
       </Wrapper>

--- a/packages/data-explorer/src/charts/grid.tsx
+++ b/packages/data-explorer/src/charts/grid.tsx
@@ -1,4 +1,3 @@
-// import { Button, InputGroup, Tooltip } from "@blueprintjs/core";
 import * as React from "react";
 import ReactTable from "react-table";
 import withFixedColumns from "react-table-hoc-fixed-columns";
@@ -36,34 +35,6 @@ const GridWrapper = styled.div`
 const NumberFilter = (props: NumberFilterProps) => {
   const { filterState, filterName, updateFunction, onChange } = props;
   const mode = filterState[filterName] || "=";
-  /* old blueprint button
-  const lockButton = (
-    <Tooltip content={`Switch to ${switchMode(mode)}`}>
-      <Button
-        minimal
-        onClick={() => {
-          updateFunction({ [filterName]: switchMode(mode) });
-        }}
-      >
-        {mode}
-      </Button>
-    </Tooltip>
-  );
-
-  return (
-    <InputGroup
-      //      allowNumericCharactersOnly={true}
-      large
-      placeholder="number"
-      rightElement={lockButton}
-      small={false}
-      type={"text"}
-      onChange={(event: React.FormEvent<HTMLInputElement>) => {
-        onChange(event.currentTarget.value);
-      }}
-    />
-  );
-    */
 
   return (
     <form
@@ -108,19 +79,6 @@ const stringFilter = () => ({ onChange }: { onChange: OnChangeProps }) => (
     />
   </form>
 );
-
-/* Blueprint string filter
-
-(
-  <InputGroup
-    large
-    placeholder="string"
-    type={"text"}
-    onChange={(event: React.FormEvent<HTMLInputElement>) => {
-      onChange(event.currentTarget.value);
-    }}
-  />
-);*/
 
 const numberFilterWrapper = (
   filterState: NumberFilterProps["filterState"],

--- a/packages/data-explorer/src/charts/grid.tsx
+++ b/packages/data-explorer/src/charts/grid.tsx
@@ -1,4 +1,4 @@
-import { Button, InputGroup, Tooltip } from "@blueprintjs/core";
+// import { Button, InputGroup, Tooltip } from "@blueprintjs/core";
 import * as React from "react";
 import ReactTable from "react-table";
 import withFixedColumns from "react-table-hoc-fixed-columns";
@@ -36,6 +36,7 @@ const GridWrapper = styled.div`
 const NumberFilter = (props: NumberFilterProps) => {
   const { filterState, filterName, updateFunction, onChange } = props;
   const mode = filterState[filterName] || "=";
+  /* old blueprint button
   const lockButton = (
     <Tooltip content={`Switch to ${switchMode(mode)}`}>
       <Button
@@ -62,9 +63,55 @@ const NumberFilter = (props: NumberFilterProps) => {
       }}
     />
   );
+    */
+
+  return (
+    <form
+      style={{
+        border: "1px solid gray",
+        background: "white",
+        borderRadius: "5px",
+        width: "100%"
+      }}
+    >
+      <input
+        type="text"
+        id="name"
+        name="user_name"
+        style={{ width: "calc(100% - 30px)", border: "none" }}
+        onChange={(event: React.FormEvent<HTMLInputElement>) => {
+          onChange(event.currentTarget.value);
+        }}
+        placeholder="number"
+      />
+      <button
+        onClick={() => {
+          updateFunction({ [filterName]: switchMode(mode) });
+        }}
+      >
+        {mode}
+      </button>
+    </form>
+  );
 };
 
 const stringFilter = () => ({ onChange }: { onChange: OnChangeProps }) => (
+  <form>
+    <input
+      type="text"
+      id="string-filter"
+      name="string-filter"
+      onChange={(event: React.FormEvent<HTMLInputElement>) => {
+        onChange(event.currentTarget.value);
+      }}
+      placeholder="string"
+    />
+  </form>
+);
+
+/* Blueprint string filter
+
+(
   <InputGroup
     large
     placeholder="string"
@@ -73,7 +120,7 @@ const stringFilter = () => ({ onChange }: { onChange: OnChangeProps }) => (
       onChange(event.currentTarget.value);
     }}
   />
-);
+);*/
 
 const numberFilterWrapper = (
   filterState: NumberFilterProps["filterState"],
@@ -209,12 +256,12 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
 
     return (
       <GridWrapper>
-        <Button
-          icon="filter"
+        <button
+          //          icon="filter"
           onClick={() => this.setState({ showFilters: !showFilters })}
         >
           {showFilters ? "Hide" : "Show"} Filters
-        </Button>
+        </button>
         <ReactTableFixedColumns
           data={data}
           columns={tableColumns}

--- a/packages/data-explorer/src/components/button-group.tsx
+++ b/packages/data-explorer/src/components/button-group.tsx
@@ -1,10 +1,13 @@
-import { Button, ButtonGroup } from "@blueprintjs/core";
-import styled from "styled-components";
+// import { Button, ButtonGroup } from "@blueprintjs/core";
+// import styled from "styled-components";
 
 /**
  * This ports over some of the overridden styles within the data
  * explorer from the migration away from styled-jsx.
  */
+
+/*
+
 export const StyledButtonGroup = styled(ButtonGroup)`
   .button-text {
     margin: 0 10px 10px 0;
@@ -39,3 +42,4 @@ export const StyledButtonGroup = styled(ButtonGroup)`
     position: relative;
   }
 `;
+*/

--- a/packages/data-explorer/src/components/button-group.tsx
+++ b/packages/data-explorer/src/components/button-group.tsx
@@ -43,3 +43,5 @@ export const StyledButtonGroup = styled(ButtonGroup)`
   }
 `;
 */
+
+export const StyledButtonGroup = null;


### PR DESCRIPTION
Blueprint CSS has had some issues for external partners so this just removes the Blueprint components and replaces them with simple HTML components. It still looks very functional but seems to maintain all the functionality. Should resolve #4261 

* Replaces Blueprint components with HTML components
* Leaves the blueprint code (commented out) so that someone can take a look at it down the line