### PR TITLE
Fix summary, area & controls

### DIFF
--- a/packages/data-explorer/src/VizControls.tsx
+++ b/packages/data-explorer/src/VizControls.tsx
@@ -27,6 +27,7 @@ const ControlWrapper = styled.div`
 
 const Wrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
   justify-content: left;
   margin-bottom: 30px;
   ${commonCSS}

--- a/packages/data-explorer/src/charts/summary.tsx
+++ b/packages/data-explorer/src/charts/summary.tsx
@@ -91,7 +91,7 @@ export const semioticSummaryChart = (
           ),
     margin: { top: 25, right: 10, bottom: 50, left: 100 },
     axis: {
-      orient: "left",
+      orient: "bottom",
       label: rAccessor,
       tickFormat: numeralFormatting
     },

--- a/packages/data-explorer/src/charts/xyplot.tsx
+++ b/packages/data-explorer/src/charts/xyplot.tsx
@@ -353,7 +353,7 @@ export const semioticScatterplot = (
 
   let marginalGraphicsAxes: object[] = [];
 
-  if (marginalGraphics !== "none") {
+  if (marginalGraphics !== "none" && type === "scatterplot") {
     marginalGraphicsAxes = [
       {
         orient: "right",


### PR DESCRIPTION
Tiny changes in the code to correct some messiness I just saw when testing the component:

Area charts were still showing marginal graphics if they were selected by the scatterplot
Axis rendering was weird in summary
New HTML controls weren't wrapping
