### PR TITLE
Apply fixes to some accessibility issues

### DIFF
--- a/packages/connected-components/src/notebook-menu/PureNotebookMenu.tsx
+++ b/packages/connected-components/src/notebook-menu/PureNotebookMenu.tsx
@@ -141,6 +141,7 @@ class PureNotebookMenu extends React.PureComponent<PureNotebookMenuProps> {
     // console.log(`::handleActionClick -> ${currentKey.key}`);
     this.handleClick(currentKey);
   };
+
   handleClick = ({ key }: { key: string }) => {
     const {
       saveNotebook,

--- a/packages/directory-listing/src/components/lastsaved.tsx
+++ b/packages/directory-listing/src/components/lastsaved.tsx
@@ -7,7 +7,7 @@ interface LastSavedProps {
 }
 
 const TimeAgoTD = styled.span`
-  color: #6a737d;
+  color: #565d66;
 `;
 
 // Rather than showing a continual counter like "0 seconds ago"

--- a/packages/dropdown-menu/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/dropdown-menu/__tests__/__snapshots__/index.spec.tsx.snap
@@ -332,7 +332,10 @@ exports[`DropdownMenu clicking dropdown content triggers the items callback and 
               <div
                 className="sc-htpNat juMQnP"
               >
-                <ul>
+                <ul
+                  aria-label="dropdown-content"
+                  role="listbox"
+                >
                   <li
                     className="alsoClickMe"
                     key=".0"

--- a/packages/dropdown-menu/src/index.tsx
+++ b/packages/dropdown-menu/src/index.tsx
@@ -150,7 +150,7 @@ export class DropdownContent extends React.PureComponent<{
   render() {
     return (
       <DropdownContentDiv>
-        <ul>
+        <ul role="listbox" aria-label="dropdown-content">
           {React.Children.map(this.props.children, child => {
             const childElement = child as React.ReactElement<any>;
             return React.cloneElement(childElement, {

--- a/packages/editor/src/components/initial-text-area.tsx
+++ b/packages/editor/src/components/initial-text-area.tsx
@@ -11,7 +11,10 @@ export const TextArea: StyledComponent<
   any,
   { autoComplete: "off" },
   "autoComplete"
-> = styled.textarea.attrs({ autoComplete: "off" })`
+> = styled.textarea.attrs({
+  autoComplete: "off",
+  ariaLabel: "codemirror-textarea"
+})`
   font-family: "Dank Mono", dm, "Source Code Pro", "Monaco", monospace;
   font-size: 14px;
   line-height: 20px;

--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
@@ -60,7 +60,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
                 "componentStyle": ComponentStyle {
                   "componentId": "sc-bxivhb",
                   "isStatic": true,
-                  "lastClassName": "igjdMy",
+                  "lastClassName": "grkuc",
                   "rules": Array [
                     "
   background-color: var(--theme-cell-toolbar-bg);
@@ -76,7 +76,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
   }
 
   @media print {
-    display: none ;
+    display: none;
   }
 
   button {
@@ -129,7 +129,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
             forwardedRef={null}
           >
             <div
-              className="sc-bxivhb igjdMy"
+              className="sc-bxivhb grkuc"
             >
               <button
                 className="executeButton"
@@ -407,7 +407,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
                 "componentStyle": ComponentStyle {
                   "componentId": "sc-bxivhb",
                   "isStatic": true,
-                  "lastClassName": "igjdMy",
+                  "lastClassName": "grkuc",
                   "rules": Array [
                     "
   background-color: var(--theme-cell-toolbar-bg);
@@ -423,7 +423,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
   }
 
   @media print {
-    display: none ;
+    display: none;
   }
 
   button {
@@ -476,7 +476,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
             forwardedRef={null}
           >
             <div
-              className="sc-bxivhb igjdMy"
+              className="sc-bxivhb grkuc"
             >
               <button
                 className="executeButton"
@@ -705,7 +705,10 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
                             <div
                               className="sc-htpNat juMQnP"
                             >
-                              <ul>
+                              <ul
+                                aria-label="dropdown-content"
+                                role="listbox"
+                              >
                                 <li
                                   aria-selected="false"
                                   className="clearOutput"

--- a/packages/notebook-app-component/src/toolbar.tsx
+++ b/packages/notebook-app-component/src/toolbar.tsx
@@ -2,10 +2,6 @@
 /* eslint jsx-a11y/click-events-have-key-events: 0 */
 /* eslint jsx-a11y/anchor-is-valid: 0 */
 
-// TODO: Fix up a11y eslint here
-// TODO: All the `<li>` below that have role button should just be `<button>`
-//  with proper styling
-
 import {
   DropdownContent,
   DropdownMenu,
@@ -51,7 +47,7 @@ export const CellToolbar = styled.div`
   }
 
   @media print {
-    display: none ;
+    display: none;
   }
 
   button {

--- a/packages/presentational-components/src/styles.tsx
+++ b/packages/presentational-components/src/styles.tsx
@@ -193,23 +193,23 @@ const GlobalCSSVariables = createGlobalStyle`
 const DarkTheme = createGlobalStyle`
 :root {
   --theme-app-bg: #2b2b2b;
-  --theme-app-fg: var(--nt-color-midnight-lightest);
-  --theme-app-border: var(--nt-color-midnight-light);
+  --theme-app-fg: var(--nt-color-alabaster-lightest);
+  --theme-app-border: var(--nt-color-alabaster-light);
 
   --theme-primary-bg: var(--nt-color-midnight);
   --theme-primary-bg-hover: var(--nt-color-midnight);
   --theme-primary-bg-focus: var(--nt-color-midnight-light);
 
-  --theme-primary-fg: var(--nt-color-midnight-light);
-  --theme-primary-fg-hover: var(--nt-color-midnight-lighter);
+  --theme-primary-fg: var(--nt-color-alabaster-light);
+  --theme-primary-fg-hover: var(--nt-color-alabaster-lighter);
   --theme-primary-fg-focus: var(--theme-app-fg);
 
   --theme-secondary-bg: var(--theme-primary-bg);
   --theme-secondary-bg-hover: var(--theme-primary-bg-hover);
   --theme-secondary-bg-focus: var(--theme-primary-bg-focus);
 
-  --theme-secondary-fg: var(--nt-color-midnight-light);
-  --theme-secondary-fg-hover: var(--nt-color-midnight-lighter);
+  --theme-secondary-fg: var(--nt-color-alabaster-light);
+  --theme-secondary-fg-hover: var(--nt-color-alabaster-lighter);
   --theme-secondary-fg-focus: var(--theme-primary-fg);
 
   --theme-primary-shadow-hover: 1px  1px 3px rgba(255, 255, 255, 0.12), -1px -1px 3px rgba(255, 255, 255, 0.12);

--- a/packages/styles/global-variables.css
+++ b/packages/styles/global-variables.css
@@ -52,9 +52,9 @@
   --nt-color-midnight-darker: hsl(0, 0%, 5%);
   --nt-color-midnight-dark: hsl(0, 0%, 10%);
   --nt-color-midnight: hsl(0, 0%, 15%);
-  --nt-color-midnight-light: hsl(0, 0%, 51%);
-  --nt-color-midnight-lighter: hsl(0, 0%, 75%);
-  --nt-color-midnight-lightest: hsl(0, 0%, 85%);
+  --nt-color-midnight-light: hsl(0, 0%, 21%);
+  --nt-color-midnight-lighter: hsl(0, 0%, 45%);
+  --nt-color-midnight-lightest: hsl(0, 0%, 55%);
   --nt-color-sky-darkest: var(--nt-color-sky-darker);
   --nt-color-sky-darker: var(--nt-color-sky-dark);
   --nt-color-sky-dark: hsl(208, 54%, 35%);


### PR DESCRIPTION
I ran nteract through the Deque Systems accessibly checker and the Lighthouse checker.

The good news: We rank at around 85% accessibility ranking in both at the moment. Not bad!

I applied some fixes to resolve the gnarliest class of issues: those related to color contrast. The big culprit here was our midnight shade which didn't have a wide enough contrast gradient across the light and lightest color variations of that shade.

I also updated our dark theme to use alabaster as the foreground color instead of midnight because it provided better contrasts against the dark background.

Following these changes, our Lighthouse accessibility score is 88%.

CodeMirror presents the gnarliest set of challenges in this regard. For one, the fact that it uses a [hidden input textarea](https://bgrins.github.io/codemirror-accessible/) causes some problems with screen readers. Also, since it is using a textarea is knocks off some accessibility points because there are no labels associated with that form element. Finally, the current color theme we use flags for accessibility for single numbers in the code cell. For example, if you have a cell with just the number 42. I started looking around the Codemirror themes page to see if they had any accessible themes but didn't find anything that passed the automated checkers.

Another class of issues comes from the kernel errors that we get back. The contrast on those is off too but that's set by the ANSI color codes and is out of our control there.

These automated checkers don't assess all things. Lighthouse provides a list of the things it doesn't check and from that list I think "Interactive controls are keyboard focusable" is one we need to work on.
