### PR TITLE
Add support for SaveAs action and epics

### DIFF
--- a/packages/actions/src/actionTypes/contents.ts
+++ b/packages/actions/src/actionTypes/contents.ts
@@ -137,6 +137,25 @@ export interface SaveFulfilled {
   };
 }
 
+export const SAVE_AS_FAILED = "SAVE_AS_FAILED";
+export interface SaveAsFailed {
+  type: "SAVE_AS_FAILED";
+  payload: {
+    contentRef: ContentRef;
+    error: Error;
+  };
+  error: true;
+}
+
+export const SAVE_AS_FULFILLED = "SAVE_AS_FULFILLED";
+export interface SaveAsFulfilled {
+  type: "SAVE_AS_FULFILLED";
+  payload: {
+    contentRef: ContentRef;
+    model: any;
+  };
+}
+
 export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
 export interface NewNotebook {
   type: "NEW_NOTEBOOK";

--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -147,6 +147,25 @@ export function saveFulfilled(payload: {
   };
 }
 
+export function saveAsFailed(
+  payload: actionTypes.SaveAsFailed["payload"]
+): actionTypes.SaveAsFailed {
+  return {
+    type: actionTypes.SAVE_AS_FAILED,
+    payload,
+    error: true
+  };
+}
+
+export function saveAsFulfilled(
+  payload: actionTypes.SaveAsFulfilled["payload"]
+): actionTypes.SaveAsFulfilled {
+  return {
+    type: actionTypes.SAVE_AS_FULFILLED,
+    payload
+  };
+}
+
 // TODO: New Notebook action should use a kernel spec type
 export function newNotebook(payload: {
   kernelSpec: KernelspecInfo;

--- a/packages/commutable/src/notebook.ts
+++ b/packages/commutable/src/notebook.ts
@@ -111,6 +111,6 @@ export function toJS(immnb: ImmutableNotebook): v4.NotebookV4 {
  *
  * @returns A string containing the notebook data.
  */
-export function stringifyNotebook(notebook: v4.NotebookV4): string {
+export function stringifyNotebook(notebook: Notebook): string {
   return JSON.stringify(notebook, null, 2);
 }

--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -97,7 +97,12 @@ describe("saveAs", () => {
       .pipe(toArray())
       .toPromise();
 
-    expect(responses).toEqual([]);
+    expect(responses).toEqual([
+      actions.saveAsFailed({
+        contentRef,
+        error: new Error("Cannot save content if no host is set.")
+      })
+    ]);
   });
   it("does not save if there is no content", async () => {
     const state = {

--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -1,9 +1,37 @@
 import FileSaver from "file-saver";
+import Immutable from "immutable";
+import { ActionsObservable, StateObservable } from "redux-observable";
+import { of, Subject } from "rxjs";
+import { toArray } from "rxjs/operators";
 
 import { stringifyNotebook } from "@nteract/commutable";
+import {
+  actions,
+  ContentRecord,
+  createContentRef,
+  createKernelspecsRef,
+  makeAppRecord,
+  makeCommsRecord,
+  makeContentsRecord,
+  makeDummyContentRecord,
+  makeEntitiesRecord,
+  makeHostsRecord,
+  makeJupyterHostRecord,
+  makeNotebookContentRecord,
+  makeStateRecord,
+  makeTransformsRecord
+} from "@nteract/core";
 
 import { fixtureJSON } from "@nteract/fixtures";
-import { downloadString } from "../src/contents";
+import { downloadString, saveAsContentEpic } from "../src/contents";
+
+jest.mock("rx-jupyter", () => ({
+  contents: {
+    save: (severConfig, filepath, model) => {
+      return of({ response: {} });
+    }
+  }
+}));
 
 describe("downloadString", () => {
   it("calls FileSaver.saveAs with notebook and filename", () => {
@@ -25,5 +53,133 @@ describe("downloadString", () => {
     });
 
     expect(actualFilename).toBe("awesome.ipynb");
+  });
+});
+
+describe("saveAs", () => {
+  const contentRef = createContentRef();
+  const kernelspecsRef = createKernelspecsRef();
+  it("does not save if no host is set", async () => {
+    const state = {
+      app: makeAppRecord({
+        version: "test"
+      }),
+      comms: makeCommsRecord(),
+      config: Immutable.Map({
+        theme: "light"
+      }),
+      core: makeStateRecord({
+        currentKernelspecsRef: kernelspecsRef,
+        entities: makeEntitiesRecord({
+          hosts: makeHostsRecord({}),
+          contents: makeContentsRecord({
+            byRef: Immutable.Map<string, ContentRecord>().set(
+              contentRef,
+              makeDummyContentRecord({
+                filepath: "test.ipynb"
+              })
+            )
+          }),
+          transforms: makeTransformsRecord({
+            displayOrder: Immutable.List([]),
+            byId: Immutable.Map({})
+          })
+        })
+      })
+    };
+
+    const responses = await saveAsContentEpic(
+      ActionsObservable.of(
+        actions.saveAs({ filepath: "test.ipynb", contentRef })
+      ),
+      new StateObservable(new Subject(), state)
+    )
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responses).toEqual([]);
+  });
+  it("does not save if there is no content", async () => {
+    const state = {
+      app: makeAppRecord({
+        version: "test",
+        host: makeJupyterHostRecord({})
+      }),
+      comms: makeCommsRecord(),
+      config: Immutable.Map({
+        theme: "light"
+      }),
+      core: makeStateRecord({
+        currentKernelspecsRef: kernelspecsRef,
+        entities: makeEntitiesRecord({
+          hosts: makeHostsRecord({}),
+          contents: makeContentsRecord({}),
+          transforms: makeTransformsRecord({
+            displayOrder: Immutable.List([]),
+            byId: Immutable.Map({})
+          })
+        })
+      })
+    };
+
+    const responses = await saveAsContentEpic(
+      ActionsObservable.of(
+        actions.saveAs({ filepath: "test.ipynb", contentRef })
+      ),
+      new StateObservable(new Subject(), state)
+    )
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responses).toEqual([
+      actions.saveAsFailed({
+        contentRef,
+        error: new Error("Content was not set.")
+      })
+    ]);
+  });
+  it("saves notebook files", async () => {
+    const state = {
+      app: makeAppRecord({
+        version: "test",
+        host: makeJupyterHostRecord({})
+      }),
+      comms: makeCommsRecord(),
+      config: Immutable.Map({
+        theme: "light"
+      }),
+      core: makeStateRecord({
+        currentKernelspecsRef: kernelspecsRef,
+        entities: makeEntitiesRecord({
+          hosts: makeHostsRecord({}),
+          contents: makeContentsRecord({
+            byRef: Immutable.Map<string, ContentRecord>().set(
+              contentRef,
+              makeNotebookContentRecord({ filepath: "test.ipynb" })
+            )
+          }),
+          transforms: makeTransformsRecord({
+            displayOrder: Immutable.List([]),
+            byId: Immutable.Map({})
+          })
+        })
+      })
+    };
+
+    const responses = await saveAsContentEpic(
+      ActionsObservable.of(
+        actions.saveAs({ filepath: "test.ipynb", contentRef })
+      ),
+      new StateObservable(new Subject(), state)
+    )
+      .pipe(toArray())
+      .toPromise();
+
+    expect(responses).toEqual([
+      actions.saveAsFulfilled({
+        contentRef,
+        model: {}
+      })
+    ]);
   });
 });

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -345,8 +345,12 @@ export function saveContentEpic(
 
         const host = selectors.currentHost(state);
         if (host.type !== "jupyter") {
-          // Dismiss any usage that isn't targeting a jupyter server
-          return empty();
+          return of(
+            actions.saveFailed({
+              error: new Error("Cannot save content if no host is set."),
+              contentRef: action.payload.contentRef
+            })
+          );
         }
         const contentRef = action.payload.contentRef;
         const content = selectors.content(state, { contentRef });
@@ -367,8 +371,12 @@ export function saveContentEpic(
         }
 
         if (content.type === "directory") {
-          // Don't save directories
-          return empty();
+          return of(
+            actions.saveFailed({
+              error: new Error("Cannot save directories."),
+              contentRef: action.payload.contentRef
+            })
+          );
         }
 
         const filepath = content.filepath;
@@ -376,7 +384,12 @@ export function saveContentEpic(
         const { serializedData, saveModel } = serializeContent(state, content);
 
         if (!saveModel || !serializedData) {
-          return empty();
+          return of(
+            actions.saveFailed({
+              error: new Error("No serialized model created for this content."),
+              contentRef: action.payload.contentRef
+            })
+          );
         }
 
         switch (action.type) {
@@ -492,8 +505,12 @@ export function saveAsContentEpic(
 
         const host = selectors.currentHost(state);
         if (host.type !== "jupyter") {
-          // Dismiss any usage that isn't targeting a jupyter server
-          return empty();
+          return of(
+            actions.saveAsFailed({
+              error: new Error("Cannot save content if no host is set."),
+              contentRef: action.payload.contentRef
+            })
+          );
         }
         const contentRef = action.payload.contentRef;
         const content = selectors.content(state, { contentRef });
@@ -507,8 +524,12 @@ export function saveAsContentEpic(
         }
 
         if (content.type === "directory") {
-          // Don't save directories
-          return empty();
+          return of(
+            actions.saveAsFailed({
+              error: new Error("Cannot save directories."),
+              contentRef: action.payload.contentRef
+            })
+          );
         }
 
         const filepath = content.filepath;
@@ -516,7 +537,12 @@ export function saveAsContentEpic(
         const { saveModel } = serializeContent(state, content);
 
         if (!saveModel) {
-          return empty();
+          return of(
+            actions.saveAsFailed({
+              error: new Error("No serialized model created for this content."),
+              contentRef: action.payload.contentRef
+            })
+          );
         }
 
         const serverConfig: ServerConfig = selectors.serverConfig(host);


### PR DESCRIPTION
This PR:
- Adds action types and creators for a SaveAs action
- Adds a saveAsContentEpic for PUTing new files to the Jupyter server
- Refactors shared logic between the saveContentEpic and the saveAsContentEpic
- Adds tests for the saveAsContentEpic
- Fixes a type error in the `stringifyNotebook` function