### PR TITLE
Tweak unhideAll to change visibility of all inputs or outputs

### DIFF
--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -74,6 +74,50 @@ describe("unhideAll", () => {
         contentRef
       }
     });
+
+    expect(
+      actions.unhideAll({ outputHidden: true, inputHidden: true, contentRef })
+    ).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: true,
+        inputHidden: true,
+        contentRef
+      }
+    });
+
+    expect(
+      actions.unhideAll({ outputHidden: false, contentRef })
+    ).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: false,
+        inputHidden: undefined,
+        contentRef
+      }
+    });
+
+    expect(
+      actions.unhideAll({ inputHidden: false, contentRef })
+    ).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: undefined,
+        inputHidden: false,
+        contentRef
+      }
+    });
+
+    expect(
+      actions.unhideAll({ contentRef })
+    ).toEqual({
+      type: actionTypes.UNHIDE_ALL,
+      payload: {
+        outputHidden: undefined,
+        inputHidden: undefined,
+        contentRef
+      }
+    });
   });
 });
 

--- a/packages/actions/src/actionTypes/cells.ts
+++ b/packages/actions/src/actionTypes/cells.ts
@@ -111,8 +111,8 @@ export const UNHIDE_ALL = "UNHIDE_ALL";
 export interface UnhideAll {
   type: "UNHIDE_ALL";
   payload: {
-    inputHidden: boolean;
-    outputHidden: boolean;
+    inputHidden?: boolean;
+    outputHidden?: boolean;
     contentRef: ContentRef;
   };
 }

--- a/packages/actions/src/actions/cells.ts
+++ b/packages/actions/src/actions/cells.ts
@@ -196,11 +196,9 @@ export function updateCellExecutionCount(payload: {
   return setInCell({ ...payload, path: ["execution_count"] });
 }
 
-export function unhideAll(payload: {
-  outputHidden: boolean;
-  inputHidden: boolean;
-  contentRef: ContentRef;
-}): actionTypes.UnhideAll {
+export function unhideAll(
+  payload: actionTypes.UnhideAll["payload"]
+): actionTypes.UnhideAll {
   return {
     type: "UNHIDE_ALL",
     payload

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -1235,4 +1235,89 @@ describe("unhideAll", () => {
         .toArray()
     ).toEqual([false,false,false,true]);
   });
+
+  test("should reveal all inputs and outputs", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        inputHidden: false,
+        outputHidden: false,
+        contentRef: undefined
+       })
+    );
+
+    // Assert
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(true);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(true);
+  });
+
+  test("should hide all inputs and outputs", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        inputHidden: true,
+        outputHidden: true,
+        contentRef: undefined
+       })
+    );
+
+    // Assert
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(false);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(false);
+  });
+
+  test("should no-op", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        contentRef: undefined
+       })
+    );
+
+    // Assert: should keep all inputs' and outputs' visibility unchanged
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).toEqual([false,false,false,true]);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).toEqual([false,true,false,false]);
+  });
 });

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -1102,3 +1102,137 @@ describe("updateOutputMetadata", () => {
     );
   });
 });
+
+describe("unhideAll", () => {
+  const cellOrder = [ uuid(), uuid(), uuid(), uuid() ];
+  let initialState = Immutable.Map();
+
+  beforeEach(() => {
+    // Arrange
+    initialState = initialDocument
+      .set(
+        "notebook",
+        Immutable.fromJS({
+          cellOrder,
+          cellMap: {
+            [cellOrder[0]]: emptyCodeCell.setIn(["metadata", "outputHidden"], false),
+            [cellOrder[1]]: emptyCodeCell.setIn(["metadata", "outputHidden"], true),
+            [cellOrder[2]]: emptyCodeCell.setIn(["metadata", "inputHidden"], false),
+            [cellOrder[3]]: emptyCodeCell.setIn(["metadata", "inputHidden"], true)
+          }
+        })
+      );
+  });
+
+  test("should reveal all inputs", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        inputHidden: false,
+        contentRef: undefined
+       })
+    );
+
+    // Assert: should unhide inputs and keep outputs' visibility unchanged
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(true);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).toEqual([false,true,false,false]);
+  });
+
+  test("should hide all inputs", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        inputHidden: true,
+        contentRef: undefined
+       })
+    );
+
+    // Assert: should hide inputs and keep outputs' visibility unchanged
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(false);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).toEqual([false,true,false,false]);
+  });
+
+  test("should reveal all outputs", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        outputHidden: false,
+        contentRef: undefined
+       })
+    );
+
+    // Assert: should unhide outputs and keep inputs' visibility unchanged
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(true);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).toEqual([false,false,false,true]);
+  });
+
+  test("should hide all outputs", () => {
+    // Act
+    const actualState = reducers(
+      initialState,
+      actions.unhideAll({
+        outputHidden: true,
+        contentRef: undefined
+       })
+    );
+
+    // Assert: should hide outputs and keep inputs' visibility unchanged
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "outputHidden"]))
+        .toList()
+        .toArray()
+    ).not.toContain(false);
+
+    expect(
+      actualState
+        .getIn(["notebook", "cellMap"])
+        .map(cell => cell.getIn(["metadata", "inputHidden"]))
+        .toList()
+        .toArray()
+    ).toEqual([false,false,false,true]);
+  });
+});

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -655,15 +655,19 @@ function unhideAll(
   state: NotebookModel,
   action: actionTypes.UnhideAll
 ): RecordOf<DocumentRecordProps> {
+  const metadataMixin: any = {};
+  if (action.payload.outputHidden !== undefined) {
+    // TODO: Verify that we convert to one namespace
+    // for hidden input/output
+    metadataMixin.outputHidden = action.payload.outputHidden
+  }
+  if (action.payload.inputHidden !== undefined) {
+    metadataMixin.inputHidden = action.payload.inputHidden
+  }
   return state.updateIn(["notebook", "cellMap"], cellMap =>
     cellMap.map((cell: ImmutableCell) => {
       if ((cell as any).get("cell_type") === "code") {
-        return cell.mergeIn(["metadata"], {
-          // TODO: Verify that we convert to one namespace
-          // for hidden input/output
-          outputHidden: action.payload.outputHidden,
-          inputHidden: action.payload.inputHidden
-        });
+        return cell.mergeIn(["metadata"], metadataMixin);
       }
       return cell;
     })

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -651,11 +651,16 @@ function toggleCellOutputVisibility(
   );
 }
 
+interface ICellVisibilityMetadata {
+  inputHidden?:boolean;
+  outputHidden?: boolean;
+}
+
 function unhideAll(
   state: NotebookModel,
   action: actionTypes.UnhideAll
 ): RecordOf<DocumentRecordProps> {
-  const metadataMixin: any = {};
+  const metadataMixin: ICellVisibilityMetadata = {};
   if (action.payload.outputHidden !== undefined) {
     // TODO: Verify that we convert to one namespace
     // for hidden input/output


### PR DESCRIPTION
The purpose of this PR is to allow `unhideAll` action to alter visibility of all cell inputs and outputs independently. 

Key changes are:
- `inputHidden` and `outputHidden` attributes will be optional
- `unhideAll` reducer will test attributes values to be not `undefined` before applying the change

Resoves #4665 