### PR TITLE
Fix #4547: Allow naming new notebooks from CLI

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -18,6 +18,8 @@ A new notebook can be created by accessing the menu,
          ⮑  <Language Kernel> (e.g. Python 3, R, Julia etc.)
 ```
 
+Or from the command line, run `nteract notebook.ipynb`
+
 ### Opening a Notebook
 
 There are several ways to open a notebook in nteract:
@@ -125,6 +127,8 @@ Examples:
 Open multiple notebooks: `nteract notebook1.ipynb notebook2.ipynb`
 
 Open new notebook with specific kernel: `nteract --kernel javascript`
+
+Open new notebook with specific filename: `nteract mynotebook.ipynb`
 
 ## Environment Variables
 

--- a/applications/desktop/__tests__/renderer/epics/loading.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/loading.spec.ts
@@ -67,6 +67,7 @@ describe("newNotebookEpic", () => {
     const action$ = ActionsObservable.of({
       type: actions.NEW_NOTEBOOK,
       payload: {
+        filepath: null,
         cwd: "/home/whatever",
         kernelSpec: {
           name: "hylang"
@@ -108,4 +109,55 @@ describe("newNotebookEpic", () => {
       }
     ]);
   });
+});
+
+describe("newNotebookEpicNamed", () => {
+  test(
+    "calls new Kernel after creating a new notebook with given name",
+      async () => {
+      const action$ = ActionsObservable.of({
+        type: actions.NEW_NOTEBOOK,
+        payload: {
+          filepath: "/home/whatever2/some.ipynb",
+          cwd: "/home/whatever",
+          kernelSpec: {
+            name: "hylang"
+          },
+          kernelRef: "kRef",
+          contentRef: "cRef"
+        }
+      });
+      const responseActions = await newNotebookEpic(action$)
+        .pipe(toArray())
+        .toPromise();
+      const filepath = process.platform === "win32"
+        ? "\\home\\whatever2\\some.ipynb"
+        : "/home/whatever2/some.ipynb";
+  
+      expect(responseActions).toEqual([
+        {
+          type: actions.FETCH_CONTENT_FULFILLED,
+          payload: {
+            contentRef: "cRef",
+            kernelRef: "kRef",
+            filepath,
+            model: {
+              type: "notebook",
+              mimetype: "application/x-ipynb+json",
+              format: "json",
+              content: toJS(
+                monocellNotebook
+                  .setIn(["metadata", "kernel_info", "name"], "hylang")
+                  .setIn(["metadata", "language_info", "name"], "hylang")
+              ),
+              writable: true,
+              name: "some.ipynb",
+              path: filepath,
+              created: expect.any(String),
+              last_modified: expect.any(String)
+            }
+          }
+        }
+      ]);
+    });
 });

--- a/applications/desktop/__tests__/renderer/menu.spec.ts
+++ b/applications/desktop/__tests__/renderer/menu.spec.ts
@@ -697,10 +697,34 @@ describe("dispatchNewNotebook", () => {
       contentRef: "123"
     };
 
-    menu.dispatchNewNotebook(props, store, {}, { spec: "hokey" });
+    menu.dispatchNewNotebook(props, store, {}, null, { spec: "hokey" });
     expect(store.dispatch).toHaveBeenCalledWith({
       type: "NEW_NOTEBOOK",
       payload: {
+        filepath: null,
+        kernelSpec: { spec: "hokey" },
+        cwd: process.cwd(),
+        kernelRef: expect.any(String),
+        contentRef: "123"
+      }
+    });
+  });
+});
+
+describe("dispatchNewNotebookNamed", () => {
+  test("dispatches a NEW_NOTEBOOK action with name", () => {
+    const store = {
+      dispatch: jest.fn()
+    };
+    const props = {
+      contentRef: "123"
+    };
+
+    menu.dispatchNewNotebook(props, store, {}, "some.ipynb", { spec: "hokey" });
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: "NEW_NOTEBOOK",
+      payload: {
+        filepath: "some.ipynb",
         kernelSpec: { spec: "hokey" },
         cwd: process.cwd(),
         kernelRef: expect.any(String),

--- a/applications/desktop/src/main/launch.ts
+++ b/applications/desktop/src/main/launch.ts
@@ -69,10 +69,10 @@ export function launch(filename?: string) {
 }
 launchIpynb = launch;
 
-export function launchNewNotebook(kernelSpec: KernelspecInfo) {
+export function launchNewNotebook(filepath: string | null, kernelSpec: KernelspecInfo) {
   const win = launch();
   win.webContents.on("did-finish-load", () => {
-    win.webContents.send("main:new", kernelSpec);
+    win.webContents.send("main:new", filepath, kernelSpec);
   });
   return win;
 }

--- a/applications/desktop/src/main/menu.ts
+++ b/applications/desktop/src/main/menu.ts
@@ -208,7 +208,7 @@ export function loadFullMenu(store = global.store) {
   const newNotebookItems = sortBy(kernelSpecs, "spec.display_name").map(
     kernel => ({
       label: kernel.spec.display_name,
-      click: () => launchNewNotebook(kernel)
+      click: () => launchNewNotebook(null, kernel)
     })
   );
 
@@ -651,7 +651,7 @@ export function loadTrayMenu(store = global.store) {
   const newNotebookItems = sortBy(kernelSpecs, "spec.display_name").map(
     kernel => ({
       label: kernel.spec.display_name,
-      click: () => launchNewNotebook(kernel)
+      click: () => launchNewNotebook(null, kernel)
     })
   );
 

--- a/applications/desktop/src/notebook/epics/loading.ts
+++ b/applications/desktop/src/notebook/epics/loading.ts
@@ -210,7 +210,11 @@ export const newNotebookEpic = (
       }
 
       const timestamp = new Date();
-      const filepath = path.join(action.payload.cwd, "Untitled.ipynb");
+      const filepath =
+        (
+          action.payload.filepath !== null &&
+          path.resolve(action.payload.filepath)
+        ) || path.join(action.payload.cwd, "Untitled.ipynb");
 
       return actions.fetchContentFulfilled({
         filepath,
@@ -221,7 +225,7 @@ export const newNotebookEpic = (
           // Back to JS, only to immutableify it inside of the reducer
           content: toJS(notebook),
           writable: true,
-          name: "Untitled.ipynb",
+          name: path.basename(filepath),
           path: filepath,
           created: timestamp.toString(),
           last_modified: timestamp.toString()

--- a/applications/desktop/src/notebook/menu.ts
+++ b/applications/desktop/src/notebook/menu.ts
@@ -552,17 +552,20 @@ export function dispatchNewNotebook(
   ownProps: { contentRef: ContentRef },
   store: DesktopStore,
   event: Event,
+  filepath: string | null,
   kernelSpec: KernelSpec
 ) {
   // It's a brand new notebook so we create a kernelRef for it
   const kernelRef = createKernelRef();
 
   store.dispatch(
+    // if filepath is null
     // for desktop, we _can_ assume this has no path except for living in `cwd`
     // which I suppose _could_ be called `${cwd}/UntitledN.ipynb`
     // for jupyter extension, we _would_ call this `${cwd}/UntitledN.ipynb`
 
     actions.newNotebook({
+      filepath,
       kernelSpec,
       cwd: cwdKernelFallback(),
       kernelRef,

--- a/packages/actions/src/actionTypes/contents.ts
+++ b/packages/actions/src/actionTypes/contents.ts
@@ -157,6 +157,7 @@ export const NEW_NOTEBOOK = "NEW_NOTEBOOK";
 export interface NewNotebook {
   type: "NEW_NOTEBOOK";
   payload: {
+    filepath: string | null;
     cwd: string;
     kernelSpec: KernelspecInfo;
     kernelRef: KernelRef;

--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -165,6 +165,7 @@ export function saveAsFulfilled(
 
 // TODO: New Notebook action should use a kernel spec type
 export function newNotebook(payload: {
+  filepath: string | null;
   kernelSpec: KernelspecInfo;
   cwd: string;
   kernelRef: KernelRef;
@@ -173,6 +174,7 @@ export function newNotebook(payload: {
   return {
     type: actionTypes.NEW_NOTEBOOK,
     payload: {
+      filepath: payload.filepath,
       kernelSpec: payload.kernelSpec,
       cwd: payload.cwd || process.cwd(), // Desktop should be passing in the cwd
       kernelRef: payload.kernelRef,


### PR DESCRIPTION
If a filename is specified on the command line that doesn't exist a
new notebook will be created with that name instead of Untitled.ipynb.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
