### PR TITLE
ansi-to-react: Fix linkification with newlines

### DIFF
--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -87,7 +87,7 @@ function convertBundleIntoReact(
     );
   }
 
-  const words = bundle.content.split(/\s+/).reduce(
+  const words = bundle.content.split(/(\s+)/).reduce(
     (words: React.ReactNode[], word: string, index: number) => {
       // If this is a separator, re-add the space removed from split.
       if (index % 2 === 1) {

--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -87,11 +87,12 @@ function convertBundleIntoReact(
     );
   }
 
-  const words = bundle.content.split(" ").reduce(
+  const words = bundle.content.split(/\s+/).reduce(
     (words: React.ReactNode[], word: string, index: number) => {
-      // If this isn't the first word, re-add the space removed from split.
-      if (index !== 0) {
-        words.push(" ");
+      // If this is a separator, re-add the space removed from split.
+      if (index % 2 === 1) {
+        words.push(word);
+        return words;
       }
 
       // If  this isn't a link, just return the word as-is.

--- a/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
+++ b/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
@@ -1545,12 +1545,53 @@ exports[`Plain should render urls as links 1`] = `
            
           <a
             href="https://google.com"
-            key="3"
+            key="6"
             target="_blank"
           >
             https://google.com
           </a>
            
+          today!
+        </span>
+      </code>
+    </Ansi>
+  </pre>
+</Plaintext>
+`;
+
+exports[`Plain should render urls on a separate line as links 1`] = `
+<Plaintext
+  data="Let's go to
+https://google.com
+today!"
+  mediaType="text/plain"
+>
+  <pre>
+    <Ansi
+      linkify={true}
+    >
+      <code>
+        <span
+          className={null}
+          key="0"
+          style={Object {}}
+        >
+          Let's
+           
+          go
+           
+          to
+          
+
+          <a
+            href="https://google.com"
+            key="6"
+            target="_blank"
+          >
+            https://google.com
+          </a>
+          
+
           today!
         </span>
       </code>

--- a/packages/outputs/__tests__/media.spec.tsx
+++ b/packages/outputs/__tests__/media.spec.tsx
@@ -131,6 +131,12 @@ describe("Plain", () => {
     expect(toJson(component)).toMatchSnapshot();
     expect(component.find("a").prop("href")).toEqual("https://google.com");
   });
+  it("should render urls on a separate line as links", () => {
+    const data = "Let's go to\nhttps://google.com\ntoday!";
+    const component = mount(<Media.Plain data={data} />);
+    expect(toJson(component)).toMatchSnapshot();
+    expect(component.find("a").prop("href")).toEqual("https://google.com");
+  });
 });
 
 describe("JavaScript", () => {


### PR DESCRIPTION
I use ansi-to-react on strings like
```
Heading
http://some.link.com/
http://some.link.com/
```
The old code would result in linkifying the whole string; the correct behavior of course is to linkify only the lines that contain URLs.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
