### PR TITLE
Upgrade typescript 3.2.2 -> 3.7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ junit.xml
 
 # ignore notebooks created while running dev copy of the desktop app
 applications/desktop/*.ipynb
+
+# Typescript incremental build data
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
     "tslint-react-a11y": "^1.0.0",
     "tslint-react-perf": "^0.3.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.2.2",
+    "typescript": "^3.7.3",
     "typescript-styled-plugin": "^0.15.0",
     "typescript-tslint-plugin": "^0.5.0",
     "unified": "^8.0.0",

--- a/packages/data-explorer/src/charts/bar.tsx
+++ b/packages/data-explorer/src/charts/bar.tsx
@@ -149,7 +149,7 @@ export const semioticBarChart = (
         return (
           <TooltipContent x={hoveredDatapoint.x} y={hoveredDatapoint.y}>
             <div
-              style={{ heightMax: "300px", display: "flex", flexWrap: "wrap" }}
+              style={{ maxHeight: "300px", display: "flex", flexWrap: "wrap" }}
             >
               {combinedOptions.map((dim: { name: string }, index: number) => (
                 <div

--- a/packages/editor/src/mode/ipython.ts
+++ b/packages/editor/src/mode/ipython.ts
@@ -20,7 +20,6 @@ CodeMirror.defineMode(
     });
     return CodeMirror.getMode(conf, ipythonConf);
   },
-  "python"
 );
 
 // @ts-ignore

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -237,7 +237,7 @@ export const payloads = () => (
   source.pipe(
     ofMessageType("execute_reply"),
     map(entry => entry.content.payload),
-    filter(Boolean),
+    filter(p => !!p),
     mergeMap(p => from(p))
   );
 

--- a/packages/reducers/src/core/entities/kernels.ts
+++ b/packages/reducers/src/core/entities/kernels.ts
@@ -17,7 +17,7 @@ import { combineReducers } from "redux-immutable";
 // TODO: we need to clean up references to old kernels at some point. Listening
 // for KILL_KERNEL_SUCCESSFUL seems like a good candidate, but I think you can
 // also end up with a dead kernel if that fails and you hit KILL_KERNEL_FAILED.
-const byRef = (state = Map(), action: Action): Map<{}, {}> => {
+const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
   let typedAction;
   switch (action.type) {
     case actionTypes.SET_LANGUAGE_INFO:
@@ -131,7 +131,7 @@ const byRef = (state = Map(), action: Action): Map<{}, {}> => {
 
 export const kernels: Reducer<
   {
-    byRef: Map<{}, {}>;
+    byRef: Map<unknown, unknown>;
   },
   Action<any>
 > = combineReducers({ byRef }, makeKernelsRecord as any);

--- a/packages/reducers/src/core/entities/kernelspecs.ts
+++ b/packages/reducers/src/core/entities/kernelspecs.ts
@@ -9,7 +9,7 @@ import { List, Map } from "immutable";
 import { Action, Reducer } from "redux";
 import { combineReducers } from "redux-immutable";
 
-const byRef = (state = Map(), action: Action): Map<{}, {}> => {
+const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
   const typedAction = action as actionTypes.FetchKernelspecsFulfilled;
   switch (action.type) {
     case actionTypes.FETCH_KERNELSPECS_FULFILLED:
@@ -46,7 +46,7 @@ const refs = (state = List(), action: Action): List<any> => {
 
 export const kernelspecs: Reducer<
   {
-    byRef: Map<{}, {}>;
+    byRef: Map<unknown, unknown>;
     refs: List<any>;
   },
   Action<any>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14209,10 +14209,10 @@ typescript@3.5.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@^3.2.2:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+typescript@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
Upgrade typescript to 3.7.3 (latest).

This is required for compatibility with current vega* packages, as they are using newer features in their type definitions.

I chose to upgrade to latest instead of minimally for future compatibility with other projects using newer features; i. e. if we make bigger upgrade jumps, we will have to make fewer of them.