### PR TITLE
Data Explorer: Move styled-components to peerDependencies

### DIFF
--- a/packages/data-explorer/README.md
+++ b/packages/data-explorer/README.md
@@ -9,7 +9,12 @@
 ## Using the Data Explorer
 
 ```
-yarn install @nteract/data-explorer
+yarn add @nteract/data-explorer
+```
+
+Install `react` and `styled-components` if you are not already using them.
+```
+yarn add react styled-components
 ```
 
 The `data` prop must be a [tabular data resource `application/vnd.dataresource+json`](https://frictionlessdata.io/specs/tabular-data-resource/)
@@ -36,16 +41,6 @@ import { DataExplorer, Toolbar, Viz } from "@nteract/data-explorer";
 <DataExplorer data={data}>
   <Viz />
 </DataExplorer>;
-```
-
-## CSS
-
-Note: you also need to include the CSS for a few dependencies as well
-
-```
-
-// CSS for the grid view on the data explorer
-import "react-table/react-table.css";
 ```
 
 ## Hacking on the nteract Data Explorer

--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -12,7 +12,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "react": "^16.3.2"
+    "react": "^16.3.2",
+    "styled-components": ">= 4"
   },
   "files": [
     "lib",
@@ -32,8 +33,7 @@
     "react-hot-loader": "^4.1.2",
     "react-table": "6.8.6",
     "react-table-hoc-fixed-columns": "2.1.0",
-    "semiotic": "^1.19.7",
-    "styled-components": "^4.1.3"
+    "semiotic": "^1.19.7"
   },
   "devDependencies": {
     "@types/d3-collection": "^1.0.7",
@@ -42,6 +42,8 @@
     "@types/d3-shape": "^1.2.7",
     "@types/numeral": "^0.0.25",
     "@types/react-color": "^2.13.6",
-    "@types/react-table": "^6.7.18"
+    "@types/react-table": "^6.7.18",
+    "react": "^16.3.2",
+    "styled-components": "^4.1.3"
   }
 }


### PR DESCRIPTION
- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

Fixes #4395.

Note: This is a BREAKING change. Any consumer already using the Data Explorer package will need to install `styled-components` (if they aren't already using it) in order to use the new version.