### PR TITLE
enforce a full parent header in raw jupyter msg

### DIFF
--- a/packages/messaging/src/wire-protocol.ts
+++ b/packages/messaging/src/wire-protocol.ts
@@ -18,11 +18,7 @@ export interface RawJupyterMessage<
   C = any
 > {
   header: JupyterMessageHeader<MT>;
-  parent_header:
-    | JupyterMessageHeader<any>
-    | {
-        msg_id?: string;
-      };
+  parent_header: JupyterMessageHeader<any>;
   metadata: object;
   content: C;
   buffers: Array<Buffer>;


### PR DESCRIPTION
Right now this was allowing `{ msg_id: string }` to be valid when ideally `session` and others would be set.