### PR TITLE
Increase text contrast, add test, remove obsolete code

### DIFF
--- a/packages/presentational-components/__tests__/styles.spec.tsx
+++ b/packages/presentational-components/__tests__/styles.spec.tsx
@@ -1,0 +1,172 @@
+import * as fs from "fs";
+
+// @ts-ignore
+import parseColor from "color-parse";
+// @ts-ignore
+import colorSpace from "color-space";
+// @ts-ignore
+import css from "css";
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { DarkTheme, LightTheme } from "../src";
+
+type Level = "fg" | "bg";
+
+interface Rule {
+  match: RegExp;
+  build: (matches: RegExpMatchArray) => {
+    key: string;
+    extends?: string;
+    set: Level;
+  };
+}
+
+interface Mapping<T> {
+  [key: string]: T;
+}
+
+interface ColorPair {
+  fg: string;
+  bg: string;
+}
+
+type ColorPairs = Mapping<Partial<ColorPair>>;
+
+interface Contrast {
+  fg: string;
+  bg: string;
+  contrast: number;
+}
+
+const GLOBALS_FILE = "packages/styles/global-variables.css";
+const ISNT_WCAG_AAA = ({ contrast }: Contrast) => contrast < 7;
+
+// Rules to build foreground/background pairs from CSS properties
+const RULES: Rule[] = [
+  {
+    // fg: --theme-...-fg(-...)
+    // bg: --theme-...-bg(-...)
+    // nodes with pseudoclasses inherit missing values from those without
+    match: /^--theme-(.*?)-([fb]g)(-(.*)|)$/,
+    build: ([_full, name, level, _suffix, pseudo]) =>
+      !pseudo
+        ? { key: name, set: level as Level }
+        : { key: `${name}:${pseudo}`, extends: name, set: level as Level },
+  },
+  {
+    // fg: --cm-...
+    // bg: --cm-background
+    match: /^--cm-([^-]*?)$/,
+    build: ([_full, name]) =>
+      (name === "background")
+        ? { key: "code (background)", set: "bg" }
+        : { key: `code (${name})`, extends: "code (background)", set: "fg" },
+  }
+];
+
+function contrastOf(a: number, b: number): number {
+  return (Math.max(a, b) + .05) / (Math.min(a, b) + .05);
+}
+
+function luminosityOf(value: string): number {
+  const color = parseColor(value);
+  const rgb = colorSpace[color.space].rgb(color.values);
+  const rgbS = rgb
+    .map((x: number) => x / 255)
+    .map((x: number) =>
+      x <= 0.03928
+        ? x / 12.92
+        : Math.pow((x + 0.055) / 1.055, 2.4));
+
+  return 0.2126 * rgbS[0] + 0.7152 * rgbS[1] + 0.0722 * rgbS[2];
+}
+
+function resolveVars(value: string, lookup: (key: string) => string): string {
+  const match = value.match(/^var\(\s*(.*?)\s*\)$/);
+
+  return match
+    ? resolveVars(lookup(match[1]), lookup)
+    : value;
+}
+
+function buildColorPairs(keys: string[], rules: Rule[]): ColorPairs {
+  const index: ColorPairs = {};
+
+  keys.forEach(key =>
+    rules.forEach(indexer => {
+      const matches = key.match(indexer.match);
+
+      if (matches) {
+        const record = indexer.build(matches);
+
+        index[record.key] = index[record.key] || {};
+        index[record.key][record.set] = `var(${key})`;
+
+        if (record.extends) {
+          index[record.extends] = index[record.extends] || {};
+          Object.setPrototypeOf(index[record.key], index[record.extends]);
+        }
+      }
+    })
+  );
+
+  return index;
+}
+
+function parseSingleRootSelector(style: string): Mapping<string> {
+  const ast = css.parse(style).stylesheet;
+
+  expect(ast.parsingErrors).toEqual([]);
+  expect(ast.rules.length).toEqual(1);
+  expect(ast.rules[0].selectors).toEqual([":root"]);
+
+  ast.rules[0].declarations.forEach((decl: any) => {
+    expect(decl.type).toEqual("declaration");
+  });
+
+  const declarations: Mapping<string> = {};
+
+  ast.rules[0].declarations.forEach((decl: any) => {
+    declarations[decl.property] = decl.value;
+  });
+
+  return declarations;
+}
+
+function contrastsInTheme(element: JSX.Element): Contrast[] {
+  const globalCSS = fs.readFileSync(GLOBALS_FILE).toString();
+  const themeCSS = (mount(element).state() as any).globalStyle.rules[0];
+
+  const globals = parseSingleRootSelector(globalCSS);
+  const theme = parseSingleRootSelector(themeCSS);
+  const lookup = (value: string) => theme[value] || globals[value];
+
+  const pairs = buildColorPairs(Object.keys(theme), RULES);
+
+  return Object
+    .values(pairs)
+    .filter(({ fg }) => fg !== undefined) // Assume not used for text
+    .map(({ fg, bg }) => ({ fg: fg!, bg: bg || "white" })) // Assume default
+    .map(({ fg, bg }): Contrast => ({
+      fg, bg,
+      contrast: contrastOf(
+        luminosityOf(resolveVars(fg, lookup)),
+        luminosityOf(resolveVars(bg, lookup)),
+      ),
+    }));
+}
+
+describe("LightTheme", () => {
+  test("contrast meets WCAG AAA", () => {
+    const failing = contrastsInTheme(<LightTheme/>).filter(ISNT_WCAG_AAA);
+    expect(failing).toEqual([]);
+  });
+});
+
+describe("DarkTheme", () => {
+  test("contrast meets WCAG AAA", () => {
+    const failing = contrastsInTheme(<DarkTheme/>).filter(ISNT_WCAG_AAA);
+    expect(failing).toEqual([]);
+  });
+});

