### PR TITLE
Fix pasting cells also pasting text

### DIFF
--- a/applications/desktop/src/main/menu.ts
+++ b/applications/desktop/src/main/menu.ts
@@ -6,7 +6,9 @@ import {
   BrowserWindow,
   dialog,
   FileFilter,
+  globalShortcut,
   Menu,
+  MenuItemConstructorOptions,
   shell,
   WebContents
 } from "electron";
@@ -440,6 +442,23 @@ export function loadFullMenu(store = global.store) {
       }
     ]
   };
+
+  // Pasting cells will also paste text, so we need to intercept the event with
+  // a global shortcut and then only trigger the IPC call.
+  function interceptAcceleratorAndForceOnlyMenuAction(
+    item: MenuItemConstructorOptions,
+  ): void {
+    globalShortcut.register(item.accelerator!, () => {
+      const focusedWindow = BrowserWindow.getFocusedWindow();
+      if (focusedWindow) { (item.click as Sender)({}, focusedWindow) }
+    });
+  }
+
+  const pasteCell = edit.submenu.find(
+    each => each.label === "Paste Cell"
+  ) as MenuItemConstructorOptions;
+
+  interceptAcceleratorAndForceOnlyMenuAction(pasteCell);
 
   const cell = {
     label: "Cell",


### PR DESCRIPTION
Fixes #3407.

After several tries to intercept the event in the editor, all of which didn't work out, I decided to intercept the accelerator globally and then just trigger the menu item.