### PR TITLE
Add @nteract/stateful-components package

### DIFF
--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -10,9 +10,10 @@ import "@blueprintjs/select/lib/css/blueprint-select.css";
 import "codemirror/addon/hint/show-hint.css";
 import "codemirror/lib/codemirror.css";
 
-// import "@nteract/styles/global-variables.css";
+import "@nteract/styles/app.css";
+import "@nteract/styles/global-variables.css";
 
-// import "@nteract/styles/editor-overrides.css";
+import "@nteract/styles/editor-overrides.css";
 
 import { CodeMirrorCSS, ShowHintCSS } from "@nteract/editor";
 
@@ -22,15 +23,7 @@ import GeoJSONTransform from "@nteract/transform-geojson";
 import ModelDebug from "@nteract/transform-model-debug";
 import PlotlyTransform from "@nteract/transform-plotly";
 import VDOMDisplay from "@nteract/transform-vdom";
-import {
-  Vega2,
-  Vega3,
-  Vega4,
-  Vega5,
-  VegaLite1,
-  VegaLite2,
-  VegaLite3
-} from "@nteract/transform-vega";
+import { Vega2, Vega3, Vega4, Vega5, VegaLite1, VegaLite2, VegaLite3 } from "@nteract/transform-vega";
 
 import { ipcRenderer as ipc, remote } from "electron";
 import { mathJaxPath } from "mathjax-electron";
@@ -55,7 +48,7 @@ import {
   makeStateRecord,
   makeTransformsRecord
 } from "@nteract/core";
-import { Notebook } from "@nteract/stateful-components";
+import NotebookApp from "@nteract/notebook-app-component";
 import { Media } from "@nteract/outputs";
 
 import * as Immutable from "immutable";