--- a/packages/presentational-components/__tests__/tsconfig.json
+++ b/packages/presentational-components/__tests__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+  },
+  "include": ["."],
+  "references": []
+}

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -25,6 +25,9 @@
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "@types/styled-components": "^4.1.4"
+    "@types/styled-components": "^4.1.4",
+    "css": "^2.2.4",
+    "color-parse": "^1.3.8",
+    "color-space": "^1.16.0"
   }
 }

--- a/packages/presentational-components/src/styles.tsx
+++ b/packages/presentational-components/src/styles.tsx
@@ -1,195 +1,5 @@
 import { createGlobalStyle } from "styled-components";
 
-// All the CSS variables used in nteract apps
-const GlobalCSSVariables = createGlobalStyle`
-:root {
-  --nt-color-alabaster-darkest: var(--nt-color-alabaster-darker);
-  --nt-color-alabaster-darker: var(--nt-color-alabaster-dark);
-  --nt-color-alabaster-dark: var(--nt-color-alabaster);
-  --nt-color-alabaster: hsl(0, 0%, 97%);
-  --nt-color-alabaster-light: var(--nt-color-alabaster);
-  --nt-color-alabaster-lighter: var(--nt-color-alabaster-light);
-  --nt-color-alabaster-lightest: var(--nt-color-alabaster-lighter);
-  --nt-color-asparagus-darkest: var(--nt-color-asparagus-darker);
-  --nt-color-asparagus-darker: var(--nt-color-asparagus-dark);
-  --nt-color-asparagus-dark: hsl(91, 28%, 37%);
-  --nt-color-asparagus: hsl(91, 28%, 55%);
-  --nt-color-asparagus-light: hsl(91, 28%, 73%);
-  --nt-color-asparagus-lighter: hsl(91, 28%, 88%);
-  --nt-color-asparagus-lightest: hsl(91, 28%, 98%);
-  --nt-color-danube-darkest: var(--nt-color-danube-darker);
-  --nt-color-danube-darker: var(--nt-color-danube-dark);
-  --nt-color-danube-dark: hsl(208, 54%, 35%);
-  --nt-color-danube: hsl(208, 54%, 53%);
-  --nt-color-danube-light: hsl(208, 54%, 71%);
-  --nt-color-danube-lighter: hsl(208, 54%, 86%);
-  --nt-color-danube-lightest: hsl(208, 54%, 98%);
-  --nt-color-gold-darkest: var(--nt-color-gold-darker);
-  --nt-color-gold-darker: var(--nt-color-gold-dark);
-  --nt-color-gold-dark: hsl(41, 89%, 35%);
-  --nt-color-gold: hsl(41, 89%, 53%);
-  --nt-color-gold-light: hsl(41, 89%, 71%);
-  --nt-color-gold-lighter: hsl(41, 89%, 86%);
-  --nt-color-gold-lightest: hsl(41, 89%, 98%);
-  --nt-color-nteract-darkest: var(--nt-color-nteract-darker);
-  --nt-color-nteract-darker: var(--nt-color-nteract-dark);
-  --nt-color-nteract-dark: var(--nt-color-nteract);
-  --nt-color-nteract: #8518f2;
-  --nt-color-nteract-light: #af8afa;
-  --nt-color-nteract-lighter: #ccb3ff;
-  --nt-color-nteract-lightest: var(--nt-color-nteract-lighter);
-  --nt-color-red-darkest: var(--nt-color-red-darker);
-  --nt-color-red-darker: var(--nt-color-red-dark);
-  --nt-color-red-dark: hsl(0, 67%, 25%);
-  --nt-color-red: hsl(0, 67%, 43%);
-  --nt-color-red-light: hsl(0, 67%, 61%);
-  --nt-color-red-lighter: hsl(0, 67%, 76%);
-  --nt-color-red-lightest: hsl(0, 67%, 88%);
-  --nt-color-grey-darkest: hsl(0, 0%, 10%);
-  --nt-color-grey-darker: hsl(0, 0%, 17%);
-  --nt-color-grey-dark: hsl(0, 0%, 40%);
-  --nt-color-grey: hsl(0, 0%, 63%);
-  --nt-color-grey-light: hsl(0, 0%, 90%);
-  --nt-color-grey-lighter: hsl(0, 0%, 94%);
-  --nt-color-grey-lightest: hsl(0, 0%, 98%);
-  --nt-color-midnight-darkest: hsl(0, 0%, 0%);
-  --nt-color-midnight-darker: hsl(0, 0%, 5%);
-  --nt-color-midnight-dark: hsl(0, 0%, 10%);
-  --nt-color-midnight: hsl(0, 0%, 15%);
-  --nt-color-midnight-light: hsl(0, 0%, 51%);
-  --nt-color-midnight-lighter: hsl(0, 0%, 75%);
-  --nt-color-midnight-lightest: hsl(0, 0%, 85%);
-  --nt-color-sky-darkest: var(--nt-color-sky-darker);
-  --nt-color-sky-darker: var(--nt-color-sky-dark);
-  --nt-color-sky-dark: hsl(208, 54%, 35%);
-  --nt-color-sky: hsl(208, 54%, 53%);
-  --nt-color-sky-light: hsl(208, 54%, 71%);
-  --nt-color-sky-lighter: hsl(208, 54%, 86%);
-  --nt-color-sky-lightest: hsl(208, 54%, 98%);
-  --nt-color-slate-darkest: var(--nt-color-slate-darker);
-  --nt-color-slate-darker: var(--nt-color-slate-dark);
-  --nt-color-slate-dark: hsl(207, 29%, 14%);
-  --nt-color-slate: hsl(207, 29%, 32%);
-  --nt-color-slate-light: hsl(207, 29%, 50%);
-  --nt-color-slate-lighter: hsl(207, 29%, 65%);
-  --nt-color-slate-lightest: hsl(207, 29%, 77%);
-  --nt-color-clementine-darkest: var(--nt-color-clementine-darker);
-  --nt-color-clementine-darker: var(--nt-color-clementine-dark);
-  --nt-color-clementine-dark: hsl(33, 75%, 34%);
-  --nt-color-clementine: hsl(33, 75%, 52%);
-  --nt-color-clementine-light: hsl(33, 75%, 70%);
-  --nt-color-clementine-lighter: hsl(33, 75%, 85%);
-  --nt-color-clementine-lightest: hsl(33, 75%, 97%);
-  --nt-border-radius-none: 0;
-  --nt-border-radius-s: 1px;
-  --nt-border-radius-m: 2px;
-  --nt-border-radius-l: 4px;
-  --nt-border-width-none: 0;
-  --nt-border-width-xs: 1px;
-  --nt-border-width-s: 2px;
-  --nt-border-width-m: 3px;
-  --nt-border-width-l: 5px;
-  --nt-font-size-none: 0;
-  --nt-font-size-xxs: 10px;
-  --nt-font-size-xs: 10px;
-  --nt-font-size-s: 12px;
-  --nt-font-size-m: 14px;
-  --nt-font-size-l: 20px;
-  --nt-font-size-xl: 25px;
-  --nt-font-size-xxl: 30px;
-  --nt-font-weight-light: 300;
-  --nt-font-weight-normal: 400;
-  --nt-font-weight-bold: 600;
-  --nt-font-weight-bolder: 700;
-  --nt-font-family-normal: 'Source Sans Pro', sans-serif;
-  --nt-font-family-mono: 'Source Code Pro', courier;
-  --nt-opacity-disabled: 0.4;
-  --nt-opacity-faded: 0.3;
-  --nt-spacing-none: 0;
-  --nt-spacing-xxs: 1px;
-  --nt-spacing-xs: 3px;
-  --nt-spacing-s: 5px;
-  --nt-spacing-m: 10px;
-  --nt-spacing-l: 15px;
-  --nt-spacing-xl: 20px;
-  --nt-spacing-xxl: 25px;
-  --nt-transition-duration-normal: 250ms;
-  --nt-z-index-menu: 100;
-  --nt-z-index-notification: 200;
-  --nt-z-index-modal: 300;
-  --nt-color-actionable-darkest: var(--nt-color-danube-darkest);
-  --nt-color-actionable-darker: var(--nt-color-danube-darker);
-  --nt-color-actionable-dark: var(--nt-color-danube-dark);
-  --nt-color-actionable: var(--nt-color-danube);
-  --nt-color-actionable-light: var(--nt-color-danube-light);
-  --nt-color-actionable-lighter: var(--nt-color-danube-lighter);
-  --nt-color-actionable-lightest: var(--nt-color-danube-lightest);
-  --nt-color-brand-darkest: var(--nt-color-nteract-darkest);
-  --nt-color-brand-darker: var(--nt-color-nteract-darker);
-  --nt-color-brand-dark: var(--nt-color-nteract-dark);
-  --nt-color-brand: var(--nt-color-nteract);
-  --nt-color-brand-light: var(--nt-color-nteract-light);
-  --nt-color-brand-lighter: var(--nt-color-nteract-lighter);
-  --nt-color-brand-lightest: var(--nt-color-nteract-lightest);
-  --nt-color-danger-darkest: var(--nt-color-red-darkest);
-  --nt-color-danger-darker: var(--nt-color-red-darker);
-  --nt-color-danger-dark: var(--nt-color-red-dark);
-  --nt-color-danger: var(--nt-color-red);
-  --nt-color-danger-light: var(--nt-color-red-light);
-  --nt-color-danger-lighter: var(--nt-color-red-lighter);
-  --nt-color-danger-lightest: var(--nt-color-red-lightest);
-  --nt-color-info-darkest: var(--nt-color-danube-darkest);
-  --nt-color-info-darker: var(--nt-color-danube-darker);
-  --nt-color-info-dark: var(--nt-color-danube-dark);
-  --nt-color-info: var(--nt-color-danube);
-  --nt-color-info-light: var(--nt-color-danube-light);
-  --nt-color-info-lighter: var(--nt-color-danube-lighter);
-  --nt-color-info-lightest: var(--nt-color-danube-lightest);
-  --nt-color-nav-darkest: var(--nt-color-slate-darkest);
-  --nt-color-nav-darker: var(--nt-color-slate-darker);
-  --nt-color-nav-dark: var(--nt-color-slate-dark);
-  --nt-color-nav: var(--nt-color-slate);
-  --nt-color-nav-light: var(--nt-color-slate-light);
-  --nt-color-nav-lighter: var(--nt-color-slate-lighter);
-  --nt-color-nav-lightest: var(--nt-color-slate-lightest);
-  --nt-color-selected-darkest: var(--nt-color-sky-darkest);
-  --nt-color-selected-darker: var(--nt-color-sky-darker);
-  --nt-color-selected-dark: var(--nt-color-sky-dark);
-  --nt-color-selected: var(--nt-color-sky);
-  --nt-color-selected-light: var(--nt-color-sky-light);
-  --nt-color-selected-lighter: var(--nt-color-sky-lighter);
-  --nt-color-selected-lightest: var(--nt-color-sky-lightest);
-  --nt-color-success-darkest: var(--nt-color-asparagus-darkest);
-  --nt-color-success-darker: var(--nt-color-asparagus-darker);
-  --nt-color-success-dark: var(--nt-color-asparagus-dark);
-  --nt-color-success: var(--nt-color-asparagus);
-  --nt-color-success-light: var(--nt-color-asparagus-light);
-  --nt-color-success-lighter: var(--nt-color-asparagus-lighter);
-  --nt-color-success-lightest: var(--nt-color-asparagus-lightest);
-  --nt-color-textcontrast-darkest: var(--nt-color-alabaster-darkest);
-  --nt-color-textcontrast-darker: var(--nt-color-alabaster-darker);
-  --nt-color-textcontrast-dark: var(--nt-color-alabaster-dark);
-  --nt-color-textcontrast: var(--nt-color-alabaster);
-  --nt-color-textcontrast-light: var(--nt-color-alabaster-light);
-  --nt-color-textcontrast-lighter: var(--nt-color-alabaster-lighter);
-  --nt-color-textcontrast-lightest: var(--nt-color-alabaster-lightest);
-  --nt-color-text-darkest: var(--nt-color-midnight-darkest);
-  --nt-color-text-darker: var(--nt-color-midnight-darker);
-  --nt-color-text-dark: var(--nt-color-midnight-dark);
-  --nt-color-text: var(--nt-color-midnight);
-  --nt-color-text-light: var(--nt-color-midnight-light);
-  --nt-color-text-lighter: var(--nt-color-midnight-lighter);
-  --nt-color-text-lightest: var(--nt-color-midnight-lightest);
-  --nt-color-warning-darkest: var(--nt-color-clementine-darkest);
-  --nt-color-warning-darker: var(--nt-color-clementine-darker);
-  --nt-color-warning-dark: var(--nt-color-clementine-dark);
-  --nt-color-warning: var(--nt-color-clementine);
-  --nt-color-warning-light: var(--nt-color-clementine-light);
-  --nt-color-warning-lighter: var(--nt-color-clementine-lighter);
-  --nt-color-warning-lightest: var(--nt-color-clementine-lightest);
-}
-`;
-
 const DarkTheme = createGlobalStyle`
 :root {
   --theme-app-bg: #2b2b2b;
@@ -212,8 +22,12 @@ const DarkTheme = createGlobalStyle`
   --theme-secondary-fg-hover: var(--nt-color-alabaster-lighter);
   --theme-secondary-fg-focus: var(--theme-primary-fg);
 
