### PR TITLE
Add support for getting ContentRef from filepath

### DIFF
--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -89,7 +89,7 @@ function buildFixtureNotebook(config: JSONObject) {
   return notebook;
 }
 
-export function fixtureStore(config: JSONObject) {
+export const mockAppState = (config: JSONObject): AppState => {
   const dummyNotebook = buildFixtureNotebook(config);
 
   const frontendToShell = new Subject();
@@ -100,7 +100,7 @@ export function fixtureStore(config: JSONObject) {
   const kernelRef = createKernelRef();
   const contentRef = createContentRef();
 
-  const initialAppState: AppState = {
+  return {
     core: makeStateRecord({
       kernelRef,
       entities: makeEntitiesRecord({
@@ -145,6 +145,10 @@ export function fixtureStore(config: JSONObject) {
     }),
     comms: makeCommsRecord()
   };
+};
+
+export function fixtureStore(config: JSONObject) {
+  const initialAppState = mockAppState(config);
 
   return createStore(rootReducer, initialAppState as any);
 }

--- a/packages/selectors/__tests__/selectors.spec.ts
+++ b/packages/selectors/__tests__/selectors.spec.ts
@@ -1,6 +1,6 @@
 import Immutable from "immutable";
 
-import { fixtureCommutable } from "@nteract/fixtures";
+import { fixtureCommutable, mockAppState } from "@nteract/fixtures";
 import * as selectors from "../src";
 
 import { makeDocumentRecord } from "@nteract/core";
@@ -23,5 +23,24 @@ describe("codeMirrorMode", () => {
       })
     );
     expect(lang2).toEqual(Immutable.fromJS({ name: "r", version: 3 }));
+  });
+});
+
+describe("contentRefByFilepath", () => {
+  test("returns undefined if filepath is not loaded", () => {
+    const state = mockAppState();
+    expect(
+      selectors.contentRefByFilepath(state, {
+        filepath: "not-a-real-path.ipynb"
+      })
+    ).toBeUndefined();
+  });
+  test("returns the correct content ref for a filepath", () => {
+    const state = mockAppState();
+    expect(
+      selectors.contentRefByFilepath(state, {
+        filepath: "dummy-store-nb.ipynb"
+      })
+    ).toBeDefined();
   });
 });

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -337,6 +337,22 @@ export const filepath = (
 };
 
 /**
+ * Returns the ContentRef associated with a given filepath.
+ *
+ * @param   state       The state of the nteract application
+ * @param   ownProps    An object containing the filepath
+ *
+ * @returns             The ContentRef for the content under a filepath
+ */
+export const contentRefByFilepath = (
+  state: AppState,
+  ownProps: { filepath: string }
+): string | undefined => {
+  const byRef = contentByRef(state);
+  return byRef.findKey(content => content.filepath === ownProps.filepath);
+};
+
+/**
  * Returns the type of modal, such as the about modal, that is currently open
  * in the nteract application.
  */


### PR DESCRIPTION
Adds support for returning a ContentRef from a given filepath per https://github.com/nteract/nteract/issues/4505.