### PR TITLE
Extract display name from kernelspec in status bar

### DIFF
--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -114,7 +114,6 @@ const makeMapStateToProps = (
       const kernelspec = selectors.kernelspecByName(state, {
         name: kernel.kernelSpecName
       });
-      console.log(kernelspec);
       kernelSpecDisplayName = kernelspec
         ? kernelspec.displayName
         : kernel.kernelSpecName;

--- a/packages/notebook-app-component/src/status-bar.tsx
+++ b/packages/notebook-app-component/src/status-bar.tsx
@@ -107,13 +107,17 @@ const makeMapStateToProps = (
     const kernelStatus =
       kernel != null && kernel.status != null ? kernel.status : NOT_CONNECTED;
 
-    // TODO: We need kernels associated to the kernelspec they came from
-    //       so we can pluck off the display_name and provide it here
     let kernelSpecDisplayName = " ";
     if (kernelStatus === NOT_CONNECTED) {
       kernelSpecDisplayName = "no kernel";
     } else if (kernel != null && kernel.kernelSpecName != null) {
-      kernelSpecDisplayName = kernel.kernelSpecName;
+      const kernelspec = selectors.kernelspecByName(state, {
+        name: kernel.kernelSpecName
+      });
+      console.log(kernelspec);
+      kernelSpecDisplayName = kernelspec
+        ? kernelspec.displayName
+        : kernel.kernelSpecName;
     } else if (content && content.type === "notebook") {
       kernelSpecDisplayName =
         selectors.notebook.displayName(content.model) || " ";


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/4012.

Note: this only appears to work in the Jupyter Extension since the desktop app does not fetch currently available kernelspecs.