### PR TITLE
Improve yarn run spawn debug

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -30,6 +30,7 @@
     "start": "npm run spawn",
     "prespawn": "npm run install:app-deps",
     "spawn": "cross-env NODE_ENV=development electron .",
+    "prespawn:debug": "npm run install:app-deps",
     "spawn:debug": "cross-env DEBUG=true NODE_ENV=development electron .",
     "prebuild": "rimraf lib",
     "build": "webpack --config webpack.dev.js --progress --colors",

--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -31,7 +31,7 @@
     "prespawn": "npm run install:app-deps",
     "spawn": "cross-env NODE_ENV=development electron .",
     "prespawn:debug": "npm run install:app-deps",
-    "spawn:debug": "cross-env DEBUG=true NODE_ENV=development electron .",
+    "spawn:debug": "cross-env DEBUG=true ELECTRON_ENABLE_LOGGING=1 NODE_ENV=development electron .",
     "prebuild": "rimraf lib",
     "build": "webpack --config webpack.dev.js --progress --colors",
     "build:clean": "rimraf lib dist",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "app:commuter": "echo \"\n[ Commuter app moved out of monorepo. See nteract/commuter repo. ]\n\"",
     "start": "npm run app:desktop",
     "spawn": "lerna run spawn --scope nteract",
-    "spawn:debug": "lerna run spawn:debug --scope nteract",
+    "spawn:debug": "lerna run spawn:debug --scope nteract --stream",
     "lint": "npm run lint:ts",
     "lint:fix": "npm run lint:ts:fix",
     "lint:ts": "tslint --config tslint.json --project tsconfig.base.json --force --format stylish",


### PR DESCRIPTION
When nteract hangs with no apparent reason and no helpful console output, I want (to) enable a debug mode, so that I can see helpful console output to troubleshoot this.

As a new contributor, i interpreted `yarn spawn:debug` as running nteract in debug mode. This PR makes nteract behave more in according with expectations of a debug mode, with more useful debug messages being output to the console(s).

(Installing app deps before running spawn:debug prevents a follow-up use case where I had checked out a new clone of nteract and did not run `yarn spawn` before `yarn spawn:debug`. This resulted in failure for nteract to start.)