### PR TITLE
Set monospace default font for outputs

### DIFF
--- a/packages/presentational-components/src/components/outputs.tsx
+++ b/packages/presentational-components/src/components/outputs.tsx
@@ -48,7 +48,7 @@ const OutputWrapper = styled.div.attrs<OutputWrapperProps>(props => ({
   }
 
   & code {
-    font-family: "Source Code Pro";
+    font-family: "Source Code Pro", monospace;
     white-space: pre-wrap;
     font-size: 14px;
   }


### PR DESCRIPTION
Just a quick fix for something I noticed.