### PR TITLE
include the wire protocol in our messaging lib

### DIFF
--- a/packages/messaging/__tests__/wire-protocol-spec.ts
+++ b/packages/messaging/__tests__/wire-protocol-spec.ts
@@ -1,0 +1,133 @@
+import { decode, encode } from "../src/wire-protocol";
+
+import { MessageType, JupyterMessageHeader } from "../src/types";
+
+const convertToWireBuffer = el =>
+  typeof el === "string" ? Buffer.from(el) : Buffer.from(JSON.stringify(el));
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toEqualMessageFrames(actuals: Array<string | Buffer | Object>): R;
+    }
+  }
+}
+
+expect.extend({
+  toEqualMessageFrames(
+    receiveds: Buffer[],
+    actuals: Array<string | Buffer | Object>
+  ) {
+    for (var i = 0; i < receiveds.length; i++) {
+      const received = receiveds[i];
+      const actual = actuals[i];
+
+      // Normalize the actual to a buffer to match the received
+      const normalizedActual = Buffer.isBuffer(actual)
+        ? actual
+        : typeof actual === "string"
+        ? Buffer.from(actual)
+        : Buffer.from(JSON.stringify(actual));
+
+      const pass = Buffer.compare(received, normalizedActual) === 0;
+
+      if (!pass) {
+        return {
+          message: () =>
+            `expected ${received.toString()} to equal ${normalizedActual.toString()} in position ${i}`,
+          pass
+        };
+      }
+    }
+
+    return {
+      pass: true,
+      message: () => `expected message frames to be the same`
+    };
+  }
+});
+
+test("encode", () => {
+  const message = {
+    parent_header: ({ msg_type: "fake" } as unknown) as JupyterMessageHeader,
+    header: {
+      msg_type: "display_data" as MessageType,
+      msg_id: "0000",
+      username: "jovyan",
+      date: "2019-12-09T22:30:13.447Z",
+      version: "54",
+      session: "1111"
+    } as JupyterMessageHeader,
+    content: { y: 3 },
+    metadata: { x: 2 }
+  };
+
+  expect(encode(message)).toEqualMessageFrames([
+    "<IDS|MSG>",
+    // HMAC signature
+    "",
+    // Header
+    {
+      msg_type: "display_data",
+      msg_id: "0000",
+      username: "jovyan",
+      date: "2019-12-09T22:30:13.447Z",
+      version: "54",
+      session: "1111"
+    },
+    // Parent Header
+    { msg_type: "fake" },
+    // Metadata
+    { x: 2 },
+    // Content
+    { y: 3 }
+  ]);
+
+  expect(encode(message, "secretkey")).toEqualMessageFrames([
+    "<IDS|MSG>",
+    // HMAC signature of the content below
+    "0d2f2106fa48fed22402ab0a009d5c0dd62155ba0a02e7c21bf9c5ee4670b635",
+    // Header
+    {
+      msg_type: "display_data",
+      msg_id: "0000",
+      username: "jovyan",
+      date: "2019-12-09T22:30:13.447Z",
+      version: "54",
+      session: "1111"
+    },
+    // Parent Header
+    { msg_type: "fake" },
+    // Metadata
+    { x: 2 },
+    // Content
+    { y: 3 }
+  ]);
+});
+
+test("decode", () => {
+  const encodedMessage = [
+    "<IDS|MSG>",
+    // HMAC signature of the content below
+    "0d2f2106fa48fed22402ab0a009d5c0dd62155ba0a02e7c21bf9c5ee4670b635",
+    // Header
+    { msg_type: "protocol_test" },
+    // Parent Header
+    { msg_type: "fake" },
+    // Metadata
+    { x: 2 },
+    // Content
+    { y: 3 }
+  ].map(el =>
+    typeof el === "string" ? Buffer.from(el) : Buffer.from(JSON.stringify(el))
+  );
+
+  expect(decode(encodedMessage)).toEqual({
+    parent_header: { msg_type: "fake" },
+    header: { msg_type: "protocol_test" },
+    content: { y: 3 },
+    metadata: { x: 2 },
+    buffers: [],
+    idents: []
+  });
+});

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -266,3 +266,7 @@ export const inputRequests = () => (source: Observable<JupyterMessage>) =>
   );
 
 export * from "./messages";
+
+import { encode, decode } from "./wire-protocol";
+
+export const wireProtocol = { encode, decode };

