### PR TITLE
Fix the ordering of cell toolbar and notifications

### DIFF
--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
@@ -15,10 +15,10 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
           "componentStyle": ComponentStyle {
             "componentId": "sc-ifAKCX",
             "isStatic": false,
-            "lastClassName": "jozPvG",
+            "lastClassName": "jlbNeh",
             "rules": Array [
               "
-  z-index: 9999;
+  z-index: 9;
   position: absolute;
   top: 0px;
   right: 0px;
@@ -44,7 +44,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
       forwardedRef={null}
     >
       <div
-        className="sc-ifAKCX jozPvG"
+        className="sc-ifAKCX jlbNeh"
         style={
           Object {
             "display": "none",
@@ -362,10 +362,10 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
           "componentStyle": ComponentStyle {
             "componentId": "sc-ifAKCX",
             "isStatic": false,
-            "lastClassName": "jozPvG",
+            "lastClassName": "jlbNeh",
             "rules": Array [
               "
-  z-index: 9999;
+  z-index: 9;
   position: absolute;
   top: 0px;
   right: 0px;
@@ -391,7 +391,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
       forwardedRef={null}
     >
       <div
-        className="sc-ifAKCX jozPvG"
+        className="sc-ifAKCX jlbNeh"
         style={
           Object {
             "display": "none",

--- a/packages/notebook-app-component/src/toolbar.tsx
+++ b/packages/notebook-app-component/src/toolbar.tsx
@@ -105,7 +105,7 @@ export const CellToolbarMask = styled.div.attrs<CellToolbarMaskProps>(
     }
   })
 )`
-  z-index: 9999;
+  z-index: 9;
   position: absolute;
   top: 0px;
   right: 0px;


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

Fixes #4404.

The cell toolbar appears over the notification element, so reorder the `z-index` so the elements appear in the right order

> notification
> toolbar
> cell