### PR TITLE
Set HostRef in RemoteKernelRecord on kernel launch

### DIFF
--- a/packages/epics/__tests__/websocket-kernel.spec.ts
+++ b/packages/epics/__tests__/websocket-kernel.spec.ts
@@ -1,18 +1,18 @@
 import * as Immutable from "immutable";
 import { ActionsObservable, StateObservable } from "redux-observable";
-import { of, Subject } from "rxjs";
+import { Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
 import * as stateModule from "@nteract/types";
 
-import { makeDocumentRecord } from "@nteract/types";
 import * as coreEpics from "../src";
 
 describe("launchWebSocketKernelEpic", () => {
   test("launches remote kernels", async () => {
     const contentRef = "fakeContentRef";
     const kernelRef = "fake";
+    const hostRef = "fakeHostRef";
     const value = {
       app: stateModule.makeAppRecord({
         host: stateModule.makeJupyterHostRecord({
@@ -39,6 +39,15 @@ describe("launchWebSocketKernelEpic", () => {
                 channels: new Subject<any>(),
                 kernelSpecName: "fancy",
                 id: "0"
+              })
+            })
+          }),
+          hosts: stateModule.makeHostsRecord({
+            byRef: Immutable.Map({
+              [hostRef]: stateModule.makeJupyterHostRecord({
+                type: "jupyter",
+                token: "eh",
+                basePath: "http://localhost:8888/"
               })
             })
           })
@@ -74,6 +83,7 @@ describe("launchWebSocketKernelEpic", () => {
           kernel: {
             info: null,
             sessionId: "1",
+            hostRef,
             type: "websocket",
             channels: expect.any(Subject),
             kernelSpecName: "fancy",

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -21,7 +21,6 @@ import {
   KernelRecord,
   RemoteKernelProps,
   ServerConfig,
-  HostRef
 } from "@nteract/types";
 
 import { AjaxResponse } from "rxjs/ajax";

--- a/packages/selectors/src/core/hosts.ts
+++ b/packages/selectors/src/core/hosts.ts
@@ -1,4 +1,9 @@
-import { AppState, JupyterHostRecord, ServerConfig } from "@nteract/types";
+import {
+  AppState,
+  JupyterHostRecord,
+  ServerConfig,
+  HostRef
+} from "@nteract/types";
 
 import { createSelector } from "reselect";
 
@@ -70,3 +75,41 @@ export const isCurrentKernelZeroMQ = createSelector(
     return hostType === "local" && kernelType === "zeromq";
   }
 );
+
+/**
+ * Returns the hosts currently registered on the application by their refs.
+ *
+ * @param state   The crrent application state
+ */
+export const hostsByRef = (state: AppState) => state.core.entities.hosts.byRef;
+
+/**
+ * Returns the HostRef associated with a HostRecord.
+ *
+ * ```
+ * const host = makeJupyterHostRecord({ endpoint: "https://example.com "});
+ * const ref = selectors.hostRefByHostRecord(state, { host });
+ * ```
+ *
+ * @param state     The current application state
+ * @param { host }  An object containing the hostRecord to retrieve an HostRef for
+ */
+export const hostRefByHostRecord = (
+  state: AppState,
+  { host }: { host: JupyterHostRecord }
+) => hostsByRef(state).findKey((record, ref) => record.equals(host));
+
+/**
+ * Returns the HostRecord associated with a hostRef.
+ *
+ * ```
+ * const hostRef = "someHostRef";
+ * const hostRecord = selectors.hostRecordByHostRef(state, { hostRef });
+ * ```
+ * @param state         The current application sate
+ * @param { hostRef }   An object containing the hostRef to retrieve a record for
+ */
+export const hostRecordByHostRef = (
+  state: AppState,
+  { hostRef }: { hostRef: HostRef }
+) => hostsByRef(state).get(hostRef);


### PR DESCRIPTION
Closes #4627.

**Changes in this PR**
- Sets HostRef in RemoteKernelRecord after launch of WebSocket kernel
- Adds selectors for accessing hosts and retrieving host record by host ref and vice versa