### PR TITLE
Pin react-table and vendorize stylesheet deps

### DIFF
--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -7,10 +7,8 @@ import * as MathJax from "@nteract/mathjax";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/select/lib/css/blueprint-select.css";
 
-import "codemirror/lib/codemirror.css";
 import "codemirror/addon/hint/show-hint.css";
-
-import "react-table/react-table.css";
+import "codemirror/lib/codemirror.css";
 
 import "@nteract/styles/app.css";
 import "@nteract/styles/global-variables.css";

--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -7,10 +7,8 @@ import { JupyterConfigData, readConfig } from "./config";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/select/lib/css/blueprint-select.css";
 
-import "codemirror/lib/codemirror.css";
 import "codemirror/addon/hint/show-hint.css";
-
-import "react-table/react-table.css";
+import "codemirror/lib/codemirror.css";
 
 // Until we're switched to blueprint for the menu, we have our own custom css
 // for the rc-menu style menu

--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -30,7 +30,7 @@
     "numeral": "^2.0.6",
     "react-color": "^2.14.1",
     "react-hot-loader": "^4.1.2",
-    "react-table": "^6.8.6",
+    "react-table": "6.8.6",
     "react-table-hoc-fixed-columns": "2.1.0",
     "semiotic": "^1.19.1",
     "styled-components": "^4.1.3"

--- a/packages/data-explorer/src/charts/grid.tsx
+++ b/packages/data-explorer/src/charts/grid.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import ReactTable from "react-table";
 import withFixedColumns from "react-table-hoc-fixed-columns";
 
+import VendorizedStyles from "../css/";
 import * as Dx from "../types";
 
 import styled from "styled-components";
@@ -28,7 +29,7 @@ interface NumberFilterProps {
   updateFunction: (input: Dx.JSONObject) => void;
 }
 
