### PR TITLE
Use cardinality to get the best default for the hierarchical view

### DIFF
--- a/packages/data-explorer/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/data-explorer/__tests__/__snapshots__/index.spec.tsx.snap
@@ -57,16 +57,19 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
       dimensions={
         Array [
           Object {
-            "name": "Country",
+            "cardinality": 3,
+            "name": "Region",
             "type": "string",
           },
           Object {
-            "name": "Region",
+            "cardinality": 9,
+            "name": "Country",
             "type": "string",
           },
         ]
       }
       key=".0"
+      largeDataset={false}
       setGrid={[Function]}
       setView={[Function]}
     />
@@ -470,11 +473,13 @@ exports[`DataExplorer composed with Toolbar to the left 1`] = `
           dimensions={
             Array [
               Object {
-                "name": "Country",
+                "cardinality": 3,
+                "name": "Region",
                 "type": "string",
               },
               Object {
-                "name": "Region",
+                "cardinality": 9,
+                "name": "Country",
                 "type": "string",
               },
             ]
@@ -808,6 +813,7 @@ exports[`Default DataExplorer export with metadata 1`] = `
     componentType="toolbar"
     currentView=""
     dimensions={Array []}
+    largeDataset={false}
     setGrid={[Function]}
     setView={[Function]}
   />
@@ -1037,6 +1043,7 @@ exports[`Default DataExplorer export without metadata 1`] = `
     componentType="toolbar"
     currentView=""
     dimensions={Array []}
+    largeDataset={false}
     setGrid={[Function]}
     setView={[Function]}
   />

--- a/packages/data-explorer/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/data-explorer/__tests__/__snapshots__/index.spec.tsx.snap
@@ -813,7 +813,6 @@ exports[`Default DataExplorer export with metadata 1`] = `
     componentType="toolbar"
     currentView=""
     dimensions={Array []}
-    largeDataset={false}
     setGrid={[Function]}
     setView={[Function]}
   />
@@ -1043,7 +1042,6 @@ exports[`Default DataExplorer export without metadata 1`] = `
     componentType="toolbar"
     currentView=""
     dimensions={Array []}
-    largeDataset={false}
     setGrid={[Function]}
     setView={[Function]}
   />

--- a/packages/data-explorer/src/components/Toolbar.tsx
+++ b/packages/data-explorer/src/components/Toolbar.tsx
@@ -26,6 +26,7 @@ interface Props {
   currentView: string;
   // How we tell the root DataExplorer to pass toolbar props to this component:
   componentType: "toolbar";
+  largeDataset: boolean;
 }
 
 const ToolbarWrapper = styled.div`
@@ -48,7 +49,8 @@ export function Toolbar({
   setGrid,
   setView,
   currentView,
-  componentType
+  componentType,
+  largeDataset
 }: Props) {
   return (
     <ToolbarWrapper className="dx-button-bar">
@@ -60,7 +62,7 @@ export function Toolbar({
       >
         <DatabaseOcticon />
       </IconButton>
-      {dimensions.length > 0 && (
+      {!largeDataset && dimensions.length > 0 && (
         <IconButton
           title={chartHelpText.bar}
           onClick={() => setView("bar")}
@@ -94,7 +96,7 @@ export function Toolbar({
       >
         <HexbinIcon />
       </IconButton>
-      {dimensions.length > 1 && (
+      {!largeDataset && dimensions.length > 1 && (
         <IconButton
           title={chartHelpText.network}
           onClick={() => setView("network")}
@@ -104,7 +106,7 @@ export function Toolbar({
           <NetworkIcon />
         </IconButton>
       )}
-      {dimensions.length > 0 && (
+      {!largeDataset && dimensions.length > 0 && (
         <IconButton
           title={chartHelpText.hierarchy}
           onClick={() => setView("hierarchy")}

--- a/packages/data-explorer/src/components/Toolbar.tsx
+++ b/packages/data-explorer/src/components/Toolbar.tsx
@@ -26,7 +26,7 @@ interface Props {
   currentView: string;
   // How we tell the root DataExplorer to pass toolbar props to this component:
   componentType: "toolbar";
-  largeDataset: boolean;
+  largeDataset?: boolean;
 }
 
 const ToolbarWrapper = styled.div`

--- a/packages/data-explorer/src/index.tsx
+++ b/packages/data-explorer/src/index.tsx
@@ -372,8 +372,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
       barGrouping,
       colors,
       primaryKey,
-      data: stateData,
-      largeDataset
+      data: stateData
     } = { ...this.state, ...updatedState };
 
     if (!this.props.data && !this.props.metadata && !this.props.initialView) {
@@ -659,7 +658,7 @@ const DataExplorerDefault: React.FunctionComponent<Props> & {
   return (
     <DataExplorer {...props}>
       <Viz />
-      <Toolbar largeDataset={false} />
+      <Toolbar />
     </DataExplorer>
   );
 };

--- a/packages/data-explorer/src/types.ts
+++ b/packages/data-explorer/src/types.ts
@@ -41,6 +41,7 @@ export interface Metric extends Field {
 
 export interface Dimension extends Field {
   type: "string" | "boolean" | "datetime";
+  cardinality?: number;
 }
 
 export interface Datapoint {

--- a/packages/data-explorer/src/types.ts
+++ b/packages/data-explorer/src/types.ts
@@ -41,7 +41,7 @@ export interface Metric extends Field {
 
 export interface Dimension extends Field {
   type: "string" | "boolean" | "datetime";
-  cardinality?: number;
+  cardinality: number;
 }
 
 export interface Datapoint {


### PR DESCRIPTION
This adds simple cardinality calculation in order to better guess at which dimension should be used for the hierarchical default. Cardinality could be used elsewhere to improve first guesses for other views.
Resolves #4374 but also lays a primitive groundwork for decorating dims and metrics with metadata to help with automatic chart generation & annotation. 