### PR TITLE
Disable experimental fs-kernels tests

### DIFF
--- a/packages/fs-kernels/__tests__/jupyter-paths.spec.ts
+++ b/packages/fs-kernels/__tests__/jupyter-paths.spec.ts
@@ -15,7 +15,7 @@ actual.config = actual.config.filter(fs.existsSync).map(path => {
   return path.toLowerCase();
 });
 
-describe("dataDirs", () => {
+describe.skip("dataDirs", () => {
   it("returns a promise that resolves to a list of directories that exist", done => {
     return jp.dataDirs({ withSysPrefix: true }).then(dirs => {
       dirs = dirs.map(dir => {
@@ -75,14 +75,14 @@ describe("dataDirs", () => {
   });
 });
 
-describe("runtimeDir", () => {
+describe.skip("runtimeDir", () => {
   it("returns the directory where runtime data is stored", async done => {
     expect(await jp.runtimeDir()).toEqual(actual.runtime[0]);
     done();
   });
 });
 
-describe("configDirs", () => {
+describe.skip("configDirs", () => {
   it("returns a promise that resolves to a list of directories that exist", done => {
     return jp.configDirs({ withSysPrefix: true }).then(dirs => {
       dirs = dirs.map(dir => {

--- a/packages/fs-kernels/__tests__/kernel.spec.ts
+++ b/packages/fs-kernels/__tests__/kernel.spec.ts
@@ -3,7 +3,7 @@ import { Kernel, launchKernel } from "../src/kernel";
 
 jest.unmock("process");
 
-describe("Kernel", () => {
+describe.skip("Kernel", () => {
   it("can launch a kernel given a name", async done => {
     const kernel = await launchKernel("python3");
     expect(kernel.process).toBeDefined();

--- a/packages/fs-kernels/__tests__/kernelspecs.spec.ts
+++ b/packages/fs-kernels/__tests__/kernelspecs.spec.ts
@@ -1,7 +1,7 @@
 import { findAll } from "../src/kernelspecs";
 
-describe("findAll", () => {
-  it.skip("retrieves a collection of kernel specs", done => {
+describe.skip("findAll", () => {
+  it("retrieves a collection of kernel specs", done => {
     return findAll().then(kernelspecs => {
       expect(kernelspecs).toHaveProperty("python3");
 

--- a/packages/fs-kernels/__tests__/spawnteract.spec.ts
+++ b/packages/fs-kernels/__tests__/spawnteract.spec.ts
@@ -12,7 +12,7 @@ function cleanup(connectionFile) {
   }
 }
 
-describe("launch", () => {
+describe.skip("launch", () => {
   let spawnResult;
   let spawnResultNoCleanup;
   let kernelName;


### PR DESCRIPTION
fs-kernels package is experimental and has integration tests that are dependent on the environment. Disabling them for now until we can get unit tests that are not environment dependent written.