@@ -174,7 +167,7 @@ export default class App extends React.PureComponent {
       <React.Fragment>
         <MathJax.Provider src={mathJaxPath} input="tex">
           <Provider store={store}>
-            <Notebook
+            <NotebookApp
               // The desktop app always keeps the same contentRef in a
               // browser window
               contentRef={contentRef}

--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -10,10 +10,9 @@ import "@blueprintjs/select/lib/css/blueprint-select.css";
 import "codemirror/addon/hint/show-hint.css";
 import "codemirror/lib/codemirror.css";
 
-import "@nteract/styles/app.css";
-import "@nteract/styles/global-variables.css";
+// import "@nteract/styles/global-variables.css";
 
-import "@nteract/styles/editor-overrides.css";
+// import "@nteract/styles/editor-overrides.css";
 
 import { CodeMirrorCSS, ShowHintCSS } from "@nteract/editor";
 
@@ -23,7 +22,15 @@ import GeoJSONTransform from "@nteract/transform-geojson";
 import ModelDebug from "@nteract/transform-model-debug";
 import PlotlyTransform from "@nteract/transform-plotly";
 import VDOMDisplay from "@nteract/transform-vdom";
-import { Vega2, Vega3, Vega4, Vega5, VegaLite1, VegaLite2, VegaLite3 } from "@nteract/transform-vega";
+import {
+  Vega2,
+  Vega3,
+  Vega4,
+  Vega5,
+  VegaLite1,
+  VegaLite2,
+  VegaLite3
+} from "@nteract/transform-vega";
 
 import { ipcRenderer as ipc, remote } from "electron";
 import { mathJaxPath } from "mathjax-electron";
@@ -48,7 +55,7 @@ import {
   makeStateRecord,
   makeTransformsRecord
 } from "@nteract/core";
-import NotebookApp from "@nteract/notebook-app-component";
+import { Notebook } from "@nteract/stateful-components";
 import { Media } from "@nteract/outputs";
 
 import * as Immutable from "immutable";
@@ -167,7 +174,7 @@ export default class App extends React.PureComponent {
       <React.Fragment>
         <MathJax.Provider src={mathJaxPath} input="tex">
           <Provider store={store}>
-            <NotebookApp
+            <Notebook
               // The desktop app always keeps the same contentRef in a
               // browser window
               contentRef={contentRef}

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -63,6 +63,7 @@ export type CodeMirrorEditorProps = {
   onChange?: (value: string, change: EditorChangeLinkedList) => void;
   onFocusChange?: (focused: boolean) => void;
   value: string;
+  editorType: "codemirror";
 } & Partial<FullEditorConfiguration>;
 
 interface CodeMirrorEditorState {
@@ -94,7 +95,8 @@ export default class CodeMirrorEditor extends React.PureComponent<
     matchBrackets: true,
     indentUnit: 4,
     lineNumbers: false,
-    cursorBlinkRate: 530
+    cursorBlinkRate: 530,
+    editorType: "codemirror"
   };
 
   textarea?: HTMLTextAreaElement | null;

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -117,7 +117,8 @@ export const mockAppState = (config: JSONObject): AppState => {
                 cellFocused:
                   config && config.codeCellCount && config.codeCellCount > 1
                     ? dummyNotebook.get("cellOrder", Immutable.List()).get(1)
-                    : null
+                    : null,
+                kernelRef
               }),
               filepath:
                 config && config.noFilename ? "" : "dummy-store-nb.ipynb"

--- a/packages/stateful-components/README.md
+++ b/packages/stateful-components/README.md
@@ -1,11 +1,67 @@
-# `stateful-components`
+# @nteract/stateful-components
 
-> TODO: description
+This package exports a set of React components that are pre-connected to the Redux state as mapped by @nteract/core. This package is designed to reduced the hassle for building React-based applications for developers who are already building on top of the core SDK. It also exposes several interfaces for extending the `mapStateToProps`, `mapDispatchToProps`, and styles of the individual components.
+
+## Installation
+
+```
+$ yarn add @nteract/stateful-components
+```
+
+```
+$ npm install --save @nteract/stateful-components
+```
 
 ## Usage
 
-```
-const statefulComponents = require('stateful-components');
+You can import the top-leval Notebook component which contains the canonical setup for a Jupyter-backed notebook application.
 
-// TODO: DEMONSTRATE API
 ```
+import { Notebook }  from "@nteract/stateful-components"
+
+class MyNotebook extends React.Component {
+    render() {
+        return <Notebook contentRef={someContentRefHere}>
+    }
+}
+```
+
+Alternatively, you can assemble your own notebook-UI from the subcomponents. For example, to swap out the canonical `MarkdownCell` implementation.
+
+```
+import { Cells, Cell, CodeCell, RawCell } from "@nteract/stateful-components";
+
+class MyMarkdownCell extends React.Component {
+    static defaultProps = {
+        cell_type: "markdown"
+    }
+
+    render() {
+        return <p>My custom logic here</p>;
+    }
+}
+
+class MyNotebook extends React.Component {
+    render() {
+        return <Cells>
+            <Cell>
+                <MyMarkdownCell/>
+                <CodeCell/>
+                <RawCell>
+            </Cell>
+        </Cells>;
+    }
+}
+```
+
+## Documentation
+
+We're working on adding more documentation for this component. Stay tuned by watching this repository!
+
+## Support
+
+If you experience an issue while using this package or have a feature request, please file an issue on the [issue board](https://github.com/nteract/nteract/issues/new/choose) and add the `pkg:stateful-components` label.
+
+## License
+
+[BSD-3-Clause](https://choosealicense.com/licenses/bsd-3-clause/)

--- a/packages/stateful-components/README.md
+++ b/packages/stateful-components/README.md
@@ -1,0 +1,11 @@
+# `stateful-components`
+
+> TODO: description
+
+## Usage
+
+```
+const statefulComponents = require('stateful-components');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/stateful-components/__tests__/cells/cell.spec.tsx
+++ b/packages/stateful-components/__tests__/cells/cell.spec.tsx
@@ -1,0 +1,71 @@
+import { mount } from "enzyme";
+import Immutable from "immutable";
+import React from "react";
+
+import { Cell } from "../../src/cells/cell";
+
+describe("Cell", () => {
+  it("picks the correct child component when it exists", () => {
+    function ChosenOneCell(props) {
+      return <p>ChosenOneCell</p>;
+    }
+    ChosenOneCell.defaultProps = { cell_type: "the_one" };
+    function NotTheOneCell(props) {
+      return <p>NotTheOneCell</p>;
+    }
+    NotTheOneCell.defaultProps = { cell_type: "not_the_one" };
+    const component = mount(
+      <Cell
+        id="cellId"
+        contentRef="contentRef"
+        cell={Immutable.Map({ cell_type: "the_one" })}
+      >
+        <ChosenOneCell />
+        <NotTheOneCell />
+      </Cell>
+    );
+    expect(component.html()).toBe("<p>ChosenOneCell</p>");
+  });
+  it("returns null when no valid child component exists", () => {
+    function ChosenOneCell(props) {
+      return <p>ChosenOneCell</p>;
+    }
+    ChosenOneCell.defaultProps = { cell_type: "the_one" };
+    function NotTheOneCell(props) {
+      return <p>NotTheOneCell</p>;
+    }
+    NotTheOneCell.defaultProps = { cell_type: "not_the_one" };
+    const component = mount(
+      <Cell
+        id="cellId"
+        contentRef="contentRef"
+        cell={Immutable.Map({ cell_type: "neither_one" })}
+      >
+        <ChosenOneCell />
+        <NotTheOneCell />
+      </Cell>
+    );
+    expect(component.children()).toHaveLength(0);
+  });
+  it("only looks for the cell_type prop when matching", () => {
+    function ChosenOneCell(props) {
+      return <p>ChosenOneCell</p>;
+    }
+    ChosenOneCell.defaultProps = { not_cell_type: "the_one" };
+    function NotTheOneCell(props) {
+      return <p>NotTheOneCell</p>;
+    }
+    NotTheOneCell.defaultProps = { cell_type: "not_the_one" };
+    const component = mount(
+      <Cell
+        id="cellId"
+        contentRef="contentRef"
+        cell={Immutable.Map({ cell_type: "the_one" })}
+      >
+        <ChosenOneCell />
+        <NotTheOneCell />
+      </Cell>
+    );
+    expect(component.children()).toHaveLength(0);
+  });
+});

--- a/packages/stateful-components/__tests__/inputs/editor.spec.tsx
+++ b/packages/stateful-components/__tests__/inputs/editor.spec.tsx
@@ -1,0 +1,36 @@
+import { selectors } from "@nteract/core";
+import { mockAppState } from "@nteract/fixtures";
+
+import { makeMapStateToProps } from "../../src/inputs/editor";
+
+describe("makeMapStateToProps", () => {
+  it("returns default values if input document is not a notebook", () => {
+    const state = mockAppState();
+    const ownProps = {
+      contentRef: "anyContentRef",
+      id: "nonExistantCell",
+      children: []
+    };
+    const mapStateToProps = makeMapStateToProps(state, ownProps);
+    expect(mapStateToProps(state)).toEqual({
+      editorType: "codemirror",
+      editorFocused: false,
+      channels: null,
+      kernelStatus: "not connected",
+      value: ""
+    });
+  });
+  it("returns kernel and channels if input cell is code cell", () => {
+    const state = mockAppState({ codeCellCount: 1 });
+    const contentRef = state.core.entities.contents.byRef.keySeq().first();
+    const model = selectors.model(state, { contentRef });
+    const id = selectors.notebook.cellOrder(model).first();
+    const ownProps = {
+      contentRef,
+      id,
+      children: []
+    };
+    const mapStateToProps = makeMapStateToProps(state, ownProps);
+    expect(mapStateToProps(state).channels).not.toBeNull();
+  });
+});

--- a/packages/stateful-components/__tests__/outputs/index.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/index.spec.tsx
@@ -1,0 +1,36 @@
+import { mount } from "enzyme";
+import Immutable from "immutable";
+import React from "react";
+
+import { Outputs } from "../../src/outputs";
+
+describe("Outputs", () => {
+  it("sets hidden class correctly based on props", () => {
+    const component = mount(
+      <Outputs
+        id={"cellId"}
+        contentRef={"contentRef"}
+        hidden={true}
+        expanded={false}
+        outputs={Immutable.List()}
+      >
+        <p>test</p>
+      </Outputs>
+    );
+    expect(component.find(".hidden").length).not.toBe(0);
+  });
+  it("sets expanded class correctly based on props", () => {
+    const component = mount(
+      <Outputs
+        id={"cellId"}
+        contentRef={"contentRef"}
+        hidden={false}
+        expanded={true}
+        outputs={Immutable.List()}
+      >
+        <p>test</p>
+      </Outputs>
+    );
+    expect(component.find(".expanded").length).not.toBe(0);
+  });
+});

--- a/packages/stateful-components/__tests__/outputs/pagers.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/pagers.spec.tsx
@@ -1,0 +1,46 @@
+import Immutable from "immutable";
+
+import { mockAppState } from "@nteract/fixtures";
+import { selectors } from "@nteract/core";
+
+import { makeMapStateToProps } from "../../src/outputs/pagers";
+
+describe("makeMapStateToProps", () => {
+  it("returns an empty set of pagers for non-notebook files", () => {
+    const state = mockAppState();
+    const ownProps = {
+      contentRef: "anyContentRef",
+      id: "nonExistantCell",
+      children: []
+    };
+    const mapStateToProps = makeMapStateToProps(state, ownProps);
+    expect(mapStateToProps(state)).toEqual({ pagers: Immutable.List() });
+  });
+  it("returns an empty set of pagers for non-existant cells", () => {
+    const state = mockAppState();
+    const contentRef = state.core.entities.contents.byRef.keySeq().first();
+    const ownProps = { contentRef, id: "nonExistantCell", children: [] };
+    const mapStateToProps = makeMapStateToProps(state, ownProps);
+    expect(mapStateToProps(state)).toEqual({ pagers: Immutable.List() });
+  });
+  it("returns a set of pagers for existant cells", () => {
+    // Generate mock state with single cell
+    const mockState = mockAppState({ codeCellCount: 1 });
+    // Extract pre-generated content ref and cell ID
+    const contentRef = mockState.core.entities.contents.byRef.keySeq().first();
+    const model = selectors.model(mockState, { contentRef });
+    const id = selectors.notebook.cellOrder(model).first();
+    // Update pagers for testing
+    const pagers = Immutable.List(["test"]);
+    const state = {
+      ...mockState,
+      core: mockState.core.setIn(
+        ["entities", "contents", "byRef", contentRef, "model", "cellPagers"],
+        Immutable.Map({ [id]: pagers })
+      )
+    };
+    const ownProps = { contentRef, id, children: [] };
+    const mapStateToProps = makeMapStateToProps(state, ownProps);
+    expect(mapStateToProps(state)).toEqual({ pagers });
+  });
+});

--- a/packages/stateful-components/__tests__/outputs/transform-media.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/transform-media.spec.tsx
@@ -1,0 +1,48 @@
+import Immutable from "immutable";
+
+import { makeDisplayData } from "@nteract/commutable";
+
+import { richestMediaType } from "../../src/outputs/transform-media";
+
+describe("richestMediaType", () => {
+  it("returns nothing if media type is not in display order", () => {
+    const output = makeDisplayData({
+      data: {
+        "text/unsupported": "test"
+      }
+    });
+    const handlers = Immutable.Map({
+      "text/supported": props => <p>Test transform</p>
+    });
+    const order = Immutable.List(["text/supported"]);
+    expect(richestMediaType(output, order, handlers)).toBeUndefined();
+  });
+  it("returns nothing if the media type has no supported transform", () => {
+    const output = makeDisplayData({
+      data: {
+        "text/supported": "test"
+      }
+    });
+    const handlers = Immutable.Map({
+      "text/unsupported": props => <p>Test transform</p>
+    });
+    const order = Immutable.List(["text/supported"]);
+    expect(richestMediaType(output, order, handlers)).toBeUndefined();
+  });
+  it("returns higher-priority media type for output", () => {
+    const output = makeDisplayData({
+      data: {
+        "text/more-important": "another-test",
+        "text/supported": "test"
+      }
+    });
+    const handlers = Immutable.Map({
+      "text/more-important": props => <p>Test transform</p>,
+      "text/supported": props => <p>Test transform</p>
+    });
+    const order = Immutable.List(["text/more-important", "text/supported"]);
+    expect(richestMediaType(output, order, handlers)).toBe(
+      "text/more-important"
+    );
+  });
+});

--- a/packages/stateful-components/__tests__/stateful-components.test.js
+++ b/packages/stateful-components/__tests__/stateful-components.test.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const statefulComponents = require('..');
-
-describe('stateful-components', () => {
-    it('needs tests');
-});

--- a/packages/stateful-components/__tests__/stateful-components.test.js
+++ b/packages/stateful-components/__tests__/stateful-components.test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const statefulComponents = require('..');
+
+describe('stateful-components', () => {
+    it('needs tests');
+});

--- a/packages/stateful-components/package.json
+++ b/packages/stateful-components/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@nteract/stateful-components",
+  "version": "1.0.0",
+  "description": "A collection of sub-components pre-connected to nteract's Redux state",
+  "keywords": [
+    "redux",
+    "react",
+    "nteract"
+  ],
+  "author": "Safia Abdalla <safia@microsoft.com>",
+  "homepage": "https://github.com/nteract/nteract/tree/master/packages/stateful-components#readme",
+  "license": "BSD-3-Clause",
+  "main": "lib/stateful-components.js",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nteract/nteract.git"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "bugs": {
+    "url": "https://github.com/nteract/nteract/issues"
+  },
+  "dependencies": {
+    "@nteract/commutable": "^7.1.4",
+    "@nteract/core": "^10.9.0",
+    "@nteract/outputs": "^2.6.0",
+    "@nteract/presentational-components": "^3.2.0",
+    "immutable": "^4.0.0-rc.12",
+    "redux": "^4.0.4"
+  }
+}

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -57,16 +57,22 @@ export class Cell extends React.Component<ComponentProps & StateProps> {
   }
 }
 
-const mapStateToProps = (state: AppState, ownProps: ComponentProps) => {
-  const { id, contentRef } = ownProps;
-  const model = selectors.model(state, { contentRef });
-  let cell = undefined;
+export const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+) => {
+  const mapStateToProps = (state: AppState) => {
+    const { id, contentRef } = ownProps;
+    const model = selectors.model(state, { contentRef });
+    let cell = undefined;
 
-  if (model && model.type === "notebook") {
-    cell = selectors.notebook.cellById(model, { id });
-  }
+    if (model && model.type === "notebook") {
+      cell = selectors.notebook.cellById(model, { id });
+    }
 
-  return { cell };
+    return { cell };
+  };
+  return mapStateToProps;
 };
 
