### PR TITLE
Don't set headers if values don't exist

### DIFF
--- a/packages/rx-jupyter/__tests__/index-spec.ts
+++ b/packages/rx-jupyter/__tests__/index-spec.ts
@@ -17,6 +17,7 @@ describe("rx-jupyter", () => {
       const request = apiVersion$.request;
       expect(request.url).toBe("https://somewhere.com/api");
       expect(request.method).toBe("GET");
+      expect(request.headers).toEqual({});
     });
   });
   describe("shutdown", () => {

--- a/packages/rx-jupyter/src/base.ts
+++ b/packages/rx-jupyter/src/base.ts
@@ -41,8 +41,10 @@ export const createAJAXSettings = (
   // Use the server config provided token if available before trying cookies
   const xsrfToken = serverConfig.xsrfToken || Cookies.get("_xsrf");
   const headers = {
-    "X-XSRFToken": xsrfToken,
-    Authorization: `token ${serverConfig.token ? serverConfig.token : ""}`
+    ...(xsrfToken && { "X-XSRFToken": xsrfToken }),
+    ...(serverConfig.token && {
+      Authorization: `token ${serverConfig.token}`
+    })
   };
 
   // Merge in our typical settings for responseType, allow setting additional


### PR DESCRIPTION
If there is no authorization or xsrf token data, don't send them in the header instead of sending invalid values.