### PR TITLE
Fix #4526 - Even out padding in NotebookApp

### DIFF
--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -520,9 +520,7 @@ const makeMapStateToProps = (
 };
 
 const Cells = styled.div`
-  padding-top: var(--nt-spacing-m, 10px);
-  padding-left: var(--nt-spacing-m, 10px);
-  padding-right: var(--nt-spacing-m, 10px);
+  padding: var(--nt-spacing-m, 10px);
 `;
 
 const mapDispatchToProps = (dispatch: Dispatch): NotebookDispatchProps => ({


### PR DESCRIPTION
Fix #4526 - Even out padding in NotebookApp

Switch padding-top,right,left into just padding for consistent padding on all sides.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
