### PR TITLE
Changing API for Bookstore

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/bootstrap.tsx
@@ -44,7 +44,7 @@ export async function main(
     token: config.token,
     origin: location.origin,
     basePath: config.baseUrl,
-    bookstoreEnabled: config.bookstore.enabled,
+    bookstoreEnabled: !!config.bookstore.version,
     showHeaderEditor: false
   });
 

--- a/packages/types/src/entities/hosts.ts
+++ b/packages/types/src/entities/hosts.ts
@@ -9,7 +9,6 @@ import { HostRef } from "../refs";
 
 export interface Bookstore {
   version: string;
-  enabled: boolean;
 }
 
 export interface ServerConfig {


### PR DESCRIPTION
Closes #4450.

I removed the `bookstore` key from the payload, and I changed the way I am checking to see if bookstore is available. I have questions around the latter since I am not sure its the best solution.

