### PR TITLE
Clear cell prompts when clearing cell outputs and add support for multiple prompts per cell

### DIFF
--- a/applications/desktop/src/notebook/epics/index.ts
+++ b/applications/desktop/src/notebook/epics/index.ts
@@ -50,6 +50,7 @@ const epics = [
   coreEpics.executeAllCellsEpic,
   coreEpics.updateContentEpic,
   coreEpics.autoSaveCurrentContentEpic,
+  coreEpics.sendInputReplyEpic,
 
   launchKernelWhenNotebookSetEpic,
   watchSpawn,

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -150,7 +150,9 @@ export function createExecuteCellStream(
   id: string,
   contentRef: ContentRef
 ): Observable<any> {
-  const kernel = selectors.kernelByContentRef(state, { contentRef: contentRef });
+  const kernel = selectors.kernelByContentRef(state, {
+    contentRef: contentRef
+  });
 
   const channels = kernel ? kernel.channels : null;
 
@@ -388,9 +390,11 @@ export const sendInputReplyEpic = (
     ofType(actions.SEND_INPUT_REPLY),
     switchMap((action: actions.SendInputReply) => {
       const state = state$.value;
-      const kernel = selectors.kernelByContentRef(state, { contentRef: action.payload.contentRef });
+      const kernel = selectors.kernelByContentRef(state, {
+        contentRef: action.payload.contentRef
+      });
 
-      if (kernel && kernel.type === "websocket") {
+      if (kernel) {
         const reply = inputReply({ value: action.payload.value });
         kernel.channels.next(reply);
       }

--- a/packages/notebook-app-component/src/notebook-app.tsx
+++ b/packages/notebook-app-component/src/notebook-app.tsx
@@ -84,7 +84,7 @@ interface AnyCellProps {
   executionCount: ExecutionCount;
   outputs: Immutable.List<any>;
   pager: Immutable.List<any>;
-  prompt?: InputRequestMessage;
+  prompts: Immutable.List<InputRequestMessage>;
   cellStatus: string;
   cellFocused: boolean; // not the ID of which is focused
   editorFocused: boolean;
@@ -133,7 +133,7 @@ const makeMapStateToCellProps = (
 
     const cellType = cell.cell_type;
     const outputs = cell.get("outputs", emptyList);
-    const prompt = selectors.notebook.cellPromptById(model, { id });
+    const prompts = selectors.notebook.cellPromptsById(model, { id });
 
     const sourceHidden =
       (cellType === "code" &&
@@ -172,7 +172,7 @@ const makeMapStateToCellProps = (
       outputHidden,
       outputs,
       pager,
-      prompt,
+      prompts,
       source: cell.get("source", ""),
       sourceHidden,
       tags,
@@ -279,7 +279,6 @@ class AnyCell extends React.PureComponent<AnyCellProps> {
       focusBelowCell,
       focusEditor,
       id,
-      prompt,
       tags,
       theme,
       selectCell,
@@ -348,9 +347,9 @@ class AnyCell extends React.PureComponent<AnyCellProps> {
                 </Output>
               ))}
             </Outputs>
-            {prompt && (
+            {this.props.prompts.map((prompt: InputRequestMessage) => (
               <PromptRequest {...prompt} submitPromptReply={sendInputReply} />
-            )}
+            ))}
           </React.Fragment>
         );
 

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -451,6 +451,28 @@ describe("clearOutputs", () => {
     const outputs = state.getIn(["notebook", "cellMap", id, "outputs"]);
     expect(outputs).toBeUndefined();
   });
+  test("clear prompts on code cells", () => {
+    let originalState = initialDocument.set(
+      "notebook",
+      appendCellToNotebook(
+        fixtureCommutable,
+        emptyCodeCell.set("outputs", ["dummy outputs"])
+      )
+    );
+    const id: string = originalState.getIn(["notebook", "cellOrder"]).last();
+    originalState = originalState.set(
+      "cellPrompts",
+      Immutable.Map({
+        [id]: Immutable.List([{ prompt: "Test: ", password: false }])
+      })
+    );
+
+    expect(originalState.getIn(["cellPrompts", id]).size).toBe(1);
+
+    const state = reducers(originalState, actions.clearOutputs({ id }));
+    const prompts = state.getIn(["cellPrompts", id]);
+    expect(prompts.size).toBe(0);
+  });
 });
 
 describe("createCellBelow", () => {
@@ -865,7 +887,7 @@ describe("updateDisplay", () => {
         metadata: {},
         transient: { display_id: "1234" }
       },
-      contentRef: undefined,
+      contentRef: undefined
     });
 
     const state = reducers(originalState, action);
@@ -896,7 +918,7 @@ describe("updateDisplay", () => {
           data: { "text/plain": "shennagins afoot" },
           transient: { display_id: "1234" }
         }
-      }),
+      })
     ];
 
     const state = actionArray.reduce(
@@ -1104,24 +1126,32 @@ describe("updateOutputMetadata", () => {
 });
 
 describe("unhideAll", () => {
-  const cellOrder = [ uuid(), uuid(), uuid(), uuid() ];
+  const cellOrder = [uuid(), uuid(), uuid(), uuid()];
   let initialState = Immutable.Map();
 
   beforeEach(() => {
     // Arrange
-    initialState = initialDocument
-      .set(
-        "notebook",
-        Immutable.fromJS({
-          cellOrder,
-          cellMap: {
-            [cellOrder[0]]: emptyCodeCell.setIn(["metadata", "outputHidden"], false),
-            [cellOrder[1]]: emptyCodeCell.setIn(["metadata", "outputHidden"], true),
-            [cellOrder[2]]: emptyCodeCell.setIn(["metadata", "inputHidden"], false),
-            [cellOrder[3]]: emptyCodeCell.setIn(["metadata", "inputHidden"], true)
-          }
-        })
-      );
+    initialState = initialDocument.set(
+      "notebook",
+      Immutable.fromJS({
+        cellOrder,
+        cellMap: {
+          [cellOrder[0]]: emptyCodeCell.setIn(
+            ["metadata", "outputHidden"],
+            false
+          ),
+          [cellOrder[1]]: emptyCodeCell.setIn(
+            ["metadata", "outputHidden"],
+            true
+          ),
+          [cellOrder[2]]: emptyCodeCell.setIn(
+            ["metadata", "inputHidden"],
+            false
+          ),
+          [cellOrder[3]]: emptyCodeCell.setIn(["metadata", "inputHidden"], true)
+        }
+      })
+    );
   });
 
   test("should reveal all inputs", () => {
@@ -1131,7 +1161,7 @@ describe("unhideAll", () => {
       actions.unhideAll({
         inputHidden: false,
         contentRef: undefined
-       })
+      })
     );
 
     // Assert: should unhide inputs and keep outputs' visibility unchanged
@@ -1149,7 +1179,7 @@ describe("unhideAll", () => {
         .map(cell => cell.getIn(["metadata", "outputHidden"]))
         .toList()
         .toArray()
-    ).toEqual([false,true,false,false]);
+    ).toEqual([false, true, false, false]);
   });
 
   test("should hide all inputs", () => {
@@ -1159,7 +1189,7 @@ describe("unhideAll", () => {
       actions.unhideAll({
         inputHidden: true,
         contentRef: undefined
-       })
+      })
     );
 
     // Assert: should hide inputs and keep outputs' visibility unchanged
@@ -1177,7 +1207,7 @@ describe("unhideAll", () => {
         .map(cell => cell.getIn(["metadata", "outputHidden"]))
         .toList()
         .toArray()
-    ).toEqual([false,true,false,false]);
+    ).toEqual([false, true, false, false]);
   });
 
   test("should reveal all outputs", () => {
@@ -1187,7 +1217,7 @@ describe("unhideAll", () => {
       actions.unhideAll({
         outputHidden: false,
         contentRef: undefined
-       })
+      })
     );
 
     // Assert: should unhide outputs and keep inputs' visibility unchanged
@@ -1205,7 +1235,7 @@ describe("unhideAll", () => {
         .map(cell => cell.getIn(["metadata", "inputHidden"]))
         .toList()
         .toArray()
-    ).toEqual([false,false,false,true]);
+    ).toEqual([false, false, false, true]);
   });
 
   test("should hide all outputs", () => {
@@ -1215,7 +1245,7 @@ describe("unhideAll", () => {
       actions.unhideAll({
         outputHidden: true,
         contentRef: undefined
-       })
+      })
     );
 
     // Assert: should hide outputs and keep inputs' visibility unchanged
@@ -1233,7 +1263,7 @@ describe("unhideAll", () => {
         .map(cell => cell.getIn(["metadata", "inputHidden"]))
         .toList()
         .toArray()
-    ).toEqual([false,false,false,true]);
+    ).toEqual([false, false, false, true]);
   });
 
   test("should reveal all inputs and outputs", () => {
@@ -1244,7 +1274,7 @@ describe("unhideAll", () => {
         inputHidden: false,
         outputHidden: false,
         contentRef: undefined
-       })
+      })
     );
 
     // Assert
@@ -1273,7 +1303,7 @@ describe("unhideAll", () => {
         inputHidden: true,
         outputHidden: true,
         contentRef: undefined
-       })
+      })
     );
 
     // Assert
