### PR TITLE
Add check for killed kernel to comms epics

### DIFF
--- a/packages/epics/__tests__/comm.spec.ts
+++ b/packages/epics/__tests__/comm.spec.ts
@@ -3,8 +3,9 @@ import { toArray } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
 import { COMM_MESSAGE, COMM_OPEN } from "@nteract/actions";
+import { ActionsObservable } from "redux-observable";
 import {
-  commActionObservable,
+  commListenEpic,
   createCommCloseMessage,
   createCommMessage,
   createCommOpenMessage
@@ -90,18 +91,20 @@ describe("commActionObservable", () => {
       buffers: new Uint8Array([])
     };
 
-    const action = actions.launchKernelSuccessful({
-      kernel: {
-        channels: of(commOpenMessage, commMessage) as Subject<any>,
-        cwd: "/home/tester",
-        type: "websocket"
-      },
-      kernelRef: "fakeKernelRef",
-      contentRef: "fakeContentRef",
-      selectNextKernel: false
-    });
+    const action = ActionsObservable.of(
+      actions.launchKernelSuccessful({
+        kernel: {
+          channels: of(commOpenMessage, commMessage) as Subject<any>,
+          cwd: "/home/tester",
+          type: "websocket"
+        },
+        kernelRef: "fakeKernelRef",
+        contentRef: "fakeContentRef",
+        selectNextKernel: false
+      })
+    );
 
-    commActionObservable(action)
+    commListenEpic(action)
       .pipe(toArray())
       .subscribe(
         actions => {

--- a/packages/epics/src/comm.ts
+++ b/packages/epics/src/comm.ts
@@ -5,11 +5,12 @@ import { createMessage, ofMessageType } from "@nteract/messaging";
 import { ofType } from "redux-observable";
 import { ActionsObservable } from "redux-observable";
 import { merge } from "rxjs";
-import { map, retry, switchMap } from "rxjs/operators";
+import { map, retry, switchMap, takeUntil } from "rxjs/operators";
 
 import {
   commMessageAction,
   commOpenAction,
+  KILL_KERNEL_SUCCESSFUL,
   LAUNCH_KERNEL_SUCCESSFUL,
   NewKernelAction
 } from "@nteract/actions";
@@ -71,28 +72,6 @@ export function createCommCloseMessage(
 }
 
 /**
- * creates all comm related actions given a new kernel action
- * @param  {Object} launchKernelAction a LAUNCH_KERNEL_SUCCESSFUL action
- * @return {ActionsObservable}          all actions resulting from comm messages on this kernel
- */
-export function commActionObservable(action: NewKernelAction) {
-  const {
-    payload: { kernel }
-  } = action;
-  const commOpenAction$ = kernel.channels.pipe(
-    ofMessageType("comm_open"),
-    map(commOpenAction)
-  );
-
-  const commMessageAction$ = kernel.channels.pipe(
-    ofMessageType("comm_msg"),
-    map(commMessageAction)
-  );
-
-  return merge(commOpenAction$, commMessageAction$).pipe(retry());
-}
-
-/**
  * An epic that emits comm actions from the backend kernel
  * @param  {ActionsObservable} action$ Action Observable from redux-observable
  * @param  {redux.Store} store   the redux store
@@ -102,5 +81,23 @@ export const commListenEpic = (action$: ActionsObservable<NewKernelAction>) =>
   action$.pipe(
     // A LAUNCH_KERNEL_SUCCESSFUL action indicates we have a new channel
     ofType(LAUNCH_KERNEL_SUCCESSFUL),
-    switchMap(commActionObservable)
+    switchMap((action: NewKernelAction) => {
+      const {
+        payload: { kernel }
+      } = action;
+      // Listen on the comms channel until KILL_KERNEL_SUCCESSFUL is emitted
+      const commOpenAction$ = kernel.channels.pipe(
+        ofMessageType("comm_open"),
+        map(commOpenAction),
+        takeUntil(action$.pipe(ofType(KILL_KERNEL_SUCCESSFUL)))
+      );
+
+      const commMessageAction$ = kernel.channels.pipe(
+        ofMessageType("comm_msg"),
+        map(commMessageAction),
+        takeUntil(action$.pipe(ofType(KILL_KERNEL_SUCCESSFUL)))
+      );
+
+      return merge(commOpenAction$, commMessageAction$);
+    })
   );

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -350,6 +350,7 @@ export const updateDisplayEpic = (
             contentRef: action.payload.contentRef
           })
         ),
+        takeUntil(action$.pipe(ofType(actions.KILL_KERNEL_SUCCESSFUL))),
         catchError(error =>
           of(
             actions.updateDisplayFailed({


### PR DESCRIPTION
This PR:

- Updates the comms epics to stop listening when a kernel has been killed
- Updates the update display epic to stop listening when a kernel has been killed