### PR TITLE
Close notebook workflow

### DIFF
--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -672,4 +672,20 @@ describe("save", () => {
       payload: { contentRef }
     });
   });
+
+  test("creates a DISPOSE_CONTENT action", () => {
+    const contentRef = createContentRef();
+    expect(actions.disposeContent({ contentRef })).toEqual({
+      type: actionTypes.DISPOSE_CONTENT,
+      payload: { contentRef }
+    });
+  });
+
+  test("creates a DISPOSE_KERNEL action", () => {
+    const kernelRef = createKernelRef();
+    expect(actions.disposeKernel({ kernelRef })).toEqual({
+      type: actionTypes.DISPOSE_KERNEL,
+      payload: { kernelRef }
+    });
+  });
 });

--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -664,4 +664,12 @@ describe("save", () => {
       payload: { contentRef, model: { fake: true } }
     });
   });
+
+  test("creates a CLOSE_NOTEBOOK action", () => {
+    const contentRef = createContentRef();
+    expect(actions.closeNotebook({ contentRef })).toEqual({
+      type: actionTypes.CLOSE_NOTEBOOK,
+      payload: { contentRef }
+    });
+  });
 });

--- a/packages/actions/src/actionTypes/contents.ts
+++ b/packages/actions/src/actionTypes/contents.ts
@@ -181,3 +181,12 @@ export interface CloseNotebook {
     contentRef: ContentRef;
   };
 }
+
+export const DISPOSE_CONTENT = "DISPOSE_CONTENT";
+export interface DisposeContent {
+  type: "DISPOSE_CONTENT";
+  payload: {
+    contentRef: ContentRef;
+  }
+}
+

--- a/packages/actions/src/actionTypes/contents.ts
+++ b/packages/actions/src/actionTypes/contents.ts
@@ -173,3 +173,11 @@ export interface UpdateFileText {
     contentRef: ContentRef;
   };
 }
+
+export const CLOSE_NOTEBOOK = "CLOSE_NOTEBOOK";
+export interface CloseNotebook {
+  type: "CLOSE_NOTEBOOK";
+  payload: {
+    contentRef: ContentRef;
+  };
+}

--- a/packages/actions/src/actionTypes/kernels.ts
+++ b/packages/actions/src/actionTypes/kernels.ts
@@ -112,6 +112,7 @@ export interface KillKernelAction {
   payload: {
     restarting: boolean;
     kernelRef?: KernelRef | null;
+    dispose?: boolean;
   };
 }
 
@@ -274,4 +275,12 @@ export interface ShutdownReplyTimedOut {
     kernelRef: KernelRef;
   };
   error: true;
+}
+
+export const DISPOSE_KERNEL = "DISPOSE_KERNEL";
+export interface DisposeKernel {
+  type: "DISPOSE_KERNEL";
+  payload: {
+    kernelRef: KernelRef;
+  };
 }

--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -206,3 +206,14 @@ export function closeNotebook(payload: {
     }
   };
 }
+
+export function disposeContent(payload: {
+  contentRef: ContentRef;
+}): actionTypes.DisposeContent {
+  return {
+    type: actionTypes.DISPOSE_CONTENT,
+    payload: {
+      contentRef: payload.contentRef
+    }
+  };
+}

--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -195,3 +195,14 @@ export function updateFileText(payload: {
     }
   };
 }
+
+export function closeNotebook(payload: {
+  contentRef: ContentRef;
+}): actionTypes.CloseNotebook {
+  return {
+    type: actionTypes.CLOSE_NOTEBOOK,
+    payload: {
+      contentRef: payload.contentRef
+    }
+  };
+}

