### PR TITLE
fix missing PromptBuffer in markdown cells

### DIFF
--- a/packages/presentational-components/src/components/prompt.md
+++ b/packages/presentational-components/src/components/prompt.md
@@ -1,7 +1,7 @@
 The `Prompt` component is typically a child of the `Input` component and serves two purposes.
 First, it serves as a visual indicator of input entry for end users. Secondly, it allows us to display relevant information about the state of a cell to the end user.
 
-```js
+```jsx static
 import { Prompt } from "@nteract/presentational-components"
 ```
 

--- a/packages/presentational-components/src/components/prompt.md
+++ b/packages/presentational-components/src/components/prompt.md
@@ -1,7 +1,7 @@
 The `Prompt` component is typically a child of the `Input` component and serves two purposes.
 First, it serves as a visual indicator of input entry for end users. Secondly, it allows us to display relevant information about the state of a cell to the end user.
 
-```jsx static
+```js
 import { Prompt } from "@nteract/presentational-components"
 ```
 
@@ -27,4 +27,9 @@ You can use the `queued` prop to indicate that a cell is queued for execution. Y
 
 ```js
 <Prompt counter={12} queued />
+```
+
+Pass the `blank` prop to create a prompt with no brackets or other indicators. This is used for Markdown cells through the `<PromptBuffer />` component.
+```js
+<Prompt blank />
 ```

--- a/packages/presentational-components/src/components/prompt.tsx
+++ b/packages/presentational-components/src/components/prompt.tsx
@@ -47,13 +47,13 @@ function promptText(props: PromptProps): string {
   if (typeof props.counter === "number") {
     return `[${props.counter}]`;
   }
+  if (props.blank) {
+    return "";
+  }
   return "[ ]";
 }
 
 const BarePrompt = (props: PromptProps) => {
-  if (props.blank) {
-    return null;
-  }
   return <div className={props.className}>{promptText(props)}</div>;
 };
 
@@ -63,8 +63,6 @@ export const Prompt = styled(BarePrompt)`
   line-height: 22px;
   /* For creating a buffer area for <Prompt blank /> */
   min-height: 22px;
-
-  color: black;
 
   width: var(--prompt-width, 50px);
   padding: 9px 0;


### PR DESCRIPTION
This PR is a fix to #4134. 

- [x] focused markdown cells can be dragged by dragging from the prompt area
- [x] navigation using a mouse work as expected in the markdown editor

The cause for  #4134 is the incorrect rendering of this prompt:

https://github.com/nteract/nteract/blob/d0fd5ba0cef3080b4ee1a095c9d5cdc739339863/packages/notebook-app-component/src/markdown-preview.tsx#L170



The `<Prompt>` component, and by extension `<PromptBuffer>`, doesn't behave exactly according to the documentation comments in `interface PromptProps`. With the changes in this PR a `<Prompt blank>` and `<PromptBuffer>` are actually rendered, but the prompt has no text/`[ ]` in it, which is the expected behavior according to comments in the `PromptProps` interface. On current master, the prompt doesn't render any elements at all, which is the reason for #4134.

Changes in this PR conform to the comments in this interface:
https://github.com/nteract/nteract/blob/4967874e56669131352958399d7478f0adcc00c7/packages/presentational-components/src/components/prompt.tsx#L5

---

Only the prompt for active markdown cells is changed by this PR:


**Before**
![Screenshot from 2019-05-07 10-31-25](https://user-images.githubusercontent.com/3074453/57281609-03b30980-70b4-11e9-8ea1-17c2dd55cfab.png)

**After**

![Screenshot from 2019-05-07 10-00-55](https://user-images.githubusercontent.com/3074453/57280913-8a66e700-70b2-11e9-836a-226202ac224c.png)

---

I also removed a CSS rule for `color` because it was defined twice for the `Prompt` component.
