### PR TITLE
Add muted attribute to splash video so that autoplay works again

### DIFF
--- a/applications/desktop/static/splash.html
+++ b/applications/desktop/static/splash.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
   </head>
   <body style="margin: 0px; overflow: hidden; background-color: white;">
-    <video autoplay="autoplay" loop="loop" width="565" height="233">
+    <video autoplay="autoplay" loop="loop" muted="muted" width="565" height="233">
       <source src="loading.mp4" type="video/mp4" />
     </video>
   </body>


### PR DESCRIPTION
I noticed (in the source code) that the splash image was in fact a video. This PR sets the video free to do what videos do best - play.

Credit for the solution goes to https://stackoverflow.com/a/50742427/682317

PS First PR here, so:
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)