--- a/packages/actions/src/actions/kernels.ts
+++ b/packages/actions/src/actions/kernels.ts
@@ -93,6 +93,7 @@ export function kernelRawStderr(payload: {
 export function killKernel(payload: {
   restarting: boolean;
   kernelRef?: KernelRef | null;
+  dispose?: boolean;
 }): actionTypes.KillKernelAction {
   return {
     type: actionTypes.KILL_KERNEL,
@@ -299,4 +300,13 @@ export function setKernelInfo(payload: {
     type: actionTypes.SET_KERNEL_INFO,
     payload
   };
+}
+
+export function disposeKernel(payload: {
+  kernelRef: KernelRef;
+}): actionTypes.DisposeKernel {
+  return {
+    type: actionTypes.DISPOSE_KERNEL,
+    payload
+  }
 }

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -547,3 +547,19 @@ export function saveAsContentEpic(
     })
   );
 }
+
+export function closeNotebookEpic(
+  action$: ActionsObservable<actions.CloseNotebook>,
+  state$: StateObservable<AppState>
+): Observable<actions.DisposeContent | actions.KillKernelAction> {
+  return action$.pipe(
+    ofType(actions.CLOSE_NOTEBOOK),
+    mergeMap((action: actions.CloseNotebook):
+      Observable<actions.DisposeContent | actions.KillKernelAction> => {
+      const state = state$.value;
+      const contentRef = (action as actions.CloseNotebook).payload.contentRef;
+      const kernelRef = selectors.kernelRefByContentRef(state, { contentRef });
+      return of(actions.disposeContent({ contentRef }), actions.killKernel({ kernelRef, restarting: false, dispose: true }));
+    })
+  );
+}

--- a/packages/epics/src/index.ts
+++ b/packages/epics/src/index.ts
@@ -3,7 +3,8 @@ import {
   autoSaveCurrentContentEpic,
   fetchContentEpic,
   saveContentEpic,
-  updateContentEpic
+  updateContentEpic,
+  closeNotebookEpic
 } from "./contents";
 import {
   executeAllCellsEpic,
@@ -51,7 +52,8 @@ const allEpics = [
   publishToBookstore,
   publishToBookstoreAfterSave,
   restartWebSocketKernelEpic,
-  sendInputReplyEpic
+  sendInputReplyEpic,
+  closeNotebookEpic
 ];
 
 export {
@@ -76,5 +78,6 @@ export {
   publishToBookstore,
   publishToBookstoreAfterSave,
   restartWebSocketKernelEpic,
-  sendInputReplyEpic
+  sendInputReplyEpic,
+  closeNotebookEpic
 };

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -273,7 +273,7 @@ const byRef = (
         .setIn([saveFulfilledAction.payload.contentRef, "error"], null);
     }
     case actionTypes.CLOSE_NOTEBOOK: {
-      const typedAction = action as actionTypes.CloseNotebookAction;
+      const typedAction = action as actionTypes.CloseNotebook;
       return state.delete(typedAction.payload.contentRef);
     }
     // Defer all notebook actions to the notebook reducer

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -272,6 +272,10 @@ const byRef = (
         .setIn([saveFulfilledAction.payload.contentRef, "saving"], false)
         .setIn([saveFulfilledAction.payload.contentRef, "error"], null);
     }
+    case actionTypes.CLOSE_NOTEBOOK: {
+      const typedAction = action as actionTypes.CloseNotebookAction;
+      return state.delete(typedAction.payload.contentRef);
+    }
     // Defer all notebook actions to the notebook reducer
     case actionTypes.SEND_EXECUTE_REQUEST:
     case actionTypes.FOCUS_CELL:

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -272,8 +272,8 @@ const byRef = (
         .setIn([saveFulfilledAction.payload.contentRef, "saving"], false)
         .setIn([saveFulfilledAction.payload.contentRef, "error"], null);
     }
-    case actionTypes.CLOSE_NOTEBOOK: {
-      const typedAction = action as actionTypes.CloseNotebook;
+    case actionTypes.DISPOSE_CONTENT: {
+      const typedAction = action as actionTypes.DisposeContent;
       return state.delete(typedAction.payload.contentRef);
     }
     // Defer all notebook actions to the notebook reducer

--- a/packages/reducers/src/core/entities/kernels.ts
+++ b/packages/reducers/src/core/entities/kernels.ts
@@ -120,6 +120,10 @@ const byRef = (state = Map(), action: Action): Map<{}, {}> => {
             `Unrecognized kernel type in kernel ${typedAction.payload.kernel}.`
           );
       }
+    case actionTypes.DISPOSE_KERNEL: {
+      typedAction = action as actionTypes.DisposeKernel;
+      return state.delete(typedAction.payload.kernelRef);
+    }
     default:
       return state;
   }


### PR DESCRIPTION
This change is an attempt to address #4571 
It introduces a CLOSE_NOTEBOOK action. An epic will trigger:
* DISPOSE_CONTENT: it deletes the contenRef from the state (which also prevents auto-save to keep saving the content ref).
* KILL_KERNEL: a `dispose` flag is added to the kill kernel action. If set, the the killer kernel epic sends a DISPOSE_KERNEL upon successful completion (in addition to the usual KILL_KERNEL_SUCCESSFUL).

DISPOSE_KERNEL deletes the kernelRef from the state.