### PR TITLE
Fix Linux config in electron-builder

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -83,9 +83,9 @@
         "AppImage",
         "tar.gz"
       ],
+      "executableName": "nteract",
       "desktop": {
         "Comment": "Interactive literate coding notebook",
-        "Exec": "/opt/nteract/nteract %U",
         "Icon": "nteract",
         "MimeType": "application/x-ipynb+json",
         "Name": "nteract",


### PR DESCRIPTION
An update in the electron builder requires this change.

We'll have to figure out how to bring the version number in automagically in the future. Using `%U` in the executableName did not work.