### PR TITLE
Data Explorer: Update react-table styles

### DIFF
--- a/packages/data-explorer/src/css/index.tsx
+++ b/packages/data-explorer/src/css/index.tsx
@@ -22,7 +22,7 @@ export default styled.div<ThemeProps>`
 
   .ReactTable.-striped .rt-tr.-even > div {
     color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#111" : "#bbb")};
+    background-color: ${props => (props.theme === "dark" ? "#111" : "#f7f7f7")};
   }
 
   .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {


### PR DESCRIPTION
This updates the background color of even table rows in the Data Explorer table view to the previous background color before #4339.

The color set by react-table css is actually `rgba(0,0,0,.03)` but a transparent color doesn't work well when other columns scroll underneath it (since it is fixed). `#f7f7f7` seems to be equivalent.

Fixes #4401.

![screenshot](https://user-images.githubusercontent.com/2413692/59069904-a4d8df80-886d-11e9-894b-40cc4835e774.png)