-export default connect(mapStateToProps)(Cell);
+export default connect(makeMapStateToProps)(Cell);

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -1,0 +1,76 @@
+import Immutable from "immutable";
+import React from "react";
+import { connect } from "react-redux";
+
+import { selectors, AppState } from "@nteract/core";
+
+interface ComponentProps {
+  id: string;
+  contentRef: string;
+}
+
+interface StateProps {
+  cell: Immutable.Map<string, any>;
+}
+
+export class Cell extends React.Component<ComponentProps & StateProps> {
+  render() {
+    // We must pick only one child to render
+    let chosenOne: React.ReactChild | null = null;
+
+    if (!this.props.cell) {
+      return null;
+    }
+
+    const cell_type = this.props.cell.cell_type;
+
+    // Find the first child element that matches something in this.props.data
+    React.Children.forEach(this.props.children, child => {
+      if (typeof child === "string" || typeof child === "number") {
+        return;
+      }
+
+      const childElement = child;
+      if (chosenOne) {
+        // Already have a selection
+        return;
+      }
+      if (childElement.props && childElement.props.cell_type) {
+        const child_cell_type: string[] = Array.isArray(
+          childElement.props.cell_type
+        )
+          ? childElement.props.cell_type
+          : [childElement.props.cell_type];
+
+        chosenOne = child_cell_type.includes(cell_type) ? childElement : null;
+        return;
+      }
+    });
+
+    // If we didn't find a match, render nothing
+    if (chosenOne === null) {
+      return null;
+    }
+
+    // Render the output component that handles this output type
+    return React.cloneElement(chosenOne, {
+      cell: this.props.cell,
+      id: this.props.id,
+      contentRef: this.props.contentRef
+    });
+  }
+}
+
+const mapStateToProps = (state: AppState, ownProps: ComponentProps) => {
+  const { id, contentRef } = ownProps;
+  const model = selectors.model(state, { contentRef });
+  let cell = undefined;
+
+  if (model && model.type === "notebook") {
+    cell = selectors.notebook.cellById(model, { id });
+  }
+
+  return { cell };
+};
+
+export default connect(mapStateToProps)(Cell);

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -22,7 +22,7 @@ export class Cell extends React.Component<ComponentProps & StateProps> {
       return null;
     }
 
