### PR TITLE
Add support for display_id in execute_result

### DIFF
--- a/packages/commutable/src/outputs.ts
+++ b/packages/commutable/src/outputs.ts
@@ -109,6 +109,7 @@ export interface OnDiskExecuteResult {
   execution_count: ExecutionCount;
   data: OnDiskMediaBundle;
   metadata: JSONObject;
+  transient?: JSONObject;
 }
 
 export interface OnDiskDisplayData {

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -7,6 +7,7 @@ import {
   emptyNotebook,
   makeDisplayData,
   makeErrorOutput,
+  makeExecuteResult,
   makeStreamOutput
 } from "@nteract/commutable";
 import * as Immutable from "immutable";
@@ -866,6 +867,14 @@ describe("updateDisplay", () => {
           transient: { display_id: "1234" }
         }
       }),
+      actions.appendOutput({
+        id,
+        output: {
+          output_type: "execute_result",
+          data: { "text/plain": "shennagins afoot" },
+          transient: { display_id: "1234" }
+        }
+      }),
       actions.updateDisplay({
         content: {
           output_type: "update_display_data",
@@ -884,6 +893,11 @@ describe("updateDisplay", () => {
       Immutable.List([
         makeDisplayData({
           output_type: "display_data",
+          data: { "text/html": "<marquee>WOO</marquee>" },
+          metadata: Immutable.Map({})
+        }),
+        makeExecuteResult({
+          output_type: "execute_result",
           data: { "text/html": "<marquee>WOO</marquee>" },
           metadata: Immutable.Map({})
         })

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -211,11 +211,14 @@ function appendOutput(
   const output = action.payload.output;
   const cellId = action.payload.id;
 
-  // If it's display data and it doesn't have a display id, fold it in like non
-  // display data
+  /**
+   * If it is not a display_data or execute_result with
+   * a display_id, then treat it as a normal output and don't
+   * add its index to the keyPaths.
+   */
   if (
-    (output.output_type !== "execute_result" ||
-      output.output_type !== "display_data") &&
+    output.output_type !== "execute_result" &&
+    output.output_type !== "display_data" &&
     !has(output, "transient.display_id")
   ) {
     return state.updateIn(

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -18,6 +18,8 @@ import {
   makeCodeCell,
   makeMarkdownCell,
   makeRawCell,
+  OnDiskDisplayData,
+  OnDiskExecuteResult,
   OnDiskOutput,
   OnDiskStreamOutput
 } from "@nteract/commutable";
@@ -236,7 +238,14 @@ function appendOutput(
   // }
 
   // We now have a display to track
-  const displayID = output.transient!.display_id;
+  let displayID;
+  let typedOutput;
+  if (output.output_type === "execute_result") {
+    typedOutput = output as OnDiskExecuteResult;
+  } else {
+    typedOutput = output as OnDiskDisplayData;
+  }
+  displayID = typedOutput.transient!.display_id;
 
   // Every time we see a display id we're going to capture the keypath
   // to the output

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -219,8 +219,8 @@ function appendOutput(
    * add its index to the keyPaths.
    */
   if (
-    output.output_type !== "execute_result" &&
-    output.output_type !== "display_data" &&
+    (output.output_type !== "execute_result" &&
+      output.output_type !== "display_data") ||
     !has(output, "transient.display_id")
   ) {
     return state.updateIn(

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -214,7 +214,8 @@ function appendOutput(
   // If it's display data and it doesn't have a display id, fold it in like non
   // display data
   if (
-    output.output_type !== "display_data" ||
+    (output.output_type !== "execute_result" ||
+      output.output_type !== "display_data") &&
     !has(output, "transient.display_id")
   ) {
     return state.updateIn(
@@ -262,12 +263,8 @@ function appendOutput(
   const immutableOutput = createImmutableOutput(output);
 
   // We'll reduce the overall state based on each keypath, updating output
-  return keyPaths
-    .reduce(
-      (currState: NotebookModel, kp: KeyPath) =>
-        currState.setIn(kp, immutableOutput),
-      state
-    )
+  return state
+    .updateIn(keyPath, () => immutableOutput)
     .setIn(["transient", "keyPathsForDisplays", displayID], keyPaths);
 }
 


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/1380.

This is basically the same stuff that @rgbkrk started in https://github.com/nteract/nteract/pull/1198 except I fixed the failing test.

Since it was reducing over the `keyPaths` every time an output was appended, it was overriding each output with the last output that was appended.

I removed the reduction over `keyPaths` and used a single `updateIn` to update the most recently inserted output as `appendOutput` was called.