### PR TITLE
[data-explorer] Remove unused dependencies

### DIFF
--- a/packages/data-explorer/package.json
+++ b/packages/data-explorer/package.json
@@ -26,11 +26,8 @@
     "d3-collection": "^1.0.7",
     "d3-scale": "^3.0.0",
     "d3-shape": "^1.2.2",
-    "d3-time-format": "^2.0.5",
-    "lodash": "^4.17.4",
     "numeral": "^2.0.6",
     "react-color": "^2.14.1",
-    "react-hot-loader": "^4.1.2",
     "react-table": "6.10.3",
     "react-table-hoc-fixed-columns": "2.1.1",
     "semiotic": "^1.19.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,10 @@
   resolved "https://registry.yarnpkg.com/@types/clone/-/clone-0.1.30.tgz#e7365648c1b42136a59c7d5040637b3b5c83b614"
   integrity sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=
 
-"@types/codemirror@^0.0.77":
-  version "0.0.77"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.77.tgz#6785a0183b4aea147de650530259ebf2a511bde9"
-  integrity sha512-nfjRJpAXgkT075jztMp92Ol2b7w7JrDvpfBU70GfVhpfdpWiZi6NqVIO3STGNzWl77/iJkTu2ZSg6hQobrEadg==
+"@types/codemirror@^0.0.78":
+  version "0.0.78"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.78.tgz#75a8eabda268c8e734855fb24e8c86192e2e18ad"
+  integrity sha512-QpMQUpEL+ZNcpEhjvYM/H6jqDx9nNcJqymA2kbkNthFS2I7ekL7ofEZ7+MoQAFTBuJers91K0FGCMpL7MwC9TQ==
   dependencies:
     "@types/tern" "*"
 
@@ -3814,7 +3814,7 @@ d3-time-format@0.2:
   dependencies:
     d3-time "~0.1.1"
 
-d3-time-format@2, d3-time-format@^2.0.5, d3-time-format@^2.1.3:
+d3-time-format@2, d3-time-format@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.3.tgz#ae06f8e0126a9d60d6364eac5b1533ae1bac826b"
   integrity sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==


### PR DESCRIPTION
## Summary

- Addresses the low-hanging fruit parts of https://github.com/nteract/nteract/issues/4205, verified by running `ctrl+f` for each of these package names in the `packages/data-explorer` directory and confirming that each is unused. 
- As a sanity check, visited the "Try the Data Explorer" notebook, and the component appears to still be working.

There's still probably room to make the project smaller through changing how the code is written, this is just a quick first pass.