### PR TITLE
Add removeHost action for removing hosts

### DIFF
--- a/packages/actions/src/actionTypes/index.ts
+++ b/packages/actions/src/actionTypes/index.ts
@@ -45,6 +45,12 @@ export interface AddHost {
   payload: { hostRef: HostRef; host: HostRecord };
 }
 
+export const REMOVE_HOST = "CORE/REMOVE_HOST";
+export interface RemoveHost {
+  type: "CORE/REMOVE_HOST";
+  payload: { hostRef: HostRef };
+}
+
 export const CHANGE_FILENAME = "CHANGE_FILENAME";
 export interface ChangeFilenameAction {
   type: "CHANGE_FILENAME";

--- a/packages/actions/src/actions/index.ts
+++ b/packages/actions/src/actions/index.ts
@@ -47,6 +47,11 @@ export const addHost = (payload: {
   payload
 });
 
+export const removeHost = (payload: { hostRef: HostRef }) => ({
+  type: actionTypes.REMOVE_HOST,
+  payload
+});
+
 export function overwriteMetadataField(payload: {
   field: string;
   value: any;

--- a/packages/reducers/src/core/entities/hosts.ts
+++ b/packages/reducers/src/core/entities/hosts.ts
@@ -36,6 +36,9 @@ const byRef = (
             `Unrecognized host type "${typedAction.payload.host.type}".`
           );
       }
+    case actions.REMOVE_HOST:
+      typedAction = action as actions.RemoveHost;
+      return state.remove(typedAction.payload.hostRef);
     default:
       return state;
   }
@@ -47,6 +50,9 @@ const refs = (state = List(), action: Action): List<string> => {
     case actions.ADD_HOST:
       typedAction = action as actions.AddHost;
       return state.push(typedAction.payload.hostRef);
+    case actions.REMOVE_HOST:
+      typedAction = action as actions.RemoveHost;
+      return state.remove(typedAction.payload.hostRef);
     default:
       return state;
   }

--- a/packages/reducers/src/core/entities/hosts.ts
+++ b/packages/reducers/src/core/entities/hosts.ts
@@ -52,7 +52,7 @@ const refs = (state = List(), action: Action): List<string> => {
       return state.push(typedAction.payload.hostRef);
     case actions.REMOVE_HOST:
       typedAction = action as actions.RemoveHost;
-      return state.remove(typedAction.payload.hostRef);
+      return state.filter(hostRef => hostRef !== typedAction.payload.hostRef);
     default:
       return state;
   }

--- a/packages/reducers/src/core/entities/hosts.ts
+++ b/packages/reducers/src/core/entities/hosts.ts
@@ -45,14 +45,13 @@ const byRef = (
 };
 
 const refs = (state = List(), action: Action): List<string> => {
-  let typedAction;
   switch (action.type) {
     case actions.ADD_HOST:
-      typedAction = action as actions.AddHost;
-      return state.push(typedAction.payload.hostRef);
+      return state.push((action as actions.AddHost).payload.hostRef);
     case actions.REMOVE_HOST:
-      typedAction = action as actions.RemoveHost;
-      return state.filter(hostRef => hostRef !== typedAction.payload.hostRef);
+      return state.filter(
+        hostRef => hostRef !== (action as actions.RemoveHost).payload.hostRef
+      );
     default:
       return state;
   }


### PR DESCRIPTION
We've got an `addHost` action that allows users to inset a new host record into the state, but no corresponding `removeHost` action to remove host records that are no longer needed (for example, in the case of disconnecting from a remote Jupyter server).