### PR TITLE
fix(ui): hide status bar during pdf export

### DIFF
--- a/applications/desktop/.gitignore
+++ b/applications/desktop/.gitignore
@@ -1,0 +1,2 @@
+# the default file name when exporting unsaved notebook to pdf from the desktop app
+..pdf

--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -279,12 +279,6 @@
           box-shadow: none !important;
         }
       }
-
-      @media not print {
-        .cells {
-          padding-bottom: calc(100vh - 110px);
-        }
-      }
     </style>
   </head>
   <body>

--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -278,6 +278,9 @@
           /*remove the box-shadow around of cells when exporting to pdf */
           box-shadow: none !important;
         }
+        .notifications-wrapper {
+          display: none;
+        }
       }
     </style>
   </head>

--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -277,9 +277,6 @@
         * {
           box-shadow: none !important;
         }
-        .status-bar {
-          display: none !important;
-        }
         .notifications-wrapper {
           display: none !important;
         }

--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -275,15 +275,8 @@
 
       @media print {
         * {
+          /*remove the box-shadow around of cells when exporting to pdf */
           box-shadow: none !important;
-        }
-        .cell.focused {
-          border: none;
-          background: var(--theme-cell-bg, white) !important;
-        }
-        .cell:focus .prompt,
-        .cell.focused .prompt {
-          background: var(--theme-pager-bg, #fafafa) !important;
         }
       }
 

--- a/applications/desktop/static/index.html
+++ b/applications/desktop/static/index.html
@@ -277,15 +277,6 @@
         * {
           box-shadow: none !important;
         }
-        .notifications-wrapper {
-          display: none !important;
-        }
-        .cell-toolbar {
-          display: none !important;
-        }
-        .cell-creator {
-          display: none !important;
-        }
         .cell.focused {
           border: none;
           background: var(--theme-cell-bg, white) !important;
@@ -293,18 +284,6 @@
         .cell:focus .prompt,
         .cell.focused .prompt {
           background: var(--theme-pager-bg, #fafafa) !important;
-        }
-        .draggable-cell {
-          padding: 0px !important;
-        }
-        .cell-drag-handle {
-          display: none !important;
-        }
-        .cell-toolbar-mask {
-          display: none !important;
-        }
-        .invisible {
-          display: none !important;
         }
       }
 

--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
@@ -60,7 +60,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
                 "componentStyle": ComponentStyle {
                   "componentId": "sc-bxivhb",
                   "isStatic": true,
-                  "lastClassName": "cgnLcD",
+                  "lastClassName": "igjdMy",
                   "rules": Array [
                     "
   background-color: var(--theme-cell-toolbar-bg);
@@ -73,6 +73,10 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
 
   :hover {
     opacity: 1;
+  }
+
+  @media print {
+    display: none ;
   }
 
   button {
@@ -125,7 +129,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
             forwardedRef={null}
           >
             <div
-              className="sc-bxivhb cgnLcD"
+              className="sc-bxivhb igjdMy"
             >
               <button
                 className="executeButton"
@@ -403,7 +407,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
                 "componentStyle": ComponentStyle {
                   "componentId": "sc-bxivhb",
                   "isStatic": true,
-                  "lastClassName": "cgnLcD",
+                  "lastClassName": "igjdMy",
                   "rules": Array [
                     "
   background-color: var(--theme-cell-toolbar-bg);
@@ -416,6 +420,10 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
 
   :hover {
     opacity: 1;
+  }
+
+  @media print {
+    display: none ;
   }
 
   button {
@@ -468,7 +476,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
             forwardedRef={null}
           >
             <div
-              className="sc-bxivhb cgnLcD"
+              className="sc-bxivhb igjdMy"
             >
               <button
                 className="executeButton"

--- a/packages/notebook-app-component/src/cell-creator.tsx
+++ b/packages/notebook-app-component/src/cell-creator.tsx
@@ -80,6 +80,10 @@ const CreatorHoverMask = styled.div`
   position: relative;
   overflow: visible;
   height: 0px;
+
+  @media print{
+    display: none;
+  }
 `;
 const CreatorHoverRegion = styled.div`
   position: relative;

--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -35,6 +35,9 @@ export const Bar = styled.div`
   line-height: 0.5em;
   background: var(--status-bar);
   z-index: 99;
+  @media print {
+     display: none;
+  }
 `;
 
 export class StatusBar extends React.Component<Props> {

--- a/packages/notebook-app-component/src/toolbar.tsx
+++ b/packages/notebook-app-component/src/toolbar.tsx
@@ -49,6 +49,10 @@ export const CellToolbar = styled.div`
     opacity: 1;
   }
 
+  @media print {
+    display: none ;
+  }
+
   button {
     display: inline-block;
 

--- a/packages/presentational-components/src/components/cell.tsx
+++ b/packages/presentational-components/src/components/cell.tsx
@@ -89,7 +89,7 @@ export const Cell = styled.div.attrs<CellProps>(props => ({
   @media print{
     /* make sure all cells look the same in print regarless of focus */
     & ${Prompt}, &.selected ${Prompt}, &:focus ${Prompt}, &:hover:not(.selected) ${Prompt} {
-      background-color: var(--theme-cell-prompt-bg, white) ! important;
+      background-color: var(--theme-cell-prompt-bg, white);
       color: var(--theme-cell-prompt-fg, black);
     }
   }

--- a/packages/presentational-components/src/components/cell.tsx
+++ b/packages/presentational-components/src/components/cell.tsx
@@ -86,6 +86,13 @@ export const Cell = styled.div.attrs<CellProps>(props => ({
     background-color: var(--theme-cell-prompt-bg-focus, hsl(0, 0%, 90%));
     color: var(--theme-cell-prompt-fg-focus, hsl(0, 0%, 51%));
   }
+  @media print{
+    /* make sure all cells look the same in print regarless of focus */
+    & ${Prompt}, &.selected ${Prompt}, &:focus ${Prompt}, &:hover:not(.selected) ${Prompt} {
+      background-color: var(--theme-cell-prompt-bg, white) ! important;
+      color: var(--theme-cell-prompt-fg, black);
+    }
+  }
 ` as StyledComponent<"div", any, CellProps, never>;
 
 Cell.displayName = "Cell";


### PR DESCRIPTION
Fixes issue #4389 by adding a missing class attribute to the top-level div of the status bar. 

The css class rule for hiding the status bar during pdf export already exists from before, but the div lost its class attribute at some point. This PR puts it back. 
 
https://github.com/nteract/nteract/blob/f63a01c4067b05541ebddd3932345d7102ea3e5b/applications/desktop/static/index.html#L276-L282