### PR TITLE
Fix wrong import in component docs

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -13,20 +13,7 @@ module.exports = {
   defaultExample: false,
   propsParser: typescriptPropsParser,
   resolver: require("react-docgen").resolver.findAllComponentDefinitions,
-  getComponentPathLine: componentPath => {
-    const toPascalCase = string => {
-      return string
-        .match(/[a-z]+/gi)
-        .map(function(word) {
-          return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
-        })
-        .join("");
-    };
-    const name = path.basename(componentPath, ".tsx");
-    const dir = path.dirname(componentPath);
-    const package = dir.match(new RegExp("packages[\\\\/](.*)[\\\\/]src"));
-    return `import { ${toPascalCase(name)} } from '@nteract/${package[1]}';`;
-  },
+  getComponentPathLine: componentPath => componentPath.replace(/^packages\//, "@nteract/").replace(/\.tsx?$/, ""),
   sections: [
     {
       name: "Introduction",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -13,7 +13,16 @@ module.exports = {
   defaultExample: false,
   propsParser: typescriptPropsParser,
   resolver: require("react-docgen").resolver.findAllComponentDefinitions,
-  getComponentPathLine: componentPath => componentPath.replace(/^packages\//, "@nteract/").replace(/\.tsx?$/, ""),
+  getComponentPathLine: componentPath => {
+    const toPascalCase = string =>
+      string
+        .match(/[a-z]+/gi)
+        .map(word => word.charAt(0).toUpperCase() + word.substr(1).toLowerCase())
+        .join("");
+    const name = path.basename(componentPath, ".tsx");
+    const from = componentPath.replace(/^packages\//, "@nteract/").replace(/\.tsx?$/, "");
+    return `import ${toPascalCase(name)} from '${from}';`;
+  },
   sections: [
     {
       name: "Introduction",


### PR DESCRIPTION
Replaces the import in the component docs with e. g. `@nteract/outputs/src/components/media/plain`. Fixes #4791.