### PR TITLE
Add github markdown styling

### DIFF
--- a/packages/markdown/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/markdown/__tests__/__snapshots__/index.spec.tsx.snap
@@ -21,6 +21,7 @@ height between texels.
 >
   <ReactMarkdown
     astPlugins={Array []}
+    className="markdown-body "
     escapeHtml={false}
     plugins={
       Array [
@@ -56,224 +57,229 @@ height between texels.
     transformLinkUri={[Function]}
   >
     <Root
+      className="markdown-body "
       key="root-1-1"
     >
-      <Heading
-        key="heading-2-1"
-        level={1}
+      <div
+        className="markdown-body "
       >
-        <h1>
-          <TextRenderer
-            key="text-2-3"
-            nodeKey="text-2-3"
-            value="Watching Paint Dry"
-          >
-            Watching Paint Dry
-          </TextRenderer>
-        </h1>
-      </Heading>
-      <p
-        key="paragraph-4-1"
-      >
-        <TextRenderer
-          key="text-4-1"
-          nodeKey="text-4-1"
-          value="The composited "
+        <Heading
+          key="heading-2-1"
+          level={1}
         >
-          The composited 
-        </TextRenderer>
-        <em
-          key="emphasis-4-16"
+          <h1>
+            <TextRenderer
+              key="text-2-3"
+              nodeKey="text-2-3"
+              value="Watching Paint Dry"
+            >
+              Watching Paint Dry
+            </TextRenderer>
+          </h1>
+        </Heading>
+        <p
+          key="paragraph-4-1"
         >
           <TextRenderer
-            key="text-4-17"
-            nodeKey="text-4-17"
-            value="color"
+            key="text-4-1"
+            nodeKey="text-4-1"
+            value="The composited "
           >
-            color
+            The composited 
           </TextRenderer>
-        </em>
-        <TextRenderer
-          key="text-4-23"
-          nodeKey="text-4-23"
-          value=" of the "
-        >
-           of the 
-        </TextRenderer>
-        <strong
-          key="strong-4-31"
-        >
+          <em
+            key="emphasis-4-16"
+          >
+            <TextRenderer
+              key="text-4-17"
+              nodeKey="text-4-17"
+              value="color"
+            >
+              color
+            </TextRenderer>
+          </em>
           <TextRenderer
-            key="text-4-33"
-            nodeKey="text-4-33"
-            value="paint"
+            key="text-4-23"
+            nodeKey="text-4-23"
+            value=" of the "
           >
-            paint
+             of the 
           </TextRenderer>
-        </strong>
-        <TextRenderer
-          key="text-4-40"
-          nodeKey="text-4-40"
-          value=" must not change during drying. The
+          <strong
+            key="strong-4-31"
+          >
+            <TextRenderer
+              key="text-4-33"
+              nodeKey="text-4-33"
+              value="paint"
+            >
+              paint
+            </TextRenderer>
+          </strong>
+          <TextRenderer
+            key="text-4-40"
+            nodeKey="text-4-40"
+            value=" must not change during drying. The
 optical blending function is used with this constraint to compensate for the new
 dry layer "
-        >
-           must not change during drying. The
+          >
+             must not change during drying. The
 optical blending function is used with this constraint to compensate for the new
 dry layer 
-        </TextRenderer>
-        <inlineMath
-          data={
-            Object {
-              "hChildren": Array [
-                Object {
-                  "type": "text",
-                  "value": "C_{d}^{prime}",
-                },
-              ],
-              "hName": "span",
-              "hProperties": Object {
-                "className": "inlineMath",
-              },
-            }
-          }
-          key="inlineMath-6-11"
-          value="C_{d}^{prime}"
-        >
-          <MathJaxNode
-            inline={true}
-            onRender={null}
-          >
-            <Provider
-              delay={0}
-              didFinishTypeset={null}
-              input="tex"
-              loading={null}
-              noGate={false}
-              onError={[Function]}
-              onLoad={null}
-              options={Object {}}
-              src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
-            >
-              <MathJaxNode
-                inline={true}
-                onRender={null}
-              />
-            </Provider>
-          </MathJaxNode>
-        </inlineMath>
-        <TextRenderer
-          key="text-6-26"
-          nodeKey="text-6-26"
-          value=", when some volume "
-        >
-          , when some volume 
-        </TextRenderer>
-        <inlineMath
-          data={
-            Object {
-              "hChildren": Array [
-                Object {
-                  "type": "text",
-                  "value": "delta_{alpha}",
-                },
-              ],
-              "hName": "span",
-              "hProperties": Object {
-                "className": "inlineMath",
-              },
-            }
-          }
-          key="inlineMath-6-45"
-          value="delta_{alpha}"
-        >
-          <MathJaxNode
-            inline={true}
-            onRender={null}
-          >
-            <Provider
-              delay={0}
-              didFinishTypeset={null}
-              input="tex"
-              loading={null}
-              noGate={false}
-              onError={[Function]}
-              onLoad={null}
-              options={Object {}}
-              src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
-            >
-              <MathJaxNode
-                inline={true}
-                onRender={null}
-              />
-            </Provider>
-          </MathJaxNode>
-        </inlineMath>
-        <TextRenderer
-          key="text-6-60"
-          nodeKey="text-6-60"
-          value=" is removed from
-the wet layer."
-        >
-           is removed from
-the wet layer.
-        </TextRenderer>
-      </p>
-      <math
-        data={
-          Object {
-            "hChildren": Array [
+          </TextRenderer>
+          <inlineMath
+            data={
               Object {
-                "type": "text",
-                "value": "C_{d}^{prime} = \\\\frac{alpha}{}",
-              },
-            ],
-            "hName": "div",
-            "hProperties": Object {
-              "className": "math",
-            },
-          }
-        }
-        key="math-9-1"
-        value="C_{d}^{prime} = \\\\frac{alpha}{}"
-      >
-        <MathJaxNode
-          inline={false}
-          onRender={null}
-        >
-          <Provider
-            delay={0}
-            didFinishTypeset={null}
-            input="tex"
-            loading={null}
-            noGate={false}
-            onError={[Function]}
-            onLoad={null}
-            options={Object {}}
-            src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+                "hChildren": Array [
+                  Object {
+                    "type": "text",
+                    "value": "C_{d}^{prime}",
+                  },
+                ],
+                "hName": "span",
+                "hProperties": Object {
+                  "className": "inlineMath",
+                },
+              }
+            }
+            key="inlineMath-6-11"
+            value="C_{d}^{prime}"
           >
             <MathJaxNode
-              inline={false}
+              inline={true}
               onRender={null}
-            />
-          </Provider>
-        </MathJaxNode>
-      </math>
-      <p
-        key="paragraph-13-1"
-      >
-        <TextRenderer
-          key="text-13-1"
-          nodeKey="text-13-1"
-          value="The dry layer of the canvas uses a relative height field to allow for unlimited
+            >
+              <Provider
+                delay={0}
+                didFinishTypeset={null}
+                input="tex"
+                loading={null}
+                noGate={false}
+                onError={[Function]}
+                onLoad={null}
+                options={Object {}}
+                src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+              >
+                <MathJaxNode
+                  inline={true}
+                  onRender={null}
+                />
+              </Provider>
+            </MathJaxNode>
+          </inlineMath>
+          <TextRenderer
+            key="text-6-26"
+            nodeKey="text-6-26"
+            value=", when some volume "
+          >
+            , when some volume 
+          </TextRenderer>
+          <inlineMath
+            data={
+              Object {
+                "hChildren": Array [
+                  Object {
+                    "type": "text",
+                    "value": "delta_{alpha}",
+                  },
+                ],
+                "hName": "span",
+                "hProperties": Object {
+                  "className": "inlineMath",
+                },
+              }
+            }
+            key="inlineMath-6-45"
+            value="delta_{alpha}"
+          >
+            <MathJaxNode
+              inline={true}
+              onRender={null}
+            >
+              <Provider
+                delay={0}
+                didFinishTypeset={null}
+                input="tex"
+                loading={null}
+                noGate={false}
+                onError={[Function]}
+                onLoad={null}
+                options={Object {}}
+                src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+              >
+                <MathJaxNode
+                  inline={true}
+                  onRender={null}
+                />
+              </Provider>
+            </MathJaxNode>
+          </inlineMath>
+          <TextRenderer
+            key="text-6-60"
+            nodeKey="text-6-60"
+            value=" is removed from
+the wet layer."
+          >
+             is removed from
+the wet layer.
+          </TextRenderer>
+        </p>
+        <math
+          data={
+            Object {
+              "hChildren": Array [
+                Object {
+                  "type": "text",
+                  "value": "C_{d}^{prime} = \\\\frac{alpha}{}",
+                },
+              ],
+              "hName": "div",
+              "hProperties": Object {
+                "className": "math",
+              },
+            }
+          }
+          key="math-9-1"
+          value="C_{d}^{prime} = \\\\frac{alpha}{}"
+        >
+          <MathJaxNode
+            inline={false}
+            onRender={null}
+          >
+            <Provider
+              delay={0}
+              didFinishTypeset={null}
+              input="tex"
+              loading={null}
+              noGate={false}
+              onError={[Function]}
+              onLoad={null}
+              options={Object {}}
+              src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+            >
+              <MathJaxNode
+                inline={false}
+                onRender={null}
+              />
+            </Provider>
+          </MathJaxNode>
+        </math>
+        <p
+          key="paragraph-13-1"
+        >
+          <TextRenderer
+            key="text-13-1"
+            nodeKey="text-13-1"
+            value="The dry layer of the canvas uses a relative height field to allow for unlimited
 volume of paint to be added, with a constraint only on the relative change in
 height between texels."
-        >
-          The dry layer of the canvas uses a relative height field to allow for unlimited
+          >
+            The dry layer of the canvas uses a relative height field to allow for unlimited
 volume of paint to be added, with a constraint only on the relative change in
 height between texels.
-        </TextRenderer>
-      </p>
+          </TextRenderer>
+        </p>
+      </div>
     </Root>
   </ReactMarkdown>
 </MarkdownRender>

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@nteract/mathjax": "^4.0.1",
     "@nteract/presentational-components": "^3.2.0",
-    "react-markdown": "^4.0.0"
+    "react-markdown": "^4.0.0",
+    "github-markdown-css":  "^3.0.1"
   },
   "peerDependencies": {
     "react": "^16.11.0"

--- a/packages/markdown/src/markdown-render.tsx
+++ b/packages/markdown/src/markdown-render.tsx
@@ -5,6 +5,8 @@ import ReactMarkdown from "react-markdown";
 
 import RemarkMathPlugin from "./remark-math";
 
+import "github-markdown-css/github-markdown.css";
+
 const math = (props: { value: string }): React.ReactElement<unknown> => (
   <MathJax.Node>{props.value}</MathJax.Node>
 );
@@ -24,6 +26,7 @@ const MarkdownRender = (props: ReactMarkdown.ReactMarkdownProps) => {
   const newProps: ReactMarkdown.ReactMarkdownProps = {
     // https://github.com/rexxars/react-markdown#options
     ...props,
+    className: `markdown-body ${props.className ?? ""}`,
     escapeHtml: false,
     renderers: {
       code,

--- a/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
+++ b/packages/outputs/__tests__/__snapshots__/media.spec.tsx.snap
@@ -1445,6 +1445,7 @@ exports[`Markdown Should render markdown 1`] = `
   >
     <ReactMarkdown
       astPlugins={Array []}
+      className="markdown-body "
       escapeHtml={false}
       plugins={
         Array [
@@ -1465,22 +1466,27 @@ exports[`Markdown Should render markdown 1`] = `
       transformLinkUri={[Function]}
     >
       <Root
+        className="markdown-body "
         key="root-1-1"
       >
-        <Heading
-          key="heading-1-1"
-          level={1}
+        <div
+          className="markdown-body "
         >
-          <h1>
-            <TextRenderer
-              key="text-1-3"
-              nodeKey="text-1-3"
-              value="Header"
-            >
-              Header
-            </TextRenderer>
-          </h1>
-        </Heading>
+          <Heading
+            key="heading-1-1"
+            level={1}
+          >
+            <h1>
+              <TextRenderer
+                key="text-1-3"
+                nodeKey="text-1-3"
+                value="Header"
+              >
+                Header
+              </TextRenderer>
+            </h1>
+          </Heading>
+        </div>
       </Root>
     </ReactMarkdown>
   </MarkdownRender>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -113,7 +113,11 @@ module.exports = {
             projectReferences: true,
             transpileOnly: true
           }
-        }
+        },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader']
+        },
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6551,6 +6551,11 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
+github-markdown-css@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/github-markdown-css/-/github-markdown-css-3.0.1.tgz#d08db1060d2e182025e0d07d547cfe2afed30205"
+  integrity sha512-9G5CIPsHoyk5ObDsb/H4KTi23J8KE1oDd4KYU51qwqeM+lKWAiO7abpSgCkyWswgmSKBiuE7/4f8xUz7f2qAiQ==
+
 github-slugger@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.2.1.tgz#47e904e70bf2dccd0014748142d31126cfd49508"


### PR DESCRIPTION
Fixes #1560.

It seems there weren't any heading styles set beyond `h1`, and that one was set by the browser reset in the static html file. I decided to just import the GitHub markdown styles, rather than come up with my own.

I think one file got its line-endings converted, which is why it's in there in whole; I only changed the className.