### PR TITLE
Fix cm editor props

### DIFF
--- a/packages/editor/__tests__/editor.spec.tsx
+++ b/packages/editor/__tests__/editor.spec.tsx
@@ -141,10 +141,10 @@ describe("editor.hint CodeMirror callback", () => {
 
 describe("Editor", () => {
   it("handles cursor blinkery changes", () => {
-    const editorWrapper = mount(<Editor cursorBlinkRate={530} />);
+    const editorWrapper = mount(<Editor cursorBlinkRate={531} />);
     const instance = editorWrapper.instance();
     const cm = instance.cm;
-    expect(cm.options.cursorBlinkRate).toBe(530);
+    expect(cm.options.cursorBlinkRate).toBe(531);
     editorWrapper.setProps({ cursorBlinkRate: 0 });
     expect(cm.options.cursorBlinkRate).toBe(0);
   });

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -249,7 +249,7 @@ export default class CodeMirrorEditor extends React.PureComponent<
     // Set up the initial options with both our defaults and all the ones we
     // allow to be passed in
     const options: FullEditorConfiguration = {
-      ...this.fullOptions,
+      ...this.fullOptions(),
       ...this.defaultOptions,
       mode: this.cleanMode()
     };


### PR DESCRIPTION
- Call `fullOptions` before trying to spread into options object
- Update test to guard against this issue