### PR TITLE
Rearrange CSS imports to resolve cell height regression

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/index.tsx
@@ -6,11 +6,13 @@
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/select/lib/css/blueprint-select.css";
 
+import "codemirror/addon/hint/show-hint.css";
+import "codemirror/lib/codemirror.css";
+
 import "@nteract/styles/app.css";
 import "@nteract/styles/editor-overrides.css";
 import "@nteract/styles/global-variables.css";
-import "codemirror/addon/hint/show-hint.css";
-import "codemirror/lib/codemirror.css";
+
 import "react-table/react-table.css";
 import urljoin from "url-join";
 


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/4408.

Also adds some newlines between the imports to avoid linters automatically re-ordering things.