### PR TITLE
Add initial docs for @nteract/stateful-components

### DIFF
--- a/packages/stateful-components/__docs__/extensibility.md
+++ b/packages/stateful-components/__docs__/extensibility.md
@@ -1,0 +1,70 @@
+# Extending your notebook UI with @nteract/stateful-components
+
+This suite of React components provides several points of extensibility for the UI. This document covers them here.
+
+## Extending editors
+
+nteract ships with the CodeMirror editor in its desktop and Jupyter extensions. However, you might want to use an alternative editor in your own notebook based UI. To add your own editor to the nteract UI, create a React component that encompasses the editor.
+
+```
+class MyCoolEditor extends React.Component {
+    static defaultProps = {
+        editorType = "myeditor"
+    }
+
+    render() {
+        return <textarea/>
+    }
+}
+```
+
+The `editorType` default prop is important here. The `editorType` is used to select between different types of editors.
+
+```
+import { Editor } from "@nteract/stateful-components"
+import CodeMirrorEditor from "@nteract/editor"
+import MyCoolEditor from "./my-cool-editor";
+
+class Editor extends React.Component {
+    render() {
+        return <Editor id={cellId} contentRef={contentRef}>
+            <CodeMirrorEditor />
+            <MyCoolEditor />
+        </Editor>;
+    }
+}
+```
+
+The `Editor` stateful component take a `cellId` and a `contentRef`, extracts the relevant state properties from the state, and passes them to the child editors.
+
+## Extending Cells
+
+The @nteract/stateful-components package ships with a default set of implementations for different types of cells: markdown, code, and raw. How do you go about adding your own set of cells?
+
+You can override the children of the `Cells` component and render your own custom `Cell` components for each cell_type. For example, to override the default `MarkdownCell`, you can do the following.
+
+```
+import { Cells, CodeCell, RawCell } from "@nteract/stateful-components"
+
+class MarkdownCell extends React.Component {
+    static defaultProps = {
+        cell_type: "markdown"
+    }
+
+    render() {
+        return <p>{this.props.value}</p>;
+    }
+}
+
+class MyCells extends React.Component {
+    render() {
+        return <Cells>
+            <MarkdownCell id={cellId} contentRef={contentRef}/>
+            <CodeCell id={cellId} contentRef={contentRef}/>
+            <RawCell id={cellId} contentRef={contentRef}/>
+        </Cells>
+    }
+}
+```
+
+Similar to the pattern for creating configurable editors, configurable cells require that a `cell_type` prop exist on the child component that matches the `cell_type` the component is intended to render.

--- a/packages/stateful-components/__docs__/overview.md
+++ b/packages/stateful-components/__docs__/overview.md
@@ -1,0 +1,25 @@
+# @nteract/stateful-components Overview
+
+The @nteract/stateful-components package exports a set of React components that are connected to the Redux and an unconnected set of components.
+
+## Using stateful-components with the nteract core SDK
+
+If you're building a notebook-based application using the nteract core SDK, you can use the connected components to render different components within a notebook, such as Cells and Outputs using the data that is stored in the Redux store.
+
+These connected components are designed to work with the Redux state model that the nteract core SDK uses. In short, it expects that certain properties are stored in particular locations within the Redux subtree.
+
+To use the connected components, you can import each of the components from the `@nteract/stateful-components` package as needed.
+
+```
+import { CodeCell } from "@nteract/stateful-components";
+
+class MyApp extends React.Component {
+    render() {
+        return <CodeCell contentRef={contentRef} id={cellId}>;
+    }
+}
+```
+
+As you can see from the example above, the connected `CodeCell` component expects to receive a `contentRef` and an `id`. The `conntetRef` is a unique ID that is used to refer to the model of a particular notebook in the nteract core Redux state. The `id` is the cell ID that references the cell as it is stored in the nteract core Redux state.
+
+All the connected components expect either a `contentRef` or a `id`. These two pieces of information are used to resolve the correct data from the Redux state and pass it to the component.

--- a/packages/stateful-components/__docs__/styling.md
+++ b/packages/stateful-components/__docs__/styling.md
@@ -1,0 +1,42 @@
+# Styling UIs built with @nteract/stateful-components
+
+NOTE: Styling support for @nteract/stateful-component is in-progress.
+
+nteract's stateful components are unstyled by default. That's right -- a beautiful blank canvas for you to paint your own experience to.
+
+You can style stateful components using either CSS-in-JS modules like styled-components or via stylesheets.
+
+## Styling with styled-components
+
+To style individual components with `styled-components` you can import them individually and style them as needed.
+
+```
+import { CodeCell } from "@nteract/stateful-components";
+import styled from "styled-components";
+
+const StyledCodeCell = styled(CodeCell)`
+    // your styles are here
+`
+```
+
+Alternativelly, you can style the pre-built `Notebook` component with styled-components and use class names to target individual components.
+
+```
+import { Notebook } from "@nteract/stateful-components"
+
+const StyledNotebook = styled(Notebook)`
+    .nteract-code-cells {
+        background-color: blue;
+    }
+`
+```
+
+## Styling with stylesheets
+
+To style with stylesheets, you can use element and combinator-based CSS selectors to desire styled elements as you wish.
+
+The following table outlines each stateful component, its CSS classname, and other CSS classes that can be conditionally applied to it.
+
+| Component | Class Name | Other Class Names |
+| Prompt | | `.nteract-prompt-component` | |
+| Output | `.nteract-output-component` | `.hidden .expanded` |


### PR DESCRIPTION
Some `__docs__` content.

I'm trying to see if we can push the limits of react-styleguidist and use that for our tutorial-based docs.