### PR TITLE
Fix media type for SVG outputs

### DIFF
--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -124,7 +124,7 @@ const store = configureStore({
           "text/html": Media.HTML,
           "text/markdown": Media.Markdown,
           "text/latex": Media.LaTeX,
-          "image/svg": Media.SVG,
+          "image/svg+xml": Media.SVG,
           "image/gif": Media.Image,
           "image/png": Media.Image,
           "image/jpeg": Media.Image,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
@@ -118,7 +118,7 @@ export async function main(config: JupyterConfigData, rootEl): Promise<void> {
             "text/html": Media.HTML,
             "text/markdown": Media.Markdown,
             "text/latex": Media.LaTeX,
-            "image/svg": Media.SVG,
+            "image/svg+xml": Media.SVG,
             "image/gif": Media.Image,
             "image/png": Media.Image,
             "image/jpeg": Media.Image,


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/4359.

I put in the wrong media type for SVGs here before. 🤦‍♀️ 