### PR TITLE
Allow users to pass down custom headers to rx-jupyter

### DIFF
--- a/applications/desktop/src/notebook/menu.ts
+++ b/applications/desktop/src/notebook/menu.ts
@@ -145,7 +145,7 @@ export function promptUserAboutNewKernel(
 
           store.dispatch(
             actions.launchKernelByName({
-              kernelSpecName: kernel.kernelSpecName,
+              kernelSpecName: kernel.kernelSpecName || "",
               cwd,
               selectNextKernel: true,
               kernelRef,

--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -192,7 +192,7 @@ describe("launchKernelByName", () => {
         kernelRef,
         contentRef,
         selectNextKernel: false,
-        opts: { headers: { "Contennt-Type": "application/json" } }
+        opts: { headers: { "Content-Type": "application/json" } }
       })
     ).toEqual({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
@@ -202,7 +202,7 @@ describe("launchKernelByName", () => {
         kernelRef,
         contentRef,
         selectNextKernel: false,
-        opts: { headers: { "Contennt-Type": "application/json" } }
+        opts: { headers: { "Content-Type": "application/json" } }
       }
     });
   });
@@ -645,13 +645,13 @@ describe("save", () => {
     expect(
       actions.save({
         contentRef,
-        opts: { headers: { "Contennt-Type": "application/json" } }
+        opts: { headers: { "Content-Type": "application/json" } }
       })
     ).toEqual({
       type: actionTypes.SAVE,
       payload: {
         contentRef,
-        opts: { headers: { "Contennt-Type": "application/json" } }
+        opts: { headers: { "Content-Type": "application/json" } }
       }
     });
   });

--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -191,7 +191,8 @@ describe("launchKernelByName", () => {
         cwd: ".",
         kernelRef,
         contentRef,
-        selectNextKernel: false
+        selectNextKernel: false,
+        opts: { headers: { "Contennt-Type": "application/json" } }
       })
     ).toEqual({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
@@ -200,7 +201,8 @@ describe("launchKernelByName", () => {
         cwd: ".",
         kernelRef,
         contentRef,
-        selectNextKernel: false
+        selectNextKernel: false,
+        opts: { headers: { "Contennt-Type": "application/json" } }
       }
     });
   });
@@ -635,6 +637,22 @@ describe("save", () => {
     expect(actions.save({ contentRef })).toEqual({
       type: actionTypes.SAVE,
       payload: { contentRef }
+    });
+  });
+
+  test("creates a SAVE action with opts", () => {
+    const contentRef = createContentRef();
+    expect(
+      actions.save({
+        contentRef,
+        opts: { headers: { "Contennt-Type": "application/json" } }
+      })
+    ).toEqual({
+      type: actionTypes.SAVE,
+      payload: {
+        contentRef,
+        opts: { headers: { "Contennt-Type": "application/json" } }
+      }
     });
   });
 

--- a/packages/actions/src/actionTypes/contents.ts
+++ b/packages/actions/src/actionTypes/contents.ts
@@ -10,6 +10,7 @@ export interface ChangeContentName {
     contentRef: ContentRef;
     filepath: string;
     prevFilePath: string;
+    opts?: object;
   };
 }
 
@@ -44,6 +45,7 @@ export interface FetchContent {
     params: object;
     kernelRef: KernelRef;
     contentRef: ContentRef;
+    opts?: object;
   };
 }
 
@@ -77,6 +79,7 @@ export interface DownloadContent {
   type: "CORE/DOWNLOAD_CONTENT";
   payload: {
     contentRef: ContentRef;
+    opts?: object;
   };
 }
 
@@ -97,6 +100,7 @@ export interface Save {
   type: "SAVE";
   payload: {
     contentRef: ContentRef;
+    opts?: object;
   };
 }
 

--- a/packages/actions/src/actionTypes/kernels.ts
+++ b/packages/actions/src/actionTypes/kernels.ts
@@ -88,6 +88,7 @@ export interface InterruptKernel {
   type: "INTERRUPT_KERNEL";
   payload: {
     kernelRef?: KernelRef | null;
+    opts?: object;
   };
 }
 
