### PR TITLE
Custom styles and themes for react-table

### DIFF
--- a/packages/data-explorer/src/charts/grid.tsx
+++ b/packages/data-explorer/src/charts/grid.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import ReactTable from "react-table";
 import withFixedColumns from "react-table-hoc-fixed-columns";
 
-import VendorizedStyles from "../css/";
+import CustomReactTableStyles from "../css/";
 import * as Dx from "../types";
 
 import styled from "styled-components";
@@ -28,10 +28,6 @@ interface NumberFilterProps {
   filterName: string;
   updateFunction: (input: Dx.JSONObject) => void;
 }
-
-const GridWrapper = styled(VendorizedStyles)`
-  width: 100%;
-`;
 
 const NumberFilter = (props: NumberFilterProps) => {
   const { filterState, filterName, updateFunction, onChange } = props;
@@ -150,6 +146,7 @@ interface State {
 interface Props {
   data: { data: Dx.Datapoint[]; schema: Dx.Schema };
   height: number;
+  theme?: string;
 }
 
 class DataResourceTransformGrid extends React.PureComponent<Props, State> {
@@ -169,7 +166,8 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
   render() {
     const {
       data: { data, schema },
-      height
+      height,
+      theme
     } = this.props;
 
     const { filters, showFilters } = this.state;
@@ -214,7 +212,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
     });
 
     return (
-      <GridWrapper>
+      <CustomReactTableStyles theme={theme}>
         <button
           //          icon="filter"
           onClick={() => this.setState({ showFilters: !showFilters })}
@@ -230,7 +228,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
           className="-striped -highlight"
           filterable={showFilters}
         />
-      </GridWrapper>
+      </CustomReactTableStyles>
     );
   }
 }

--- a/packages/data-explorer/src/css/index.tsx
+++ b/packages/data-explorer/src/css/index.tsx
@@ -3,8 +3,44 @@ import styled from "styled-components";
 import reactTableStyles from "./react-table";
 import reactTableFixedColumnStyles from "./react-table-hoc-fixed-columns";
 
-// concatenate style dependencies into a styled-component wrapper for grid view
-export default styled.div`
+interface ThemeProps {
+  theme: string | undefined;
+}
+
+export default styled.div<ThemeProps>`
+  /* React table style customization */
+  width: 100%;
+
+  .ReactTable .rt-thead.-header .rt-th {
+    color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
+    background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#fff")};
+  }
+  .ReactTable.-striped .rt-tr.-odd > div {
+    color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
+    background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#fff")};
+  }
+
+  .ReactTable.-striped .rt-tr.-even > div {
+    color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
+    background-color: ${props => (props.theme === "dark" ? "#111" : "#bbb")};
+  }
+
+  .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
+    /* 
+    What does this selector do? 
+    These classes were in our react-table style sheet previously
+    color: var(--theme-app-fg);
+    background: var(--cm-background); 
+    */
+  }
+
+  .ReactTable .-pagination .-btn {
+  }
+
+  /* 
+  These parts are mostly copied from the dependency packages, 
+  but we remove some things that clash with us
+  */
   ${reactTableStyles}
   ${reactTableFixedColumnStyles}
 `;

--- a/packages/data-explorer/src/css/react-table-hoc-fixed-columns.ts
+++ b/packages/data-explorer/src/css/react-table-hoc-fixed-columns.ts
@@ -18,30 +18,30 @@ export default `
 
   .rthfc .rt-th,
   .rthfc .rt-td {
-    background-color: #fff;
+    
   }
 
   .rthfc .-headerGroups .rt-th {
-    background-color: #f7f7f7;
+    
   }
 
   .rthfc.-striped .rt-tr.-odd .rt-td {
-    background-color: #f7f7f7;
+    
   }
 
   .rthfc.-highlight .rt-tr:hover .rt-td {
-    background-color: #f2f2f2;
+    
   }
 
   .rthfc .-filters .rt-th.rthfc-th-fixed-left-last,
   .rthfc .rt-th.rthfc-th-fixed-left-last,
   .rthfc .rt-td.rthfc-td-fixed-left-last {
-    border-right: solid 1px #ccc;
+    border-right: solid 1px;
   }
 
   .rthfc .rt-th.rthfc-th-fixed-right-first,
   .rthfc .rt-td.rthfc-td-fixed-right-first {
-    border-left: solid 1px #ccc;
+    border-left: solid 1px;
   }
 
   /*------------ Sticky position version: -sp ------------*/
