### PR TITLE
Adjust z-index for leaflet component

### DIFF
--- a/packages/transform-geojson/src/leafletCss.ts
+++ b/packages/transform-geojson/src/leafletCss.ts
@@ -17,6 +17,7 @@ export default createGlobalStyle`
 	}
 .leaflet-container {
 	overflow: hidden;
+	z-index: 9;
 	}
 .leaflet-tile,
 .leaflet-marker-icon,


### PR DESCRIPTION
Fixes #4316

The leaflet map appears over the status bar, so reorder the `z-index` so the elements appears in the right order.