### PR TITLE
Add support for opening local links

### DIFF
--- a/applications/desktop/src/main/launch.ts
+++ b/applications/desktop/src/main/launch.ts
@@ -6,11 +6,6 @@ import { loadFullMenu } from "./menu";
 
 let launchIpynb: (path: string) => void;
 
-export function getPath(url: string) {
-  const nUrl = url.substring(url.indexOf("static"));
-  return path.join(__dirname, "..", "..", nUrl.replace("static/", ""));
-}
-
 // Given a URL from any browser window, determine whether to launch
 // a notebook or open an external URL
 export function deferURL(event: Event, url: string) {
@@ -18,7 +13,7 @@ export function deferURL(event: Event, url: string) {
   if (!url.startsWith("file:")) {
     shell.openExternal(url);
   } else if (url.endsWith(".ipynb")) {
-    launchIpynb(getPath(url));
+    launchIpynb(url);
   }
 }
 

--- a/applications/desktop/src/notebook/menu.ts
+++ b/applications/desktop/src/notebook/menu.ts
@@ -534,6 +534,10 @@ export function dispatchLoad(
   // We are loading a new document so we will create a kernelRef
   const kernelRef = createKernelRef();
 
+  // Remove the protocol string from requests originating from
+  // another notebook
+  filepath = filepath.replace("file://", "");
+
   store.dispatch(
     actions.fetchContent({
       filepath,


### PR DESCRIPTION
Clicking a link to a relative or absolute path to another notebook in a notebook now opens the notebook in another Electron window.

Closes https://github.com/nteract/nteract/issues/349.

![click-to-open](https://user-images.githubusercontent.com/1857993/55927625-57c4ee00-5bdb-11e9-8a65-dadbb26dc743.gif)
