### PR TITLE
Add nteract node_modules as NODE_PATH

### DIFF
--- a/applications/desktop/src/main/kernel-specs.ts
+++ b/applications/desktop/src/main/kernel-specs.ts
@@ -20,7 +20,8 @@ const KERNEL_SPECS: Kernelspecs = {
       display_name: "Node.js (nteract)",
       language: "javascript",
       env: {
-        ELECTRON_RUN_AS_NODE: "1"
+        ELECTRON_RUN_AS_NODE: "1",
+        NODE_PATH: join(__dirname, "..", "node_modules")
       }
     }
   }


### PR DESCRIPTION
I found this a great idea, mentioned in https://github.com/nteract/nteract/issues/2765#issue-314426122

It allows the bundled Javascript kernel to access more modules out of the box.