### PR TITLE
Fix type mismatch bug in clearAllOutputs reducer

### DIFF
--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -206,7 +206,7 @@ function clearAllOutputs(
   return state
     .setIn(["notebook", "cellMap"], cellMap)
     .set("transient", transient)
-    .setIn("cellPrompts", Map());
+    .set("cellPrompts", Map());
 }
 
 type UpdatableOutputContent =


### PR DESCRIPTION
The `set` operator needed to be used since we were not using a nested selector. This caused the clearAllOutputs action to fail. This PR uses the correct Immutable.js method in order to fix that bug.