### PR TITLE
Fixes `hidden` attribute default value

### DIFF
--- a/packages/presentational-components/src/components/input.md
+++ b/packages/presentational-components/src/components/input.md
@@ -5,7 +5,7 @@ The `Input` component is a container component that serves as a container for th
 import { Input } from "@nteract/presentational-components"
 ```
 
-The `Input` component provides a `hidden` prop which you can use to dictate whether or not the children of the container are rendered. The default value is set to `true`, so you'll see the text "You can see this." rendered here.
+The `Input` component provides a `hidden` prop which you can use to dictate whether or not the children of the container are rendered. The default value is set to `false`, so you'll see the text "You can see this." rendered here.
 
 ```
 <Input>
@@ -13,7 +13,7 @@ You can see this.
 </ Input>
 ```
 
-You can also set the prop to `true` to hide all children. Take a look at the code for the component below to see how.
+You can also set the `hidden` prop to `true` to hide all children. Take a look at the code for the component below to see how.
 
 ```
 <Input hidden={true}>


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

The documentation indicates that the default value for the `Input` component's `hidden` attribute was `true`, but then in a later paragraph said that you can also set it to true. I'm assuming from context that the actual default value for that attribute is `false`, so I've made a correction. I also tried to make it more clear which attribute is being talked about in the paragraph where it's mentioned that the value can be set to `true`. This is something that I was confused about because the attribute did not appear in the previous code sample.
