### PR TITLE
Remove reconnecting WebSocket logic

### DIFF
--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -151,35 +151,6 @@ export const connect = (
     protocol: serverConfig.wsProtocol
   });
 
-  wsSubject.pipe(
-    retryWhen(error$ => {
-      // Keep track of how many times we've already re-tried
-      let counter = 0;
-      const maxRetries = 100;
-
-      return error$.pipe(
-        tap(e => {
-          counter++;
-          // This will only retry on error when it's a close event that is not
-          // from a .complete() of the websocket subject
-          if (counter > maxRetries || e instanceof Event === false) {
-            console.error(
-              `bubbling up Error on websocket after retrying ${counter} times out of ${maxRetries}`,
-              e
-            );
-            throw e;
-          } else {
-            // We'll retry at this point
-            console.log("attempting to retry kernel connection after error", e);
-          }
-        }),
-        delay(1000)
-      );
-    }),
-    // The websocket subject is multicast and we need the retryWhen logic to retain that property
-    share()
-  );
-
   // Create a subject that does some of the handling inline for the session
   // and ensuring it's serialized
   return Subject.create(

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -1,6 +1,5 @@
 import { Subject, Subscriber } from "rxjs";
 import { ajax } from "rxjs/ajax";
-import { delay, retryWhen, share, tap } from "rxjs/operators";
 import { webSocket } from "rxjs/webSocket";
 import urljoin from "url-join";
 import URLSearchParams from "url-search-params";


### PR DESCRIPTION
This bit of logic has admirable aspirations but is rather buggy, so I'm nuking it for now. Related to #4612.

My suspicion is that we will need to move this retry logic to higher up in the stack, probably as a kernel lifecycle epic or the like.

Placing it in a kernel lifecycle epic has the benefit of making it easier to test and debug, easier for consumers to disable, and easier to integrate with other kernel status/reliability features.