### PR TITLE
Pass down props for Markdown component

### DIFF
--- a/packages/outputs/src/components/media/markdown.tsx
+++ b/packages/outputs/src/components/media/markdown.tsx
@@ -20,7 +20,8 @@ export class Markdown extends React.PureComponent<Props> {
   };
 
   render() {
-    return <MarkdownComponent source={this.props.data} />;
+    const { data, mediaType, ...other } = this.props;
+    return <MarkdownComponent source={data} {...other} />;
   }
 }
 


### PR DESCRIPTION
This allows properties to be passed down inside the markdown component allowing more control for customization of your provided component.

In particular, hydrogen needs to be able to set `className` prop in order to revert some style choices, but are unable to since properties aren't being passed down.

I am unsure if every component needs this, but markdown should have it.