### PR TITLE
Adds aria-expanded on Toolbar for screen reader support

### DIFF
--- a/packages/dropdown-menu/__tests__/index.spec.tsx
+++ b/packages/dropdown-menu/__tests__/index.spec.tsx
@@ -92,4 +92,22 @@ describe("DropdownMenu", () => {
     expect(wrapper.find(".alsoClickMe").length).toEqual(0);
     expect(toJSON(wrapper)).toMatchSnapshot();
   });
+  test("clicking dropdown trigger onDisplayChanged", () => {
+    const expandedChanged = jest.fn();
+    const exampleDropdown = (
+      <DropdownMenu onDisplayChanged={expandedChanged}>
+        <DropdownTrigger>
+          <div className="clickMe">Click me</div>
+        </DropdownTrigger>
+        <DropdownContent>
+          <li>1</li>
+        </DropdownContent>
+      </DropdownMenu>
+    );
+    const wrapper = mount(exampleDropdown);
+    wrapper.find(".clickMe").simulate("click");
+    setTimeout(() => {
+      expect(expandedChanged.mock.calls.length).toBe(1);
+    }, 1000);
+  });
 });

--- a/packages/dropdown-menu/src/index.tsx
+++ b/packages/dropdown-menu/src/index.tsx
@@ -9,6 +9,7 @@ import { areComponentsEqual } from "react-hot-loader";
 import styled from "styled-components";
 
 interface DropdownMenuProps {
+  onDisplayChanged?: (isExpanded: boolean) => void;
   children: React.ReactNode;
 }
 
@@ -35,6 +36,19 @@ export class DropdownMenu extends React.PureComponent<
       menuHidden: true
     };
   }
+
+  componentDidUpdate(
+    prevProps: DropdownMenuProps,
+    prevState: DropdownMenuState
+  ) {
+    if (
+      prevState.menuHidden !== this.state.menuHidden &&
+      this.props.onDisplayChanged
+    ) {
+      this.props.onDisplayChanged(!this.state.menuHidden);
+    }
+  }
+
   handleKeyUp = (ev: React.KeyboardEvent<HTMLElement>) => {
     if (!this.state.menuHidden) {
       if (ev.key === "Escape") {

--- a/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
+++ b/packages/notebook-app-component/__tests__/__snapshots__/toolbar.spec.tsx.snap
@@ -172,7 +172,9 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
                   </Component>
                 </span>
               </button>
-              <DropdownMenu>
+              <DropdownMenu
+                onDisplayChanged={[Function]}
+              >
                 <DropdownDiv
                   onKeyUp={[Function]}
                 >
@@ -251,6 +253,7 @@ exports[`Toolbar View should be able to render a toolbar 1`] = `
                               onClick={[Function]}
                             >
                               <button
+                                aria-expanded={false}
                                 title="show additional actions"
                               >
                                 <span
@@ -523,7 +526,9 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
                   </Component>
                 </span>
               </button>
-              <DropdownMenu>
+              <DropdownMenu
+                onDisplayChanged={[Function]}
+              >
                 <DropdownDiv
                   onKeyUp={[Function]}
                 >
@@ -602,6 +607,7 @@ exports[`Toolbar View should be able to render a toolbar 2`] = `
                               onClick={[Function]}
                             >
                               <button
+                                aria-expanded={true}
                                 title="show additional actions"
                               >
                                 <span

--- a/packages/notebook-app-component/src/toolbar.tsx
+++ b/packages/notebook-app-component/src/toolbar.tsx
@@ -33,6 +33,10 @@ export interface PureToolbarProps {
   sourceHidden: boolean;
 }
 
+interface PureToolbarState {
+  moreActionsMenuExpanded: boolean;
+}
+
 export const CellToolbar = styled.div`
   background-color: var(--theme-cell-toolbar-bg);
   opacity: 0.4;
@@ -114,10 +118,18 @@ export const CellToolbarMask = styled.div.attrs<CellToolbarMaskProps>(
                           focus/hide the toolbar before they get there */
 ` as StyledComponent<"div", any, CellToolbarMaskProps, never>;
 
-export class PureToolbar extends React.PureComponent<PureToolbarProps> {
+export class PureToolbar extends React.PureComponent<
+  PureToolbarProps,
+  PureToolbarState
+> {
   static defaultProps: Partial<PureToolbarProps> = {
     type: "code"
   };
+
+  constructor(props: PureToolbarProps) {
+    super(props);
+    this.state = { moreActionsMenuExpanded: false };
+  }
 
   render(): JSX.Element {
     const { executeCell, deleteCell, sourceHidden } = this.props;
@@ -139,9 +151,16 @@ export class PureToolbar extends React.PureComponent<PureToolbarProps> {
               </span>
             </button>
           )}
-          <DropdownMenu>
+          <DropdownMenu
+            onDisplayChanged={(expanded: boolean) => {
+              this.setState({ moreActionsMenuExpanded: expanded });
+            }}
+          >
             <DropdownTrigger>
-              <button title="show additional actions">
+              <button
+                title="show additional actions"
+                aria-expanded={this.state.moreActionsMenuExpanded}
+              >
                 <span className="octicon toggle-menu">
                   <ChevronDownOcticon />
                 </span>


### PR DESCRIPTION
This changes aria-expanded on the dropdown menu in Toolbar to support narrator. This wasn't done for all dropdown menus because that would require being opinionated about what goes in the DropdownTrigger (aria-expanded needs to be added to the button itself, a containing div will not work)

![temp](https://user-images.githubusercontent.com/55718965/70585278-97801300-1b78-11ea-9687-44b7dc64f06b.gif)