-    const cell_type = this.props.cell.cell_type;
+    const cell_type = this.props.cell.get("cell_type");
 
     // Find the first child element that matches something in this.props.data
     React.Children.forEach(this.props.children, child => {
@@ -30,19 +30,15 @@ export class Cell extends React.Component<ComponentProps & StateProps> {
         return;
       }
 
-      const childElement = child;
       if (chosenOne) {
         // Already have a selection
         return;
       }
-      if (childElement.props && childElement.props.cell_type) {
-        const child_cell_type: string[] = Array.isArray(
-          childElement.props.cell_type
-        )
-          ? childElement.props.cell_type
-          : [childElement.props.cell_type];
 
-        chosenOne = child_cell_type.includes(cell_type) ? childElement : null;
+      if (child.props && child.props.cell_type) {
+        const child_cell_type = child.props.cell_type;
+
+        chosenOne = child_cell_type === cell_type ? child : null;
         return;
       }
     });

--- a/packages/stateful-components/src/cells/cells.tsx
+++ b/packages/stateful-components/src/cells/cells.tsx
@@ -1,0 +1,57 @@
+import Immutable from "immutable";
+import React from "react";
+import { connect } from "react-redux";
+
+import { AppState, ContentRef, selectors } from "@nteract/core";
+
+import Cell from "./cell";
+import RawCell from "./raw-cell";
+import MarkdownCell from "./markdown-cell";
+import CodeCell from "./code-cell";
+
+interface ComponentProps {
+  contentRef: ContentRef;
+}
+
+interface StateProps {
+  cellOrder: Immutable.List<string>;
+}
+
+export class Cells extends React.Component<StateProps & ComponentProps> {
+  render() {
+    const { cellOrder, contentRef } = this.props;
+    return (
+      <div className="nteract-cells">
+        {cellOrder.map((id: string) => (
+          <Cell id={id} contentRef={contentRef} key={id}>
+            <MarkdownCell id={id} contentRef={contentRef} />
+            <RawCell id={id} contentRef={contentRef} />
+            <CodeCell id={id} contentRef={contentRef} />
+          </Cell>
+        ))}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (
+  state: AppState,
+  ownProps: ComponentProps
+): StateProps => {
+  const { contentRef } = ownProps;
+  const model = selectors.model(state, { contentRef });
+
+  let cellOrder = Immutable.List();
+
+  if (model && model.type === "notebook") {
+    cellOrder = model.notebook.cellOrder;
+  }
+
+  return {
+    cellOrder
+  };
+};
+
+export default connect<StateProps, void, ComponentProps, AppState>(
+  mapStateToProps
+)(Cells);

--- a/packages/stateful-components/src/cells/cells.tsx
+++ b/packages/stateful-components/src/cells/cells.tsx
@@ -34,24 +34,27 @@ export class Cells extends React.Component<StateProps & ComponentProps> {
   }
 }
 
-const mapStateToProps = (
+const makeMapStateToProps = (
   state: AppState,
   ownProps: ComponentProps
-): StateProps => {
-  const { contentRef } = ownProps;
-  const model = selectors.model(state, { contentRef });
+): ((state: AppState) => StateProps) => {
+  const mapStateToProps = (state: AppState) => {
+    const { contentRef } = ownProps;
+    const model = selectors.model(state, { contentRef });
 
-  let cellOrder = Immutable.List();
+    let cellOrder = Immutable.List();
 
-  if (model && model.type === "notebook") {
-    cellOrder = model.notebook.cellOrder;
-  }
+    if (model && model.type === "notebook") {
+      cellOrder = model.notebook.cellOrder;
+    }
 
-  return {
-    cellOrder
+    return {
+      cellOrder
+    };
   };
+  return mapStateToProps;
 };
 
 export default connect<StateProps, void, ComponentProps, AppState>(
-  mapStateToProps
+  makeMapStateToProps
 )(Cells);

--- a/packages/stateful-components/src/cells/cells.tsx
+++ b/packages/stateful-components/src/cells/cells.tsx
@@ -11,6 +11,7 @@ import CodeCell from "./code-cell";
 
 interface ComponentProps {
   contentRef: ContentRef;
+  children?: React.ReactNode;
 }
 
 interface StateProps {
@@ -19,16 +20,20 @@ interface StateProps {
 
 export class Cells extends React.Component<StateProps & ComponentProps> {
   render() {
-    const { cellOrder, contentRef } = this.props;
+    const { cellOrder, contentRef, children } = this.props;
     return (
       <div className="nteract-cells">
-        {cellOrder.map((id: string) => (
-          <Cell id={id} contentRef={contentRef} key={id}>
-            <MarkdownCell id={id} contentRef={contentRef} />
-            <RawCell id={id} contentRef={contentRef} />
-            <CodeCell id={id} contentRef={contentRef} />
-          </Cell>
-        ))}
+        {cellOrder.map((id: string) =>
+          children ? (
+            React.cloneElement(children, { id, contentRef })
+          ) : (
+            <Cell id={id} contentRef={contentRef} key={id}>
+              <MarkdownCell id={id} contentRef={contentRef} />
+              <RawCell id={id} contentRef={contentRef} />
+              <CodeCell id={id} contentRef={contentRef} />
+            </Cell>
+          )
+        )}
       </div>
     );
   }

--- a/packages/stateful-components/src/cells/cells.tsx
+++ b/packages/stateful-components/src/cells/cells.tsx
@@ -39,7 +39,7 @@ export class Cells extends React.Component<StateProps & ComponentProps> {
   }
 }
 
-const makeMapStateToProps = (
+export const makeMapStateToProps = (
   state: AppState,
   ownProps: ComponentProps
 ): ((state: AppState) => StateProps) => {

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -3,13 +3,15 @@ import React from "react";
 
 import { ContentRef } from "@nteract/core";
 import { Media, KernelOutputError, StreamText } from "@nteract/outputs";
-import { Source, Input, Prompt } from "@nteract/presentational-components";
+import { Source } from "@nteract/presentational-components";
 import CodeMirrorEditor from "@nteract/editor";
 
 import Editor from "../inputs/editor";
+import Prompt from "../inputs/prompt";
 import TransformMedia from "../outputs/transform-media";
 import Outputs from "../outputs";
 import Pagers from "../outputs/pagers";
+import Input from "../inputs/input";
 
 interface ComponentProps {
   id: string;
@@ -17,6 +19,13 @@ interface ComponentProps {
   cell: Immutable.Map<string, any>;
   cell_type: "code";
 }
+
+const PromptText = (props: any) => {
+  if (props.status === "busy") {
+    return <React.Fragment>{"[*]"}</React.Fragment>;
+  }
+  return <React.Fragment>{"[ ]"}</React.Fragment>;
+};
 
 export default class CodeCell extends React.Component<ComponentProps> {
   static defaultProps = {
@@ -28,8 +37,10 @@ export default class CodeCell extends React.Component<ComponentProps> {
 
     return (
       <div className="nteract-code-cell">
-        <Input>
-          <Prompt id={id} contentRef={contentRef} />
+        <Input id={id} contentRef={contentRef}>
+          <Prompt id={id} contentRef={contentRef}>
+            <PromptText />
+          </Prompt>
           <Source>
             <Editor id={id} contentRef={contentRef}>
               <CodeMirrorEditor />

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -11,6 +11,7 @@ import Prompt from "../inputs/prompt";
 import TransformMedia from "../outputs/transform-media";
 import Outputs from "../outputs";
 import Pagers from "../outputs/pagers";
+import InputPrompts from "../outputs/input-prompts";
 import Input from "../inputs/input";
 
 interface ComponentProps {
@@ -77,7 +78,7 @@ export default class CodeCell extends React.Component<ComponentProps> {
           <KernelOutputError />
           <StreamText />
         </Outputs>
-        {/* <InputPrompts id={id} contentRef={contentRef} /> */}
+        <InputPrompts id={id} contentRef={contentRef} />
       </div>
     );
   }

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -1,0 +1,67 @@
+import Immutable from "immutable";
+import React from "react";
+
+import { ContentRef } from "@nteract/core";
+import { Media, KernelOutputError, StreamText } from "@nteract/outputs";
+import { Source, Input, Prompt } from "@nteract/presentational-components";
+import CodeMirrorEditor from "@nteract/editor";
+
+import Editor from "../inputs/editor";
+import TransformMedia from "../outputs/transform-media";
+import Outputs from "../outputs";
+import Pagers from "../outputs/pagers";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+  cell: Immutable.Map<string, any>;
+  cell_type: "code";
+}
+
+export default class CodeCell extends React.Component<ComponentProps> {
+  static defaultProps = {
+    cell_type: "code"
+  };
+
+  render() {
+    const { id, contentRef } = this.props;
+
+    return (
+      <div className="nteract-code-cell">
+        <Input>
+          <Prompt id={id} contentRef={contentRef} />
+          <Source>
+            <Editor id={id} contentRef={contentRef}>
+              <CodeMirrorEditor />
+            </Editor>
+          </Source>
+        </Input>
+        <Pagers id={id} contentRef={contentRef}>
+          <Media.Json />
+          <Media.JavaScript />
+          <Media.HTML />
+          <Media.Markdown />
+          <Media.LaTeX />
+          <Media.SVG />
+          <Media.Image />
+          <Media.Plain />
+        </Pagers>
+        <Outputs id={id} contentRef={contentRef}>
+          <TransformMedia
+            output_type={"display_data"}
+            id={id}
+            contentRef={contentRef}
+          />
+          <TransformMedia
+            output_type={"execute_result"}
+            id={id}
+            contentRef={contentRef}
+          />
+          <KernelOutputError />
+          <StreamText />
+        </Outputs>
+        {/* <InputPrompts id={id} contentRef={contentRef} /> */}
+      </div>
+    );
+  }
+}

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -24,6 +24,12 @@ const PromptText = (props: any) => {
   if (props.status === "busy") {
     return <React.Fragment>{"[*]"}</React.Fragment>;
   }
+  if (props.status === "queued") {
+    return <React.Fragment>{"[…]"}</React.Fragment>;
+  }
+  if (typeof props.executionCount === "number") {
+    return <React.Fragment>{`[${props.counter}]`}</React.Fragment>;
+  }
   return <React.Fragment>{"[ ]"}</React.Fragment>;
 };
 

--- a/packages/stateful-components/src/cells/markdown-cell.tsx
+++ b/packages/stateful-components/src/cells/markdown-cell.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import Immutable from "immutable";
+
+import { ContentRef, AppState, selectors, actions } from "@nteract/core";
+import { Source } from "@nteract/presentational-components";
+import { MarkdownPreviewer } from "@nteract/markdown";
+import CodeMirrorEditor from "@nteract/editor";
+
+import Editor from "../inputs/editor";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+  cell: Immutable.Map<string, any>;
+  cell_type: "markdown";
+}
+
+interface StateProps {
+  isCellFocused: boolean;
+  isEditorFocused: boolean;
+}
+
+interface DispatchProps {
+  focusAboveCell: () => void;
+  focusBelowCell: () => void;
+  focusEditor: () => void;
+  unfocusEditor: () => void;
+}
+
+export class PureMarkdownCell extends React.Component<
+  ComponentProps & DispatchProps & StateProps
+> {
+  render() {
+    const { contentRef, id, cell } = this.props;
+
+    const { isEditorFocused, isCellFocused } = this.props;
+
+    const {
+      focusAboveCell,
+      focusBelowCell,
+      focusEditor,
+      unfocusEditor
+    } = this.props;
+
+    const source = cell.get("source", "");
+
+    return (
+      <MarkdownPreviewer
+        focusAbove={focusAboveCell}
+        focusBelow={focusBelowCell}
+        focusEditor={focusEditor}
+        cellFocused={isCellFocused}
+        editorFocused={isEditorFocused}
+        unfocusEditor={unfocusEditor}
+        source={source}
+      >
+        <Source>
+          <Editor id={id} contentRef={contentRef}>
+            <CodeMirrorEditor />
+          </Editor>
+        </Source>
+      </MarkdownPreviewer>
+    );
+  }
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+): ((state: AppState) => StateProps) => {
+  const { id, contentRef } = ownProps;
+  const mapStateToProps = (state: AppState): StateProps => {
+    const model = selectors.model(state, { contentRef });
+    let isCellFocused = false;
+    let isEditorFocused = false;
+
+    if (model && model.type === "notebook") {
+      isCellFocused = model.cellFocused === id;
+      isEditorFocused = model.editorFocused === id;
+    }
+
+    return {
+      isCellFocused,
+      isEditorFocused
+    };
+  };
+
+  return mapStateToProps;
+};
+
+const makeMapDispatchToProps = (
+  initialDispatch: Dispatch,
+  ownProps: ComponentProps
+): ((dispatch: Dispatch) => DispatchProps) => {
+  const { id, contentRef } = ownProps;
+
+  const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+    focusAboveCell: () => {
+      dispatch(actions.focusPreviousCell({ id, contentRef }));
+      dispatch(actions.focusPreviousCellEditor({ id, contentRef }));
+    },
+    focusBelowCell: () => {
+      dispatch(
+        actions.focusNextCell({ id, createCellIfUndefined: true, contentRef })
+      );
+      dispatch(actions.focusNextCellEditor({ id, contentRef }));
+    },
+    focusEditor: () => dispatch(actions.focusCellEditor({ id, contentRef })),
+    unfocusEditor: () =>
+      dispatch(actions.focusCellEditor({ id: undefined, contentRef }))
+  });
+
+  return mapDispatchToProps;
+};
+
+const MarkdownCell = connect(
+  makeMapStateToProps,
+  makeMapDispatchToProps
+)(PureMarkdownCell);
+
+MarkdownCell.defaultProps = {
+  cell_type: "markdown"
+};
+
+export default MarkdownCell;

--- a/packages/stateful-components/src/cells/markdown-cell.tsx
+++ b/packages/stateful-components/src/cells/markdown-cell.tsx
@@ -115,13 +115,13 @@ const makeMapDispatchToProps = (
   return mapDispatchToProps;
 };
 
-MarkdownCell.defaultProps = {
-  cell_type: "markdown"
-};
-
 const MarkdownCell = connect(
   makeMapStateToProps,
   makeMapDispatchToProps
 )(PureMarkdownCell);
+
+MarkdownCell.defaultProps = {
+  cell_type: "markdown"
+};
 
 export default MarkdownCell;

--- a/packages/stateful-components/src/cells/markdown-cell.tsx
+++ b/packages/stateful-components/src/cells/markdown-cell.tsx
@@ -66,7 +66,7 @@ export class PureMarkdownCell extends React.Component<
   }
 }
 
-const makeMapStateToProps = (
+export const makeMapStateToProps = (
   initialState: AppState,
   ownProps: ComponentProps
 ): ((state: AppState) => StateProps) => {
@@ -115,13 +115,13 @@ const makeMapDispatchToProps = (
   return mapDispatchToProps;
 };
 
+MarkdownCell.defaultProps = {
+  cell_type: "markdown"
+};
+
 const MarkdownCell = connect(
   makeMapStateToProps,
   makeMapDispatchToProps
 )(PureMarkdownCell);
-
-MarkdownCell.defaultProps = {
-  cell_type: "markdown"
-};
 
 export default MarkdownCell;

--- a/packages/stateful-components/src/cells/raw-cell.tsx
+++ b/packages/stateful-components/src/cells/raw-cell.tsx
@@ -39,32 +39,35 @@ export class PureRawCell extends React.Component<
   }
 }
 
-const mapDispatchToProps = (
+export const makeMapDispatchToProps = (
   dispatch: Dispatch,
   ownProps: ComponentProps
-): DispatchProps => {
-  const { id, contentRef } = ownProps;
-  return {
-    focusAboveCell: () => {
-      dispatch(actions.focusPreviousCell({ id, contentRef }));
-      dispatch(actions.focusPreviousCellEditor({ id, contentRef }));
-    },
-    focusBelowCell: () => {
-      dispatch(
-        actions.focusNextCell({ id, createCellIfUndefined: true, contentRef })
-      );
-      dispatch(actions.focusNextCellEditor({ id, contentRef }));
-    }
+): ((dispatch: Dispatch) => DispatchProps) => {
+  const mapDispatchToProps = (dispatch: Dispatch) => {
+    const { id, contentRef } = ownProps;
+    return {
+      focusAboveCell: () => {
+        dispatch(actions.focusPreviousCell({ id, contentRef }));
+        dispatch(actions.focusPreviousCellEditor({ id, contentRef }));
+      },
+      focusBelowCell: () => {
+        dispatch(
+          actions.focusNextCell({ id, createCellIfUndefined: true, contentRef })
+        );
+        dispatch(actions.focusNextCellEditor({ id, contentRef }));
+      }
+    };
   };
-};
-
-PureRawCell.defaultProps = {
-  cell_type: "raw"
+  return mapDispatchToProps;
 };
 
 const RawCell = connect<void, DispatchProps, ComponentProps, AppState>(
   null,
-  mapDispatchToProps
+  makeMapDispatchToProps
 )(PureRawCell);
+
+RawCell.defaultProps = {
+  cell_type: "raw"
+};
 
 export default RawCell;

--- a/packages/stateful-components/src/cells/raw-cell.tsx
+++ b/packages/stateful-components/src/cells/raw-cell.tsx
@@ -3,7 +3,7 @@ import Immutable from "immutable";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
-import { ContentRef, actions } from "@nteract/core";
+import { ContentRef, actions, AppState } from "@nteract/core";
 import { Source } from "@nteract/presentational-components";
 
 import Editor from "../inputs/editor";
@@ -58,10 +58,13 @@ const mapDispatchToProps = (
   };
 };
 
-const RawCell = connect(null, mapDispatchToProps)(PureRawCell);
-
 PureRawCell.defaultProps = {
   cell_type: "raw"
 };
+
+const RawCell = connect<void, DispatchProps, ComponentProps, AppState>(
+  null,
+  mapDispatchToProps
+)(PureRawCell);
 
 export default RawCell;

--- a/packages/stateful-components/src/cells/raw-cell.tsx
+++ b/packages/stateful-components/src/cells/raw-cell.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import Immutable from "immutable";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import { ContentRef, actions } from "@nteract/core";
+import { Source } from "@nteract/presentational-components";
+
+import Editor from "../inputs/editor";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+  cell: Immutable.Map<string, any>;
+  cell_type: "raw";
+}
+
+interface DispatchProps {
+  focusAboveCell: () => void;
+  focusBelowCell: () => void;
+}
+
+export class PureRawCell extends React.Component<
+  ComponentProps & DispatchProps
+> {
+  render() {
+    const { id, contentRef, focusAboveCell, focusBelowCell } = this.props;
+
+    return (
+      <Source>
+        <Editor
+          id={id}
+          contentRef={contentRef}
+          focusAbove={focusAboveCell}
+          focusBelow={focusBelowCell}
+        />
+      </Source>
+    );
+  }
+}
+
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+  ownProps: ComponentProps
+): DispatchProps => {
+  const { id, contentRef } = ownProps;
+  return {
+    focusAboveCell: () => {
+      dispatch(actions.focusPreviousCell({ id, contentRef }));
+      dispatch(actions.focusPreviousCellEditor({ id, contentRef }));
+    },
+    focusBelowCell: () => {
+      dispatch(
+        actions.focusNextCell({ id, createCellIfUndefined: true, contentRef })
+      );
+      dispatch(actions.focusNextCellEditor({ id, contentRef }));
+    }
+  };
+};
+
+const RawCell = connect(null, mapDispatchToProps)(PureRawCell);
+
+PureRawCell.defaultProps = {
+  cell_type: "raw"
+};
+
+export default RawCell;

--- a/packages/stateful-components/src/cells/toolbar.tsx
+++ b/packages/stateful-components/src/cells/toolbar.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import { ContentRef, actions } from "@nteract/core";
+import { CellType } from "@nteract/commutable";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+  children: React.ReactNode;
+}
+
+interface DispatchProps {
+  executeCell: () => void;
+  deleteCell: () => void;
+  clearOutputs: () => void;
+  toggleParameterCell: () => void;
+  toggleCellInputVisibility: () => void;
+  toggleCellOutputVisibility: () => void;
+  toggleOutputExpansion: () => void;
+  changeToMarkdownCell: () => void;
+  changeToCodeCell: () => void;
+  changeCellType: (to: CellType) => void;
+  selectCell: () => void;
+  focusEditor: () => void;
+  focusAboveCell: () => void;
+  focusBelowCell: () => void;
+  unfocusEditor: () => void;
+}
+
+export class CellToolbar extends React.Component {
+  render() {
+    return React.cloneElement(this.props.children, this.props);
+  }
+}
+
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+  ownProps: ComponentProps
+): DispatchProps => {
+  const { id, contentRef } = ownProps;
+  return {
+    executeCell: () => dispatch(actions.executeCell({ id, contentRef })),
+    deleteCell: () => dispatch(actions.deleteCell({ id, contentRef })),
+    clearOutputs: () => dispatch(actions.clearOutputs({ id, contentRef })),
+    toggleParameterCell: () =>
+      dispatch(actions.toggleParameterCell({ id, contentRef })),
+    toggleCellInputVisibility: () =>
+      dispatch(actions.toggleCellInputVisibility({ id, contentRef })),
+    toggleCellOutputVisibility: () =>
+      dispatch(actions.toggleCellOutputVisibility({ id, contentRef })),
+    toggleOutputExpansion: () =>
+      dispatch(actions.toggleOutputExpansion({ id, contentRef })),
+    changeToMarkdownCell: () =>
+      dispatch(actions.changeCellType({ id, contentRef, to: "markdown" })),
+    changeToCodeCell: () =>
+      dispatch(actions.changeCellType({ id, contentRef, to: "code" })),
+    changeCellType: (to: CellType) =>
+      dispatch(actions.changeCellType({ id, contentRef, to })),
+    selectCell: () => dispatch(actions.focusCell({ id, contentRef })),
+    focusEditor: () => dispatch(actions.focusCellEditor({ id, contentRef })),
+    focusAboveCell: () => {
+      dispatch(actions.focusPreviousCell({ id, contentRef }));
+      dispatch(actions.focusPreviousCellEditor({ id, contentRef }));
+    },
+    focusBelowCell: () => {
+      dispatch(
+        actions.focusNextCell({ id, createCellIfUndefined: true, contentRef })
+      );
+      dispatch(actions.focusNextCellEditor({ id, contentRef }));
+    },
+    unfocusEditor: () =>
+      dispatch(actions.focusCellEditor({ id: undefined, contentRef }))
+  };
+};
+
+export default connect(null, mapDispatchToProps)(CellToolbar);

--- a/packages/stateful-components/src/index.tsx
+++ b/packages/stateful-components/src/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import Cells from "./cells/cells";
+
+interface ComponentProps {
+  contentRef: string;
+}
+
+export class Notebook extends React.Component<ComponentProps> {
+  render() {
+    const { contentRef } = this.props;
+    return <Cells contentRef={contentRef} />;
+  }
+}

--- a/packages/stateful-components/src/inputs/editor.tsx
+++ b/packages/stateful-components/src/inputs/editor.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import { AppState, ContentRef, actions, selectors } from "@nteract/core";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+}
+
+interface StateProps {
+  editorType: string;
+  editorFocused: boolean;
+  value: string;
+  channels: any;
+  kernelStatus: string;
+}
+
+export class Editor extends React.Component<ComponentProps & StateProps> {
+  render() {
+    const { editorType } = this.props;
+
+    let chosenOne: React.ReactChild | null = null;
+
+    // Find the first child element that matches something in this.props.data
+    React.Children.forEach(this.props.children, child => {
+      if (typeof child === "string" || typeof child === "number") {
+        return;
+      }
+
+      const childElement = child;
+      if (chosenOne) {
+        // Already have a selection
+        return;
+      }
+      if (childElement.props && childElement.props.editorType) {
+        const child_editor_type: string[] = Array.isArray(
+          childElement.props.editorType
+        )
+          ? childElement.props.editorType
+          : [childElement.props.editorType];
+
+        chosenOne = child_editor_type.includes(editorType)
+          ? childElement
+          : null;
+        return;
+      }
+    });
+
+    // If we didn't find a match, render nothing
+    if (chosenOne === null) {
+      return null;
+    }
+
+    // Render the output component that handles this output type
+    return React.cloneElement(chosenOne, {
+      editorFocused: this.props.editorFocused,
+      value: this.props.value,
+      channels: this.props.channels,
+      kernelStatus: this.props.kernelStatus,
+      editorType: this.props.editorType,
+      className: "nteract-editor"
+    });
+  }
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+) => {
+  const { id, contentRef } = ownProps;
+  const mapStateToProps = (state: AppState): StateProps => {
+    const model = selectors.model(state, { contentRef });
+
+    let editorFocused = false;
+    let channels = null;
+    let kernelStatus = "not connected";
+    let value = "";
+    let editorType = "codemirror";
+
+    if (model && model.type === "notebook") {
+      const cell = selectors.notebook.cellById(model, { id });
+      if (cell) {
+        editorFocused = model.editorFocused === id;
+        value = cell.get("source", "");
+        if (cell.cell_type === "code") {
+          const kernel = selectors.kernelByContentRef(state, { contentRef });
+          if (kernel) {
+            channels = kernel.channels;
+            kernelStatus = kernel.status || "not connected";
+          }
+        }
+      }
+    }
+
+    return {
+      editorFocused,
+      value,
+      channels,
+      kernelStatus,
+      editorType
+    };
+  };
+
+  return mapStateToProps;
+};
+
+const makeMapDispatchToProps = (
+  initialDispatch: Dispatch,
+  ownProps: ComponentProps
+) => {
+  const { id, contentRef } = ownProps;
+  const mapDispatchToProps = (dispatch: Dispatch) => {
+    return {
+      onChange: (text: string) => {
+        dispatch(actions.updateCellSource({ id, value: text, contentRef }));
+      },
+
+      onFocusChange(focused: boolean): void {
+        if (focused) {
+          dispatch(actions.focusCellEditor({ id, contentRef }));
+          // Assume we can focus the cell if now focusing the editor
+          // If this doesn't work, we need to go back to checking !cellFocused
+          dispatch(actions.focusCell({ id, contentRef }));
+        }
+      }
+    };
+  };
+  return mapDispatchToProps;
+};
+
+export default connect(makeMapStateToProps, makeMapDispatchToProps)(Editor);

--- a/packages/stateful-components/src/inputs/editor.tsx
+++ b/packages/stateful-components/src/inputs/editor.tsx
@@ -7,6 +7,7 @@ import { AppState, ContentRef, actions, selectors } from "@nteract/core";
 interface ComponentProps {
   id: string;
   contentRef: ContentRef;
+  children: React.ReactNode;
 }
 
 interface StateProps {
@@ -35,15 +36,9 @@ export class Editor extends React.Component<ComponentProps & StateProps> {
         return;
       }
       if (childElement.props && childElement.props.editorType) {
-        const child_editor_type: string[] = Array.isArray(
-          childElement.props.editorType
-        )
-          ? childElement.props.editorType
-          : [childElement.props.editorType];
+        const child_editor_type = childElement.props.editorType;
 
-        chosenOne = child_editor_type.includes(editorType)
-          ? childElement
-          : null;
+        chosenOne = child_editor_type === editorType ? childElement : null;
         return;
       }
     });
@@ -65,7 +60,7 @@ export class Editor extends React.Component<ComponentProps & StateProps> {
   }
 }
 
-const makeMapStateToProps = (
+export const makeMapStateToProps = (
   initialState: AppState,
   ownProps: ComponentProps
 ) => {
@@ -84,6 +79,7 @@ const makeMapStateToProps = (
       if (cell) {
         editorFocused = model.editorFocused === id;
         value = cell.get("source", "");
+        console.log(cell);
         if (cell.cell_type === "code") {
           const kernel = selectors.kernelByContentRef(state, { contentRef });
           if (kernel) {
@@ -106,7 +102,7 @@ const makeMapStateToProps = (
   return mapStateToProps;
 };
 
-const makeMapDispatchToProps = (
+export const makeMapDispatchToProps = (
   initialDispatch: Dispatch,
   ownProps: ComponentProps
 ) => {

--- a/packages/stateful-components/src/inputs/input.tsx
+++ b/packages/stateful-components/src/inputs/input.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import { ContentRef, AppState, selectors } from "@nteract/core";
+import { connect } from "react-redux";
+
+interface ComponentProps {
+  children: React.ReactNode;
+  id: string;
+  contentRef: ContentRef;
+}
+
+interface StateProps {
+  hidden: boolean;
+}
+
+export class Input extends React.Component<ComponentProps & StateProps> {
+  render() {
+    if (this.props.hidden) {
+      return null;
+    }
+
+    return <div className="nteract-input">{this.props.children}</div>;
+  }
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+) => {
+  const mapStateToProps = (state: AppState) => {
+    const { contentRef, id } = ownProps;
+    const model = selectors.model(state, { contentRef });
+
+    let hidden = false;
+
+    if (model && model.type == "notebook") {
+      const cell = selectors.notebook.cellById(model, { id });
+      if (cell) {
+        hidden = cell.getIn(["metadata", "inputHidden"]);
+      }
+    }
+
+    return {
+      hidden
+    };
+  };
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps, null)(Input);

--- a/packages/stateful-components/src/inputs/input.tsx
+++ b/packages/stateful-components/src/inputs/input.tsx
@@ -47,4 +47,6 @@ const makeMapStateToProps = (
   return mapStateToProps;
 };
 
-export default connect(makeMapStateToProps, null)(Input);
+export default connect<StateProps, void, ComponentProps, AppState>(
+  makeMapStateToProps
+)(Input);

--- a/packages/stateful-components/src/inputs/prompt.tsx
+++ b/packages/stateful-components/src/inputs/prompt.tsx
@@ -25,28 +25,31 @@ export class Prompt extends React.Component<ComponentProps, StateProps> {
   }
 }
 
-const mapStateToProps = (
+const makeMapStateToProps = (
   state: AppState,
   ownProps: ComponentProps
-): StateProps => {
-  const { contentRef, id } = ownProps;
-  const model = selectors.model(state, { contentRef });
+): ((state: AppState) => StateProps) => {
+  const mapStateToProps = (state: AppState) => {
+    const { contentRef, id } = ownProps;
+    const model = selectors.model(state, { contentRef });
 
-  let status;
-  let executionCount;
+    let status;
+    let executionCount;
 
-  if (model && model.type == "notebook") {
-    status = model.transient.getIn(["cellMap", id, "status"]);
-    const cell = selectors.notebook.cellById(model, { id });
-    if (cell) {
-      executionCount = cell.get("execution_count", undefined);
+    if (model && model.type == "notebook") {
+      status = model.transient.getIn(["cellMap", id, "status"]);
+      const cell = selectors.notebook.cellById(model, { id });
+      if (cell) {
+        executionCount = cell.get("execution_count", undefined);
+      }
     }
-  }
 
-  return {
-    status,
-    executionCount
+    return {
+      status,
+      executionCount
+    };
   };
+  return mapStateToProps;
 };
 
 export default connect<StateProps, void, ComponentProps, AppState>(

--- a/packages/stateful-components/src/inputs/prompt.tsx
+++ b/packages/stateful-components/src/inputs/prompt.tsx
@@ -53,5 +53,5 @@ const makeMapStateToProps = (
 };
 
 export default connect<StateProps, void, ComponentProps, AppState>(
-  mapStateToProps
+  makeMapStateToProps
 )(Prompt);

--- a/packages/stateful-components/src/inputs/prompt.tsx
+++ b/packages/stateful-components/src/inputs/prompt.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { connect } from "react-redux";
+
+import { ContentRef, AppState, selectors } from "@nteract/core";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+  children: React.ReactNode;
+}
+
+interface StateProps {
+  status?: string;
+  executionCount?: number;
+}
+
+export class Prompt extends React.Component<ComponentProps, StateProps> {
+  render() {
+    const { children } = this.props;
+    return (
+      <div className="nteract-cell-prompt">
+        {React.cloneElement(children, this.props)}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (
+  state: AppState,
+  ownProps: ComponentProps
+): StateProps => {
+  const { contentRef, id } = ownProps;
+  const model = selectors.model(state, { contentRef });
+
+  let status;
+  let executionCount;
+
+  if (model && model.type == "notebook") {
+    status = model.transient.getIn(["cellMap", id, "status"]);
+    const cell = selectors.notebook.cellById(model, { id });
+    if (cell) {
+      executionCount = cell.get("execution_count", undefined);
+    }
+  }
+
+  return {
+    status,
+    executionCount
+  };
+};
+
+export default connect<StateProps, void, ComponentProps, AppState>(
+  mapStateToProps
+)(Prompt);

--- a/packages/stateful-components/src/outputs/index.tsx
+++ b/packages/stateful-components/src/outputs/index.tsx
@@ -1,5 +1,5 @@
 import Immutable from "immutable";
-import React, { Component } from "react";
+import React from "react";
 import { connect } from "react-redux";
 
 import { selectors, AppState, ContentRef } from "@nteract/core";

--- a/packages/stateful-components/src/outputs/index.tsx
+++ b/packages/stateful-components/src/outputs/index.tsx
@@ -34,7 +34,7 @@ export class Outputs extends React.PureComponent<ComponentProps & StateProps> {
   }
 }
 
-const makeMapStateToProps = (
+export const makeMapStateToProps = (
   initialState: AppState,
   ownProps: ComponentProps
 ): ((state: AppState) => StateProps) => {

--- a/packages/stateful-components/src/outputs/index.tsx
+++ b/packages/stateful-components/src/outputs/index.tsx
@@ -1,0 +1,66 @@
+import Immutable from "immutable";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+
+import { selectors, AppState, ContentRef } from "@nteract/core";
+import { Output } from "@nteract/outputs";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+}
+
+interface StateProps {
+  hidden: boolean;
+  expanded: boolean;
+  outputs: Immutable.List<any>;
+}
+
+export class Outputs extends React.PureComponent<ComponentProps & StateProps> {
+  render() {
+    const { outputs, children, hidden, expanded } = this.props;
+    return (
+      <div
+        className={`nteract-outputs ${hidden && "hidden"} ${expanded &&
+          "expanded"}`}
+      >
+        {outputs.map((output, index) => (
+          <Output output={output} index={index}>
+            {children}
+          </Output>
+        ))}
+      </div>
+    );
+  }
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+): ((state: AppState) => StateProps) => {
+  const mapStateToProps = (state: AppState): StateProps => {
+    let outputs = Immutable.List();
+    let hidden = false;
+    let expanded = false;
+
+    const { contentRef, id } = ownProps;
+    const model = selectors.model(state, { contentRef });
+
+    if (model && model.type == "notebook") {
+      const cell = selectors.notebook.cellById(model, { id });
+      if (cell) {
+        outputs = cell.get("outputs", Immutable.List());
+        hidden =
+          cell.cell_type === "code" && cell.getIn(["metadata", "outputHidden"]);
+        expanded =
+          cell.cell_type === "code" &&
+          cell.getIn(["metadata", "outputExpanded"]);
+      }
+    }
+
+    return { outputs, hidden, expanded };
+  };
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps, null)(Outputs);

--- a/packages/stateful-components/src/outputs/input-prompts.tsx
+++ b/packages/stateful-components/src/outputs/input-prompts.tsx
@@ -1,0 +1,103 @@
+import Immutable from "immutable";
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import {
+  actions,
+  selectors,
+  ContentRef,
+  AppState,
+  InputRequestMessage
+} from "@nteract/core";
+
+interface ComponentProps {
+  contentRef: ContentRef;
+  id: string;
+}
+
+interface StateProps {
+  prompts: Immutable.List<InputRequestMessage>;
+}
+
+interface DispatchProps {
+  submitPromptReply: (value: string) => void;
+}
+
+interface State {
+  value: string;
+}
+
+type Props = ComponentProps & StateProps & DispatchProps;
+
+export class PromptRequest extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { value: "" };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmitPromptReply = this.handleSubmitPromptReply.bind(this);
+  }
+
+  handleSubmitPromptReply(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    this.props.submitPromptReply(this.state.value);
+  }
+
+  handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    this.setState({ value: event.target.value });
+  }
+
+  render() {
+    const { prompts } = this.props;
+    return (
+      <div>
+        {prompts.map(prompt => (
+          <form onSubmit={this.handleSubmitPromptReply}>
+            <label>{prompt.prompt}</label>
+            <input
+              type={prompt.password ? "password" : "text"}
+              value={this.state.value}
+              onChange={this.handleChange}
+            />
+            <input type="submit" />
+          </form>
+        ))}
+      </div>
+    );
+  }
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+): ((state: AppState) => StateProps) => {
+  const mapStateToProps = (state: AppState) => {
+    const { contentRef, id } = ownProps;
+    const model = selectors.model(state, { contentRef });
+    if (model && model.type == "notebook") {
+      const prompts = selectors.notebook.cellPromptsById(model, { id });
+      return { prompts };
+    }
+    return { prompts: Immutable.List() };
+  };
+  return mapStateToProps;
+};
+
+const makeMapDispatchToProps = (
+  initialDispatch: Dispatch,
+  ownProps: ComponentProps
+): ((dispatch: Dispatch) => DispatchProps) => {
+  const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
+    const { contentRef } = ownProps;
+    return {
+      submitPromptReply: (value: string) =>
+        dispatch(actions.sendInputReply({ value, contentRef }))
+    };
+  };
+  return mapDispatchToProps;
+};
+
+export default connect<StateProps, DispatchProps, ComponentProps, AppState>(
+  makeMapStateToProps,
+  makeMapDispatchToProps
+)(PromptRequest);

--- a/packages/stateful-components/src/outputs/pagers.tsx
+++ b/packages/stateful-components/src/outputs/pagers.tsx
@@ -1,0 +1,55 @@
+import Immutable from "immutable";
+import React from "react";
+import { connect } from "react-redux";
+
+import { selectors, AppState, ContentRef } from "@nteract/core";
+import { RichMedia } from "@nteract/outputs";
+
+interface ComponentProps {
+  id: string;
+  contentRef: ContentRef;
+  children: React.ReactNode;
+}
+
+interface StateProps {
+  pagers: Immutable.List<any>;
+}
+
+export class Pagers extends React.PureComponent<ComponentProps & StateProps> {
+  render() {
+    const { pagers, children } = this.props;
+    return (
+      <div className="nteract-pagers">
+        {pagers.map(pager => (
+          <RichMedia data={pager.data} metadata={pager.metadata}>
+            {children}
+          </RichMedia>
+        ))}
+      </div>
+    );
+  }
+}
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+): ((state: AppState) => StateProps) => {
+  const mapStateToProps = (state: AppState): StateProps => {
+    let pagers = Immutable.List();
+
+    const { contentRef, id } = ownProps;
+    const model = selectors.model(state, { contentRef });
+
+    if (model && model.type == "notebook") {
+      const cell = selectors.notebook.cellById(model, { id });
+      if (cell) {
+        pagers = model.getIn(["cellPagers", id]) || Immutable.List();
+      }
+    }
+
+    return { pagers };
+  };
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps, null)(Pagers);

--- a/packages/stateful-components/src/outputs/pagers.tsx
+++ b/packages/stateful-components/src/outputs/pagers.tsx
@@ -30,7 +30,7 @@ export class Pagers extends React.PureComponent<ComponentProps & StateProps> {
   }
 }
 
-const makeMapStateToProps = (
+export const makeMapStateToProps = (
   initialState: AppState,
   ownProps: ComponentProps
 ): ((state: AppState) => StateProps) => {
@@ -52,4 +52,6 @@ const makeMapStateToProps = (
   return mapStateToProps;
 };
 
-export default connect(makeMapStateToProps, null)(Pagers);
+export default connect<StateProps, void, ComponentProps, AppState>(
+  makeMapStateToProps
+)(Pagers);

--- a/packages/stateful-components/src/outputs/transform-media.tsx
+++ b/packages/stateful-components/src/outputs/transform-media.tsx
@@ -6,7 +6,6 @@ import { Dispatch } from "redux";
 import {
   ImmutableDisplayData,
   ImmutableExecuteResult,
-  ImmutableOutput,
   JSONObject
 } from "@nteract/commutable";
 import { actions, selectors, AppState, ContentRef } from "@nteract/core";
@@ -89,7 +88,7 @@ const makeMapStateToProps = (
   initialState: AppState,
   ownProps: ComponentProps
 ) => {
-  const { contentRef, index, id, output_type, output } = ownProps;
+  const { output_type, output } = ownProps;
 
   const memoizedMetadata = memoizeOne(immutableMetadata =>
     immutableMetadata ? immutableMetadata.toJS() : {}

--- a/packages/stateful-components/src/outputs/transform-media.tsx
+++ b/packages/stateful-components/src/outputs/transform-media.tsx
@@ -66,10 +66,10 @@ const PureTransformMedia = (
   );
 };
 
-const richestMediaType = (
+export const richestMediaType = (
   output: ImmutableExecuteResult | ImmutableDisplayData,
   order: Immutable.List<string>,
-  handlers: { [k: string]: any } | Immutable.Map<string, any>
+  handlers: Immutable.Map<string, any>
 ) => {
   const outputData = output.data;
 

--- a/packages/stateful-components/src/outputs/transform-media.tsx
+++ b/packages/stateful-components/src/outputs/transform-media.tsx
@@ -1,0 +1,170 @@
+import Immutable from "immutable";
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import {
+  ImmutableDisplayData,
+  ImmutableExecuteResult,
+  ImmutableOutput,
+  JSONObject
+} from "@nteract/commutable";
+import { actions, selectors, AppState, ContentRef } from "@nteract/core";
+
+import memoizeOne from "memoize-one";
+
+interface ComponentProps {
+  output_type: string;
+  id: string;
+  contentRef: ContentRef;
+  index: number;
+  output: any;
+}
+
+interface StateProps {
+  Media: React.ComponentType<any>;
+  mediaType?: string;
+  output?: ImmutableDisplayData | ImmutableExecuteResult;
+  data?: any;
+  metadata?: Immutable.Map<string, any>;
+  theme?: string;
+}
+
+interface DispatchProps {
+  mediaActions: {
+    onMetadataChange: (metadata: JSONObject, mediaType: string) => void;
+  };
+}
+
+const PureTransformMedia = (
+  props: ComponentProps & StateProps & DispatchProps
+) => {
+  const {
+    Media,
+    mediaActions,
+    mediaType,
+    data,
+    metadata,
+    theme,
+    contentRef,
+    id
+  } = props;
+
+  // If we had no valid result, return an empty output
+  if (!mediaType || !data) {
+    return null;
+  }
+
+  return (
+    <Media
+      {...mediaActions}
+      data={data}
+      metadata={metadata}
+      theme={theme}
+      contentRef={contentRef}
+      id={id}
+    />
+  );
+};
+
+const richestMediaType = (
+  output: ImmutableExecuteResult | ImmutableDisplayData,
+  order: Immutable.List<string>,
+  handlers: { [k: string]: any } | Immutable.Map<string, any>
+) => {
+  const outputData = output.data;
+
+  // Find the first mediaType in the output data that we support with a handler
+  const mediaType = order.find(key => {
+    return (
+      outputData.hasOwnProperty(key) &&
+      (handlers.hasOwnProperty(key) || handlers.get(key, false))
+    );
+  });
+
+  return mediaType;
+};
+
+const makeMapStateToProps = (
+  initialState: AppState,
+  ownProps: ComponentProps
+) => {
+  const { contentRef, index, id, output_type, output } = ownProps;
+
+  const memoizedMetadata = memoizeOne(immutableMetadata =>
+    immutableMetadata ? immutableMetadata.toJS() : {}
+  );
+
+  const mapStateToProps = (state: AppState): StateProps => {
+    // This component should only be used with display data and execute result
+    if (
+      !output ||
+      !(output_type === "display_data" || output_type === "execute_result")
+    ) {
+      console.warn(
+        "connected transform media managed to get a non media bundle output"
+      );
+      return {
+        Media: () => null
+      };
+    }
+
+    const handlers = selectors.transformsById(state);
+    const order = selectors.displayOrder(state);
+    const theme = selectors.userTheme(state);
+
+    const mediaType = richestMediaType(output, order, handlers);
+
+    if (mediaType) {
+      const metadata = memoizedMetadata(output.metadata.get(mediaType));
+      const data = output.data[mediaType];
+      const Media = selectors.transform(state, { id: mediaType });
+      return {
+        Media,
+        mediaType,
+        data,
+        metadata,
+        theme
+      };
+    }
+    return {
+      Media: () => null,
+      mediaType,
+      output,
+      theme
+    };
+  };
+  return mapStateToProps;
+};
+
+const makeMapDispatchToProps = (
+  initialDispath: Dispatch,
+  ownProps: ComponentProps
+) => {
+  const { id, contentRef, index } = ownProps;
+  const mapDispatchToProps = (dispatch: Dispatch) => {
+    return {
+      mediaActions: {
+        onMetadataChange: (metadata: JSONObject, mediaType: string) => {
+          dispatch(
+            actions.updateOutputMetadata({
+              id,
+              contentRef,
+              metadata,
+              index,
+              mediaType
+            })
+          );
+        }
+      }
+    };
+  };
+  return mapDispatchToProps;
+};
+
+const TransformMedia = connect(
+  makeMapStateToProps,
+  makeMapDispatchToProps
+)(PureTransformMedia);
+
+export default TransformMedia;

--- a/packages/stateful-components/tsconfig.json
+++ b/packages/stateful-components/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../messaging"
+    },
+    { "path": "../commutable" },
+    { "path": "../actions" },
+    { "path": "../selectors" },
+    { "path": "../types" },
+    { "path": "../rx-jupyter" }
+  ]
+}

--- a/packages/webpack-configurator/monorepo.js
+++ b/packages/webpack-configurator/monorepo.js
@@ -9,173 +9,203 @@
 module.exports = {
   lernaModules: [
     {
+      name: "@nteract/actions",
+      version: "2.9.0",
+      private: false
+    },
+    {
       name: "ansi-to-react",
-      version: "4.0.0-alpha.0",
+      version: "5.1.0",
       private: false
     },
     {
       name: "@nteract/commutable",
-      version: "6.0.0-alpha.0",
+      version: "7.1.4",
       private: false
     },
     {
       name: "@nteract/connected-components",
-      version: "5.0.0-alpha.0",
+      version: "6.7.0",
       private: false
     },
     {
       name: "@nteract/core",
-      version: "9.0.0-alpha.0",
+      version: "10.9.0",
+      private: false
+    },
+    {
+      name: "@nteract/data-explorer",
+      version: "7.1.6",
       private: false
     },
     {
       name: "@nteract/directory-listing",
-      version: "1.0.0-alpha.0",
+      version: "2.0.6",
       private: false
     },
     {
       name: "@nteract/dropdown-menu",
-      version: "0.5.7",
+      version: "1.0.1",
       private: false
     },
     {
       name: "@nteract/editor",
-      version: "8.0.0-alpha.0",
+      version: "9.3.2",
       private: false
     },
     {
       name: "enchannel-zmq-backend",
-      version: "8.0.0-alpha.0",
+      version: "9.1.7",
+      private: false
+    },
+    {
+      name: "@nteract/epics",
+      version: "2.9.0",
+      private: false
+    },
+    {
+      name: "@nteract/fixtures",
+      version: "2.2.6",
+      private: false
+    },
+    {
+      name: "@nteract/fs-kernels",
+      version: "2.1.7",
       private: false
     },
     {
       name: "fs-observable",
-      version: "3.0.2",
+      version: "4.0.0",
       private: false
     },
     {
       name: "@mybinder/host-cache",
-      version: "1.0.0-alpha.0",
+      version: "2.1.9",
       private: false
     },
     {
       name: "@nteract/iron-icons",
-      version: "0.2.5",
+      version: "1.0.0",
       private: false
     },
     {
       name: "@nteract/jupyter-widgets",
-      version: "1.0.0-alpha.0",
+      version: "4.3.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/logos",
-      version: "0.1.5",
+      version: "1.0.0",
       private: false
     },
     {
       name: "@nteract/markdown",
-      version: "3.0.1",
+      version: "4.2.0",
       private: false
     },
     {
       name: "@nteract/mathjax",
-      version: "3.0.1",
+      version: "4.0.1",
       private: false
     },
     {
       name: "@nteract/messaging",
-      version: "5.0.0-alpha.0",
+      version: "6.1.7",
       private: false
     },
     {
       name: "@nteract/monaco-editor",
-      version: "2.0.0-alpha.0",
+      version: "3.0.3",
       private: false
     },
     {
       name: "@nteract/notebook-app-component",
-      version: "4.0.0-alpha.0",
+      version: "6.0.1-alpha.0",
       private: false
     },
     {
       name: "@nteract/octicons",
-      version: "1.0.0-alpha.0",
+      version: "2.0.0",
       private: false
     },
     {
       name: "@nteract/outputs",
-      version: "1.0.0-alpha.0",
+      version: "2.6.0",
       private: false
     },
     {
       name: "@nteract/presentational-components",
-      version: "2.0.0-alpha.0",
+      version: "3.2.0",
+      private: false
+    },
+    {
+      name: "@nteract/reducers",
+      version: "2.8.0",
       private: false
     },
     {
       name: "rx-binder",
-      version: "3.0.0-alpha.0",
+      version: "4.0.2",
       private: false
     },
     {
       name: "rx-jupyter",
-      version: "4.0.0-alpha.0",
+      version: "5.4.4",
       private: false
     },
     {
       name: "@nteract/selectors",
+      version: "2.5.0",
+      private: false
+    },
+    {
+      name: "@nteract/stateful-components",
       version: "1.0.0",
       private: false
     },
     {
       name: "@nteract/styled-blueprintjsx",
-      version: "1.1.1",
+      version: "2.0.2",
       private: false
     },
     {
-      name: "@nteract/styleguide-components",
-      version: "0.1.4",
-      private: false
-    },
-    {
-      name: "@nteract/data-explorer",
-      version: "5.0.0-alpha.0",
+      name: "@nteract/styles",
+      version: "2.1.0",
       private: false
     },
     {
       name: "@nteract/transform-geojson",
-      version: "4.0.0-alpha.0",
+      version: "5.1.0",
       private: false
     },
     {
       name: "@nteract/transform-model-debug",
-      version: "4.0.0-alpha.0",
+      version: "5.0.1",
       private: false
     },
     {
       name: "@nteract/transform-plotly",
-      version: "4.0.0-alpha.0",
+      version: "6.0.0",
       private: false
     },
     {
       name: "@nteract/transform-vdom",
-      version: "3.0.0-alpha.0",
+      version: "4.0.3",
       private: false
     },
     {
       name: "@nteract/transform-vega",
-      version: "4.0.0-alpha.0",
+      version: "6.0.3",
       private: false
     },
     {
       name: "@nteract/types",
-      version: "1.0.0",
+      version: "4.4.1",
       private: false
     },
     {
       name: "@nteract/webpack-configurator",
-      version: "2.0.0-alpha.0",
+      version: "3.0.0",
       private: false
     }
   ]

--- a/packages/webpack-configurator/monorepo.js
+++ b/packages/webpack-configurator/monorepo.js
@@ -9,203 +9,178 @@
 module.exports = {
   lernaModules: [
     {
-      name: "@nteract/actions",
-      version: "2.9.0",
-      private: false
-    },
-    {
       name: "ansi-to-react",
-      version: "5.1.0",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/commutable",
-      version: "7.1.4",
+      version: "6.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/connected-components",
-      version: "6.7.0",
+      version: "5.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/core",
-      version: "10.9.0",
-      private: false
-    },
-    {
-      name: "@nteract/data-explorer",
-      version: "7.1.6",
+      version: "9.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/directory-listing",
-      version: "2.0.6",
+      version: "1.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/dropdown-menu",
-      version: "1.0.1",
+      version: "0.5.7",
       private: false
     },
     {
       name: "@nteract/editor",
-      version: "9.3.2",
+      version: "8.0.0-alpha.0",
       private: false
     },
     {
       name: "enchannel-zmq-backend",
-      version: "9.1.7",
-      private: false
-    },
-    {
-      name: "@nteract/epics",
-      version: "2.9.0",
-      private: false
-    },
-    {
-      name: "@nteract/fixtures",
-      version: "2.2.6",
-      private: false
-    },
-    {
-      name: "@nteract/fs-kernels",
-      version: "2.1.7",
+      version: "8.0.0-alpha.0",
       private: false
     },
     {
       name: "fs-observable",
-      version: "4.0.0",
+      version: "3.0.2",
       private: false
     },
     {
       name: "@mybinder/host-cache",
-      version: "2.1.9",
+      version: "1.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/iron-icons",
-      version: "1.0.0",
+      version: "0.2.5",
       private: false
     },
     {
       name: "@nteract/jupyter-widgets",
-      version: "4.3.0-alpha.0",
+      version: "1.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/logos",
-      version: "1.0.0",
+      version: "0.1.5",
       private: false
     },
     {
       name: "@nteract/markdown",
-      version: "4.2.0",
+      version: "3.0.1",
       private: false
     },
     {
       name: "@nteract/mathjax",
-      version: "4.0.1",
+      version: "3.0.1",
       private: false
     },
     {
       name: "@nteract/messaging",
-      version: "6.1.7",
+      version: "5.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/monaco-editor",
-      version: "3.0.3",
+      version: "2.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/notebook-app-component",
-      version: "6.0.1-alpha.0",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/octicons",
-      version: "2.0.0",
+      version: "1.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/outputs",
-      version: "2.6.0",
+      version: "1.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/presentational-components",
-      version: "3.2.0",
-      private: false
-    },
-    {
-      name: "@nteract/reducers",
-      version: "2.8.0",
+      version: "2.0.0-alpha.0",
       private: false
     },
     {
       name: "rx-binder",
-      version: "4.0.2",
+      version: "3.0.0-alpha.0",
       private: false
     },
     {
       name: "rx-jupyter",
-      version: "5.4.4",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/selectors",
-      version: "2.5.0",
-      private: false
-    },
-    {
-      name: "@nteract/stateful-components",
       version: "1.0.0",
       private: false
     },
     {
       name: "@nteract/styled-blueprintjsx",
-      version: "2.0.2",
+      version: "1.1.1",
       private: false
     },
     {
-      name: "@nteract/styles",
-      version: "2.1.0",
+      name: "@nteract/styleguide-components",
+      version: "0.1.4",
+      private: false
+    },
+    {
+      name: "@nteract/data-explorer",
+      version: "5.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/transform-geojson",
-      version: "5.1.0",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/transform-model-debug",
-      version: "5.0.1",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/transform-plotly",
-      version: "6.0.0",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/transform-vdom",
-      version: "4.0.3",
+      version: "3.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/transform-vega",
-      version: "6.0.3",
+      version: "4.0.0-alpha.0",
       private: false
     },
     {
       name: "@nteract/types",
-      version: "4.4.1",
+      version: "1.0.0",
       private: false
     },
     {
       name: "@nteract/webpack-configurator",
-      version: "3.0.0",
+      version: "2.0.0-alpha.0",
+      private: false
+    },
+    {
+      name: "@nteract/stateful-components",
+      version: "1.0.0",
       private: false
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -11984,6 +11984,14 @@ redux@^4.0.0, redux@^4.0.1:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
 
+redux@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
+  integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
+
 refractor@^2.4.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.6.2.tgz#8e0877ab8864165275aafeea5d9c8eebe871552f"


### PR DESCRIPTION
This PR lays the groundwork for work around @nteract/stateful-componetns as outlined in https://github.com/nteract/nteract/issues/4696.

Namely, it does the following:
- Decomposes the elements that were previously in @nteract/notebook-app-component into their own individual bits
- Provides an interface for accessing React components that aren't connect to Redux
- Provides a set of exported connected components that developers can use out of the box
- Removes the assumptions about styles to pave the way for a more sensible theming story

This is a big PR, so I'm gonna go ahead and post comments inline as notation.

Some work still remains here, in particular:
- Adding the CellToolbar component to the CodeCell and MarkdownCell components
- Adding an InputPrompt component
- Adding more docs about the different ways this can be leveraged

I figure this is good to go in with the code, tests, and docs that exist in the moment and we can continue building.