@@ -57,7 +57,7 @@ export default `
   }
 
   .rthfc.-sp .rt-thead.-headerGroups {
-    border-bottom-color: #f2f2f2;
+    
   }
 
   .rthfc.-sp .rt-tfoot {

--- a/packages/data-explorer/src/css/react-table.ts
+++ b/packages/data-explorer/src/css/react-table.ts
@@ -267,9 +267,6 @@ export default `
   .ReactTable .rt-tfoot .rt-td:last-child {
     border-right: 0;
   }
-  .ReactTable.-striped .rt-tr.-odd {
-    background: rgba(0, 0, 0, 0.03);
-  }
   .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {
     background: rgba(0, 0, 0, 0.05);
   }
@@ -311,8 +308,6 @@ export default `
     border-radius: 3px;
     padding: 6px;
     font-size: 1em;
-    color: rgba(0, 0, 0, 0.6);
-    background: rgba(0, 0, 0, 0.1);
     transition: all 0.1s ease;
     cursor: pointer;
     outline: none;

--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -273,6 +273,7 @@ class AnyCell extends React.PureComponent<AnyCellProps> {
       focusEditor,
       id,
       tags,
+      theme,
       selectCell,
       unfocusEditor,
       contentRef,

--- a/packages/notebook-app-component/src/transform-media.tsx
+++ b/packages/notebook-app-component/src/transform-media.tsx
@@ -12,8 +12,8 @@ import {
 import { actions, selectors } from "@nteract/core";
 import { AppState, ContentRef } from "@nteract/types";
 
-import memoizeOne from "memoize-one";
 import { get } from "https";
+import memoizeOne from "memoize-one";
 
 interface OwnProps {
   output_type: string;
@@ -28,6 +28,7 @@ interface MappedProps {
   output?: ImmutableDisplayData | ImmutableExecuteResult;
   data?: any;
   metadata?: Immutable.Map<string, any>;
+  theme?: string;
 }
 
 interface DispatchProps {
@@ -37,14 +38,16 @@ interface DispatchProps {
 }
 
 const PureTransformMedia = (props: MappedProps & DispatchProps) => {
-  const { Media, mediaActions, mediaType, data, metadata } = props;
+  const { Media, mediaActions, mediaType, data, metadata, theme } = props;
 
   // If we had no valid result, return an empty output
   if (!mediaType || !data) {
     return null;
   }
 
-  return <Media {...mediaActions} data={data} metadata={metadata} />;
+  return (
+    <Media {...mediaActions} data={data} metadata={metadata} theme={theme} />
+  );
 };
 
 const richestMediaType = (
@@ -99,6 +102,7 @@ const makeMapStateToProps = (
 
     const handlers = selectors.transformsById(state);
     const order = selectors.displayOrder(state);
+    const theme = selectors.userTheme(state);
 
     const mediaType = richestMediaType(output, order, handlers);
 
@@ -110,13 +114,15 @@ const makeMapStateToProps = (
         Media,
         mediaType,
         data,
-        metadata
+        metadata,
+        theme
       };
     }
     return {
       Media: () => null,
       mediaType,
-      output
+      output,
+      theme
     };
   };
   return mapStateToProps;


### PR DESCRIPTION
Add custom react-table styling with support for light/dark theme props
- These styles are just a start so we can iterate
- Fixes a couple styles issues from #4339
- No nteract internal css variables are used so it can work on external apps

Most of our output component already expect an optional theme prop, but we weren't passing down in our apps previously, so I've added that support.