### PR TITLE
Clean up the ipython-mode a bit

### DIFF
--- a/packages/editor/src/mode/ipython.ts
+++ b/packages/editor/src/mode/ipython.ts
@@ -1,5 +1,5 @@
 // https://github.com/nteract/nteract/issues/389
-import CodeMirror, { EditorConfiguration, Mode } from "codemirror";
+import CodeMirror from "codemirror";
 
 import "codemirror/mode/meta";
 import "codemirror/mode/python/python";

--- a/packages/editor/src/mode/ipython.ts
+++ b/packages/editor/src/mode/ipython.ts
@@ -4,16 +4,12 @@ import CodeMirror, { EditorConfiguration, Mode } from "codemirror";
 import "codemirror/mode/meta";
 import "codemirror/mode/python/python";
 
-// The TypeScript definitions are missing these versions
-// of the codemirror define* functions that IPython uses for
-// highlighting magics
-// @ts-ignore
 CodeMirror.defineMode(
   "ipython",
-  (conf: EditorConfiguration, parserConf: any): Mode<any> => {
+  (conf, parserConf) => {
     const ipythonConf = Object.assign({}, parserConf, {
       name: "python",
-      singleOperators: new RegExp("^[\\+\\-\\*/%&|@\\^~<>!\\?]"),
+      singleOperators: new RegExp("^[+\\-*/%&|@^~<>!?]"),
       identifiers: new RegExp(
         "^[_A-Za-z\u00A1-\uFFFF][_A-Za-z0-9\u00A1-\uFFFF]*"
       ) // Technically Python3
@@ -22,5 +18,4 @@ CodeMirror.defineMode(
   },
 );
 
-// @ts-ignore
 CodeMirror.defineMIME("text/x-ipython", "ipython");


### PR DESCRIPTION
We're no longer using the deprecated version of `defineMode()`, so we can use type checking, which makes the comments outdated and allows types to be inferred. Also fixes warnings about unnecessary escapes.