### PR TITLE
React + Redux Devtool

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -121,6 +121,7 @@
   },
   "devDependencies": {
     "electron": "5.0.12",
-    "file-loader": "^5.0.0"
+    "file-loader": "^5.0.0",
+    "remote-redux-devtools": "^0.5.16"
   }
 }

--- a/applications/desktop/src/main/index.ts
+++ b/applications/desktop/src/main/index.ts
@@ -87,6 +87,12 @@ ipc.on("show-message-box", (event: Event, arg: any) => {
 
 app.on("ready", initAutoUpdater);
 
+
+app.on("ready", () => {
+  BrowserWindow.addDevToolsExtension("C:\\Users\\Wade\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Extensions\\fmkadmapgofadopljbjfkapdkoienihi\\4.2.1_0");
+  BrowserWindow.addDevToolsExtension("C:\\Users\\Wade\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Extensions\\lmhkpmbekcpmknklioeibfkpmmfibljd\\2.17.0_0");
+});
+
 const electronReady$ = new Observable(observer => {
   app.on("ready", (event: Event) => observer.next(event));
 });

--- a/applications/desktop/src/main/launch.ts
+++ b/applications/desktop/src/main/launch.ts
@@ -33,6 +33,7 @@ export function launch(filename?: string) {
     show: false,
     webPreferences: { nodeIntegration: true }
   });
+  win.webContents.openDevTools();
 
   win.once("ready-to-show", () => {
     win.show();

--- a/applications/desktop/src/main/store.ts
+++ b/applications/desktop/src/main/store.ts
@@ -1,5 +1,6 @@
 import { middlewares as coreMiddlewares } from "@nteract/core";
 import { applyMiddleware, compose, createStore, Middleware } from "redux";
+import { composeWithDevTools } from 'remote-redux-devtools';
 
 import reducers from "./reducers";
 
@@ -11,5 +12,5 @@ if (process.env.DEBUG === "true") {
 }
 
 export default function configureStore() {
-  return createStore(reducers, compose(applyMiddleware(...middlewares)));
+  return createStore(reducers, composeWithDevTools({realtime: true, name:"main"})(applyMiddleware(...middlewares)));
 }

--- a/applications/desktop/src/notebook/store.ts
+++ b/applications/desktop/src/notebook/store.ts
@@ -1,5 +1,5 @@
 import { middlewares as coreMiddlewares, reducers } from "@nteract/core";
-import { applyMiddleware, combineReducers, createStore, Store } from "redux";
+import { applyMiddleware, combineReducers, createStore, Store, compose } from "redux";
 import {
   combineEpics,
   createEpicMiddleware,
@@ -51,10 +51,13 @@ const rootReducer = combineReducers({
 export default function configureStore(
   initialState: Partial<DesktopNotebookAppState>
 ): DesktopStore {
+  const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   const store = createStore(
     rootReducer,
     (initialState as unknown) as any,
-    applyMiddleware(...middlewares)
+    composeEnhancers(
+      applyMiddleware(...middlewares)
+    )
   );
   epicMiddleware.run(rootEpic);
   return store as DesktopStore;

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "regenerator-runtime": "^0.13.0",
     "remark-parse": "^7.0.0",
     "remark-stringify": "^7.0.0",
+    "remote-redux-devtools": "^0.5.16",
     "rimraf": "^3.0.0",
     "rxjs": "^6.3.3",
     "shell-env": "^3.0.0",


### PR DESCRIPTION
I used my previous experience working with atom devtools to create this local manual build of getting react and redux devtools working in electron.

My review of this PR will explain all that I know.

If anyone wants to build further on this to make it cross platform or at least windows system they may. I would suggest most of this being hidden behind a yarn script similar to the redux script you already have, but all this code works in my local environment using `yarn app:desktop`.

I haven't tried, but I am unsure of how reliable this setup is to the watch and dynamic build as I am unfamiliar with that tooling.

The purpose of this PR is not for me to add the tools to the main dev process, but to show case how to do it so that if someone wishes they can