### PR TITLE
Emit notebook actions in callbacks for ipywidget messages

### DIFF
--- a/packages/jupyter-widgets/src/index.tsx
+++ b/packages/jupyter-widgets/src/index.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { connect } from "react-redux";
-import { selectors, AppState } from "@nteract/core";
+import { selectors, AppState, ContentRef } from "@nteract/core";
 
 import Manager from "./manager";
 import { WidgetModel } from "@jupyter-widgets/base";
+import { CellId } from "@nteract/commutable";
 
 interface JupyterWidgetData {
   model_id: string;
@@ -14,6 +15,8 @@ interface JupyterWidgetData {
 interface Props {
   data: JupyterWidgetData;
   model: WidgetModel;
+  id: CellId;
+  contentRef: ContentRef;
 }
 
 /**

--- a/packages/jupyter-widgets/src/index.tsx
+++ b/packages/jupyter-widgets/src/index.tsx
@@ -28,7 +28,12 @@ export class WidgetDisplay extends React.Component<Props> {
 
   render() {
     return (
-      <Manager model={this.props.model} model_id={this.props.data.model_id} />
+      <Manager
+        model={this.props.model}
+        model_id={this.props.data.model_id}
+        id={this.props.id}
+        contentRef={this.props.contentRef}
+      />
     );
   }
 }

--- a/packages/jupyter-widgets/src/manager/index.tsx
+++ b/packages/jupyter-widgets/src/manager/index.tsx
@@ -9,8 +9,10 @@ import {
   actions,
   KernelNotStartedProps,
   LocalKernelProps,
-  RemoteKernelProps
+  RemoteKernelProps,
+  ContentRef
 } from "@nteract/core";
+import { CellId } from "@nteract/commutable";
 import { WidgetModel } from "@jupyter-widgets/base";
 
 interface ConnectedProps {
@@ -21,12 +23,24 @@ interface ConnectedProps {
     | RecordOf<RemoteKernelProps>
     | null;
 }
+
+interface DispatchProps {
+  actions: {
+    appendOutput: (output: any) => void;
+    clearOutput: () => void;
+    updateCellStatus: (status: string) => void;
+    promptImputRequest: (prompt: string, password: boolean) => void;
+  };
+}
+
 interface OwnProps {
   model: WidgetModel;
   model_id: string;
+  id: CellId;
+  contentRef: ContentRef;
 }
 
-type Props = ConnectedProps & OwnProps;
+type Props = ConnectedProps & OwnProps & DispatchProps;
 
 /**
  * This component is is a wrapper component that initializes a
@@ -89,7 +103,7 @@ const mapStateToProps = (state: AppState, props: OwnProps): ConnectedProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: any, props: OwnProps): any => {
+const mapDispatchToProps = (dispatch: any, props: OwnProps): DispatchProps => {
   return {
     actions: {
       appendOutput: (output: any) =>
@@ -107,7 +121,7 @@ const mapDispatchToProps = (dispatch: any, props: OwnProps): any => {
             contentRef: props.contentRef
           })
         ),
-      updateCellStatus: status =>
+      updateCellStatus: (status: string) =>
         dispatch(
           actions.updateCellStatus({
             id: props.id,
@@ -115,7 +129,7 @@ const mapDispatchToProps = (dispatch: any, props: OwnProps): any => {
             status
           })
         ),
-      promptImputRequest: (prompt, password) =>
+      promptImputRequest: (prompt: string, password: boolean) =>
         dispatch(
           actions.promptInputRequest({
             id: props.id,

--- a/packages/jupyter-widgets/src/manager/index.tsx
+++ b/packages/jupyter-widgets/src/manager/index.tsx
@@ -24,12 +24,12 @@ interface ConnectedProps {
     | null;
 }
 
-interface DispatchProps {
+export interface ManagerActions {
   actions: {
     appendOutput: (output: any) => void;
     clearOutput: () => void;
     updateCellStatus: (status: string) => void;
-    promptImputRequest: (prompt: string, password: boolean) => void;
+    promptInputRequest: (prompt: string, password: boolean) => void;
   };
 }
 
@@ -40,7 +40,7 @@ interface OwnProps {
   contentRef: ContentRef;
 }
 
-type Props = ConnectedProps & OwnProps & DispatchProps;
+type Props = ConnectedProps & OwnProps & ManagerActions;
 
 /**
  * This component is is a wrapper component that initializes a
@@ -103,7 +103,7 @@ const mapStateToProps = (state: AppState, props: OwnProps): ConnectedProps => {
   };
 };
 
-const mapDispatchToProps = (dispatch: any, props: OwnProps): DispatchProps => {
+const mapDispatchToProps = (dispatch: any, props: OwnProps): ManagerActions => {
   return {
     actions: {
       appendOutput: (output: any) =>
@@ -129,7 +129,7 @@ const mapDispatchToProps = (dispatch: any, props: OwnProps): DispatchProps => {
             status
           })
         ),
-      promptImputRequest: (prompt: string, password: boolean) =>
+      promptInputRequest: (prompt: string, password: boolean) =>
         dispatch(
           actions.promptInputRequest({
             id: props.id,

--- a/packages/jupyter-widgets/src/manager/index.tsx
+++ b/packages/jupyter-widgets/src/manager/index.tsx
@@ -99,6 +99,30 @@ const mapDispatchToProps = (dispatch: any, props: OwnProps): any => {
             contentRef: props.contentRef,
             output
           })
+        ),
+      clearOutput: () =>
+        dispatch(
+          actions.clearOutputs({
+            id: props.id,
+            contentRef: props.contentRef
+          })
+        ),
+      updateCellStatus: status =>
+        dispatch(
+          actions.updateCellStatus({
+            id: props.id,
+            contentRef: props.contentRef,
+            status
+          })
+        ),
+      promptImputRequest: (prompt, password) =>
+        dispatch(
+          actions.promptInputRequest({
+            id: props.id,
+            contentRef: props.contentRef,
+            prompt,
+            password
+          })
         )
     }
   };

--- a/packages/jupyter-widgets/src/manager/index.tsx
+++ b/packages/jupyter-widgets/src/manager/index.tsx
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import {
   AppState,
   selectors,
+  actions,
   KernelNotStartedProps,
   LocalKernelProps,
   RemoteKernelProps
@@ -53,10 +54,15 @@ class Manager extends React.Component<Props> {
     if (Manager.manager === undefined) {
       Manager.manager = new WidgetManager(
         this.props.kernel,
-        this.props.modelById
+        this.props.modelById,
+        this.props.actions
       );
     } else {
-      Manager.manager.update(this.props.kernel, this.props.modelById);
+      Manager.manager.update(
+        this.props.kernel,
+        this.props.modelById,
+        this.props.actions
+      );
     }
     return Manager.manager;
   }
@@ -82,4 +88,23 @@ const mapStateToProps = (state: AppState, props: OwnProps): ConnectedProps => {
     kernel: selectors.currentKernel(state)
   };
 };
-export default connect(mapStateToProps)(Manager);
+
+const mapDispatchToProps = (dispatch: any, props: OwnProps): any => {
+  return {
+    actions: {
+      appendOutput: (output: any) =>
+        dispatch(
+          actions.appendOutput({
+            id: props.id,
+            contentRef: props.contentRef,
+            output
+          })
+        )
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Manager);

--- a/packages/jupyter-widgets/src/manager/widget-comms.ts
+++ b/packages/jupyter-widgets/src/manager/widget-comms.ts
@@ -184,6 +184,7 @@ export class WidgetComm implements IClassicComm {
             case "display_data":
             case "execute_result":
             case "stream":
+            case "error":
               callbacks.iopub.output(reply);
               break;
             default:

--- a/packages/jupyter-widgets/src/manager/widget-comms.ts
+++ b/packages/jupyter-widgets/src/manager/widget-comms.ts
@@ -183,6 +183,7 @@ export class WidgetComm implements IClassicComm {
           switch (reply.header.msg_type) {
             case "display_data":
             case "execute_result":
+            case "stream":
               callbacks.iopub.output(reply);
               break;
             default:

--- a/packages/jupyter-widgets/src/manager/widget-manager.ts
+++ b/packages/jupyter-widgets/src/manager/widget-manager.ts
@@ -37,16 +37,19 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
     | RecordOf<LocalKernelProps>
     | RecordOf<RemoteKernelProps>
     | null;
+  actions: any;
 
-  constructor(kernel: any, stateModelById: (id: string) => any) {
+  constructor(kernel: any, stateModelById: (id: string) => any, actions: any) {
     super();
     this.kernel = kernel;
     this.stateModelById = stateModelById;
+    this.actions = actions;
   }
 
-  update(kernel: any, stateModelById: (id: string) => any) {
+  update(kernel: any, stateModelById: (id: string) => any, actions: any) {
     this.kernel = kernel;
     this.stateModelById = stateModelById;
+    this.actions = actions;
   }
 
   /**
@@ -140,6 +143,18 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
     options: any
   ): Promise<base.DOMWidgetView> {
     throw Error("display_view not implemented. Use render_view instead.");
+  }
+
+  callbacks() {
+    return {
+      iopub: {
+        output: reply =>
+          this.actions.appendOutput({
+            ...reply.content,
+            output_type: reply.header.msg_type
+          })
+      }
+    };
   }
 
   /**

--- a/packages/jupyter-widgets/src/manager/widget-manager.ts
+++ b/packages/jupyter-widgets/src/manager/widget-manager.ts
@@ -152,8 +152,16 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
           this.actions.appendOutput({
             ...reply.content,
             output_type: reply.header.msg_type
-          })
-      }
+          }),
+        clear_output: reply => this.actions.clearOutput(),
+        status: reply =>
+          this.actions.updateCellStatus(reply.content.execution_state)
+      },
+      input: reply =>
+        this.actions.promptInputRequest(
+          reply.content.prompt,
+          reply.content.password
+        )
     };
   }
 

--- a/packages/jupyter-widgets/src/manager/widget-manager.ts
+++ b/packages/jupyter-widgets/src/manager/widget-manager.ts
@@ -15,6 +15,7 @@ import {
   RemoteKernelProps
 } from "@nteract/core";
 import { JupyterMessage } from "@nteract/messaging";
+import { ManagerActions } from "../manager/index";
 
 interface IDomWidgetModel extends DOMWidgetModel {
   _model_name: string;
@@ -38,16 +39,24 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
     | RecordOf<LocalKernelProps>
     | RecordOf<RemoteKernelProps>
     | null;
-  actions: any;
+  actions: ManagerActions["actions"];
 
-  constructor(kernel: any, stateModelById: (id: string) => any, actions: any) {
+  constructor(
+    kernel: any,
+    stateModelById: (id: string) => any,
+    actions: ManagerActions["actions"]
+  ) {
     super();
     this.kernel = kernel;
     this.stateModelById = stateModelById;
     this.actions = actions;
   }
 
-  update(kernel: any, stateModelById: (id: string) => any, actions: any) {
+  update(
+    kernel: any,
+    stateModelById: (id: string) => any,
+    actions: ManagerActions["actions"]
+  ) {
     this.kernel = kernel;
     this.stateModelById = stateModelById;
     this.actions = actions;

--- a/packages/jupyter-widgets/src/manager/widget-manager.ts
+++ b/packages/jupyter-widgets/src/manager/widget-manager.ts
@@ -14,6 +14,7 @@ import {
   LocalKernelProps,
   RemoteKernelProps
 } from "@nteract/core";
+import { JupyterMessage } from "@nteract/messaging";
 
 interface IDomWidgetModel extends DOMWidgetModel {
   _model_name: string;
@@ -145,19 +146,26 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
     throw Error("display_view not implemented. Use render_view instead.");
   }
 
-  callbacks() {
+  /**
+   * The ManagerBase type definition for the callbacks method expects
+   * the message types to be as defined by the IMessage interface from
+   * @jupyterlab/services. It is typed as any here so that we can use
+   * our JupyterMessage types that are emitted from our kernel.channels
+   * pipeline.
+   */
+  callbacks(): any {
     return {
       iopub: {
-        output: reply =>
+        output: (reply: JupyterMessage) =>
           this.actions.appendOutput({
             ...reply.content,
             output_type: reply.header.msg_type
           }),
-        clear_output: reply => this.actions.clearOutput(),
-        status: reply =>
+        clear_output: (reply: JupyterMessage) => this.actions.clearOutput(),
+        status: (reply: JupyterMessage) =>
           this.actions.updateCellStatus(reply.content.execution_state)
       },
-      input: reply =>
+      input: (reply: JupyterMessage) =>
         this.actions.promptInputRequest(
           reply.content.prompt,
           reply.content.password

--- a/packages/notebook-app-component/src/transform-media.tsx
+++ b/packages/notebook-app-component/src/transform-media.tsx
@@ -38,7 +38,16 @@ interface DispatchProps {
 }
 
 const PureTransformMedia = (props: MappedProps & DispatchProps) => {
-  const { Media, mediaActions, mediaType, data, metadata, theme } = props;
+  const {
+    Media,
+    mediaActions,
+    mediaType,
+    data,
+    metadata,
+    theme,
+    contentRef,
+    cellId
+  } = props;
 
   // If we had no valid result, return an empty output
   if (!mediaType || !data) {
@@ -46,7 +55,14 @@ const PureTransformMedia = (props: MappedProps & DispatchProps) => {
   }
 
   return (
-    <Media {...mediaActions} data={data} metadata={metadata} theme={theme} />
+    <Media
+      {...mediaActions}
+      data={data}
+      metadata={metadata}
+      theme={theme}
+      contentRef={contentRef}
+      id={cellId}
+    />
   );
 };
 

--- a/packages/notebook-app-component/src/transform-media.tsx
+++ b/packages/notebook-app-component/src/transform-media.tsx
@@ -37,7 +37,7 @@ interface DispatchProps {
   };
 }
 
-const PureTransformMedia = (props: MappedProps & DispatchProps) => {
+const PureTransformMedia = (props: MappedProps & DispatchProps & OwnProps) => {
   const {
     Media,
     mediaActions,


### PR DESCRIPTION
Fix for #4645 

Output-related events are now handled properly for widgets on observe. Note, the lag in the image below is due to my machine lagging, not an actual issue with the appending of outputs.

![widget-output](https://user-images.githubusercontent.com/1857993/68424501-ff49d500-0158-11ea-8667-50d52a3389e8.gif)

To make this change, I had to pass in the cellId and contentRef to the rendered media component. This way, I could set up some dispatch actions that would invoke our appendOutput/clearOutputs functions on the appropriate notebook and cell.