### PR TITLE
Fix execute and shift focus flow on Markdown cells

### DIFF
--- a/packages/notebook-app-component/__tests__/notebook.spec.tsx
+++ b/packages/notebook-app-component/__tests__/notebook.spec.tsx
@@ -79,8 +79,8 @@ describe("NotebookApp", () => {
 
       expect(executeFocusedCell).toHaveBeenCalled();
     });
-    test("detects a focus to next cell keypress", () => {
-      const focusedCell = fixtureCommutable.getIn(["cellOrder", 1]);
+    test("detects a focus to next cell keypress on code cells", () => {
+      const focusedCell = fixtureCommutable.getIn(["cellOrder", 0]);
 
       const context = { store: fixtureStore() };
 
@@ -95,7 +95,7 @@ describe("NotebookApp", () => {
           transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
           cellPagers={new Immutable.Map()}
           cellStatuses={dummyCellStatuses}
-          cellFocused={focusedCell}
+          focusedCell={focusedCell}
           executeFocusedCell={executeFocusedCell}
           focusNextCell={focusNextCell}
           focusNextCellEditor={focusNextCellEditor}
@@ -114,6 +114,43 @@ describe("NotebookApp", () => {
       expect(executeFocusedCell).toHaveBeenCalled();
       expect(focusNextCell).toHaveBeenCalled();
       expect(focusNextCellEditor).toHaveBeenCalled();
+    });
+    test("detects a focus to next cell keypress on  markdown cells", () => {
+      const focusedCell = fixtureCommutable.getIn(["cellOrder", 1]);
+
+      const context = { store: fixtureStore() };
+
+      context.store.dispatch = jest.fn();
+      const executeFocusedCell = jest.fn();
+      const focusNextCell = jest.fn();
+      const focusNextCellEditor = jest.fn();
+      const component = shallow(
+        <NotebookApp
+          // We reverse here so that the markdown cell is the second cell
+          cellOrder={fixtureCommutable.get("cellOrder").reverse()}
+          cellMap={fixtureCommutable.get("cellMap")}
+          transient={new Immutable.Map({ cellMap: new Immutable.Map() })}
+          cellPagers={new Immutable.Map()}
+          cellStatuses={dummyCellStatuses}
+          focusedCell={focusedCell}
+          executeFocusedCell={executeFocusedCell}
+          focusNextCell={focusNextCell}
+          focusNextCellEditor={focusNextCellEditor}
+        />,
+        { context }
+      );
+
+      const inst = component.instance();
+
+      const evt = new window.CustomEvent("keydown");
+      evt.shiftKey = true;
+      evt.keyCode = 13;
+
+      inst.keyDown(evt);
+
+      expect(executeFocusedCell).toHaveBeenCalled();
+      expect(focusNextCell).toHaveBeenCalled();
+      expect(focusNextCellEditor).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -482,8 +482,7 @@ const makeMapStateToProps = (
   const mapStateToProps = (state: AppState): NotebookStateProps => {
     const content = selectors.content(state, { contentRef });
     const model = selectors.model(state, { contentRef });
-    const focusedCell = selectors.notebook.cellFocused(model);
-    const cellMap = selectors.notebook.cellMap(model);
+
 
     if (!model || !content) {
       throw new Error(
@@ -507,6 +506,9 @@ const makeMapStateToProps = (
         "<Notebook /> has to have content & model that are notebook types"
       );
     }
+
+    const focusedCell = selectors.notebook.cellFocused(model);
+    const cellMap = selectors.notebook.cellMap(model);
 
     return {
       cellOrder: model.notebook.cellOrder,
@@ -620,7 +622,7 @@ export class NotebookApp extends React.PureComponent<NotebookProps> {
         nextCell === undefined ||
         (nextCell && nextCell.get("cell_type") === "code")
       ) {
-        focusNextCellEditor({ id: focusedCell, contentRef });
+        focusNextCellEditor({ id: focusedCell || undefined, contentRef });
       }
     }
   }


### PR DESCRIPTION
Closes #4524 

Ctrl + Enter now shifts to focus on the editor only if the following cell is a code cell or a cell added at the end of the notebook. Ctrl + Enter will still focus on Markdown cells but not enter edit mode.