--- a/packages/messaging/src/wire-protocol.ts
+++ b/packages/messaging/src/wire-protocol.ts
@@ -1,0 +1,175 @@
+const crypt = require("crypto");
+
+import { JupyterMessageHeader, MessageType } from "./types";
+
+const WIRE_PROTOCOL_DELIMITER = "<IDS|MSG>";
+
+// There must be at least 5 frames after the delimiter:
+// HMAC signature, serialized header, serialized parent header,
+// serialized metadata, serialized content
+const REQUIRED_NUMBER_OF_MESSAGE_FRAMES = 5;
+
+function toJSON(value: any) {
+  return JSON.parse(value.toString());
+}
+
+export interface RawJupyterMessage<
+  MT extends MessageType = MessageType,
+  C = any
+> {
+  header: JupyterMessageHeader<MT>;
+  parent_header:
+    | JupyterMessageHeader<any>
+    | {
+        msg_id?: string;
+      };
+  metadata: object;
+  content: C;
+  buffers: Array<Buffer>;
+  idents: Array<Buffer>;
+}
+
+function initializeMessage(
+  _message: Partial<RawJupyterMessage>
+): RawJupyterMessage {
+  const message = Object.assign(
+    {},
+    {
+      header: {},
+      parent_header: {},
+      metadata: {},
+      content: {},
+      idents: [],
+      buffers: []
+    },
+    _message
+  );
+
+  return message;
+}
+
+/**
+ * Convert from Pythonic HMAC scheme string to node.js compatible name.
+ *
+ * Only support sha256 at the moment, which is all Jupyter uses nowadays anyhow.
+ *
+ * @param _scheme Examples: "hmac-sha256", "sha256"
+ */
+function identifyHMACScheme(_scheme: string) {
+  let scheme = _scheme;
+  switch (_scheme) {
+    case "hmac-sha256":
+      scheme = "sha256";
+      break;
+  }
+
+  return scheme;
+}
+
+/**
+ * Convert raw message frames from a Jupyter ZeroMQ connection to the object based JupyterMessage format
+ *
+ * @param messageFrames individual components of a message
+ * @param _scheme only sha256 is supported at the moment
+ * @param key HMAC key for frames 2+
+ */
+export function decode(
+  messageFrames: Array<Buffer>,
+  key?: string,
+  _scheme = "sha256"
+): RawJupyterMessage {
+  var i = 0;
+  const idents = [];
+  for (i = 0; i < messageFrames.length; i++) {
+    var frame = messageFrames[i];
+    if (frame.toString() === WIRE_PROTOCOL_DELIMITER) {
+      break;
+    }
+    idents.push(frame);
+  }
+
+  if (messageFrames.length - i < REQUIRED_NUMBER_OF_MESSAGE_FRAMES) {
+    throw new Error("Message Decoding: Not enough message frames");
+  }
+
+  if (messageFrames[i].toString() !== WIRE_PROTOCOL_DELIMITER) {
+    throw new Error("Message Decoding: Missing delimiter");
+  }
+
+  if (key) {
+    const scheme = identifyHMACScheme(_scheme);
+    var obtainedSignature = messageFrames[i + 1].toString();
+
+    var hmac = crypt.createHmac(scheme, key);
+    hmac.update(messageFrames[i + 2]);
+    hmac.update(messageFrames[i + 3]);
+    hmac.update(messageFrames[i + 4]);
+    hmac.update(messageFrames[i + 5]);
+    var expectedSignature = hmac.digest("hex");
+
+    if (expectedSignature !== obtainedSignature) {
+      throw new Error(`Message Decoding: Incorrect;
+Obtained "${obtainedSignature}"
+Expected "${expectedSignature}"`);
+    }
+  }
+
+  var message = initializeMessage({
+    idents: idents,
+    header: toJSON(messageFrames[i + 2]),
+    parent_header: toJSON(messageFrames[i + 3]),
+    content: toJSON(messageFrames[i + 5]),
+    metadata: toJSON(messageFrames[i + 4]),
+    buffers: Array.prototype.slice.apply(messageFrames, [i + 6])
+  });
+
+  return message;
+}
+
+/**
+ * Convert from the object based jupyter message to raw message frames
+ */
+export function encode(
+  _message: Partial<RawJupyterMessage>,
+  key?: string,
+  _scheme = "sha256"
+) {
+  // Ensure defaults are set for the message
+  const message = initializeMessage(_message);
+
+  const scheme = identifyHMACScheme(_scheme);
+
+  const idents = message.idents;
+
+  const header = Buffer.from(JSON.stringify(message.header), "utf-8");
+  const parent_header = Buffer.from(
+    JSON.stringify(message.parent_header),
+    "utf-8"
+  );
+  const metadata = Buffer.from(JSON.stringify(message.metadata), "utf-8");
+  const content = Buffer.from(JSON.stringify(message.content), "utf-8");
+
+  let signature = "";
+  if (key) {
+    const hmac = crypt.createHmac(scheme, key);
+    hmac.update(header);
+    hmac.update(parent_header);
+    hmac.update(metadata);
+    hmac.update(content);
+    signature = hmac.digest("hex");
+  }
+
+  var response = idents
+    .concat([
+      // idents
+      Buffer.from(WIRE_PROTOCOL_DELIMITER), // delimiter
+      Buffer.from(signature), // HMAC signature
+      header, // header
+      parent_header, // parent header
+      metadata, // metadata
+      content // content
+    ])
+    .concat(message.buffers);
+
+  return response;
+}


### PR DESCRIPTION
This brings the wire protocol over to nteract as individual functions, with an `encode` and a `decode`. I wrote this code untyped originally within https://github.com/rgbkrk/trying-out-new-zeromq-with-jupyter.

~~One thing to possibly be wary of -- I'm not sure if my `require('crypto')` will impact builds of the frontend. You would hope that webpack will tree shake that right on out of there.~~ We're all set on this front.

* [x] Fully type
* [x] Test it all!
* [x] Determine if this impacts the frontend build(s)

-------

The main motivation here is to get us off of `jmp` and onto a library we control for the pretty simple use case of encoding and decoding wire protocol messages in node.js


```js
const message = encode(executeRequest(`print("hello")`));
const reply = decode(await shell_socket.send(message));
```

My follow on PR to this will be the `async` `await`-able ZeroMQ sockets we can incorporate in the desktop app.