### PR TITLE
Dynamically set base path for notebook

### DIFF
--- a/packages/notebook-app-component/__tests__/notebook.spec.tsx
+++ b/packages/notebook-app-component/__tests__/notebook.spec.tsx
@@ -32,6 +32,22 @@ describe("NotebookApp", () => {
     expect(component).not.toBeNull();
   });
 
+  describe("NotebookApp", () => {
+    test("contains a base attribute", () => {
+      const component = shallow(
+        <NotebookApp
+          cellOrder={fixtureCommutable.get("cellOrder")}
+          cellMap={fixtureCommutable.get("cellMap")}
+          transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
+          cellPagers={new Immutable.Map()}
+          cellStatuses={new Immutable.Map()}
+          contentRef={"contentRef"}
+        />
+      );
+      expect(component.find("base")).toBeDefined();
+    });
+  });
+
   describe("keyDown", () => {
     test("detects a cell execution keypress", () => {
       const focusedCell = fixtureCommutable.getIn(["cellOrder", 1]);

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -33,6 +33,7 @@
     "date-fns": "^1.29.0",
     "react-dnd": "^7.0.0",
     "react-dnd-html5-backend": "^7.0.0",
+    "react-helmet": "^5.2.0",
     "react-hot-loader": "^4.1.2",
     "react-redux": "^6.0.0",
     "redux": "^4.0.0"

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -43,5 +43,8 @@
     "react": "^16.3.2"
   },
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "@types/react-helmet": "^5.0.8"
+  }
 }

--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable no-return-assign */
 import {
   CellId,
+  CellType,
   ExecutionCount,
   ImmutableCodeCell,
-  JSONObject,
-  CellType
+  JSONObject
 } from "@nteract/commutable";
 import { actions, selectors } from "@nteract/core";
 import {
@@ -38,6 +38,7 @@ import DraggableCell from "./draggable-cell";
 import Editor from "./editor";
 import { HijackScroll } from "./hijack-scroll";
 import MarkdownPreviewer from "./markdown-preview";
+import NotebookHelmet from "./notebook-helmet";
 import StatusBar from "./status-bar";
 import Toolbar, { CellToolbarMask } from "./toolbar";
 import TransformMedia from "./transform-media";
@@ -586,9 +587,10 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
     }
   }
 
-  render() {
+  render(): JSX.Element {
     return (
       <React.Fragment>
+        <NotebookHelmet contentRef={this.props.contentRef} />
         <Cells>
           <CellCreator
             id={this.props.cellOrder.get(0)}

--- a/packages/notebook-app-component/src/notebook-helmet.tsx
+++ b/packages/notebook-app-component/src/notebook-helmet.tsx
@@ -1,0 +1,44 @@
+import * as selectors from "@nteract/selectors";
+import { AppState, ContentRef } from "@nteract/types";
+import path from "path";
+import React from "react";
+import { Helmet } from "react-helmet";
+import { connect } from "react-redux";
+
+interface Props {
+  filePath: string | null;
+}
+
+export class NotebookHelmet extends React.PureComponent<Props> {
+  render(): JSX.Element {
+    return (
+      <React.Fragment>
+        <Helmet>
+          <base href={this.props.filePath || "."} />
+        </Helmet>
+      </React.Fragment>
+    );
+  }
+}
+
+interface InitialProps {
+  contentRef: ContentRef;
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  initialProps: InitialProps
+): ((state: AppState) => Props) => {
+  const { contentRef } = initialProps;
+
+  const mapStateToProps = (state: AppState) => {
+    const filePath = selectors.filepath(state, { contentRef });
+    return {
+      filePath
+    };
+  };
+
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps)(NotebookHelmet);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,6 +1146,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^5.0.8":
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.8.tgz#f080eea6652e44f60b4574463d238f268d81d9af"
+  integrity sha512-ZTr12eDAYI0yUiMx1K82EHqRYa8J1BOOLus+0gL+AkksUiIPwLE0wLiXa9FNqD8r9GXAi+yRPZImkRh1JNlTkQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-json-tree@^0.6.8":
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/@types/react-json-tree/-/react-json-tree-0.6.9.tgz#5935d8e8d75b51534c67a68287c46bddbfb84b10"
@@ -4884,6 +4891,11 @@ execa@^1.0.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
 
 exit@^0.1.2:
   version "0.1.2"
@@ -10645,6 +10657,16 @@ react-group@^3.0.0:
   dependencies:
     prop-types "^15.6.2"
 
+react-helmet@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
+  integrity sha1-qBgR3yExOm1VxfBYxK66XW89l6c=
+  dependencies:
+    deep-equal "^1.0.1"
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-side-effect "^1.1.0"
+
 react-hot-loader@^4.1.2:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.6.3.tgz#d9c8923c45b35fd51538ba4297081a00be6bccb1"
@@ -10781,6 +10803,14 @@ react-router@5.0.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-side-effect@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
+  integrity sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react-simple-code-editor@^0.9.3:
   version "0.9.3"
@@ -11885,7 +11915,7 @@ shallowequal@^0.2.2:
   dependencies:
     lodash.keys "^3.1.2"
 
-shallowequal@^1.0.2, shallowequal@^1.1.0:
+shallowequal@^1.0.1, shallowequal@^1.0.2, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/1242.

Relative paths within a notebook are now relative to the location of the notebook file.

For new notebooks, this will continue to default to the location of the install. If we want, we can do something like default it to their home directory.