@@ -1300,7 +1330,7 @@ describe("unhideAll", () => {
       initialState,
       actions.unhideAll({
         contentRef: undefined
-       })
+      })
     );
 
     // Assert: should keep all inputs' and outputs' visibility unchanged
@@ -1310,7 +1340,7 @@ describe("unhideAll", () => {
         .map(cell => cell.getIn(["metadata", "inputHidden"]))
         .toList()
         .toArray()
-    ).toEqual([false,false,false,true]);
+    ).toEqual([false, false, false, true]);
 
     expect(
       actualState
@@ -1318,6 +1348,6 @@ describe("unhideAll", () => {
         .map(cell => cell.getIn(["metadata", "outputHidden"]))
         .toList()
         .toArray()
-    ).toEqual([false,true,false,false]);
+    ).toEqual([false, true, false, false]);
   });
 });

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -147,7 +147,7 @@ function clearOutputs(
     return cleanedState
       .setIn(["notebook", "cellMap", id, "outputs"], List())
       .setIn(["notebook", "cellMap", id, "execution_count"], null)
-      .setIn(["cellPrompts", id], null);
+      .setIn(["cellPrompts", id], List());
   }
   return cleanedState;
 }
@@ -906,10 +906,12 @@ function promptInputRequest(
   action: actionTypes.PromptInputRequest
 ): RecordOf<DocumentRecordProps> {
   const { id, password, prompt } = action.payload;
-  return state.setIn(["cellPrompts", id], {
-    prompt,
-    password
-  });
+  return state.updateIn(["cellPrompts", id], prompts =>
+    prompts.push({
+      prompt,
+      password
+    })
+  );
 }
 
 // DEPRECATION WARNING: Below, the following action types are being deprecated: RemoveCell, CreateCellAfter and CreateCellBefore

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -24,7 +24,12 @@ import {
   OnDiskStreamOutput
 } from "@nteract/commutable";
 import { UpdateDisplayDataContent } from "@nteract/messaging";