-const GridWrapper = styled.div`
+const GridWrapper = styled(VendorizedStyles)`
   width: 100%;
 `;
 

--- a/packages/data-explorer/src/css/index.tsx
+++ b/packages/data-explorer/src/css/index.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+import reactTableStyles from "./react-table";
+import reactTableFixedColumnStyles from "./react-table-hoc-fixed-columns";
+
+// concatenate style dependencies into a styled-component wrapper for grid view
+export default styled.div`
+  ${reactTableStyles}
+  ${reactTableFixedColumnStyles}
+`;

--- a/packages/data-explorer/src/css/react-table-hoc-fixed-columns.ts
+++ b/packages/data-explorer/src/css/react-table-hoc-fixed-columns.ts
@@ -1,0 +1,96 @@
+// just a string copy/paste for now:
+/*  
+'react-table-hoc-fixed-columns@6.8.6' vendorized css
+'react-table-hoc-fixed-columns/lib/styles.css'
+*/
+// to be merged with react-table styles and combined into one styled-component
+
+export default `
+
+  .rthfc .rt-thead.-headerGroups,
+  .rthfc .rt-thead.-header {
+    z-index: 3;
+  }
+
+  .rthfc .rt-thead.-filters {
+    z-index: 2;
+  }
+
+  .rthfc .rt-th,
+  .rthfc .rt-td {
+    background-color: #fff;
+  }
+
+  .rthfc .-headerGroups .rt-th {
+    background-color: #f7f7f7;
+  }
+
+  .rthfc.-striped .rt-tr.-odd .rt-td {
+    background-color: #f7f7f7;
+  }
+
+  .rthfc.-highlight .rt-tr:hover .rt-td {
+    background-color: #f2f2f2;
+  }
+
+  .rthfc .-filters .rt-th.rthfc-th-fixed-left-last,
+  .rthfc .rt-th.rthfc-th-fixed-left-last,
+  .rthfc .rt-td.rthfc-td-fixed-left-last {
+    border-right: solid 1px #ccc;
+  }
+
+  .rthfc .rt-th.rthfc-th-fixed-right-first,
+  .rthfc .rt-td.rthfc-td-fixed-right-first {
+    border-left: solid 1px #ccc;
+  }
+
+  /*------------ Sticky position version: -sp ------------*/
+
+  .rthfc.-sp .rt-tbody {
+    overflow: visible;
+    flex: 1 0 auto;
+  }
+
+  .rthfc.-sp .rt-thead {
+    position: -webkit-sticky;
+    position: sticky;
+  }
+
+  .rthfc.-sp .rt-thead.-headerGroups {
+    border-bottom-color: #f2f2f2;
+  }
+
+  .rthfc.-sp .rt-tfoot {
+    position: -webkit-sticky;
+    position: sticky;
+    z-index: 1;
+    bottom: 0px;
+  }
+
+  .rthfc.-sp .rthfc-th-fixed,
+  .rthfc.-sp .rthfc-td-fixed {
+    position: -webkit-sticky;
+    position: sticky;
+    z-index: 1;
+  }
+
+  .rthfc.-sp .rthfc-th-fixed-left,
+  .rthfc.-sp .rthfc-td-fixed-left {
+    left: 0;
+  }
+
+  .rthfc.-sp .rthfc-th-fixed-right,
+  .rthfc.-sp .rthfc-td-fixed-right {
+    left: 0;
+  }
+
+  /*------------ scroll event version: -se ------------*/
+
+  .rthfc.-se .-header .rt-th.rthfc-th-fixed,
+  .rthfc.-se .-headerGroups .rt-th.rthfc-th-fixed,
+  .rthfc.-se .-filters .rt-th.rthfc-th-fixed,
+  .rthfc.-se .rt-td.rthfc-td-fixed {
+    position: relative;
+    z-index: 1;
+  }
+`;

--- a/packages/data-explorer/src/css/react-table.ts
+++ b/packages/data-explorer/src/css/react-table.ts
@@ -1,6 +1,10 @@
-import { createGlobalStyle } from "styled-components";
+// just a string copy/paste for now
+/*  'react-table@6.8.6' vendorized css */
+/* 'react-table/react-table.css' */
+// this will be merged with other styles and combined into one styled-component
 
-export default createGlobalStyle`
+export default `
+  
   .ReactTable {
     position: relative;
     display: -webkit-box;
@@ -263,14 +267,8 @@ export default createGlobalStyle`
   .ReactTable .rt-tfoot .rt-td:last-child {
     border-right: 0;
   }
-  .ReactTable .rt-thead.-header .rt-th {
-    background: var(--cm-background);
-  }
-  .ReactTable.-striped .rt-tr.-odd > div {
-    background: var(--theme-app-bg);
-  }
-  .ReactTable.-striped .rt-tr.-even > div {
-    background: var(--cm-background);
+  .ReactTable.-striped .rt-tr.-odd {
+    background: rgba(0, 0, 0, 0.03);
   }
   .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
     background: rgba(0, 0, 0, 0.05);
@@ -313,8 +311,8 @@ export default createGlobalStyle`
     border-radius: 3px;
     padding: 6px;
     font-size: 1em;
-    color: var(--theme-app-fg);
-    background: var(--cm-background);
+    color: rgba(0, 0, 0, 0.6);
+    background: rgba(0, 0, 0, 0.1);
     transition: all 0.1s ease;
     cursor: pointer;
     outline: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10908,7 +10908,7 @@ react-table-hoc-fixed-columns@2.1.0:
     classnames "^2.2.6"
     uniqid "^5.0.3"
 
-react-table@^6.8.6:
+react-table@6.8.6:
   version "6.8.6"
   resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.8.6.tgz#a0ad8b4839319052d5befc012603fb161e52ede3"
   integrity sha1-oK2LSDkxkFLVvvwBJgP7Fh5S7eM=


### PR DESCRIPTION
This is a quick and dirty copy/paste of the react-table and react-table-hoc-fixed-columns stylesheet dependencies.

In the future, instead of hard pinning these react-table dependencies, we could set up a script to produce the vendorized css files to account for any css updates (see @nteract/styled-blueprintjsx as an example). I thought I would keep it simple for now and iterate since this would have no visible difference to the user.

Fixes #4306