### PR TITLE
tear reselect out of comms & kernelspecs selectors

### DIFF
--- a/packages/selectors/src/comms.ts
+++ b/packages/selectors/src/comms.ts
@@ -1,7 +1,5 @@
 import { AppState } from "@nteract/types";
 
-import { createSelector } from "reselect";
-
 /**
  * Returns the Jupyter comms data for a given nteract application.
  */
@@ -10,26 +8,17 @@ export const comms = (state: AppState) => state.comms;
 /**
  * Returns the comms models that are stored in the nteract application state.
  */
-export const models = createSelector(
-  comms,
-  comms => comms.models
-);
+export const models = (state: AppState) => state.comms.models;
 
 /**
  * Returns the registered comm targets that are stored in the nteract application state.
  */
-export const targets = createSelector(
-  comms,
-  comms => comms.targets
-);
+export const targets = (state: AppState) => state.comms.targets;
 
 /**
  * Returns the information associated with currently registered comms.
  */
-export const info = createSelector(
-  comms,
-  comms => comms.info
-);
+export const info = (state: AppState) => state.comms.info;
 
 /**
  * Returns the model associated with a comm at a certain id.
@@ -38,7 +27,7 @@ export const info = createSelector(
  * @param { commId }  The commId to get info for
  */
 export const modelById = (state: AppState, { commId }: { commId: string }) =>
-  models(state).get(commId);
+  state.comms.models.get(commId);
 
 /**
  * Returns the handler associated with a comm target at a certain id.
@@ -47,7 +36,7 @@ export const modelById = (state: AppState, { commId }: { commId: string }) =>
  * @param { commId }  The commId to get target for
  */
 export const targetById = (state: AppState, { commId }: { commId: string }) =>
-  targets(state).get(commId);
+  state.comms.targets.get(commId);
 
 /**
  * Returns the information associated with a comm registered at a certain id.
@@ -56,4 +45,4 @@ export const targetById = (state: AppState, { commId }: { commId: string }) =>
  * @param { commId }  The commId to get info for
  */
 export const infoById = (state: AppState, { commId }: { commId: string }) =>
-  info(state).get(commId);
+  state.comms.info.get(commId);

--- a/packages/selectors/src/core/contents/notebook.ts
+++ b/packages/selectors/src/core/contents/notebook.ts
@@ -92,31 +92,19 @@ export const codeCellIdsBelow = (
 /**
  * Returns the CellIds of the hidden cells in a notebook.
  */
-export const hiddenCellIds = createSelector(
-  [cellMap, cellOrder],
-  (cellMap, cellOrder) => {
-    return cellOrder.filter(id =>
-      cellMap.getIn([id, "metadata", "inputHidden"])
-    );
-  }
-);
+export const hiddenCellIds = (model: NotebookModel) =>
+  model.notebook.cellOrder.filter(id =>
+    model.notebook.cellMap.getIn([id, "metadata", "inputHidden"])
+  );
 
 /**
  * Returns the CellIds of the cells with hidden outputs in the
  * notebook.
  */
-export const idsOfHiddenOutputs = createSelector(
-  [cellMap, cellOrder],
-  (cellMap, cellOrder): Immutable.List<CellId> => {
-    if (!cellOrder || !cellMap) {
-      return Immutable.List<CellId>();
-    }
-
-    return cellOrder.filter(CellId =>
-      cellMap.getIn([CellId, "metadata", "outputHidden"])
-    );
-  }
-);
+export const idsOfHiddenOutputs = (model: NotebookModel) =>
+  model.notebook.cellOrder.filter(id =>
+    model.notebook.cellMap.getIn([id, "metadata", "outputHidden"])
+  );
 
 /**
  * Returns a transient version of the cell map within a notebook. This cell
@@ -135,12 +123,10 @@ export const cellPromptById = (model: NotebookModel, { id }: { id: CellId }) =>
 /**
  * Returns the CellIds of the code cells within a notebook.
  */
-export const codeCellIds = createSelector(
-  [cellMap, cellOrder],
-  (cellMap, cellOrder) => {
-    return cellOrder.filter(id => cellMap.getIn([id, "cell_type"]) === "code");
-  }
-);
+export const codeCellIds = (model: NotebookModel) =>
+  model.notebook.cellOrder.filter(
+    id => model.notebook.cellMap.getIn([id, "cell_type"]) === "code"
+  );
 
 /**
  * Returns the metadata of a notebook. Returns an empty Immutable.Map if

--- a/packages/selectors/src/core/kernelspecs.ts
+++ b/packages/selectors/src/core/kernelspecs.ts
@@ -1,7 +1,5 @@
 import { AppState, KernelspecsByRefRecord } from "@nteract/types";
 
-import { createSelector } from "reselect";
-
 /**
  * Returns a ref to the kernelspec of the kernel the nteract application
  * is currently connected to.
@@ -29,7 +27,16 @@ export const kernelspecsByRef = (state: AppState) =>
  */
 export const currentKernelspecs: (
   state: AppState
-) => KernelspecsByRefRecord | null | undefined = createSelector(
-  [currentKernelspecsRef, kernelspecsByRef],
-  (ref, byRef) => (ref ? byRef.get(ref) : null)
-);
+) => KernelspecsByRefRecord | null = (state: AppState) => {
+  const ref = state.core.currentKernelspecsRef;
+
+  if (ref) {
+    const kernelspecs = state.core.entities.kernelspecs.byRef.get(ref);
+    if (kernelspecs) {
+      return kernelspecs;
+    }
+  }
+
+  // If we don't have a current kernelspecs ref, return null
+  return null;
+};


### PR DESCRIPTION
We can just pluck the values out of our state tree, we don't need to memoize these operations. In some cases it's just silly (now that we have `Record`s, we can directly access properties). In other cases it's misguided because `reselect` memoizes one while we end up having to get different cells and other entities by ID.

This is a WIP PR while I tear it out from each file using `reselect` individually.