@@ -115,6 +116,7 @@ export interface KillKernelAction {
   payload: {
     restarting: boolean;
     kernelRef?: KernelRef | null;
+    opts?: object;
   };
 }
 
@@ -186,6 +188,7 @@ export interface ChangeKernelByName {
     kernelSpecName: string;
     oldKernelRef?: KernelRef | null;
     contentRef: ContentRef;
+    opts?: object;
   };
 }
 
@@ -198,6 +201,7 @@ export interface LaunchKernelByNameAction {
     kernelRef: KernelRef;
     selectNextKernel: boolean;
     contentRef: ContentRef;
+    opts?: object;
   };
 }
 

--- a/packages/actions/src/actionTypes/kernelspecs.ts
+++ b/packages/actions/src/actionTypes/kernelspecs.ts
@@ -15,6 +15,7 @@ export interface FetchKernelspecs {
   payload: {
     kernelspecsRef: KernelspecsRef;
     hostRef: HostRef;
+    opts?: object;
   };
 }
 

--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -7,11 +7,9 @@ import * as actionTypes from "../actionTypes";
 
 import { contents } from "rx-jupyter";
 
-export const changeContentName = (payload: {
-  filepath: string;
-  contentRef: ContentRef;
-  prevFilePath: string;
-}): actionTypes.ChangeContentName => ({
+export const changeContentName = (
+  payload: actionTypes.ChangeContentName["payload"]
+): actionTypes.ChangeContentName => ({
   type: actionTypes.CHANGE_CONTENT_NAME,
   payload
 });
@@ -74,9 +72,9 @@ export function changeFilename(payload: {
   };
 }
 
-export function downloadContent(payload: {
-  contentRef: ContentRef;
-}): actionTypes.DownloadContent {
+export function downloadContent(
+  payload: actionTypes.DownloadContent["payload"]
+): actionTypes.DownloadContent {
   return {
     type: actionTypes.DOWNLOAD_CONTENT,
     payload
@@ -101,7 +99,7 @@ export function downloadContentFulfilled(payload: {
   };
 }
 
-export function save(payload: { contentRef: ContentRef }): actionTypes.Save {
+export function save(payload: actionTypes.Save["payload"]): actionTypes.Save {
   return {
     type: actionTypes.SAVE,
     payload

--- a/packages/actions/src/actions/kernels.ts
+++ b/packages/actions/src/actions/kernels.ts
@@ -49,24 +49,18 @@ export function launchKernel(payload: {
   };
 }
 
-export function changeKernelByName(payload: {
-  kernelSpecName: any;
-  oldKernelRef?: KernelRef | null;
-  contentRef: ContentRef;
-}): actionTypes.ChangeKernelByName {
+export function changeKernelByName(
+  payload: actionTypes.ChangeKernelByName["payload"]
+): actionTypes.ChangeKernelByName {
   return {
     type: actionTypes.CHANGE_KERNEL_BY_NAME,
     payload
   };
 }
 
-export function launchKernelByName(payload: {
-  kernelSpecName: any;
-  cwd: string;
-  kernelRef: KernelRef;
-  selectNextKernel: boolean;
-  contentRef: ContentRef;
-}): actionTypes.LaunchKernelByNameAction {
+export function launchKernelByName(
+  payload: actionTypes.LaunchKernelByNameAction["payload"]
+): actionTypes.LaunchKernelByNameAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_BY_NAME,
     payload
@@ -93,10 +87,9 @@ export function kernelRawStderr(payload: {
   };
 }
 
-export function killKernel(payload: {
-  restarting: boolean;
-  kernelRef?: KernelRef | null;
-}): actionTypes.KillKernelAction {
+export function killKernel(
+  payload: actionTypes.KillKernelAction["payload"]
+): actionTypes.KillKernelAction {
   return {
     type: actionTypes.KILL_KERNEL,
     payload
@@ -123,9 +116,9 @@ export function killKernelSuccessful(payload: {
   };
 }
 
-export function interruptKernel(payload: {
-  kernelRef?: KernelRef | null;
-}): actionTypes.InterruptKernel {
+export function interruptKernel(
+  payload: actionTypes.InterruptKernel["payload"]
+): actionTypes.InterruptKernel {
   return {
     type: actionTypes.INTERRUPT_KERNEL,
     payload

--- a/packages/actions/src/actions/kernelspecs.ts
+++ b/packages/actions/src/actions/kernelspecs.ts
@@ -10,10 +10,9 @@ import {
 
 import * as actionTypes from "../actionTypes";
 
-export const fetchKernelspecs = (payload: {
-  kernelspecsRef: KernelspecsRef;
-  hostRef: HostRef;
-}): actionTypes.FetchKernelspecs => ({
+export const fetchKernelspecs = (
+  payload: actionTypes.FetchKernelspecs["payload"]
+): actionTypes.FetchKernelspecs => ({
   type: actionTypes.FETCH_KERNELSPECS,
   payload
 });

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -232,7 +232,7 @@ describe("restartKernelEpic", () => {
           kernelRef: "oldKernelRef"
         }),
         d: actionsModule.launchKernelByName({
-          kernelSpecName: null,
+          kernelSpecName: "",
           cwd: ".",
           kernelRef: newKernelRef,
           selectNextKernel: true,
@@ -301,15 +301,17 @@ describe("restartKernelEpic", () => {
           kernelRef: "oldKernelRef"
         }),
         d: actionsModule.launchKernelByName({
-          kernelSpecName: null,
+          kernelSpecName: "",
           cwd: ".",
           kernelRef: newKernelRef,
-          selectNextKernel: true
+          selectNextKernel: true,
+          contentRef: undefined
         }),
         e: actionsModule.restartKernelSuccessful({
-          kernelRef: newKernelRef
+          kernelRef: newKernelRef,
+          contentRef: undefined
         }),
-        f: actionsModule.executeAllCells({})
+        f: actionsModule.executeAllCells({ contentRef: undefined })
       };
 
       const inputMarbles = "a---b---|";

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -257,7 +257,7 @@ export const restartKernelEpic = (
       });
 
       const relaunch = actions.launchKernelByName({
-        kernelSpecName: oldKernel.kernelSpecName,
+        kernelSpecName: oldKernel.kernelSpecName || "",
         cwd: oldKernel.cwd,
         kernelRef: newKernelRef,
         selectNextKernel: true,

--- a/packages/epics/src/kernelspecs.ts
+++ b/packages/epics/src/kernelspecs.ts
@@ -19,7 +19,7 @@ export const fetchKernelspecsEpic = (
     ofType(actions.FETCH_KERNELSPECS),
     mergeMap((action: actions.FetchKernelspecs) => {
       const {
-        payload: { hostRef, kernelspecsRef }
+        payload: { hostRef, kernelspecsRef, opts }
       } = action;
       const state = state$.value;
 
@@ -30,7 +30,7 @@ export const fetchKernelspecsEpic = (
       }
       const serverConfig: ServerConfig = selectors.serverConfig(host);
 
-      return kernelspecs.list(serverConfig).pipe(
+      return kernelspecs.list(serverConfig, opts).pipe(
         map(data => {
           const defaultKernelName = data.response.default;
           const kernelspecs: { [key: string]: KernelspecProps } = {};

--- a/packages/rx-jupyter/src/contents.ts
+++ b/packages/rx-jupyter/src/contents.ts
@@ -65,10 +65,15 @@ export interface IContent<FT extends FileType = FileType>
  *
  * @returns An Observable with the request response
  */
-export const remove = (serverConfig: ServerConfig, path: string) =>
+export const remove = (
+  serverConfig: ServerConfig,
+  path: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
     createAJAXSettings(serverConfig, formURI(path), {
-      method: "DELETE"
+      method: "DELETE",
+      ...opts
     })
   );
 
@@ -93,7 +98,8 @@ interface IGetParams {
 export function get(
   serverConfig: ServerConfig,
   path: string,
-  params: Partial<IGetParams> = {}
+  params: Partial<IGetParams> = {},
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ) {
   let uri = formURI(path);
   const query = querystring.stringify(params);
@@ -104,7 +110,7 @@ export function get(
   // NOTE: If the user requests with params.content === 0
   // Then the response is IEmptyContent
   return ajax(
-    createAJAXSettings(serverConfig, uri, { cache: false })
+    createAJAXSettings(serverConfig, uri, { cache: false, ...opts })
   ) as Observable<JupyterAjaxResponse<IContent<FileType>>>;
 }
 
@@ -120,7 +126,8 @@ export function get(
 export function update<FT extends FileType>(
   serverConfig: ServerConfig,
   path: string,
-  model: Partial<IContent>
+  model: Partial<IContent>,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ) {
   return ajax(
     createAJAXSettings(serverConfig, formURI(path), {
@@ -128,7 +135,8 @@ export function update<FT extends FileType>(
       headers: {
         "Content-Type": "application/json"
       },
-      method: "PATCH"
+      method: "PATCH",
+      ...opts
     })
   );
 }
@@ -145,7 +153,8 @@ export function update<FT extends FileType>(
 export function create<FT extends FileType>(
   serverConfig: ServerConfig,
   path: string,
-  model: Partial<IContent<FT>> & { type: FT }
+  model: Partial<IContent<FT>> & { type: FT },
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ) {
   return ajax(
     createAJAXSettings(serverConfig, formURI(path), {
@@ -153,7 +162,8 @@ export function create<FT extends FileType>(
       headers: {
         "Content-Type": "application/json"
       },
-      method: "POST"
+      method: "POST",
+      ...opts
     })
   );
 }
@@ -171,7 +181,8 @@ export function create<FT extends FileType>(
 export function save<FT extends FileType>(
   serverConfig: ServerConfig,
   path: string,
-  model: Partial<IContent<FT>>
+  model: Partial<IContent<FT>>,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ) {
   return ajax(
     createAJAXSettings(serverConfig, formURI(path), {
@@ -179,7 +190,8 @@ export function save<FT extends FileType>(
       headers: {
         "Content-Type": "application/json"
       },
-      method: "PUT"
+      method: "PUT",
+      ...opts
     })
   ) as Observable<
     JupyterAjaxResponse<{ path: string; [property: string]: string }>
@@ -194,11 +206,16 @@ export function save<FT extends FileType>(
  *
  * @returns An Observable with the request response
  */
-export const listCheckpoints = (serverConfig: ServerConfig, path: string) =>
+export const listCheckpoints = (
+  serverConfig: ServerConfig,
+  path: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, ""), {
       cache: false,
-      method: "GET"
+      method: "GET",
+      ...opts
     })
   );
 
@@ -212,10 +229,15 @@ export const listCheckpoints = (serverConfig: ServerConfig, path: string) =>
  *
  * @returns An Observable with the request response
  */
-export const createCheckpoint = (serverConfig: ServerConfig, path: string) =>
+export const createCheckpoint = (
+  serverConfig: ServerConfig,
+  path: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, ""), {
-      method: "POST"
+      method: "POST",
+      ...opts
     })
   );
 
@@ -231,11 +253,13 @@ export const createCheckpoint = (serverConfig: ServerConfig, path: string) =>
 export const deleteCheckpoint = (
   serverConfig: ServerConfig,
   path: string,
-  checkpointID: string
+  checkpointID: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, checkpointID), {
-      method: "DELETE"
+      method: "DELETE",
+      ...opts
     })
   );
 
@@ -251,10 +275,12 @@ export const deleteCheckpoint = (
 export const restoreFromCheckpoint = (
   serverConfig: ServerConfig,
   path: string,
-  checkpointID: string
+  checkpointID: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, checkpointID), {
-      method: "POST"
+      method: "POST",
+      ...opts
     })
   );

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Subject, Subscriber } from "rxjs";
-import { ajax } from "rxjs/ajax";
+import { ajax, AjaxRequest } from "rxjs/ajax";
 import { delay, retryWhen, share, tap } from "rxjs/operators";
 import { webSocket } from "rxjs/webSocket";
 import urljoin from "url-join";
@@ -18,8 +18,13 @@ import { JupyterMessage } from "@nteract/messaging";
  *
  * @returns An Observable with the request response
  */
-export const list = (serverConfig: ServerConfig) =>
-  ajax(createAJAXSettings(serverConfig, "/api/kernels", { cache: false }));
+export const list = (
+  serverConfig: ServerConfig,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
+  ajax(
+    createAJAXSettings(serverConfig, "/api/kernels", { cache: false, ...opts })
+  );
 
 /**
  * Creates an AjaxObservable for getting info about a kernel.
@@ -29,9 +34,16 @@ export const list = (serverConfig: ServerConfig) =>
  *
  * @returns An Observable with the request response
  */
-export const get = (serverConfig: ServerConfig, id: string) =>
+export const get = (
+  serverConfig: ServerConfig,
+  id: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
-    createAJAXSettings(serverConfig, `/api/kernels/${id}`, { cache: false })
+    createAJAXSettings(serverConfig, `/api/kernels/${id}`, {
+      cache: false,
+      ...opts
+    })
   );
 
 /**
@@ -43,14 +55,20 @@ export const get = (serverConfig: ServerConfig, id: string) =>
  *
  * @returns An Observable with the request response
  */
-export const start = (serverConfig: ServerConfig, name: string, path: string) =>
+export const start = (
+  serverConfig: ServerConfig,
+  name: string,
+  path: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
     createAJAXSettings(serverConfig, "/api/kernels", {
       headers: {
         "Content-Type": "application/json"
       },
       method: "POST",
-      body: { path, name }
+      body: { path, name },
+      ...opts
     })
   );
 
@@ -62,9 +80,16 @@ export const start = (serverConfig: ServerConfig, name: string, path: string) =>
  *
  * @returns An Observable with the request response
  */
-export const kill = (serverConfig: ServerConfig, id: string) =>
+export const kill = (
+  serverConfig: ServerConfig,
+  id: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
-    createAJAXSettings(serverConfig, `/api/kernels/${id}`, { method: "DELETE" })
+    createAJAXSettings(serverConfig, `/api/kernels/${id}`, {
+      method: "DELETE",
+      ...opts
+    })
   );
 
 /**
@@ -75,10 +100,15 @@ export const kill = (serverConfig: ServerConfig, id: string) =>
  *
  * @returns An Observable with the request response
  */
-export const interrupt = (serverConfig: ServerConfig, id: string) =>
+export const interrupt = (
+  serverConfig: ServerConfig,
+  id: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernels/${id}/interrupt`, {
-      method: "POST"
+      method: "POST",
+      ...opts
     })
   );
 
@@ -90,10 +120,15 @@ export const interrupt = (serverConfig: ServerConfig, id: string) =>
  *
  * @returns An Observable with the request response
  */
-export const restart = (serverConfig: ServerConfig, id: string) =>
+export const restart = (
+  serverConfig: ServerConfig,
+  id: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+) =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernels/${id}/restart`, {
-      method: "POST"
+      method: "POST",
+      ...opts
     })
   );
 

--- a/packages/rx-jupyter/src/kernelspecs.ts
+++ b/packages/rx-jupyter/src/kernelspecs.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Observable } from "rxjs";
-import { ajax, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 
 /**
@@ -12,8 +12,16 @@ import { createAJAXSettings, ServerConfig } from "./base";
  *
  * @return An Observable with the request response
  */
-export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
-  ajax(createAJAXSettings(serverConfig, "/api/kernelspecs", { cache: false }));
+export const list = (
+  serverConfig: ServerConfig,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+): Observable<AjaxResponse> =>
+  ajax(
+    createAJAXSettings(serverConfig, "/api/kernelspecs", {
+      cache: false,
+      ...opts
+    })
+  );
 
 /**
  * Returns the specification of available kernels with the given
@@ -26,10 +34,12 @@ export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
  */
 export const get = (
   serverConfig: ServerConfig,
-  name: string
+  name: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernelspecs/${name}`, {
-      cache: false
+      cache: false,
+      ...opts
     })
   );

--- a/packages/rx-jupyter/src/sessions.ts
+++ b/packages/rx-jupyter/src/sessions.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Observable } from "rxjs";
-import { ajax, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 
 /**
@@ -13,8 +13,13 @@ import { createAJAXSettings, ServerConfig } from "./base";
  *
  * @returns An Observable with the request response
  */
-export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
-  ajax(createAJAXSettings(serverConfig, "/api/sessions", { cache: false }));
+export const list = (
+  serverConfig: ServerConfig,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+): Observable<AjaxResponse> =>
+  ajax(
+    createAJAXSettings(serverConfig, "/api/sessions", { cache: false, ...opts })
+  );
 
 /**
  * Creates an AjaxObservable for getting a particular session's information.
@@ -26,11 +31,13 @@ export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
  */
 export const get = (
   serverConfig: ServerConfig,
-  sessionID: string
+  sessionID: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
-      cache: false
+      cache: false,
+      ...opts
     })
   );
 
@@ -44,11 +51,13 @@ export const get = (
  */
 export const destroy = (
   serverConfig: ServerConfig,
-  sessionID: string
+  sessionID: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
-      method: "DELETE"
+      method: "DELETE",
+      ...opts
     })
   );
 
@@ -65,7 +74,8 @@ export const destroy = (
 export const update = (
   serverConfig: ServerConfig,
   sessionID: string,
-  body: object
+  body: object,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
@@ -73,7 +83,8 @@ export const update = (
       headers: {
         "Content-Type": "application/json"
       },
-      body
+      body,
+      ...opts
     })
   );
 
@@ -88,7 +99,8 @@ export const update = (
  */
 export const create = (
   serverConfig: ServerConfig,
-  body: object
+  body: object,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, "/api/sessions", {
@@ -96,6 +108,7 @@ export const create = (
       headers: {
         "Content-Type": "application/json"
       },
-      body
+      body,
+      ...opts
     })
   );

--- a/packages/rx-jupyter/src/terminals.ts
+++ b/packages/rx-jupyter/src/terminals.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Observable } from "rxjs";
-import { ajax, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
 import urljoin from "url-join";
 
 import { createAJAXSettings, normalizeBaseURL, ServerConfig } from "./base";
@@ -16,10 +16,14 @@ const formURI = (path: string) => urljoin("/api/terminals/", path);
  *
  * @returns An Observable with the request response
  */
-export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
+export const list = (
+  serverConfig: ServerConfig,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, "/api/terminals/", {
-      method: "GET"
+      method: "GET",
+      ...opts
     })
   );
 
@@ -30,10 +34,14 @@ export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
  *
  * @return An Observable with the request response
  */
-export const create = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
+export const create = (
+  serverConfig: ServerConfig,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, "/api/terminals/", {
-      method: "POST"
+      method: "POST",
+      ...opts
     })
   );
 
@@ -47,11 +55,13 @@ export const create = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
  */
 export const get = (
   serverConfig: ServerConfig,
-  id: string
+  id: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, formURI(id), {
-      method: "GET"
+      method: "GET",
+      ...opts
     })
   );
 
@@ -65,11 +75,13 @@ export const get = (
  */
 export const destroy = (
   serverConfig: ServerConfig,
-  id: string
+  id: string,
+  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, formURI(id), {
-      method: "DELETE"
+      method: "DELETE",
+      ...opts
     })
   );
 


### PR DESCRIPTION
Adds support for passing custom headers to rx-jupyter's base HTTP request object from the epics and actions.