### PR TITLE
Add support for AJAX and WS options in ServerConfig

### DIFF
--- a/applications/desktop/src/notebook/menu.ts
+++ b/applications/desktop/src/notebook/menu.ts
@@ -145,7 +145,7 @@ export function promptUserAboutNewKernel(
 
           store.dispatch(
             actions.launchKernelByName({
-              kernelSpecName: kernel.kernelSpecName || "",
+              kernelSpecName: kernel.kernelSpecName,
               cwd,
               selectNextKernel: true,
               kernelRef,

--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -191,8 +191,7 @@ describe("launchKernelByName", () => {
         cwd: ".",
         kernelRef,
         contentRef,
-        selectNextKernel: false,
-        opts: { headers: { "Content-Type": "application/json" } }
+        selectNextKernel: false
       })
     ).toEqual({
       type: actionTypes.LAUNCH_KERNEL_BY_NAME,
@@ -201,8 +200,7 @@ describe("launchKernelByName", () => {
         cwd: ".",
         kernelRef,
         contentRef,
-        selectNextKernel: false,
-        opts: { headers: { "Content-Type": "application/json" } }
+        selectNextKernel: false
       }
     });
   });
@@ -637,22 +635,6 @@ describe("save", () => {
     expect(actions.save({ contentRef })).toEqual({
       type: actionTypes.SAVE,
       payload: { contentRef }
-    });
-  });
-
-  test("creates a SAVE action with opts", () => {
-    const contentRef = createContentRef();
-    expect(
-      actions.save({
-        contentRef,
-        opts: { headers: { "Content-Type": "application/json" } }
-      })
-    ).toEqual({
-      type: actionTypes.SAVE,
-      payload: {
-        contentRef,
-        opts: { headers: { "Content-Type": "application/json" } }
-      }
     });
   });
 

--- a/packages/actions/src/actionTypes/contents.ts
+++ b/packages/actions/src/actionTypes/contents.ts
@@ -10,7 +10,6 @@ export interface ChangeContentName {
     contentRef: ContentRef;
     filepath: string;
     prevFilePath: string;
-    opts?: object;
   };
 }
 
@@ -45,7 +44,6 @@ export interface FetchContent {
     params: object;
     kernelRef: KernelRef;
     contentRef: ContentRef;
-    opts?: object;
   };
 }
 
@@ -79,7 +77,6 @@ export interface DownloadContent {
   type: "CORE/DOWNLOAD_CONTENT";
   payload: {
     contentRef: ContentRef;
-    opts?: object;
   };
 }
 
@@ -100,7 +97,6 @@ export interface Save {
   type: "SAVE";
   payload: {
     contentRef: ContentRef;
-    opts?: object;
   };
 }
 

--- a/packages/actions/src/actionTypes/kernels.ts
+++ b/packages/actions/src/actionTypes/kernels.ts
@@ -88,7 +88,6 @@ export interface InterruptKernel {
   type: "INTERRUPT_KERNEL";
   payload: {
     kernelRef?: KernelRef | null;
-    opts?: object;
   };
 }
 
@@ -116,7 +115,6 @@ export interface KillKernelAction {
   payload: {
     restarting: boolean;
     kernelRef?: KernelRef | null;
-    opts?: object;
   };
 }
 
@@ -188,7 +186,6 @@ export interface ChangeKernelByName {
     kernelSpecName: string;
     oldKernelRef?: KernelRef | null;
     contentRef: ContentRef;
-    opts?: object;
   };
 }
 
@@ -201,7 +198,6 @@ export interface LaunchKernelByNameAction {
     kernelRef: KernelRef;
     selectNextKernel: boolean;
     contentRef: ContentRef;
-    opts?: object;
   };
 }
 

--- a/packages/actions/src/actionTypes/kernelspecs.ts
+++ b/packages/actions/src/actionTypes/kernelspecs.ts
@@ -15,7 +15,6 @@ export interface FetchKernelspecs {
   payload: {
     kernelspecsRef: KernelspecsRef;
     hostRef: HostRef;
-    opts?: object;
   };
 }
 

--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -7,9 +7,11 @@ import * as actionTypes from "../actionTypes";
 
 import { contents } from "rx-jupyter";
 
