### PR TITLE
ignore notebooks in the desktop folder in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ nteract-packages/public
 
 # jest reporting coverage
 junit.xml
+
+# ignore notebooks created while running dev copy of the desktop app
+applications/desktop/*.ipynb


### PR DESCRIPTION
Whenever I'm trying things out with Desktop on `master`, it creates `applications/desktop/Untitled.ipynb`. I'd like to gitignore it to keep our workspace clean if possible. 🙏 