### PR TITLE
Use verbs Quit/Cancel in quit prompt insted of Yes/No

### DIFF
--- a/applications/desktop/src/notebook/epics/close-notebook.ts
+++ b/applications/desktop/src/notebook/epics/close-notebook.ts
@@ -55,7 +55,7 @@ export const closeNotebookEpic = (
         dirtyPromptObservable = Observable.create((observer: Observer<any>) => {
           const promptDialog = {
             type: "question",
-            buttons: ["Yes", "No"],
+            buttons: ["Quit", "Cancel"],
             title: "Confirm",
             message: "Unsaved data will be lost. Are you sure you want to quit?"
           };


### PR DESCRIPTION
When quitting the Nteract desktop app, I always need to read the prompt to know which button to press. It would be nice to have verbs on the button labels to save a second or two. 

It's a stupidly small change. I know.

Go from this:

![Before](https://user-images.githubusercontent.com/3074453/57162237-4cd63580-6df6-11e9-8d81-942b74a48268.png)

To this:

![after](https://user-images.githubusercontent.com/3074453/57162132-041e7c80-6df6-11e9-8214-c2ca01c2521f.png)