-  --theme-primary-shadow-hover: 1px  1px 3px rgba(255, 255, 255, 0.12), -1px -1px 3px rgba(255, 255, 255, 0.12);
-  --theme-primary-shadow-focus: 3px  3px 9px rgba(255, 255, 255, 0.12), -3px -3px 9px rgba(255, 255, 255, 0.12);
+  --theme-primary-shadow-hover:
+    1px  1px 3px rgba(255, 255, 255, 0.12),
+    -1px -1px 3px rgba(255, 255, 255, 0.12);
+  --theme-primary-shadow-focus:
+    3px  3px 9px rgba(255, 255, 255, 0.12),
+    -3px -3px 9px rgba(255, 255, 255, 0.12);
 
   --theme-title-bar-bg: var(--nt-color-midnight-darkest);
 
@@ -273,10 +87,10 @@ const DarkTheme = createGlobalStyle`
 
   --cm-gutter-bg: #777;
 
-  --cm-comment: #777;
-  --cm-keyword: #3498db;
+  --cm-comment: #aaa;
+  --cm-keyword: hsl(204deg, 70%, 60%);
   --cm-string: #f1c40f;
-  --cm-builtin: #16a085;
+  --cm-builtin: hsl(168deg, 76%, 45%);
   --cm-special: #1abc9c;
   --cm-variable: #ecf0f1;
   --cm-number: #2ecc71;
@@ -320,8 +134,10 @@ const LightTheme = createGlobalStyle`
   --theme-secondary-fg-hover: var(--nt-color-midnight-light);
   --theme-secondary-fg-focus: var(--theme-primary-fg);
 
