### PR TITLE
Pass Immutable objects through React components

### DIFF
--- a/packages/jupyter-widgets/src/manager/index.tsx
+++ b/packages/jupyter-widgets/src/manager/index.tsx
@@ -65,7 +65,7 @@ class Manager extends React.Component<Props> {
     return (
       <React.Fragment>
         <BackboneWrapper
-          model={this.props.model.get("state").toJS()}
+          model={this.props.model.get("state")}
           manager={this.getManager()}
           model_id={this.props.model_id}
           widgetContainerRef={this.widgetContainerRef}
@@ -78,7 +78,7 @@ class Manager extends React.Component<Props> {
 const mapStateToProps = (state: AppState, props: OwnProps): ConnectedProps => {
   return {
     modelById: (model_id: string) =>
-      selectors.modelById(state, { commId: model_id }).toJS(),
+      selectors.modelById(state, { commId: model_id }),
     kernel: selectors.currentKernel(state)
   };
 };

--- a/packages/jupyter-widgets/src/manager/widget-manager.ts
+++ b/packages/jupyter-widgets/src/manager/widget-manager.ts
@@ -83,7 +83,9 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
   get_model(model_id: string): Promise<WidgetModel> | undefined {
     let model = super.get_model(model_id);
     if (model === undefined) {
-      let model_state = this.stateModelById(model_id).state;
+      let model_state = this.stateModelById(model_id)
+        .get("state")
+        .toJS();
       model = this.new_widget_from_state_and_id(model_state, model_id);
     }
     return model;
@@ -104,7 +106,6 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
       view_module: state._view_module,
       view_module_version: state._view_module_version
     };
-    console.log(modelInfo);
     return this.new_widget(modelInfo, state);
   }
 

--- a/packages/jupyter-widgets/src/renderer/backbone-wrapper.tsx
+++ b/packages/jupyter-widgets/src/renderer/backbone-wrapper.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Immutable from "immutable";
 import { WidgetManager } from "../manager/widget-manager";
 
 /**
@@ -22,7 +23,7 @@ require("jquery-ui/themes/base/base.css");
 require("jquery-ui/themes/base/theme.css");
 
 interface Props {
-  model: any;
+  model: Immutable.Map<string, any>;
   manager?: WidgetManager;
   model_id: string;
   widgetContainerRef: React.RefObject<HTMLDivElement>;
@@ -35,7 +36,7 @@ export default class BackboneWrapper extends React.Component<Props> {
     if (!this.created) {
       if (manager) {
         this.created = true;
-        const widget = await manager.create_view(model, {
+        const widget = await manager.create_view(model.toJS(), {
           model_id: this.props.model_id,
           el: widgetContainerRef.current
         });


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/4643.

@miduncan @rgbkrk Thoughts on relying on Immutable structures more deeply in the WidgetManager implementation? One the one hand, we get the benefit of immutable structures throughout the manager class. On the other hand, we'd have to rewrite more methods that are currently implemented by the `ManagerBase` like `new_widget`.