### PR TITLE
Update type used in setKernelspecInfo and fix bug in reducer

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/kernel-launch.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch.spec.ts
@@ -76,13 +76,6 @@ describe("launchKernelEpic", () => {
       .toPromise();
 
     expect(responses[0]).toEqual(
-      actionsModule.setKernelspecInfo({
-        kernelInfo: { spec: "hokey", name: "woohoo" },
-        contentRef: "abc"
-      })
-    );
-
-    expect(responses[1]).toEqual(
       actionsModule.launchKernelSuccessful({
         kernel: {
           info: null,
@@ -102,7 +95,7 @@ describe("launchKernelEpic", () => {
       })
     );
 
-    expect(responses[2]).toEqual(
+    expect(responses[1]).toEqual(
       actionsModule.setExecutionState({
         kernelStatus: "launched",
         kernelRef: "123"

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.ts
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.ts
@@ -52,7 +52,8 @@ export function launchKernelObservable(
   kernelSpec: KernelspecInfo,
   cwd: string,
   kernelRef: KernelRef,
-  contentRef: ContentRef
+  contentRef: ContentRef,
+  state: AppState
 ): Observable<Actions> {
   const spec = kernelSpec.spec;
 
@@ -112,12 +113,17 @@ export function launchKernelObservable(
             undefined,
             jmp
           );
-          observer.next(
-            actions.setKernelspecInfo({
-              contentRef,
-              kernelInfo: kernelSpec
-            })
-          );
+          const kernelInfo = selectors.kernelspecByName(state, {
+            name: kernelSpec.name
+          });
+          if (kernelInfo) {
+            observer.next(
+              actions.setKernelMetadata({
+                contentRef,
+                kernelInfo
+              })
+            );
+          }
 
           const kernel: LocalKernelProps = {
             info: null,
@@ -257,7 +263,8 @@ export const launchKernelEpic = (
           action.payload.kernelSpec,
           action.payload.cwd,
           action.payload.kernelRef,
-          action.payload.contentRef
+          action.payload.contentRef,
+          state$.value
         ),
         // Was there a kernel before (?) -- kill it if so, otherwise nothing else
         cleanupOldKernel$

--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -86,9 +86,7 @@ describe("unhideAll", () => {
       }
     });
 
-    expect(
-      actions.unhideAll({ outputHidden: false, contentRef })
-    ).toEqual({
+    expect(actions.unhideAll({ outputHidden: false, contentRef })).toEqual({
       type: actionTypes.UNHIDE_ALL,
       payload: {
         outputHidden: false,
@@ -97,9 +95,7 @@ describe("unhideAll", () => {
       }
     });
 
-    expect(
-      actions.unhideAll({ inputHidden: false, contentRef })
-    ).toEqual({
+    expect(actions.unhideAll({ inputHidden: false, contentRef })).toEqual({
       type: actionTypes.UNHIDE_ALL,
       payload: {
         outputHidden: undefined,
@@ -108,9 +104,7 @@ describe("unhideAll", () => {
       }
     });
 
-    expect(
-      actions.unhideAll({ contentRef })
-    ).toEqual({
+    expect(actions.unhideAll({ contentRef })).toEqual({
       type: actionTypes.UNHIDE_ALL,
       payload: {
         outputHidden: undefined,
@@ -250,12 +244,12 @@ describe("launchKernelByName", () => {
   });
 });
 
-describe("setKernelspecInfo", () => {
-  test("creates a SET_KERNELSPEC_INFO action", () => {
+describe("setKernelMetadata", () => {
+  test("creates a SET_KERNEL_METADATA action", () => {
     const kernelInfo = { name: "japanese" };
     const contentRef = createContentRef();
-    expect(actions.setKernelspecInfo({ kernelInfo, contentRef })).toEqual({
-      type: actionTypes.SET_KERNELSPEC_INFO,
+    expect(actions.setKernelMetadata({ kernelInfo, contentRef })).toEqual({
+      type: actionTypes.SET_KERNEL_METADATA,
       payload: {
         contentRef,
         kernelInfo: {

--- a/packages/actions/src/actionTypes/kernelspecs.ts
+++ b/packages/actions/src/actionTypes/kernelspecs.ts
@@ -35,11 +35,11 @@ export interface FetchKernelspecsFailed {
   };
 }
 
-export const SET_KERNELSPEC_INFO = "SET_KERNELSPEC_INFO";
-export interface SetKernelspecInfo {
-  type: "SET_KERNELSPEC_INFO";
+export const SET_KERNEL_METADATA = "SET_KERNEL_METADATA";
+export interface SetKernelMetadata {
+  type: "SET_KERNEL_METADATA";
   payload: {
-    kernelInfo?: KernelspecRecord | null;
+    kernelInfo: KernelspecRecord;
     contentRef: ContentRef;
   };
 }

--- a/packages/actions/src/actionTypes/kernelspecs.ts
+++ b/packages/actions/src/actionTypes/kernelspecs.ts
@@ -1,8 +1,8 @@
 import {
   ContentRef,
   HostRef,
-  KernelspecInfo,
   KernelspecProps,
+  KernelspecRecord,
   KernelspecsRef
 } from "@nteract/types";
 
@@ -35,13 +35,11 @@ export interface FetchKernelspecsFailed {
   };
 }
 
-// "legacy" action that pushes kernelspec info back up
-// for the notebook document
 export const SET_KERNELSPEC_INFO = "SET_KERNELSPEC_INFO";
 export interface SetKernelspecInfo {
   type: "SET_KERNELSPEC_INFO";
   payload: {
-    kernelInfo: KernelspecInfo;
+    kernelInfo?: KernelspecRecord | null;
     contentRef: ContentRef;
   };
 }

--- a/packages/actions/src/actions/kernelspecs.ts
+++ b/packages/actions/src/actions/kernelspecs.ts
@@ -35,12 +35,12 @@ export const fetchKernelspecsFailed = (payload: {
 
 // "legacy" action that pushes kernelspec info back up
 // for the notebook document
-export function setKernelspecInfo(payload: {
+export function setKernelMetadata(payload: {
   kernelInfo: any;
   contentRef: ContentRef;
-}): actionTypes.SetKernelspecInfo {
+}): actionTypes.SetKernelMetadata {
   return {
-    type: actionTypes.SET_KERNELSPEC_INFO,
+    type: actionTypes.SET_KERNEL_METADATA,
     payload
   };
 }

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -182,10 +182,7 @@ describe("acquireKernelInfo", () => {
       {
         payload: {
           contentRef: "fakeContentRef",
-          kernelInfo: {
-            name: "python",
-            spec: null
-          }
+          kernelInfo: null
         },
         type: "SET_KERNELSPEC_INFO"
       }

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -96,6 +96,13 @@ describe("acquireKernelInfo", () => {
                 })
               })
             })
+          }),
+          kernelspecs: stateModule.makeKernelspecsRecord({
+            byRef: Immutable.Map({
+              currentKernelspecsRef: stateModule.makeKernelspecsByRefRecord({
+                byName: Immutable.Map({ python: stateModule.makeKernelspec() })
+              })
+            })
           })
         })
       }),
@@ -182,9 +189,9 @@ describe("acquireKernelInfo", () => {
       {
         payload: {
           contentRef: "fakeContentRef",
-          kernelInfo: null
+          kernelInfo: stateModule.makeKernelspec()
         },
-        type: "SET_KERNELSPEC_INFO"
+        type: "SET_KERNEL_METADATA"
       }
     ]);
 

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -23,7 +23,7 @@ import {
 
 import * as actions from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
-import { ContentRef, KernelRef, AppState, KernelInfo } from "@nteract/types";
+import { AppState, ContentRef, KernelInfo, KernelRef } from "@nteract/types";
 import { createKernelRef } from "@nteract/types";
 
 const path = require("path");
@@ -116,7 +116,6 @@ export function acquireKernelInfo(
         ];
       } else {
         const kernelspec = selectors.kernelspecByName(state, { name: l.name });
-        const kernelInfo = { name: l.name, spec: kernelspec };
         result = [
           // The original action we were using
           actions.setLanguageInfo({
@@ -130,7 +129,7 @@ export function acquireKernelInfo(
           }),
           actions.setKernelspecInfo({
             contentRef,
-            kernelInfo
+            kernelInfo: kernelspec
           })
         ];
       }

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -127,11 +127,13 @@ export function acquireKernelInfo(
             kernelRef,
             info
           }),
-          actions.setKernelspecInfo({
-            contentRef,
-            kernelInfo: kernelspec
-          })
-        ];
+          kernelspec
+            ? actions.setKernelMetadata({
+                contentRef,
+                kernelInfo: kernelspec
+              })
+            : undefined
+        ].filter(Boolean);
       }
 
       return of(...result);

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -185,7 +185,7 @@ describe("setLanguageInfo", () => {
     };
     const state = reducers(
       initialDocument,
-      actions.setKernelspecInfo({ kernelInfo })
+      actions.setKernelMetadata({ kernelInfo })
     );
     const metadata = state.getIn(["notebook", "metadata"]);
     expect(metadata.getIn(["kernel_info", "name"])).toBe("french");

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -180,7 +180,8 @@ describe("setLanguageInfo", () => {
   test("adds the metadata fields for the kernelspec and kernel_info", () => {
     const kernelInfo = {
       name: "french",
-      spec: { language: "french", display_name: "français" }
+      language: "french",
+      displayName: "français"
     };
     const state = reducers(
       initialDocument,

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -314,7 +314,7 @@ const byRef = (
     case actionTypes.ACCEPT_PAYLOAD_MESSAGE:
     case actionTypes.UPDATE_CELL_STATUS:
     case actionTypes.SET_LANGUAGE_INFO:
-    case actionTypes.SET_KERNELSPEC_INFO:
+    case actionTypes.SET_KERNEL_METADATA:
     case actionTypes.OVERWRITE_METADATA_FIELD:
     case actionTypes.DELETE_METADATA_FIELD:
     case actionTypes.COPY_CELL:

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -773,9 +773,9 @@ function setLanguageInfo(
   return state.setIn(["notebook", "metadata", "language_info"], langInfo);
 }
 
-function setKernelspecInfo(
+function setKernelMetadata(
   state: NotebookModel,
-  action: actionTypes.SetKernelspecInfo
+  action: actionTypes.SetKernelMetadata
 ): RecordOf<DocumentRecordProps> {
   const { kernelInfo } = action.payload;
   if (kernelInfo) {
@@ -982,7 +982,7 @@ type DocumentAction =
   | actionTypes.UpdateCellStatus
   | actionTypes.UpdateOutputMetadata
   | actionTypes.SetLanguageInfo
-  | actionTypes.SetKernelspecInfo
+  | actionTypes.SetKernelMetadata
   | actionTypes.OverwriteMetadataField
   | actionTypes.DeleteMetadataField
   | actionTypes.CopyCell
@@ -1078,8 +1078,8 @@ export function notebook(
       return updateOutputMetadata(state, action);
     case actionTypes.SET_LANGUAGE_INFO:
       return setLanguageInfo(state, action);
-    case actionTypes.SET_KERNELSPEC_INFO:
-      return setKernelspecInfo(state, action);
+    case actionTypes.SET_KERNEL_METADATA:
+      return setKernelMetadata(state, action);
     case actionTypes.OVERWRITE_METADATA_FIELD:
       return overwriteMetadataField(state, action);
     case actionTypes.DELETE_METADATA_FIELD:

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -778,14 +778,14 @@ function setKernelspecInfo(
   action: actionTypes.SetKernelspecInfo
 ): RecordOf<DocumentRecordProps> {
   const { kernelInfo } = action.payload;
-  if (kernelInfo.spec) {
+  if (kernelInfo) {
     return state
       .setIn(
         ["notebook", "metadata", "kernelspec"],
         fromJS({
           name: kernelInfo.name,
-          language: kernelInfo.spec.language,
-          display_name: kernelInfo.spec.display_name
+          language: kernelInfo.language,
+          display_name: kernelInfo.displayName
         })
       )
       .setIn(["notebook", "metadata", "kernel_info", "name"], kernelInfo.name);


### PR DESCRIPTION
Follow up to https://github.com/nteract/nteract/pull/4737.

- Updates the type passed to the `setKernelspecInfo` action to be a `KernelspecRecord` stored in the state
- Updates the tests to reflect this new type
- Removes the `legacy` comment about this type since we still need it
- Fixes bug where display_name was not set correctly in notebooks