### PR TITLE
Fix typo in @nteract/outputs

### DIFF
--- a/packages/outputs/src/components/stream-text.tsx
+++ b/packages/outputs/src/components/stream-text.tsx
@@ -21,7 +21,7 @@ export class StreamText extends React.PureComponent<Props> {
     const { text, name } = output;
 
     return (
-      <Ansi linkify={false} className={`"nteract-display-area-${name}`}>
+      <Ansi linkify={false} className={`nteract-display-area-${name}`}>
         {text}
       </Ansi>
     );


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

Hi, `nteract/nteract`! This is my first time using a Monorepo, so its a little exciting.

Anyways, I am a newer contributor to `nteract/hydrogen`, and while updating our dependencies, I noticed what I believe to be a typo in the `nteract/outputs` package. This little typo was messing with some css we had attached to the class for `stderr`. If I am mistaken, please correct me. If I am accurate however, how long until it gets published since my PR nteract/hydrogen#1641 relies on a published fix.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