-export const changeContentName = (
-  payload: actionTypes.ChangeContentName["payload"]
-): actionTypes.ChangeContentName => ({
+export const changeContentName = (payload: {
+  filepath: string;
+  contentRef: ContentRef;
+  prevFilePath: string;
+}): actionTypes.ChangeContentName => ({
   type: actionTypes.CHANGE_CONTENT_NAME,
   payload
 });
@@ -72,9 +74,9 @@ export function changeFilename(payload: {
   };
 }
 
-export function downloadContent(
-  payload: actionTypes.DownloadContent["payload"]
-): actionTypes.DownloadContent {
+export function downloadContent(payload: {
+  contentRef: ContentRef;
+}): actionTypes.DownloadContent {
   return {
     type: actionTypes.DOWNLOAD_CONTENT,
     payload
@@ -99,7 +101,7 @@ export function downloadContentFulfilled(payload: {
   };
 }
 
-export function save(payload: actionTypes.Save["payload"]): actionTypes.Save {
+export function save(payload: { contentRef: ContentRef }): actionTypes.Save {
   return {
     type: actionTypes.SAVE,
     payload

--- a/packages/actions/src/actions/kernels.ts
+++ b/packages/actions/src/actions/kernels.ts
@@ -49,18 +49,24 @@ export function launchKernel(payload: {
   };
 }
 
-export function changeKernelByName(
-  payload: actionTypes.ChangeKernelByName["payload"]
-): actionTypes.ChangeKernelByName {
+export function changeKernelByName(payload: {
+  kernelSpecName: any;
+  oldKernelRef?: KernelRef | null;
+  contentRef: ContentRef;
+}): actionTypes.ChangeKernelByName {
   return {
     type: actionTypes.CHANGE_KERNEL_BY_NAME,
     payload
   };
 }
 
-export function launchKernelByName(
-  payload: actionTypes.LaunchKernelByNameAction["payload"]
-): actionTypes.LaunchKernelByNameAction {
+export function launchKernelByName(payload: {
+  kernelSpecName: any;
+  cwd: string;
+  kernelRef: KernelRef;
+  selectNextKernel: boolean;
+  contentRef: ContentRef;
+}): actionTypes.LaunchKernelByNameAction {
   return {
     type: actionTypes.LAUNCH_KERNEL_BY_NAME,
     payload
@@ -87,9 +93,10 @@ export function kernelRawStderr(payload: {
   };
 }
 
-export function killKernel(
-  payload: actionTypes.KillKernelAction["payload"]
-): actionTypes.KillKernelAction {
+export function killKernel(payload: {
+  restarting: boolean;
+  kernelRef?: KernelRef | null;
+}): actionTypes.KillKernelAction {
   return {
     type: actionTypes.KILL_KERNEL,
     payload
@@ -116,9 +123,9 @@ export function killKernelSuccessful(payload: {
   };
 }
 
-export function interruptKernel(
-  payload: actionTypes.InterruptKernel["payload"]
-): actionTypes.InterruptKernel {
+export function interruptKernel(payload: {
+  kernelRef?: KernelRef | null;
+}): actionTypes.InterruptKernel {
   return {
     type: actionTypes.INTERRUPT_KERNEL,
     payload

--- a/packages/actions/src/actions/kernelspecs.ts
+++ b/packages/actions/src/actions/kernelspecs.ts
@@ -10,9 +10,10 @@ import {
 
 import * as actionTypes from "../actionTypes";
 
-export const fetchKernelspecs = (
-  payload: actionTypes.FetchKernelspecs["payload"]
-): actionTypes.FetchKernelspecs => ({
+export const fetchKernelspecs = (payload: {
+  kernelspecsRef: KernelspecsRef;
+  hostRef: HostRef;
+}): actionTypes.FetchKernelspecs => ({
   type: actionTypes.FETCH_KERNELSPECS,
   payload
 });

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -232,7 +232,7 @@ describe("restartKernelEpic", () => {
           kernelRef: "oldKernelRef"
         }),
         d: actionsModule.launchKernelByName({
-          kernelSpecName: "",
+          kernelSpecName: null,
           cwd: ".",
           kernelRef: newKernelRef,
           selectNextKernel: true,
@@ -301,17 +301,15 @@ describe("restartKernelEpic", () => {
           kernelRef: "oldKernelRef"
         }),
         d: actionsModule.launchKernelByName({
-          kernelSpecName: "",
+          kernelSpecName: null,
           cwd: ".",
           kernelRef: newKernelRef,
-          selectNextKernel: true,
-          contentRef: undefined
+          selectNextKernel: true
         }),
         e: actionsModule.restartKernelSuccessful({
-          kernelRef: newKernelRef,
-          contentRef: undefined
+          kernelRef: newKernelRef
         }),
-        f: actionsModule.executeAllCells({ contentRef: undefined })
+        f: actionsModule.executeAllCells({})
       };
 
       const inputMarbles = "a---b---|";

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -42,11 +42,11 @@ export function updateContentEpic(
         return empty();
       }
 
-      const { contentRef, filepath, prevFilePath, opts } = action.payload;
+      const { contentRef, filepath, prevFilePath } = action.payload;
       const serverConfig: ServerConfig = selectors.serverConfig(host);
 
       return contents
-        .update(serverConfig, prevFilePath, { path: filepath.slice(1) }, opts)
+        .update(serverConfig, prevFilePath, { path: filepath.slice(1) })
         .pipe(
           tap(xhr => {
             if (xhr.status !== 200) {
@@ -120,8 +120,7 @@ export function fetchContentEpic(
         .get(
           serverConfig,
           (action as actions.FetchContent).payload.filepath,
-          (action as actions.FetchContent).payload.params,
-          (action as actions.FetchContent).payload.opts
+          (action as actions.FetchContent).payload.params
         )
         .pipe(
           tap(xhr => {
@@ -382,66 +381,59 @@ export function saveContentEpic(
           }
           case actions.SAVE: {
             const serverConfig: ServerConfig = selectors.serverConfig(host);
-            const {
-              payload: { opts }
-            } = action;
 
             // Check to see if the file was modified since the last time we saved
             // TODO: Determine how we handle what to do
             // Don't bother doing this if the file is new(?)
-            return contents
-              .get(serverConfig, filepath, { content: 0 }, opts)
-              .pipe(
-                // Make sure that the modified time is within some delta
-                mergeMap(xhr => {
-                  // TODO: What does it mean if we have a failed GET on the content
-                  if (xhr.status !== 200) {
-                    throw new Error(xhr.response.toString());
-                  }
-                  if (typeof xhr.response === "string") {
-                    throw new Error(
-                      `jupyter server response invalid: ${xhr.response}`
-                    );
-                  }
+            return contents.get(serverConfig, filepath, { content: 0 }).pipe(
+              // Make sure that the modified time is within some delta
+              mergeMap(xhr => {
+                // TODO: What does it mean if we have a failed GET on the content
+                if (xhr.status !== 200) {
+                  throw new Error(xhr.response.toString());
+                }
+                if (typeof xhr.response === "string") {
+                  throw new Error(
+                    `jupyter server response invalid: ${xhr.response}`
+                  );
+                }
 
-                  const model = xhr.response;
+                const model = xhr.response;
 
-                  const diskDate = new Date(model.last_modified);
-                  const inMemoryDate = content.lastSaved
-                    ? new Date(content.lastSaved)
-                    : // FIXME: I'm unsure if we don't have a date if we should default to the disk date
-                      diskDate;
-                  const diffDate = diskDate.getTime() - inMemoryDate.getTime();
+                const diskDate = new Date(model.last_modified);
+                const inMemoryDate = content.lastSaved
+                  ? new Date(content.lastSaved)
+                  : // FIXME: I'm unsure if we don't have a date if we should default to the disk date
+                    diskDate;
+                const diffDate = diskDate.getTime() - inMemoryDate.getTime();
 
-                  if (Math.abs(diffDate) > 600) {
-                    return of(
+                if (Math.abs(diffDate) > 600) {
+                  return of(
+                    actions.saveFailed({
+                      error: new Error("open in another tab possibly..."),
+                      contentRef: action.payload.contentRef
+                    })
+                  );
+                }
+
+                return contents.save(serverConfig, filepath, saveModel).pipe(
+                  map((xhr: AjaxResponse) => {
+                    return actions.saveFulfilled({
+                      contentRef: action.payload.contentRef,
+                      model: xhr.response
+                    });
+                  }),
+                  catchError((error: Error) =>
+                    of(
                       actions.saveFailed({
-                        error: new Error("open in another tab possibly..."),
+                        error,
                         contentRef: action.payload.contentRef
                       })
-                    );
-                  }
-
-                  return contents
-                    .save(serverConfig, filepath, saveModel, opts)
-                    .pipe(
-                      map((xhr: AjaxResponse) => {
-                        return actions.saveFulfilled({
-                          contentRef: action.payload.contentRef,
-                          model: xhr.response
-                        });
-                      }),
-                      catchError((error: Error) =>
-                        of(
-                          actions.saveFailed({
-                            error,
-                            contentRef: action.payload.contentRef
-                          })
-                        )
-                      )
-                    );
-                })
-              );
+                    )
+                  )
+                );
+              })
+            );
           }
           default:
             // NOTE: Our ofType should prevent reaching here, this

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -272,7 +272,7 @@ export const restartKernelEpic = (
       });
 
       const relaunch = actions.launchKernelByName({
-        kernelSpecName: oldKernel.kernelSpecName || "",
+        kernelSpecName: oldKernel.kernelSpecName,
         cwd: oldKernel.cwd,
         kernelRef: newKernelRef,
         selectNextKernel: true,

--- a/packages/epics/src/kernelspecs.ts
+++ b/packages/epics/src/kernelspecs.ts
@@ -19,7 +19,7 @@ export const fetchKernelspecsEpic = (
     ofType(actions.FETCH_KERNELSPECS),
     mergeMap((action: actions.FetchKernelspecs) => {
       const {
-        payload: { hostRef, kernelspecsRef, opts }
+        payload: { hostRef, kernelspecsRef }
       } = action;
       const state = state$.value;
 
@@ -30,7 +30,7 @@ export const fetchKernelspecsEpic = (
       }
       const serverConfig: ServerConfig = selectors.serverConfig(host);
 
-      return kernelspecs.list(serverConfig, opts).pipe(
+      return kernelspecs.list(serverConfig).pipe(
         map(data => {
           const defaultKernelName = data.response.default;
           const kernelspecs: { [key: string]: KernelspecProps } = {};

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -45,7 +45,7 @@ export const launchWebSocketKernelEpic = (
       const serverConfig: ServerConfig = selectors.serverConfig(host);
 
       const {
-        payload: { kernelSpecName, cwd, kernelRef, contentRef, opts }
+        payload: { kernelSpecName, cwd, kernelRef, contentRef }
       } = action;
 
       const content = selectors.content(state, { contentRef });
@@ -66,7 +66,7 @@ export const launchWebSocketKernelEpic = (
       };
 
       // TODO: Handle failure cases here
-      return sessions.create(serverConfig, sessionPayload, opts).pipe(
+      return sessions.create(serverConfig, sessionPayload).pipe(
         mergeMap(data => {
           const session = data.response;
 
@@ -116,7 +116,7 @@ export const changeWebSocketKernelEpic = (
     // coordinated in a different way.
     switchMap((action: actions.ChangeKernelByName) => {
       const {
-        payload: { contentRef, oldKernelRef, kernelSpecName, opts }
+        payload: { contentRef, oldKernelRef, kernelSpecName }
       } = action;
       const state = state$.value;
       const host = selectors.currentHost(state);
@@ -154,7 +154,7 @@ export const changeWebSocketKernelEpic = (
       const { cwd } = extractNewKernel(filepath, notebook);
 
       const kernelRef = createKernelRef();
-      return kernels.start(serverConfig, kernelSpecName, cwd, opts).pipe(
+      return kernels.start(serverConfig, kernelSpecName, cwd).pipe(
         mergeMap(({ response }) => {
           const { id: kernelId } = response;
           const sessionPayload = {
@@ -162,38 +162,36 @@ export const changeWebSocketKernelEpic = (
           };
           // The sessions API will close down the old kernel for us if it is
           // on this session
-          return sessions
-            .update(serverConfig, sessionId, sessionPayload, opts)
-            .pipe(
-              mergeMap(({ response: session }) => {
-                const kernel: RemoteKernelProps = Object.assign(
-                  {},
-                  session.kernel,
-                  {
-                    type: "websocket",
-                    sessionId,
-                    cwd,
-                    channels: kernels.connect(
-                      serverConfig,
-                      session.kernel.id,
-                      sessionId
-                    ),
-                    kernelSpecName
-                  }
-                );
-                return of(
-                  actions.launchKernelSuccessful({
-                    kernel,
-                    kernelRef,
-                    contentRef: action.payload.contentRef,
-                    selectNextKernel: true
-                  })
-                );
-              }),
-              catchError(error =>
-                of(actions.launchKernelFailed({ error, kernelRef, contentRef }))
-              )
-            );
+          return sessions.update(serverConfig, sessionId, sessionPayload).pipe(
+            mergeMap(({ response: session }) => {
+              const kernel: RemoteKernelProps = Object.assign(
+                {},
+                session.kernel,
+                {
+                  type: "websocket",
+                  sessionId,
+                  cwd,
+                  channels: kernels.connect(
+                    serverConfig,
+                    session.kernel.id,
+                    sessionId
+                  ),
+                  kernelSpecName
+                }
+              );
+              return of(
+                actions.launchKernelSuccessful({
+                  kernel,
+                  kernelRef,
+                  contentRef: action.payload.contentRef,
+                  selectNextKernel: true
+                })
+              );
+            }),
+            catchError(error =>
+              of(actions.launchKernelFailed({ error, kernelRef, contentRef }))
+            )
+          );
         }),
         catchError(error =>
           of(actions.launchKernelFailed({ error, kernelRef, contentRef }))
@@ -242,11 +240,8 @@ export const interruptKernelEpic = (
       }
 
       const id = kernel.id;
-      const {
-        payload: { opts }
-      } = action;
 
-      return kernels.interrupt(serverConfig, id, opts).pipe(
+      return kernels.interrupt(serverConfig, id).pipe(
         map(() =>
           actions.interruptKernelSuccessful({
             kernelRef: action.payload.kernelRef
@@ -307,14 +302,10 @@ export const killKernelEpic = (
         );
       }
 
-      const {
-        payload: { opts }
-      } = action;
-
       // TODO: If this was a kernel language change, we shouldn't be using this
       //       kill kernel epic because we need to make sure that creation happens
       //       after deletion
-      return sessions.destroy(serverConfig, kernel.sessionId, opts).pipe(
+      return sessions.destroy(serverConfig, kernel.sessionId).pipe(
         map(() =>
           actions.killKernelSuccessful({
             kernelRef: action.payload.kernelRef

--- a/packages/rx-jupyter/__tests__/index-spec.ts
+++ b/packages/rx-jupyter/__tests__/index-spec.ts
@@ -19,6 +19,21 @@ describe("rx-jupyter", () => {
       expect(request.method).toBe("GET");
       expect(request.headers).toEqual({});
     });
+    test("creates an AjaxObservable with the correct custom options", () => {
+      const apiVersion$ = jupyter.apiVersion({
+        endpoint: "https://somewhere.com",
+        crossDomain: true,
+        ajaxOptions: {
+          headers: {
+            From: "test@tester.com"
+          }
+        }
+      }) as AjaxObservable;
+      const request = apiVersion$.request;
+      expect(request.url).toBe("https://somewhere.com/api");
+      expect(request.method).toBe("GET");
+      expect(request.headers).toEqual({ From: "test@tester.com" });
+    });
   });
   describe("shutdown", () => {
     test(" Creates an AjaxObservable for shutting down a notebook server", () => {

--- a/packages/rx-jupyter/src/base.ts
+++ b/packages/rx-jupyter/src/base.ts
@@ -6,7 +6,7 @@ import Cookies from "js-cookie";
 import { AjaxRequest, AjaxResponse } from "rxjs/ajax";
 
 export const normalizeBaseURL = (url = "") => url.replace(/\/+$/, "");
-s;
+
 export interface ServerConfig {
   endpoint?: string;
   url?: string;
@@ -59,7 +59,11 @@ export const createAJAXSettings = (
     ...serverConfig.ajaxOptions,
     ...opts,
     // Make sure we merge in the auth headers with user given headers
-    headers: { ...headers, ...opts.headers }
+    headers: {
+      ...headers,
+      ...opts.headers,
+      ...(serverConfig.ajaxOptions && serverConfig.ajaxOptions.headers)
+    }
   };
   delete settings.endpoint;
   delete settings.cache;

--- a/packages/rx-jupyter/src/base.ts
+++ b/packages/rx-jupyter/src/base.ts
@@ -14,7 +14,7 @@ export interface ServerConfig {
   xsrfToken?: string;
   crossDomain?: boolean;
   ajaxOptions?: Partial<AjaxRequest>;
-  wsOptions?: string | string[];
+  wsProtocol?: string | string[];
 }
 
 /**

--- a/packages/rx-jupyter/src/base.ts
+++ b/packages/rx-jupyter/src/base.ts
@@ -6,13 +6,15 @@ import Cookies from "js-cookie";
 import { AjaxRequest, AjaxResponse } from "rxjs/ajax";
 
 export const normalizeBaseURL = (url = "") => url.replace(/\/+$/, "");
-
+s;
 export interface ServerConfig {
   endpoint?: string;
   url?: string;
   token?: string;
   xsrfToken?: string;
   crossDomain?: boolean;
+  ajaxOptions?: Partial<AjaxRequest>;
+  wsOptions?: string | string[];
 }
 
 /**
@@ -54,6 +56,7 @@ export const createAJAXSettings = (
     responseType: "json",
     createXHR: () => new XMLHttpRequest(),
     ...serverConfig,
+    ...serverConfig.ajaxOptions,
     ...opts,
     // Make sure we merge in the auth headers with user given headers
     headers: { ...headers, ...opts.headers }

--- a/packages/rx-jupyter/src/contents.ts
+++ b/packages/rx-jupyter/src/contents.ts
@@ -65,15 +65,10 @@ export interface IContent<FT extends FileType = FileType>
  *
  * @returns An Observable with the request response
  */
-export const remove = (
-  serverConfig: ServerConfig,
-  path: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const remove = (serverConfig: ServerConfig, path: string) =>
   ajax(
     createAJAXSettings(serverConfig, formURI(path), {
-      method: "DELETE",
-      ...opts
+      method: "DELETE"
     })
   );
 
@@ -98,8 +93,7 @@ interface IGetParams {
 export function get(
   serverConfig: ServerConfig,
   path: string,
-  params: Partial<IGetParams> = {},
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  params: Partial<IGetParams> = {}
 ) {
   let uri = formURI(path);
   const query = querystring.stringify(params);
@@ -110,7 +104,7 @@ export function get(
   // NOTE: If the user requests with params.content === 0
   // Then the response is IEmptyContent
   return ajax(
-    createAJAXSettings(serverConfig, uri, { cache: false, ...opts })
+    createAJAXSettings(serverConfig, uri, { cache: false })
   ) as Observable<JupyterAjaxResponse<IContent<FileType>>>;
 }
 
@@ -126,8 +120,7 @@ export function get(
 export function update<FT extends FileType>(
   serverConfig: ServerConfig,
   path: string,
-  model: Partial<IContent>,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  model: Partial<IContent>
 ) {
   return ajax(
     createAJAXSettings(serverConfig, formURI(path), {
@@ -135,8 +128,7 @@ export function update<FT extends FileType>(
       headers: {
         "Content-Type": "application/json"
       },
-      method: "PATCH",
-      ...opts
+      method: "PATCH"
     })
   );
 }
@@ -153,8 +145,7 @@ export function update<FT extends FileType>(
 export function create<FT extends FileType>(
   serverConfig: ServerConfig,
   path: string,
-  model: Partial<IContent<FT>> & { type: FT },
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  model: Partial<IContent<FT>> & { type: FT }
 ) {
   return ajax(
     createAJAXSettings(serverConfig, formURI(path), {
@@ -162,8 +153,7 @@ export function create<FT extends FileType>(
       headers: {
         "Content-Type": "application/json"
       },
-      method: "POST",
-      ...opts
+      method: "POST"
     })
   );
 }
@@ -181,8 +171,7 @@ export function create<FT extends FileType>(
 export function save<FT extends FileType>(
   serverConfig: ServerConfig,
   path: string,
-  model: Partial<IContent<FT>>,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  model: Partial<IContent<FT>>
 ) {
   return ajax(
     createAJAXSettings(serverConfig, formURI(path), {
@@ -190,8 +179,7 @@ export function save<FT extends FileType>(
       headers: {
         "Content-Type": "application/json"
       },
-      method: "PUT",
-      ...opts
+      method: "PUT"
     })
   ) as Observable<
     JupyterAjaxResponse<{ path: string; [property: string]: string }>
@@ -206,16 +194,11 @@ export function save<FT extends FileType>(
  *
  * @returns An Observable with the request response
  */
-export const listCheckpoints = (
-  serverConfig: ServerConfig,
-  path: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const listCheckpoints = (serverConfig: ServerConfig, path: string) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, ""), {
       cache: false,
-      method: "GET",
-      ...opts
+      method: "GET"
     })
   );
 
@@ -229,15 +212,10 @@ export const listCheckpoints = (
  *
  * @returns An Observable with the request response
  */
-export const createCheckpoint = (
-  serverConfig: ServerConfig,
-  path: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const createCheckpoint = (serverConfig: ServerConfig, path: string) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, ""), {
-      method: "POST",
-      ...opts
+      method: "POST"
     })
   );
 
@@ -253,13 +231,11 @@ export const createCheckpoint = (
 export const deleteCheckpoint = (
   serverConfig: ServerConfig,
   path: string,
-  checkpointID: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  checkpointID: string
 ) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, checkpointID), {
-      method: "DELETE",
-      ...opts
+      method: "DELETE"
     })
   );
 
@@ -275,12 +251,10 @@ export const deleteCheckpoint = (
 export const restoreFromCheckpoint = (
   serverConfig: ServerConfig,
   path: string,
-  checkpointID: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  checkpointID: string
 ) =>
   ajax(
     createAJAXSettings(serverConfig, formCheckpointURI(path, checkpointID), {
-      method: "POST",
-      ...opts
+      method: "POST"
     })
   );

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -150,7 +150,7 @@ export const connect = (
 ): Subject<any> => {
   const wsSubject = webSocket<JupyterMessage>({
     url: formWebSocketURL(serverConfig, kernelID, sessionID),
-    protocol: serverConfig.wsOptions
+    protocol: serverConfig.wsProtocol
   });
 
   wsSubject.pipe(

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -34,15 +34,10 @@ export const list = (
  *
  * @returns An Observable with the request response
  */
-export const get = (
-  serverConfig: ServerConfig,
-  id: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const get = (serverConfig: ServerConfig, id: string) =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernels/${id}`, {
-      cache: false,
-      ...opts
+      cache: false
     })
   );
 
@@ -181,9 +176,10 @@ export const connect = (
   kernelID: string,
   sessionID?: string
 ): Subject<any> => {
-  const wsSubject = webSocket<JupyterMessage>(
-    formWebSocketURL(serverConfig, kernelID, sessionID)
-  );
+  const wsSubject = webSocket<JupyterMessage>({
+    url: formWebSocketURL(serverConfig, kernelID, sessionID),
+    protocol: serverConfig.wsOptions
+  });
 
   wsSubject.pipe(
     retryWhen(error$ => {

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Subject, Subscriber } from "rxjs";
-import { ajax, AjaxRequest } from "rxjs/ajax";
+import { ajax } from "rxjs/ajax";
 import { delay, retryWhen, share, tap } from "rxjs/operators";
 import { webSocket } from "rxjs/webSocket";
 import urljoin from "url-join";
@@ -18,13 +18,8 @@ import { JupyterMessage } from "@nteract/messaging";
  *
  * @returns An Observable with the request response
  */
-export const list = (
-  serverConfig: ServerConfig,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
-  ajax(
-    createAJAXSettings(serverConfig, "/api/kernels", { cache: false, ...opts })
-  );
+export const list = (serverConfig: ServerConfig) =>
+  ajax(createAJAXSettings(serverConfig, "/api/kernels", { cache: false }));
 
 /**
  * Creates an AjaxObservable for getting info about a kernel.
@@ -50,20 +45,14 @@ export const get = (serverConfig: ServerConfig, id: string) =>
  *
  * @returns An Observable with the request response
  */
-export const start = (
-  serverConfig: ServerConfig,
-  name: string,
-  path: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const start = (serverConfig: ServerConfig, name: string, path: string) =>
   ajax(
     createAJAXSettings(serverConfig, "/api/kernels", {
       headers: {
         "Content-Type": "application/json"
       },
       method: "POST",
-      body: { path, name },
-      ...opts
+      body: { path, name }
     })
   );
 
@@ -75,16 +64,9 @@ export const start = (
  *
  * @returns An Observable with the request response
  */
-export const kill = (
-  serverConfig: ServerConfig,
-  id: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const kill = (serverConfig: ServerConfig, id: string) =>
   ajax(
-    createAJAXSettings(serverConfig, `/api/kernels/${id}`, {
-      method: "DELETE",
-      ...opts
-    })
+    createAJAXSettings(serverConfig, `/api/kernels/${id}`, { method: "DELETE" })
   );
 
 /**
@@ -95,15 +77,10 @@ export const kill = (
  *
  * @returns An Observable with the request response
  */
-export const interrupt = (
-  serverConfig: ServerConfig,
-  id: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const interrupt = (serverConfig: ServerConfig, id: string) =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernels/${id}/interrupt`, {
-      method: "POST",
-      ...opts
+      method: "POST"
     })
   );
 
@@ -115,15 +92,10 @@ export const interrupt = (
  *
  * @returns An Observable with the request response
  */
-export const restart = (
-  serverConfig: ServerConfig,
-  id: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-) =>
+export const restart = (serverConfig: ServerConfig, id: string) =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernels/${id}/restart`, {
-      method: "POST",
-      ...opts
+      method: "POST"
     })
   );
 

--- a/packages/rx-jupyter/src/kernelspecs.ts
+++ b/packages/rx-jupyter/src/kernelspecs.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Observable } from "rxjs";
-import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxResponse } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 
 /**
@@ -12,16 +12,8 @@ import { createAJAXSettings, ServerConfig } from "./base";
  *
  * @return An Observable with the request response
  */
-export const list = (
-  serverConfig: ServerConfig,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-): Observable<AjaxResponse> =>
-  ajax(
-    createAJAXSettings(serverConfig, "/api/kernelspecs", {
-      cache: false,
-      ...opts
-    })
-  );
+export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
+  ajax(createAJAXSettings(serverConfig, "/api/kernelspecs", { cache: false }));
 
 /**
  * Returns the specification of available kernels with the given
@@ -34,12 +26,10 @@ export const list = (
  */
 export const get = (
   serverConfig: ServerConfig,
-  name: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  name: string
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/kernelspecs/${name}`, {
-      cache: false,
-      ...opts
+      cache: false
     })
   );

--- a/packages/rx-jupyter/src/sessions.ts
+++ b/packages/rx-jupyter/src/sessions.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Observable } from "rxjs";
-import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxResponse } from "rxjs/ajax";
 import { createAJAXSettings, ServerConfig } from "./base";
 
 /**
@@ -13,13 +13,8 @@ import { createAJAXSettings, ServerConfig } from "./base";
  *
  * @returns An Observable with the request response
  */
-export const list = (
-  serverConfig: ServerConfig,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-): Observable<AjaxResponse> =>
-  ajax(
-    createAJAXSettings(serverConfig, "/api/sessions", { cache: false, ...opts })
-  );
+export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
+  ajax(createAJAXSettings(serverConfig, "/api/sessions", { cache: false }));
 
 /**
  * Creates an AjaxObservable for getting a particular session's information.
@@ -31,13 +26,11 @@ export const list = (
  */
 export const get = (
   serverConfig: ServerConfig,
-  sessionID: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  sessionID: string
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
-      cache: false,
-      ...opts
+      cache: false
     })
   );
 
@@ -51,13 +44,11 @@ export const get = (
  */
 export const destroy = (
   serverConfig: ServerConfig,
-  sessionID: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  sessionID: string
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
-      method: "DELETE",
-      ...opts
+      method: "DELETE"
     })
   );
 
@@ -74,8 +65,7 @@ export const destroy = (
 export const update = (
   serverConfig: ServerConfig,
   sessionID: string,
-  body: object,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  body: object
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, `/api/sessions/${sessionID}`, {
@@ -83,8 +73,7 @@ export const update = (
       headers: {
         "Content-Type": "application/json"
       },
-      body,
-      ...opts
+      body
     })
   );
 
@@ -99,8 +88,7 @@ export const update = (
  */
 export const create = (
   serverConfig: ServerConfig,
-  body: object,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  body: object
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, "/api/sessions", {
@@ -108,7 +96,6 @@ export const create = (
       headers: {
         "Content-Type": "application/json"
       },
-      body,
-      ...opts
+      body
     })
   );

--- a/packages/rx-jupyter/src/terminals.ts
+++ b/packages/rx-jupyter/src/terminals.ts
@@ -2,7 +2,7 @@
  * @module rx-jupyter
  */
 import { Observable } from "rxjs";
-import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxResponse } from "rxjs/ajax";
 import urljoin from "url-join";
 
 import { createAJAXSettings, normalizeBaseURL, ServerConfig } from "./base";
@@ -16,14 +16,10 @@ const formURI = (path: string) => urljoin("/api/terminals/", path);
  *
  * @returns An Observable with the request response
  */
-export const list = (
-  serverConfig: ServerConfig,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-): Observable<AjaxResponse> =>
+export const list = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, "/api/terminals/", {
-      method: "GET",
-      ...opts
+      method: "GET"
     })
   );
 
@@ -34,14 +30,10 @@ export const list = (
  *
  * @return An Observable with the request response
  */
-export const create = (
-  serverConfig: ServerConfig,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
-): Observable<AjaxResponse> =>
+export const create = (serverConfig: ServerConfig): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, "/api/terminals/", {
-      method: "POST",
-      ...opts
+      method: "POST"
     })
   );
 
@@ -55,13 +47,11 @@ export const create = (
  */
 export const get = (
   serverConfig: ServerConfig,
-  id: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  id: string
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, formURI(id), {
-      method: "GET",
-      ...opts
+      method: "GET"
     })
   );
 
@@ -75,13 +65,11 @@ export const get = (
  */
 export const destroy = (
   serverConfig: ServerConfig,
-  id: string,
-  opts: Partial<AjaxRequest & { cache?: boolean }> = {}
+  id: string
 ): Observable<AjaxResponse> =>
   ajax(
     createAJAXSettings(serverConfig, formURI(id), {
-      method: "DELETE",
-      ...opts
+      method: "DELETE"
     })
   );
 

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -33,7 +33,9 @@ export const serverConfig = (host: JupyterHostRecord): ServerConfig => {
   return {
     endpoint: host.origin + host.basePath,
     crossDomain: host.crossDomain ? host.crossDomain : undefined,
-    token: host.token ? host.token : undefined
+    token: host.token ? host.token : undefined,
+    ajaxOptions: host.ajaxOptions ? host.ajaxOptions : undefined,
+    wsProtocol: host.wsProtocol ? host.wsProtocol : undefined
   };
 };
 

--- a/packages/types/src/entities/hosts.ts
+++ b/packages/types/src/entities/hosts.ts
@@ -2,6 +2,7 @@
  * @module types
  */
 import * as Immutable from "immutable";
+import { AjaxRequest } from "rxjs/ajax";
 
 import { HostId } from "../ids";
 import { HostRef } from "../refs";
@@ -31,6 +32,8 @@ export type JupyterHostRecordProps = BaseHostProps & {
   origin: string;
   basePath: string;
   crossDomain?: boolean | null;
+  ajaxOptions?: Partial<AjaxRequest>;
+  wsProtocol?: string | string[];
 };
 
 export const makeJupyterHostRecord = Immutable.Record<JupyterHostRecordProps>({
@@ -40,7 +43,9 @@ export const makeJupyterHostRecord = Immutable.Record<JupyterHostRecordProps>({
   token: null,
   origin: typeof location === "undefined" ? "" : location.origin,
   basePath: "/",
-  crossDomain: false
+  crossDomain: false,
+  ajaxOptions: undefined,
+  wsProtocol: undefined
 });
 
 export type JupyterHostRecord = Immutable.RecordOf<JupyterHostRecordProps>;


### PR DESCRIPTION
This PR:
- Reverts changes introduced in https://github.com/nteract/nteract/pull/4349
- Allows users to pass custom options to configure Ajax and Websocket requests via the server config
- Closes https://github.com/nteract/nteract/issues/4373

**Example**

A JupyterHostRecord configured with the following properties will send a From request header on all headers going outbound from rx-jupyter and will add the "ws_session; blah" string to the `Sec-WebSocket-Protocol` header.

```
const host = makeJupyterHostRecord({
    origin: "https://example.com",
    ajaxOptions: { headers: { From: "email@example.com" } },
    wsProtocol: ["ws_session", "blah"]
});
```
