### PR TITLE
Upgrade husky and webpack-cli to ingest their fixes to opencollective post install hooks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.1",
-    "husky": "^3.0.0",
+    "husky": "^3.0.5",
     "immutable": "^4.0.0-rc.12",
     "jest": "^24.0.0",
     "jest-junit": "^8.0.0",
@@ -240,7 +240,7 @@
     "unist-builder": "^1.0.2",
     "webfontloader": "^1.6.28",
     "webpack": "^4.28.3",
-    "webpack-cli": "^3.2.1",
+    "webpack-cli": "^3.3.7",
     "webpack-dev-server": "^3.1.14",
     "webpack-merge": "^4.2.1",
     "yargs": "^13.0.0"


### PR DESCRIPTION
Fixes #4552 