### PR TITLE
Move ServerConfig definition from rx-jupyter to @nteract/types

### DIFF
--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -5,7 +5,7 @@ import { sample } from "lodash";
 import { Action } from "redux";
 import { ofType } from "redux-observable";
 import { ActionsObservable, StateObservable } from "redux-observable";
-import { contents, ServerConfig } from "rx-jupyter";
+import { contents } from "rx-jupyter";
 import { empty, from, interval, Observable, of } from "rxjs";
 import {
   catchError,
@@ -26,7 +26,8 @@ import {
   DirectoryContentRecordProps,
   DummyContentRecordProps,
   FileContentRecordProps,
-  NotebookContentRecordProps
+  NotebookContentRecordProps,
+  ServerConfig
 } from "@nteract/types";
 import { AjaxResponse } from "rxjs/ajax";
 

--- a/packages/epics/src/hosts.ts
+++ b/packages/epics/src/hosts.ts
@@ -8,12 +8,13 @@ import {
   DirectoryContentRecordProps,
   DummyContentRecordProps,
   FileContentRecordProps,
-  NotebookContentRecordProps
+  NotebookContentRecordProps,
+  ServerConfig
 } from "@nteract/types";
 import { RecordOf } from "immutable";
 import { ofType } from "redux-observable";
 import { ActionsObservable, StateObservable } from "redux-observable";
-import { bookstore, contents, ServerConfig } from "rx-jupyter";
+import { bookstore, contents } from "rx-jupyter";
 import { IContent } from "rx-jupyter/lib/contents";
 import { empty, Observable, of } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";

--- a/packages/epics/src/kernelspecs.ts
+++ b/packages/epics/src/kernelspecs.ts
@@ -1,12 +1,12 @@
 import { ofType } from "redux-observable";
 import { ActionsObservable } from "redux-observable";
-import { kernelspecs, ServerConfig } from "rx-jupyter";
+import { kernelspecs } from "rx-jupyter";
 import { empty, of } from "rxjs";
 import { catchError, map, mergeMap } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
-import { KernelspecProps } from "@nteract/types";
+import { KernelspecProps, ServerConfig } from "@nteract/types";
 
 export const fetchKernelspecsEpic = (
   action$: ActionsObservable<actions.FetchKernelspecs>,

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -1,7 +1,7 @@
 import { kernelInfoRequest } from "@nteract/messaging";
 import { ofType } from "redux-observable";
 import { ActionsObservable, StateObservable } from "redux-observable";
-import { kernels, ServerConfig, sessions } from "rx-jupyter";
+import { kernels, sessions } from "rx-jupyter";
 import { empty, of } from "rxjs";
 import {
   catchError,
@@ -17,7 +17,7 @@ import * as selectors from "@nteract/selectors";
 import { castToSessionId } from "@nteract/types";
 import { createKernelRef } from "@nteract/types";
 import { AppState } from "@nteract/types";
-import { RemoteKernelProps } from "@nteract/types";
+import { RemoteKernelProps, ServerConfig } from "@nteract/types";
 
 import { AjaxResponse } from "rxjs/ajax";
 import { extractNewKernel } from "./kernel-lifecycle";

--- a/packages/host-cache/src/host-storage.ts
+++ b/packages/host-cache/src/host-storage.ts
@@ -2,6 +2,7 @@ import { binder } from "rx-binder";
 import { kernels } from "rx-jupyter";
 import { of } from "rxjs";
 import { catchError, filter, map, tap } from "rxjs/operators";
+import { ServerConfig as BaseServerConfig } from "@nteract/types";
 
 // NOTE: The old flow type for BinderKey was an opaque type so that you couldn't use _any_ string,
 // it had to use our special Binder key type from this module.
@@ -17,9 +18,7 @@ interface BinderOptions {
   binderURL?: string;
 }
 
-export interface ServerConfig {
-  endpoint: string;
-  token: string;
+export interface ServerConfig extends BaseServerConfig {
   // Assume always cross domain
   crossDomain: true;
 }

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -29,6 +29,6 @@
     "@types/js-cookie": "^2.2.0",
     "@types/url-join": "^4.0.0",
     "@types/url-search-params": "^1.0.0",
-    "@types/nteract": "^5.3.2"
+    "@nteract/types": "^4.3.2"
   }
 }

--- a/packages/rx-jupyter/package.json
+++ b/packages/rx-jupyter/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/js-cookie": "^2.2.0",
     "@types/url-join": "^4.0.0",
-    "@types/url-search-params": "^1.0.0"
+    "@types/url-search-params": "^1.0.0",
+    "@types/nteract": "^5.3.2"
   }
 }

