### PR TITLE
Switch is to ==

### DIFF
--- a/applications/jupyter-extension/nteract_on_jupyter/handlers.py
+++ b/applications/jupyter-extension/nteract_on_jupyter/handlers.py
@@ -45,7 +45,7 @@ class NAppHandler(IPythonHandler):
 
         asset_url = config.asset_url
 
-        if asset_url is "":
+        if asset_url == "":
             asset_url = base_url
 
         # Ensure there's a trailing slash


### PR DESCRIPTION
I ran this with Python 3.8 and got a warning:

```
/Users/saul/p/nteract/applications/jupyter-extension/nteract_on_jupyter/handlers.py:48: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
