### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: numfocus
+custom: https://numfocus.org/donate-to-nteract


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature is launching today at GitHub Universe!

Also add a custom link to the nteract donation page.

More info on sponsor buttons here: https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository

cc @captainsafia @rgbkrk

- [ X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)