### PR TITLE
Extract last_modified and created date from model

### DIFF
--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -214,8 +214,9 @@ const byRef = (
           return state.set(
             fetchContentFulfilledAction.payload.contentRef,
             makeNotebookContentRecord({
-              created: fetchContentFulfilledAction.payload.created,
-              lastSaved: fetchContentFulfilledAction.payload.lastSaved,
+              created: fetchContentFulfilledAction.payload.model.created,
+              lastSaved:
+                fetchContentFulfilledAction.payload.model.last_modified,
               filepath: fetchContentFulfilledAction.payload.filepath,
               model: makeDocumentRecord({
                 notebook: immutableNotebook,


### PR DESCRIPTION
For some reason, the "notebook" case in the FetchContentFulfilled reducer was attempting to read the initial values from properties that did not exist.

It should be reading `created` and `lastSaved` from the `created` and `last_modified` properties within the model, respectively.