### PR TITLE
[tests] Add NodeJS Global Types for test-shim.ts

### DIFF
--- a/scripts/test-shim.ts
+++ b/scripts/test-shim.ts
@@ -11,22 +11,23 @@
 // For some reason, this property does not get set above.
 global.Image = global.window.Image;
 
-global.Range = function Range() {};
+global.Range = function Range(): void {};
 
-global.Blob = function(content, options) {
+global.Blob = function(content: any[], options: object): any {
   return { content, options };
 };
 
-const createContextualFragment = html => {
+const createContextualFragment = (html: string) => {
   const div = document.createElement("div");
   div.innerHTML = html;
-  return div.children[0]; // so hokey it's not even funny
+  // Element and DocumentFragment are technically incompatible
+  return (div.children[0] as unknown) as DocumentFragment; // so hokey it's not even funny
 };
 
-Range.prototype.createContextualFragment = html =>
+Range.prototype.createContextualFragment = (html: string) =>
   createContextualFragment(html);
 
-global.window.URL.createObjectURL = function() {};
+global.window.URL.createObjectURL = function(): void {};
 global.window.focus = () => {};
 
 // HACK: Polyfill that allows codemirror to render in a JSDOM env.

--- a/types/node/index.d.ts
+++ b/types/node/index.d.ts
@@ -1,0 +1,32 @@
+// Extends the DefinitelyTyped definitions with properties needed by test-shim.ts
+
+// Merges with definitions in @types/node
+// https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-interfaces
+
+declare namespace NodeJS {
+
+  interface Image {
+    prototype: HTMLImageElement;
+    new(): HTMLImageElement;
+  }
+
+  interface Global {
+    Image: Image;
+    Range: () => void;
+    Blob: (content: any[], options: object) => Blob;
+
+    window: {
+      document: {
+        // Codemirror Hack Polyfill
+        createRange: () => any;
+      }
+      focus: () => void;
+      Image: Image;
+      URL: {
+        prototype: URL;
+        new(): URL;
+        createObjectURL: () => void;
+      };
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- I started to look at https://github.com/nteract/nteract/issues/3997 with some potential contributors  earlier this week, and noticed that the app-specific test code wasn't even running when trying to test `vega.spec.ts` due to type errors on the `test-shim` file. (we can reproduce by running `yarn test`).

This change should free people up to focus on errors that are specific to the test files.

- To reproduce these errors, make sure this line is set to `false`.

https://github.com/nteract/nteract/blob/a400cf406ab1d39bc29850b3a4bfc27435e5b71c/package.json#L89

Here's the before + after result when patching our `@types/node` definition.

<a href="https://cl.ly/a5948bb7964d" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/19300W1N2N0Y193b0U24/Image%202019-10-05%20at%203.35.32%20PM.png" style="display: block;height: auto;width: 100%;"/></a>