### PR TITLE
Bugfix issue #4408 - Update CSS overrides order

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -6,11 +6,11 @@
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/select/lib/css/blueprint-select.css";
 
+import "codemirror/addon/hint/show-hint.css";
+import "codemirror/lib/codemirror.css";
 import "@nteract/styles/app.css";
 import "@nteract/styles/editor-overrides.css";
 import "@nteract/styles/global-variables.css";
-import "codemirror/addon/hint/show-hint.css";
-import "codemirror/lib/codemirror.css";
 import "react-table/react-table.css";
 import urljoin from "url-join";
 


### PR DESCRIPTION
During my last `nteract/master` alignment merge on my fork, I noticed the notebook's cells that contains even a few lines (1-4 lines) was taking almost half of my screen height. Since I noticed also the notebook's cells that contains a lot of lines (more than 15 lines) had a scrollbar!? I ended up by thinking that may was a problem. With the help of @giux78, I am opening a PR to solve the unexpected described _UI_ behavior.

**Cause**
`@nteract/styles/editor-overrides.css` styles classes get overridden by "codemirror" imports

**Solution**
`import "@nteract/styles/editor-overrides.css"` has to be placed down "codemirror" imports because as the name suggest they are and act as overrides for "codemirror" styles so overrides should be placed at the end of these.
This because _Webpack_ is going to parse all of these CSS imports in the same order as written in [applications/jupyter-extension/nteract_on_jupyter/app/index.tsx](https://github.com/nteract/nteract/blob/master/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx)

- Updates vendor modules imports order in "nteract_on_jupyter"
entrypoint to get CSS overrides work as expected
- Fix issue #4408 

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

**Before Fix**
![BeforeFix](https://user-images.githubusercontent.com/32514668/57839338-d60e4480-77c6-11e9-8d2c-54daf9244d4f.png)

**After Fix**
![AfterFix](https://user-images.githubusercontent.com/32514668/57839362-e0304300-77c6-11e9-91a6-af6a8aeb12cb.png)