### PR TITLE
Update payload interface for action functions in contents.ts

### DIFF
--- a/packages/actions/src/actions/contents.ts
+++ b/packages/actions/src/actions/contents.ts
@@ -1,42 +1,30 @@
-// Vendor modules
-import { ContentRef, KernelRef, KernelspecInfo } from "@nteract/types";
-import { contents } from "rx-jupyter";
-
 // Local modules
 import * as actionTypes from "../actionTypes";
 
-export const toggleHeaderEditor = (payload: {
-  contentRef: ContentRef;
-}): actionTypes.ToggleHeaderEditor => ({
+export const toggleHeaderEditor = (
+  payload: actionTypes.ToggleHeaderEditor["payload"]
+): actionTypes.ToggleHeaderEditor => ({
   type: actionTypes.TOGGLE_HEADER_EDITOR,
   payload
 });
 
-export const changeContentName = (payload: {
-  filepath: string;
-  contentRef: ContentRef;
-  prevFilePath: string;
-}): actionTypes.ChangeContentName => ({
+export const changeContentName = (
+  payload: actionTypes.ChangeContentName["payload"]
+): actionTypes.ChangeContentName => ({
   type: actionTypes.CHANGE_CONTENT_NAME,
   payload
 });
 
-export const changeContentNameFulfilled = (payload: {
-  filepath: string;
-  contentRef: ContentRef;
-  prevFilePath: string;
-}): actionTypes.ChangeContentNameFulfilled => ({
+export const changeContentNameFulfilled = (
+  payload: actionTypes.ChangeContentNameFulfilled["payload"]
+): actionTypes.ChangeContentNameFulfilled => ({
   type: actionTypes.CHANGE_CONTENT_NAME_FULFILLED,
   payload
 });
 
-export const changeContentNameFailed = (payload: {
-  basepath: string;
-  filepath: string;
-  error: Error;
-  contentRef: ContentRef;
-  prevFilePath: string;
-}): actionTypes.ChangeContentNameFailed => ({
+export const changeContentNameFailed = (
+  payload: actionTypes.ChangeContentNameFailed["payload"]
+): actionTypes.ChangeContentNameFailed => ({
   type: actionTypes.CHANGE_CONTENT_NAME_FAILED,
   payload
 });
@@ -48,85 +36,76 @@ export const fetchContent = (
   payload
 });
 
-export const fetchContentFulfilled = (payload: {
-  filepath: string;
-  model: contents.IContent;
-  kernelRef: KernelRef;
-  contentRef: ContentRef;
-}): actionTypes.FetchContentFulfilled => ({
+export const fetchContentFulfilled = (
+  payload: actionTypes.FetchContentFulfilled["payload"]
+): actionTypes.FetchContentFulfilled => ({
   type: actionTypes.FETCH_CONTENT_FULFILLED,
   payload
 });
 
-export const fetchContentFailed = (payload: {
-  filepath: string;
-  error: Error;
-  kernelRef: KernelRef;
-  contentRef: ContentRef;
-}): actionTypes.FetchContentFailed => ({
+export const fetchContentFailed = (
+  payload: actionTypes.FetchContentFailed["payload"]
+): actionTypes.FetchContentFailed => ({
   type: actionTypes.FETCH_CONTENT_FAILED,
   payload,
   error: true
 });
 
-export function changeFilename(payload: {
-  filepath?: string;
-  contentRef: ContentRef;
-}): actionTypes.ChangeFilenameAction {
+export function changeFilename(
+  payload: actionTypes.ChangeFilenameAction["payload"]
+): actionTypes.ChangeFilenameAction {
   return {
     type: actionTypes.CHANGE_FILENAME,
     payload
   };
 }
 
-export function downloadContent(payload: {
-  contentRef: ContentRef;
-}): actionTypes.DownloadContent {
+export function downloadContent(
+  payload: actionTypes.DownloadContent["payload"]
+): actionTypes.DownloadContent {
   return {
     type: actionTypes.DOWNLOAD_CONTENT,
     payload
   };
 }
 
-export function downloadContentFailed(payload: {
-  contentRef: ContentRef;
-}): actionTypes.DownloadContentFailed {
+export function downloadContentFailed(
+  payload: actionTypes.DownloadContentFailed["payload"]
+): actionTypes.DownloadContentFailed {
   return {
     type: actionTypes.DOWNLOAD_CONTENT_FAILED,
     payload
   };
 }
 
-export function downloadContentFulfilled(payload: {
-  contentRef: ContentRef;
-}): actionTypes.DownloadContentFulfilled {
+export function downloadContentFulfilled(
+  payload: actionTypes.DownloadContentFulfilled["payload"]
+): actionTypes.DownloadContentFulfilled {
   return {
     type: actionTypes.DOWNLOAD_CONTENT_FULFILLED,
     payload
   };
 }
 
-export function save(payload: { contentRef: ContentRef }): actionTypes.Save {
+export function save(payload: actionTypes.Save["payload"]): actionTypes.Save {
   return {
     type: actionTypes.SAVE,
     payload
   };
 }
 
-export function saveAs(payload: {
-  filepath: string;
-  contentRef: ContentRef;
-}): actionTypes.SaveAs {
+export function saveAs(
+  payload: actionTypes.SaveAs["payload"]
+): actionTypes.SaveAs {
   return {
     type: actionTypes.SAVE_AS,
     payload
   };
 }
 
-export function saveFailed(payload: {
-  error: Error;
-  contentRef: ContentRef;
-}): actionTypes.SaveFailed {
+export function saveFailed(
+  payload: actionTypes.SaveFailed["payload"]
+): actionTypes.SaveFailed {
   return {
     type: actionTypes.SAVE_FAILED,
     payload,
@@ -134,10 +113,9 @@ export function saveFailed(payload: {
   };
 }
 
-export function saveFulfilled(payload: {
-  contentRef: ContentRef;
-  model: any;
-}): actionTypes.SaveFulfilled {
+export function saveFulfilled(
+  payload: actionTypes.SaveFulfilled["payload"]
+): actionTypes.SaveFulfilled {
   return {
     type: actionTypes.SAVE_FULFILLED,
     payload
@@ -164,13 +142,9 @@ export function saveAsFulfilled(
 }
 
 // TODO: New Notebook action should use a kernel spec type
-export function newNotebook(payload: {
-  filepath: string | null;
-  kernelSpec: KernelspecInfo;
-  cwd: string;
-  kernelRef: KernelRef;
-  contentRef: ContentRef;
-}): actionTypes.NewNotebook {
+export function newNotebook(
+  payload: actionTypes.NewNotebook["payload"]
+): actionTypes.NewNotebook {
   return {
     type: actionTypes.NEW_NOTEBOOK,
     payload: {
@@ -183,10 +157,9 @@ export function newNotebook(payload: {
   };
 }
 
-export function updateFileText(payload: {
-  contentRef: ContentRef;
-  text: string;
-}): actionTypes.UpdateFileText {
+export function updateFileText(
+  payload: actionTypes.UpdateFileText["payload"]
+): actionTypes.UpdateFileText {
   return {
     type: actionTypes.UPDATE_FILE_TEXT,
     payload: {


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

This PR updates the type definition for the `payload` argument for functions in `actions/contents.ts` to use the defined `actionTypes` to follow DRY principals for issue #4561 and for this year's Hacktoberfest! 

Please let me know if I'm missing anything in this PR :) 