-import { DocumentRecordProps, makeDocumentRecord, NotebookModel, PayloadMessage } from "@nteract/types";
+import {
+  DocumentRecordProps,
+  makeDocumentRecord,
+  NotebookModel,
+  PayloadMessage
+} from "@nteract/types";
 import { escapeCarriageReturnSafe } from "escape-carriage";
 import { fromJS, List, Map, RecordOf, Set } from "immutable";
 import { has } from "lodash";
@@ -141,7 +146,8 @@ function clearOutputs(
   if (type === "code") {
     return cleanedState
       .setIn(["notebook", "cellMap", id, "outputs"], List())
-      .setIn(["notebook", "cellMap", id, "execution_count"], null);
+      .setIn(["notebook", "cellMap", id, "execution_count"], null)
+      .setIn(["cellPrompts", id], null);
   }
   return cleanedState;
 }
@@ -199,43 +205,44 @@ function clearAllOutputs(
 
   return state
     .setIn(["notebook", "cellMap"], cellMap)
-    .set("transient", transient);
+    .set("transient", transient)
+    .setIn("cellPrompts", Map());
 }
 
 type UpdatableOutputContent =
   | OnDiskExecuteResult
   | OnDiskDisplayData
-  | UpdateDisplayDataContent
-  ;
+  | UpdateDisplayDataContent;
 
 // Utility function used in two reducers below
 function updateAllDisplaysWithID(
   state: NotebookModel,
-  content: UpdatableOutputContent,
+  content: UpdatableOutputContent
 ): NotebookModel {
   if (!content || !content.transient || !content.transient.display_id) {
     return state;
   }
 
-  const keyPaths: KeyPaths = state.getIn([
-    "transient",
-    "keyPathsForDisplays",
-    content.transient.display_id,
-  ]) || List();
+  const keyPaths: KeyPaths =
+    state.getIn([
+      "transient",
+      "keyPathsForDisplays",
+      content.transient.display_id
+    ]) || List();
 
   const updateOutput = (output: any) => {
     if (output) {
       // We already have something here, don't change the other fields
       return output.merge({
         data: createFrozenMediaBundle(content.data),
-        metadata: fromJS(content.metadata || {}),
+        metadata: fromJS(content.metadata || {})
       });
     } else if (content.output_type === "update_display_data") {
       // Nothing here and we have no valid output, just create a basic output
       return {
         data: createFrozenMediaBundle(content.data),
         metadata: fromJS(content.metadata || {}),
-        output_type: "display_data",
+        output_type: "display_data"
       };
     } else {
       // Nothing here, but we have a valid output
@@ -243,9 +250,8 @@ function updateAllDisplaysWithID(
     }
   };
 
-  const updateOneDisplay =
-    (currState: NotebookModel, keyPath: KeyPath) =>
-      currState.updateIn(keyPath, updateOutput);
+  const updateOneDisplay = (currState: NotebookModel, keyPath: KeyPath) =>
+    currState.updateIn(keyPath, updateOutput);
 
   return keyPaths.reduce(updateOneDisplay, state);
 }
@@ -315,7 +321,7 @@ function appendOutput(
 
   return updateAllDisplaysWithID(
     state.setIn(["transient", "keyPathsForDisplays", displayID], keyPaths),
-    output,
+    output
   );
 }
 
@@ -652,7 +658,7 @@ function toggleCellOutputVisibility(
 }
 
 interface ICellVisibilityMetadata {
-  inputHidden?:boolean;
+  inputHidden?: boolean;
   outputHidden?: boolean;
 }
 
@@ -664,10 +670,10 @@ function unhideAll(
   if (action.payload.outputHidden !== undefined) {
     // TODO: Verify that we convert to one namespace
     // for hidden input/output
-    metadataMixin.outputHidden = action.payload.outputHidden
+    metadataMixin.outputHidden = action.payload.outputHidden;
   }
   if (action.payload.inputHidden !== undefined) {
-    metadataMixin.inputHidden = action.payload.inputHidden
+    metadataMixin.inputHidden = action.payload.inputHidden;
   }
   return state.updateIn(["notebook", "cellMap"], cellMap =>
     cellMap.map((cell: ImmutableCell) => {

--- a/packages/selectors/src/core/contents/notebook.ts
+++ b/packages/selectors/src/core/contents/notebook.ts
@@ -117,8 +117,8 @@ export const idsOfHiddenOutputs = (model: NotebookModel) =>
 export const transientCellMap = (model: NotebookModel) =>
   model.transient.get("cellMap", Immutable.Map());
 
-export const cellPromptById = (model: NotebookModel, { id }: { id: CellId }) =>
-  model.cellPrompts.get(id);
+export const cellPromptsById = (model: NotebookModel, { id }: { id: CellId }) =>
+  model.cellPrompts.get(id, Immutable.List());
 
 /**
  * Returns the CellIds of the code cells within a notebook.

--- a/packages/types/src/entities/contents/notebook.ts
+++ b/packages/types/src/entities/contents/notebook.ts
@@ -62,7 +62,7 @@ export interface DocumentRecordProps {
   // right now it's keypaths and then it looks like it's able to handle any per
   // cell transient data that will be deleted when the kernel is restarted
   cellPagers: any;
-  cellPrompts: Immutable.Map<CellId, InputRequestMessage>;
+  cellPrompts: Immutable.Map<CellId, Immutable.List<InputRequestMessage>>;
   editorFocused?: CellId | null;
   cellFocused?: CellId | null;
   copied: ImmutableCell | null;


### PR DESCRIPTION
**Changes in this PR**
- Store multiple input prompts per cell in the state
- Send input replies to both WebSockets and 0mq-backed kernels
- Clear input prompts when cell outputs are cleared