--- a/packages/rx-jupyter/src/base.ts
+++ b/packages/rx-jupyter/src/base.ts
@@ -1,18 +1,9 @@
 /** tslint:disable:jsdoc-format */
 import Cookies from "js-cookie";
 import { AjaxRequest, AjaxResponse } from "rxjs/ajax";
+import { ServerConfig } from "@nteract/types";
 
 export const normalizeBaseURL = (url = "") => url.replace(/\/+$/, "");
-
-export interface ServerConfig {
-  endpoint?: string;
-  url?: string;
-  token?: string;
-  xsrfToken?: string;
-  crossDomain?: boolean;
-  ajaxOptions?: Partial<AjaxRequest>;
-  wsProtocol?: string | string[];
-}
 
 /**
  * Creates an AJAX request to connect to a given server. This function

--- a/packages/rx-jupyter/src/bookstore.ts
+++ b/packages/rx-jupyter/src/bookstore.ts
@@ -1,11 +1,11 @@
 // Vendor modules
-import { BookstoreDataModel } from "@nteract/types";
+import { BookstoreDataModel, ServerConfig } from "@nteract/types";
 import { Observable } from "rxjs";
 import { ajax, AjaxResponse } from "rxjs/ajax";
 import urljoin from "url-join";
 
 // Local modules
-import { createAJAXSettings, ServerConfig } from "./base";
+import { createAJAXSettings } from "./base";
 
 const formURI = (path: string) => urljoin("/api/bookstore/published", path);
 

--- a/packages/rx-jupyter/src/contents.ts
+++ b/packages/rx-jupyter/src/contents.ts
@@ -1,9 +1,10 @@
 import { Notebook } from "@nteract/commutable";
 import querystring from "querystring";
 import { Observable } from "rxjs";
-import { ajax, AjaxRequest, AjaxResponse } from "rxjs/ajax";
+import { ajax, AjaxResponse } from "rxjs/ajax";
 import urljoin from "url-join";
-import { createAJAXSettings, JupyterAjaxResponse, ServerConfig } from "./base";
+import { ServerConfig } from "@nteract/types";
+import { createAJAXSettings, JupyterAjaxResponse } from "./base";
 
 const formURI = (path: string) => urljoin("/api/contents/", path);
 

--- a/packages/rx-jupyter/src/index.ts
+++ b/packages/rx-jupyter/src/index.ts
@@ -1,8 +1,6 @@
 import { ajax, AjaxResponse } from "rxjs/ajax";
-import { createAJAXSettings, ServerConfig as _ServerConfig } from "./base";
-
-// Workaround an issue with re-exporting an interface by type aliasing it
-export type ServerConfig = _ServerConfig;
+import { ServerConfig } from "@nteract/types";
+import { createAJAXSettings } from "./base";
 
 import { Observable } from "rxjs";
 import * as bookstore from "./bookstore";

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -4,8 +4,9 @@ import { delay, retryWhen, share, tap } from "rxjs/operators";
 import { webSocket } from "rxjs/webSocket";
 import urljoin from "url-join";
 import URLSearchParams from "url-search-params";
-import { createAJAXSettings, ServerConfig } from "./base";
+import { createAJAXSettings } from "./base";
 
+import { ServerConfig } from "@nteract/types";
 import { JupyterMessage } from "@nteract/messaging";
 
 /**

--- a/packages/rx-jupyter/src/kernelspecs.ts
+++ b/packages/rx-jupyter/src/kernelspecs.ts
@@ -1,6 +1,7 @@
 import { Observable } from "rxjs";
 import { ajax, AjaxResponse } from "rxjs/ajax";
-import { createAJAXSettings, ServerConfig } from "./base";
+import { ServerConfig } from "@nteract/types";
+import { createAJAXSettings } from "./base";
 
 /**
  * Creates an AjaxObservable for listing avaialble kernelspecs.

--- a/packages/rx-jupyter/src/sessions.ts
+++ b/packages/rx-jupyter/src/sessions.ts
@@ -1,6 +1,7 @@
 import { Observable } from "rxjs";
 import { ajax, AjaxResponse } from "rxjs/ajax";
-import { createAJAXSettings, ServerConfig } from "./base";
+import { ServerConfig } from "@nteract/types";
+import { createAJAXSettings } from "./base";
 
 /**
  * Creates an AjaxObservable for listing available sessions.

--- a/packages/rx-jupyter/src/terminals.ts
+++ b/packages/rx-jupyter/src/terminals.ts
@@ -2,7 +2,8 @@ import { Observable } from "rxjs";
 import { ajax, AjaxResponse } from "rxjs/ajax";
 import urljoin from "url-join";
 
-import { createAJAXSettings, normalizeBaseURL, ServerConfig } from "./base";
+import { ServerConfig } from "@nteract/types";
+import { createAJAXSettings, normalizeBaseURL } from "./base";
 
 const formURI = (path: string) => urljoin("/api/terminals/", path);
 

--- a/packages/rx-jupyter/tsconfig.json
+++ b/packages/rx-jupyter/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../commutable" }, { "path": "../messaging" }]
+  "references": [{ "path": "../commutable" }, { "path": "../messaging" }, { "path": "../types" }]
 }

--- a/packages/selectors/src/core/hosts.ts
+++ b/packages/selectors/src/core/hosts.ts
@@ -1,6 +1,4 @@
-import { AppState, JupyterHostRecord } from "@nteract/types";
-
-import { ServerConfig } from "rx-jupyter";
+import { AppState, JupyterHostRecord, ServerConfig } from "@nteract/types";
 
 import { createSelector } from "reselect";
 

--- a/packages/selectors/tsconfig.json
+++ b/packages/selectors/tsconfig.json
@@ -7,7 +7,6 @@
   "include": ["src"],
   "references": [
     { "path": "../commutable" },
-    { "path": "../types" },
-    { "path": "../rx-jupyter" }
+    { "path": "../types" }
   ]
 }

--- a/packages/types/src/entities/hosts.ts
+++ b/packages/types/src/entities/hosts.ts
@@ -10,8 +10,12 @@ export interface Bookstore {
 
 export interface ServerConfig {
   endpoint: string;
-  crossDomain: boolean | null | undefined;
-  token: string | null | undefined;
+  url?: string;
+  crossDomain?: boolean;
+  token?: string;
+  xsrfToken?: string;
+  ajaxOptions?: Partial<AjaxRequest>;
+  wsProtocol?: string | string[];
 }
 
 export interface EmptyHost {


### PR DESCRIPTION
Merge `ServerConfig` definition in `rx-jupyter` with one that already exists in `types/src/entities/hosts.ts`

When integrating nteract notebook into my application, it won't compile:
node_modules/@nteract/selectors/lib/index.d.ts(12,132): error TS2307: Cannot find module '../../rx-jupyter/lib/base'.

This change:
* Removes the `ServerConfig` definition in `packages/rx-jupyter/src/base.ts`
* Updates the `ServerConfig` definition in `types/src/entities/hosts.ts` with the additional fields found in `rx-jupyter`'s definition.
* Makes `crossDomain` and `token` optional fields (was: `boolean | null | undefined` before. There could be some subtle type semantic difference that I'm missing, but I wanted them to be consistent with the other definitions).
* Updates all packages import that rely on `ServerConfig`.

Notes:
* I found some similar definition of ServerConfig in [host-cache/src/host-storage.ts](https://github.com/nteract/nteract/blob/01d9338daf10ad2b3d9c1d0ee11cd95252db7cca/packages/host-cache/src/host-storage.ts#L20). I left it as-is. I'm open to suggestions as to how to eliminate the duplication.
* It seems that `ServerConfig.url` is redundant with `ServerConfig.endpoint`. Can `url` be removed?

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
