### PR TITLE
Update link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ questions. If you have trouble creating an account on Slack, please post an issu
 
 ### Overview of nteract's monorepo
 
-This repository is a [monorepo](./doc/design/monorepo.md), which basically
+This repository is a [monorepo](https://trunkbaseddevelopment.com/monorepos/), which basically
 means that the repository hosts more than one module or application. In our
 case, we have two main directories:
 


### PR DESCRIPTION
The "monorepo" link points to https://github.com/nteract/nteract/blob/master/doc/design/monorepo.md which returns a 404. I couldn't locate monorepo.md so I pointed the link to a site that defines monorepos  instead (https://trunkbaseddevelopment.com/monorepos/).

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