-  --theme-primary-shadow-hover: 1px  1px 3px rgba(0, 0, 0, 0.12), -1px -1px 3px rgba(0, 0, 0, 0.12);
-  --theme-primary-shadow-focus: 3px  3px 9px rgba(0, 0, 0, 0.12), -3px -3px 9px rgba(0, 0, 0, 0.12);
+  --theme-primary-shadow-hover: 1px  1px 3px rgba(0, 0, 0, 0.12),
+    -1px -1px 3px rgba(0, 0, 0, 0.12);
+  --theme-primary-shadow-focus: 3px  3px 9px rgba(0, 0, 0, 0.12),
+    -3px -3px 9px rgba(0, 0, 0, 0.12);
 
   --theme-title-bar-bg: var(--theme-primary-bg-hover);
 
@@ -381,15 +197,15 @@ const LightTheme = createGlobalStyle`
 
   --cm-gutter-bg: white;
 
-  --cm-comment: #a86;
+  --cm-comment: hsl(30deg, 29%, 30%);
   --cm-keyword: blue;
-  --cm-string: #a22;
-  --cm-builtin: #077;
-  --cm-special: #0aa;
+  --cm-string: hsl(0deg, 67%, 35%);
+  --cm-builtin: hsl(180deg, 100%, 18%);
+  --cm-special: hsl(190deg, 100%, 20%);
   --cm-variable: black;
-  --cm-number: #3a3;
+  --cm-number: hsl(120deg, 54%, 25%);
   --cm-meta: #555;
-  --cm-link: #3a3;
+  --cm-link: hsl(120deg, 54%, 25%);
   --cm-operator: black;
   --cm-def: black;
 
@@ -406,4 +222,4 @@ const LightTheme = createGlobalStyle`
 }
 `;
 
-export { GlobalCSSVariables, DarkTheme, LightTheme };
+export { DarkTheme, LightTheme };

--- a/packages/presentational-components/tsconfig.json
+++ b/packages/presentational-components/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "."
   },
-  "include": ["src"],
+  "include": ["src", "__tests__"],
   "references": []
 }

--- a/packages/presentational-components/tsconfig.json
+++ b/packages/presentational-components/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "."
+    "rootDir": "src"
   },
-  "include": ["src", "__tests__"],
+  "include": ["src"],
   "references": []
 }

--- a/packages/styles/global-variables.css
+++ b/packages/styles/global-variables.css
@@ -53,7 +53,7 @@
   --nt-color-midnight-dark: hsl(0, 0%, 10%);
   --nt-color-midnight: hsl(0, 0%, 15%);
   --nt-color-midnight-light: hsl(0, 0%, 21%);
-  --nt-color-midnight-lighter: hsl(0, 0%, 45%);
+  --nt-color-midnight-lighter: hsl(0, 0%, 33%);
   --nt-color-midnight-lightest: hsl(0, 0%, 55%);
   --nt-color-sky-darkest: var(--nt-color-sky-darker);
   --nt-color-sky-darker: var(--nt-color-sky-dark);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,6 +2414,11 @@ ajv@^6.1.0, ajv@^6.5.5, ajv@^6.7.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+almost-equal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/almost-equal/-/almost-equal-1.1.0.tgz#f851c631138757994276aa2efbe8dfa3066cccdd"
+  integrity sha1-+FHGMROHV5lCdqou++jfowZszN0=
+
 anser@^1.4.1:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.8.tgz#19a3bfc5f0e31c49efaea38f58fd0d136597f2a3"
@@ -3725,6 +3730,28 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+color-name@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-parse@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/color-parse/-/color-parse-1.3.8.tgz#eaf54cd385cb34c0681f18c218aca38478082fa3"
+  integrity sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==
+  dependencies:
+    color-name "^1.0.0"
+    defined "^1.0.0"
+    is-plain-obj "^1.1.0"
+
+color-space@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/color-space/-/color-space-1.16.0.tgz#611781bca41cd8582a1466fd9e28a7d3d89772a2"
+  integrity sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==
+  dependencies:
+    hsluv "^0.0.3"
+    mumath "^3.3.4"
+
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -4307,6 +4334,16 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
   integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
 
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -4858,6 +4895,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
 
 del@^4.1.1:
   version "4.1.1"
@@ -6792,6 +6834,11 @@ hpack.js@^2.1.6:
     obuf "^1.0.0"
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
+
+hsluv@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/hsluv/-/hsluv-0.0.3.tgz#829107dafb4a9f8b52a1809ed02e091eade6754c"
+  integrity sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw=
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
@@ -9487,6 +9534,13 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
+mumath@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/mumath/-/mumath-3.3.4.tgz#48d4a0f0fd8cad4e7b32096ee89b161a63d30bbf"
+  integrity sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=
+  dependencies:
+    almost-equal "^1.1.0"
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -11886,18 +11940,17 @@ regenerator-runtime@^0.13.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz#522ea2aafd9200a00eee143dc14219a35a0f3991"
   integrity sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==
 
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
 regenerator-transform@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
   integrity sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
   dependencies:
     private "^0.1.6"
-
-regenerator-runtime@^0.13.2:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
-  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -12830,7 +12883,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==


### PR DESCRIPTION
- Adds a test that reads the CSS to check contrast for WCAG AAA (as far as possible).
- Changes theme styles to conform to WCAG AAA.
- Removes obsolete code (`GlobalCSSVariables`) that appears to have been moved to `global-variables.css` and doesn't appear to be referenced anywhere in the repo.