### PR TITLE
Add support for complete_reply Jupyter Kernel message type

### DIFF
--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -27,6 +27,7 @@ export type MessageType =
   | "comm_open"
   | "comm_msg"
   | "comm_close"
+  | "complete_reply"
   | "execute_reply";
 
 export interface JupyterMessageHeader<MT extends MessageType = MessageType> {


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [X ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

Nteract currently does not allow creating messages for type `complete_reply` . Adding this type to the appropriate interface allows us to support Jupyter Kernel messages better.

Related: #4694 