### PR TITLE
Fix restart flow for remote kernel types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build": "cross-env NODE_ENV=production npm run build:packages",
     "build:clean": "npm run build:packages -- --clean",
     "build:apps": "lerna run build --scope nteract --scope nteract-on-jupyter --parallel --stream",
+    "build:jext": "lerna run hot --scope nteract-on-jupyter --stream",
     "build:desktop": "lerna run build --scope nteract --stream",
     "build:desktop:watch": "lerna run build:watch --scope nteract --stream",
     "build:packages": "tsc -b packages",

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -409,5 +409,6 @@ describe("restartKernelEpic", () => {
       );
 
       expectObservable(outputAction$).toBe(outputMarbles, outputActions);
-  })
+    });
+  });
 });

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -211,6 +211,10 @@ export const launchKernelWhenNotebookSetEpic = (
     })
   );
 
+/**
+ * Restarts a Jupyter kernel in the local scenario, where a restart requires
+ * killing the existing kernel process and starting an ew one.
+ */
 export const restartKernelEpic = (
   action$: ActionsObservable<actions.RestartKernel | actions.NewKernelAction>,
   state$: any,
@@ -220,7 +224,11 @@ export const restartKernelEpic = (
     ofType(actions.RESTART_KERNEL),
     concatMap((action: actions.RestartKernel | actions.NewKernelAction) => {
       const state = state$.value;
-      const oldKernelRef = selectors.kernelRefByContentRef(state$.value, { contentRef: action.payload.contentRef });
+
+      const oldKernelRef = selectors.kernelRefByContentRef(state$.value, {
+        contentRef: action.payload.contentRef
+      });
+
       const notificationSystem = selectors.notificationSystem(state);
 
       if (!oldKernelRef) {
@@ -235,6 +243,10 @@ export const restartKernelEpic = (
       }
 
       const oldKernel = selectors.kernel(state, { kernelRef: oldKernelRef });
+
+      if (oldKernel && oldKernel.type === "websocket") {
+        return empty();
+      }
 
       if (!oldKernelRef || !oldKernel) {
         notificationSystem.addNotification({

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -370,15 +370,9 @@ export const restartWebSocketKernelEpic = (
       const state = state$.value;
 
       const { contentRef, outputHandling } = action.payload;
-      let { kernelRef } = action.payload;
-
-      /**
-       * If there is no KernelRef provided try to resolve one from
-       * the ContentRef.
-       */
-      if (!kernelRef) {
-        kernelRef = selectors.kernelRefByContentRef(state, { contentRef });
-      }
+      const kernelRef =
+        selectors.kernelRefByContentRef(state, { contentRef }) ||
+        action.payload.kernelRef;
 
       /**
        * If there is still no KernelRef, then throw an error.

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -248,7 +248,7 @@ export const interruptKernelEpic = (
       }
 
       if (!kernel.id) {
-          return of(
+        return of(
           actions.interruptKernelFailed({
             error: new Error("Kernel does not have ID set"),
             kernelRef: action.payload.kernelRef
@@ -301,11 +301,11 @@ export const killKernelEpic = (
 
       let kernel: KernelRecord | null | undefined;
       if (contentRef) {
-          kernel = selectors.kernelByContentRef(state, { contentRef });
+        kernel = selectors.kernelByContentRef(state, { contentRef });
       } else if (kernelRef) {
         kernel = selectors.kernel(state, { kernelRef });
       } else {
-          kernel = selectors.currentKernel(state);
+        kernel = selectors.currentKernel(state);
       }
 
       if (!kernel) {
@@ -328,7 +328,7 @@ export const killKernelEpic = (
         );
       }
 
-            if (!kernel.id || !kernel.sessionId) {
+      if (!kernel.id || !kernel.sessionId) {
         return of(
           actions.killKernelFailed({
             error: new Error(
@@ -369,8 +369,20 @@ export const restartWebSocketKernelEpic = (
     concatMap((action: actions.RestartKernel) => {
       const state = state$.value;
 
-      const { contentRef, kernelRef, outputHandling } = action.payload;
+      const { contentRef, outputHandling } = action.payload;
+      let { kernelRef } = action.payload;
 
+      /**
+       * If there is no KernelRef provided try to resolve one from
+       * the ContentRef.
+       */
+      if (!kernelRef) {
+        kernelRef = selectors.kernelRefByContentRef(state, { contentRef });
+      }
+
+      /**
+       * If there is still no KernelRef, then throw an error.
+       */
       if (!kernelRef) {
         return of(
           actions.restartKernelFailed({


### PR DESCRIPTION
Closes #4575  

**Changes in this PR**
The restartKernelEpic in kernel-lifecycle.ts was set-up to restart local-based kernels, while the restartWebsocketKernelEpic in websocket-kernel.ts was set up to restart remote-kernels. This distinction is a little weird, we should probably have one epic that has some casing logic to dispatch both. However, I stopped going down that track because I want to invest more time in cleaning up the handling of flows that are specific to local or remote kernels and potentional other execution targets. For now, the following changes have been made.

- restartKernelEpic will do nothing if the target kernel is a WebSocket kernel
- Fixed a bug in restartWebsocketKernelEpic that was preventing the correct KernelRef from being found
- Adds npm script for building the Jext app with hot-reload