### PR TITLE
Add global error handler for redux-observable

### DIFF
--- a/applications/desktop/src/notebook/store.ts
+++ b/applications/desktop/src/notebook/store.ts
@@ -21,7 +21,7 @@ const rootEpic = (
 ) =>
   combineEpics(...epics)(action$, store$, dependencies).pipe(
     catchError((error: any, source: Observable<any>) => {
-      console.log(error);
+      console.error(error);
       return source;
     })
   );

--- a/applications/desktop/src/notebook/store.ts
+++ b/applications/desktop/src/notebook/store.ts
@@ -1,13 +1,31 @@
 import { middlewares as coreMiddlewares, reducers } from "@nteract/core";
 import { applyMiddleware, combineReducers, createStore, Store } from "redux";
-import { combineEpics, createEpicMiddleware } from "redux-observable";
+import {
+  combineEpics,
+  createEpicMiddleware,
+  ActionsObservable,
+  StateObservable
+} from "redux-observable";
+import { catchError } from "rxjs/operators";
 
 import { Actions } from "./actions";
 import epics from "./epics";
 import { handleDesktopNotebook } from "./reducers";
 import { DesktopNotebookAppState } from "./state";
+import { Observable } from "rxjs";
 
-const rootEpic = combineEpics(...epics);
+const rootEpic = (
+  action$: ActionsObservable<any>,
+  store$: StateObservable<any>,
+  dependencies: any
+) =>
+  combineEpics(...epics)(action$, store$, dependencies).pipe(
+    catchError((error: any, source: Observable<any>) => {
+      console.log(error);
+      return source;
+    })
+  );
+
 const epicMiddleware = createEpicMiddleware<
   Actions,
   Actions,

--- a/applications/jupyter-extension/nteract_on_jupyter/app/store.ts
+++ b/applications/jupyter-extension/nteract_on_jupyter/app/store.ts
@@ -37,7 +37,7 @@ export default function configureStore(initialState: Partial<AppState>) {
       dependencies
     ).pipe(
       catchError((error: any, source: Observable<any>) => {
-        console.log(error);
+        console.error(error);
         return source;
       })
     );


### PR DESCRIPTION
The `combineEpics` function in redux-observable merges a set of epics into a mega-epic.

This mega-epic lacks error handling by default. For more context on this, see https://github.com/redux-observable/redux-observable/issues/591.

This PR adds global error handling to the master epic in both the desktop application and the Jupyter extension.

This error handler logs the error and returns the re-subscribes to the source Observable stream.