### PR TITLE
Allow multiple output_types

### DIFF
--- a/packages/outputs/__tests__/output.spec.tsx
+++ b/packages/outputs/__tests__/output.spec.tsx
@@ -140,3 +140,60 @@ describe("Full Outputs usage", () => {
     expect(chosen.text()).toEqual("This is some HTML that WILL render");
   });
 });
+
+describe("Output with an array of output_types", () => {
+  const displayOutput = {
+    output_type: "display_data",
+    data: {
+      "text/html": "<p>This is some HTML that <b>WILL</b> render</p>",
+      "text/plain": "This is some plain text that WILL NOT render"
+    },
+    metadata: {}
+  };
+
+  const executeResultOutput = Object.assign({}, displayOutput, {
+    output_type: "execute_result"
+  });
+
+  const someOtherOutput = {
+    output_type: "stream",
+    name: "stdout",
+    text: "hey"
+  };
+
+  function CompositeOutput(props) {
+    const { output, children } = props;
+
+    return (
+      <RichMedia data={output.data} metadata={output.metadata}>
+        {children}
+      </RichMedia>
+    );
+  }
+  CompositeOutput.defaultProps = {
+    output: null,
+    output_type: ["display_data", "execute_result"]
+  };
+
+  function Usage(props) {
+    return (
+      <Output output={props.output}>
+        <CompositeOutput>
+          <Media.Json />
+          <Media.HTML />
+          <Media.Plain />
+        </CompositeOutput>
+      </Output>
+    );
+  }
+
+  it("should render if any output_type matches", () => {
+    const wrapperDisplay = mount(<Usage output={displayOutput} />);
+    const wrapperExecuteResult = mount(<Usage output={executeResultOutput} />);
+    const wrapperOtherOutput = mount(<Usage output={someOtherOutput} />);
+
+    expect(wrapperDisplay.find(Media.HTML).exists()).toEqual(true);
+    expect(wrapperExecuteResult.find(Media.HTML).exists()).toEqual(true);
+    expect(wrapperOtherOutput.html()).toEqual(null);
+  });
+});

--- a/packages/outputs/src/components/output.md
+++ b/packages/outputs/src/components/output.md
@@ -149,3 +149,55 @@ const outputs = [
   ))}
 </div>;
 ```
+
+If your app handles both `display_data` and `execute_result` output types in
+the same manner, you can pass an `output_type` array instead of a string.
+
+```jsx
+const Media = require("./media/");
+const { RichMedia } = require("./rich-media");
+const DisplayData = require("./display-data");
+
+// Our custom DisplayData/ExecuteResult component
+function CompositeOutput(props) {
+  const { output, children } = props;
+
+  return (
+    <RichMedia data={output.data} metadata={output.metadata}>
+      {children}
+    </RichMedia>
+  );
+}
+CompositeOutput.defaultProps = {
+  output: null,
+  output_type: ["display_data", "execute_result"]
+};
+
+const displayOutput = {
+  output_type: "display_data",
+  data: {
+    "text/html":
+      "<p>This is a <code>display_data</code> HTML output that <b>WILL</b> render</p>",
+    "text/plain": "This is some plain text that WILL NOT render"
+  }
+};
+
+const executeResultOutput = {
+  output_type: "execute_result",
+  data: {
+    "text/html":
+      "<p>This is an <code>execute_result</code> HTML output that <b>WILL</b> render</p>",
+    "text/plain": "This is some plain text that WILL NOT render"
+  }
+};
+
+// Try replacing `executeResultOutput` with `displayOutput`
+// both output_type will render as expected
+<Output output={executeResultOutput}>
+  <CompositeOutput>
+    <Media.Json />
+    <Media.HTML />
+    <Media.Plain />
+  </CompositeOutput>
+</Output>;
+```

--- a/packages/outputs/src/components/output.tsx
+++ b/packages/outputs/src/components/output.tsx
@@ -100,12 +100,16 @@ export class Output extends React.PureComponent<Props, State> {
         // Already have a selection
         return;
       }
-      if (
-        childElement.props &&
-        childElement.props.output_type &&
-        childElement.props.output_type === output_type
-      ) {
-        chosenOne = childElement;
+      if (childElement.props && childElement.props.output_type) {
+        const child_output_type: string[] = Array.isArray(
+          childElement.props.output_type
+        )
+          ? childElement.props.output_type
+          : [childElement.props.output_type];
+
+        chosenOne = child_output_type.includes(output_type)
+          ? childElement
+          : null;
         return;
       }
     });


### PR DESCRIPTION
This allows a single custom Output child component to handle multiple
output_types. e.g. ['display_data', 'execute_result']

A large part of the motivation for this is the upgrade work @wadethestealth took the lead on over on Hydrogen. [See this comment](https://github.com/nteract/hydrogen/pull/1655/files#r291652015) for more