### PR TITLE
Lazy launch kernel

### DIFF
--- a/applications/desktop/src/notebook/epics/index.ts
+++ b/applications/desktop/src/notebook/epics/index.ts
@@ -48,6 +48,7 @@ const epics = [
   coreEpics.updateDisplayEpic,
   coreEpics.commListenEpic,
   coreEpics.executeAllCellsEpic,
+  coreEpics.executeFocusedCellEpic,
   coreEpics.updateContentEpic,
   coreEpics.autoSaveCurrentContentEpic,
   coreEpics.sendInputReplyEpic,

--- a/packages/actions/src/actionTypes/index.ts
+++ b/packages/actions/src/actionTypes/index.ts
@@ -21,6 +21,7 @@ export * from "./cells";
 export * from "./contents";
 export * from "./kernels";
 export * from "./kernelspecs";
+export * from "./messages";
 
 export const OVERWRITE_METADATA_FIELDS = "CORE/OVERWRITE_METADATA_FIELDS";
 export interface OverwriteMetadataFields {

--- a/packages/actions/src/actionTypes/kernels.ts
+++ b/packages/actions/src/actionTypes/kernels.ts
@@ -1,5 +1,4 @@
 import { CellId } from "@nteract/commutable";
-import { ExecuteRequest } from "@nteract/messaging";
 import {
   ContentRef,
   KernelInfo,
@@ -14,7 +13,6 @@ export interface SendExecuteRequest {
   type: "SEND_EXECUTE_REQUEST";
   payload: {
     id: CellId;
-    message: ExecuteRequest;
     contentRef: ContentRef;
   };
 }

--- a/packages/actions/src/actionTypes/messages.ts
+++ b/packages/actions/src/actionTypes/messages.ts
@@ -1,0 +1,16 @@
+import { CellId } from "@nteract/commutable";
+import { ContentRef } from "@nteract/types";
+
+export const ENQUEUE_ACTION = "ENQUEUE_ACTION";
+export interface EnqueueAction {
+  type: "ENQUEUE_ACTION";
+  payload: {
+    id: CellId;
+    contentRef: ContentRef;
+  };
+}
+
+export const CLEAR_MESSAGE_QUEUE = "CLEAR_MESSAGE_QUEUE";
+export interface ClearMessageQueue {
+  type: "CLEAR_MESSAGE_QUEUE";
+}

--- a/packages/actions/src/actions/index.ts
+++ b/packages/actions/src/actions/index.ts
@@ -24,6 +24,7 @@ export * from "./contents";
 export * from "./hosts";
 export * from "./kernels";
 export * from "./kernelspecs";
+export * from "./messages";
 
 export const openModal = (payload: { modalType: string }) => ({
   type: actionTypes.OPEN_MODAL,

--- a/packages/actions/src/actions/kernels.ts
+++ b/packages/actions/src/actions/kernels.ts
@@ -6,7 +6,6 @@ import {
   RemoteKernelProps
 } from "@nteract/types";
 
-import { ExecuteRequest } from "@nteract/messaging";
 import * as actionTypes from "../actionTypes";
 
 export function launchKernelFailed(payload: {
@@ -179,7 +178,6 @@ export function restartKernelSuccessful(payload: {
 
 export function sendExecuteRequest(payload: {
   id: string;
-  message: ExecuteRequest;
   contentRef: ContentRef;
 }): actionTypes.SendExecuteRequest {
   return {
@@ -187,6 +185,7 @@ export function sendExecuteRequest(payload: {
     payload
   };
 }
+
 export function executeCell(payload: {
   id: string;
   contentRef: ContentRef;

--- a/packages/actions/src/actions/messages.ts
+++ b/packages/actions/src/actions/messages.ts
@@ -2,17 +2,17 @@ import { ContentRef } from "@nteract/types";
 import * as actionTypes from "../actionTypes";
 
 export function enqueueAction(payload: {
-    id: string;
-    contentRef: ContentRef;
+  id: string;
+  contentRef: ContentRef;
 }): actionTypes.EnqueueAction {
-    return {
-      type: actionTypes.ENQUEUE_ACTION,
-      payload
-    };
+  return {
+    type: actionTypes.ENQUEUE_ACTION,
+    payload
+  };
 }
   
 export function clearMessageQueue(): actionTypes.ClearMessageQueue {
-    return {
-      type: actionTypes.CLEAR_MESSAGE_QUEUE
-    };
+  return {
+    type: actionTypes.CLEAR_MESSAGE_QUEUE
+  };
 }

--- a/packages/actions/src/actions/messages.ts
+++ b/packages/actions/src/actions/messages.ts
@@ -1,0 +1,18 @@
+import { ContentRef } from "@nteract/types";
+import * as actionTypes from "../actionTypes";
+
+export function enqueueAction(payload: {
+    id: string;
+    contentRef: ContentRef;
+}): actionTypes.EnqueueAction {
+    return {
+      type: actionTypes.ENQUEUE_ACTION,
+      payload
+    };
+}
+  
+export function clearMessageQueue(): actionTypes.ClearMessageQueue {
+    return {
+      type: actionTypes.CLEAR_MESSAGE_QUEUE
+    };
+}

--- a/packages/epics/__tests__/websocket-kernel.spec.ts
+++ b/packages/epics/__tests__/websocket-kernel.spec.ts
@@ -88,7 +88,8 @@ describe("launchWebSocketKernelEpic", () => {
             channels: expect.any(Subject),
             kernelSpecName: "fancy",
             cwd: "/",
-            id: "0"
+            id: "0",
+            status: undefined
           }
         }
       }

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -314,13 +314,14 @@ export function lazyLaunchKernelEpic(
         content.type !== "notebook" ||
         content.model.type !== "notebook"
       ) {
-        return actions.launchKernelFailed({
-          contentRef,
-          error: new Error(
-            "Launch kernel failed because the source content is not a notebook"
-          ),
-          kernelRef
-        });
+        return of(
+          actions.launchKernelFailed({
+            error: new Error(
+              "Launch kernel failed because the source content is not a notebook"
+            ),
+            contentRef
+          })
+        );
       }
 
       const filepath = content.filepath;

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -13,6 +13,7 @@ import {
   outputs,
   payloads
 } from "@nteract/messaging";
+import { AnyAction } from "redux";
 import { ofType } from "redux-observable";
 import { ActionsObservable, StateObservable } from "redux-observable";
 import { empty, merge, Observable, Observer, of, throwError } from "rxjs";
@@ -28,8 +29,10 @@ import {
   share,
   switchMap,
   takeUntil,
-  tap
+  tap,
+  withLatestFrom
 } from "rxjs/operators";
+import { extractNewKernel } from "./kernel-lifecycle";
 
 import * as actions from "@nteract/actions";
 import { CellId, OnDiskOutput } from "@nteract/commutable";
@@ -40,8 +43,7 @@ import {
   InputRequestMessage,
   PayloadMessage
 } from "@nteract/types";
-
-const Immutable = require("immutable");
+import { List } from "immutable";
 
 /**
  * Observe all the reactions to running code for cell with id.
@@ -134,15 +136,7 @@ export function executeCellStream(
 }
 
 export function createExecuteCellStream(
-  action$: ActionsObservable<
-    | actions.ExecuteCanceled
-    | actions.DeleteCell
-    | actions.LaunchKernelAction
-    | actions.LaunchKernelByNameAction
-    | actions.KillKernelAction
-    | actions.ExecuteCell
-    | actions.ExecuteFocusedCell
-  >,
+  action$: ActionsObservable<actions.SendExecuteRequest>,
   state: any,
   message: ExecuteRequest,
   id: string,
@@ -168,51 +162,10 @@ export function createExecuteCellStream(
     );
   }
 
-  const cellStream = executeCellStream(channels, id, message, contentRef).pipe(
-    takeUntil(
-      merge(
-        action$.pipe(
-          ofType(actions.EXECUTE_CANCELED, actions.DELETE_CELL),
-          filter(
-            (
-              action:
-                | actions.ExecuteCanceled
-                | actions.DeleteCell
-                | actions.LaunchKernelAction
-                | actions.LaunchKernelByNameAction
-                | actions.KillKernelAction
-                | actions.ExecuteCell
-                | actions.ExecuteFocusedCell
-            ) => (action as actions.ExecuteCanceled).payload.id === id
-          )
-        ),
-        action$.pipe(
-          ofType(
-            actions.LAUNCH_KERNEL,
-            actions.LAUNCH_KERNEL_BY_NAME,
-            actions.KILL_KERNEL
-          ),
-          filter(
-            (
-              action:
-                | actions.ExecuteCanceled
-                | actions.DeleteCell
-                | actions.LaunchKernelAction
-                | actions.LaunchKernelByNameAction
-                | actions.KillKernelAction
-                | actions.ExecuteCell
-                | actions.ExecuteFocusedCell
-            ) => action.payload.contentRef === contentRef
-          )
-        )
-      )
-    )
-  );
+  const cellStream = executeCellStream(channels, id, message, contentRef);
 
   return merge(
-    // We make sure to propagate back to "ourselves" the actual message
-    // that we sent to the kernel with the sendExecuteRequest action
-    of(actions.sendExecuteRequest({ id, message, contentRef })),
+    of(actions.clearOutputs({ id, contentRef })),
     // Merging it in with the actual stream
     cellStream
   );
@@ -237,7 +190,7 @@ export function executeAllCellsEpic(
           return empty();
         }
 
-        let codeCellIds = Immutable.List();
+        let codeCellIds = List();
 
         if (action.type === actions.EXECUTE_ALL_CELLS) {
           codeCellIds = selectors.notebook.codeCellIds(model);
@@ -254,18 +207,13 @@ export function executeAllCellsEpic(
   );
 }
 
-/**
- * the execute cell epic processes execute requests for all cells, creating
- * inner observable streams of the running execution responses
- */
-export function executeCellEpic(
-  action$: ActionsObservable<actions.ExecuteCell | actions.ExecuteFocusedCell>,
-  state$: any
+export function executeFocusedCellEpic(
+  action$: ActionsObservable<actions.ExecuteFocusedCell>,
+  state$: StateObservable<AppState>
 ) {
   return action$.pipe(
-    ofType(actions.EXECUTE_CELL, actions.EXECUTE_FOCUSED_CELL),
-    mergeMap((action: actions.ExecuteCell | actions.ExecuteFocusedCell) => {
-      if (action.type === actions.EXECUTE_FOCUSED_CELL) {
+    ofType(actions.EXECUTE_FOCUSED_CELL),
+    mergeMap((action: actions.ExecuteFocusedCell) => {
         const contentRef = action.payload.contentRef;
         const state = state$.value;
         const model = selectors.model(state, { contentRef });
@@ -282,22 +230,115 @@ export function executeCellEpic(
         return of(
           actions.executeCell({ id, contentRef: action.payload.contentRef })
         );
-      }
-      return of(action);
-    }),
+    })
+  );
+}
+
+export function executeCellEpic(
+  action$: ActionsObservable<actions.ExecuteCell>,
+  state$: StateObservable<AppState>
+) {
+  return action$.pipe(
+    ofType(actions.EXECUTE_CELL),
     tap((action: actions.ExecuteCell) => {
       if (!action.payload.id) {
         throw new Error("execute cell needs an id");
       }
     }),
+    withLatestFrom(state$),
+    mergeMap(([action, state]) => {
+      const contentRef = action.payload.contentRef;
+      const kernel = selectors.kernelByContentRef(state, { contentRef });
+      
+      if (!kernel) {
+        const content = selectors.content(state, { contentRef });
+        const kernelRef = selectors.kernelRefByContentRef(state, {
+          contentRef
+        });
+
+        if (
+          !kernelRef || !content ||
+          content.type !== "notebook" ||
+          content.model.type !== "notebook"
+        ) {
+          return empty();
+        }
+
+        const filepath = content.filepath;
+        const notebook = content.model.notebook;
+        const { cwd, kernelSpecName } = extractNewKernel(filepath, notebook);
+
+        return of(
+          actions.launchKernelByName({
+            kernelSpecName,
+            cwd,
+            kernelRef,
+            selectNextKernel: true,
+            contentRef
+          }),
+          actions.enqueueAction(action.payload)
+        );
+      }
+      
+      if (kernel.channels && (kernel.status === "idle" || kernel.status === "busy")) {
+        return of(actions.sendExecuteRequest(action.payload));
+      }
+
+      return of(actions.enqueueAction(action.payload));
+    })
+  )
+}
+
+export function executeCellAfterKernelLaunchEpic(
+  action$: ActionsObservable<actions.NewKernelAction>,
+  state$: StateObservable<AppState>
+) {
+  return action$.pipe(
+    ofType(actions.LAUNCH_KERNEL_SUCCESSFUL),
+    withLatestFrom(state$),
+    filter(([action, state]) => {
+      if (selectors.messageQueue(state).size === 0) {
+        return false;
+      }
+
+      const contentRef = action.payload.contentRef;
+      const kernel = selectors.kernelByContentRef(state, { contentRef });
+      return !!(kernel && kernel.channels &&
+        (kernel.status === "idle" || kernel.status === "busy"));
+    }),
+    concatMap(([, state]) => {
+      return merge(
+        of(
+          ...(selectors.messageQueue(state).map(
+            (queuedAction: AnyAction) =>
+              actions.executeCell(queuedAction.payload)
+          ))
+        ),
+        of(actions.clearMessageQueue())
+      );
+    })
+  )
+}
+
+
+/**
+ * the execute cell epic processes execute requests for all cells, creating
+ * inner observable streams of the running execution responses
+ */
+export function sendExecuteRequestEpic(
+  action$: ActionsObservable<actions.SendExecuteRequest>,
+  state$: any
+) {
+  return action$.pipe(
+    ofType(actions.SEND_EXECUTE_REQUEST),
     // Split stream by cell IDs
-    groupBy((action: actions.ExecuteCell) => action.payload.id),
+    groupBy((action: actions.SendExecuteRequest) => action.payload.id),
     // Work on each cell's stream
     map(cellAction$ =>
       cellAction$.pipe(
         // When a new EXECUTE_CELL comes in with the current ID, we create a
         // a new stream and unsubscribe from the old one.
-        switchMap((action: actions.ExecuteCell) => {
+        switchMap((action: actions.SendExecuteRequest) => {
           const { id } = action.payload;
 
           const state = state$.value;

--- a/packages/epics/src/index.ts
+++ b/packages/epics/src/index.ts
@@ -11,6 +11,7 @@ import {
   executeCellAfterKernelLaunchEpic,
   executeCellEpic,
   executeFocusedCellEpic,
+  lazyLaunchKernelEpic,
   sendExecuteRequestEpic,
   sendInputReplyEpic,
   updateDisplayEpic
@@ -37,6 +38,7 @@ import {
 const allEpics = [
   executeCellAfterKernelLaunchEpic,
   executeCellEpic,
+  lazyLaunchKernelEpic,
   sendExecuteRequestEpic,
   updateDisplayEpic,
   executeAllCellsEpic,
@@ -65,6 +67,7 @@ export {
   allEpics,
   executeCellAfterKernelLaunchEpic,
   executeCellEpic,
+  lazyLaunchKernelEpic,
   sendExecuteRequestEpic,
   updateDisplayEpic,
   executeAllCellsEpic,

--- a/packages/epics/src/index.ts
+++ b/packages/epics/src/index.ts
@@ -8,7 +8,10 @@ import {
 } from "./contents";
 import {
   executeAllCellsEpic,
+  executeCellAfterKernelLaunchEpic,
   executeCellEpic,
+  executeFocusedCellEpic,
+  sendExecuteRequestEpic,
   sendInputReplyEpic,
   updateDisplayEpic
 } from "./execute";
@@ -32,9 +35,12 @@ import {
 // rely on `import { epics } from ""@nteract/core"`
 // as it would collide the array with the named exports
 const allEpics = [
+  executeCellAfterKernelLaunchEpic,
   executeCellEpic,
+  sendExecuteRequestEpic,
   updateDisplayEpic,
   executeAllCellsEpic,
+  executeFocusedCellEpic,
   commListenEpic,
   launchWebSocketKernelEpic,
   changeWebSocketKernelEpic,
@@ -42,7 +48,6 @@ const allEpics = [
   killKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
-  launchKernelWhenNotebookSetEpic,
   restartKernelEpic,
   fetchKernelspecsEpic,
   fetchContentEpic,
@@ -58,9 +63,12 @@ const allEpics = [
 
 export {
   allEpics,
+  executeCellAfterKernelLaunchEpic,
   executeCellEpic,
+  sendExecuteRequestEpic,
   updateDisplayEpic,
   executeAllCellsEpic,
+  executeFocusedCellEpic,
   commListenEpic,
   launchWebSocketKernelEpic,
   changeWebSocketKernelEpic,

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -86,7 +86,8 @@ export const launchWebSocketKernelEpic = (
               sessionId
             ),
             kernelSpecName,
-            hostRef
+            hostRef,
+            status: session.kernel.execution_state
           });
 
           kernel.channels.next(kernelInfoRequest());

--- a/packages/reducers/__tests__/document.spec.ts
+++ b/packages/reducers/__tests__/document.spec.ts
@@ -1037,40 +1037,6 @@ describe("cleanCellTransient", () => {
   });
 });
 
-describe("sendExecuteRequest", () => {
-  test("cleans up the outputs, pagers, and status", () => {
-    const notebook = appendCellToNotebook(emptyNotebook, emptyCodeCell);
-    const id = notebook.get("cellOrder").first();
-
-    const initialState = makeDocumentRecord({
-      filename: "test.ipynb",
-      notebook,
-      cellPagers: Immutable.Map({
-        // Hokey data, we're just expecting it to be cleared
-        id: Immutable.List(["a", "b"])
-      }),
-      transient: Immutable.Map({
-        cellMap: Immutable.Map({
-          id: Immutable.Map({
-            status: "idle"
-          })
-        })
-      })
-    });
-
-    const state = reducers(
-      initialState,
-      actions.sendExecuteRequest({ id, message: {} })
-    );
-
-    expect(state.getIn(["transient", "cellMap", id, "status"])).toEqual(
-      "queued"
-    );
-
-    expect(state.getIn(["cellPagers", id])).toEqual(Immutable.List());
-  });
-});
-
 describe("acceptPayloadMessage", () => {
   test("processes jupyter payload message types", () => {
     const notebook = appendCellToNotebook(emptyNotebook, emptyCodeCell);

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -233,7 +233,8 @@ const byRef = (
                   keyPathsForDisplays: Map(),
                   cellMap: Map()
                 }),
-                cellFocused: immutableNotebook.getIn(["cellOrder", 0])
+                cellFocused: immutableNotebook.getIn(["cellOrder", 0]),
+                kernelRef: fetchContentFulfilledAction.payload.kernelRef
               }),
               loading: false,
               saving: false,

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -634,32 +634,6 @@ function acceptPayloadMessage(
   return state;
 }
 
-function sendExecuteRequest(
-  state: NotebookModel,
-  action: actionTypes.SendExecuteRequest
-): RecordOf<DocumentRecordProps> {
-  const id = action.payload.id ? action.payload.id : state.cellFocused;
-  const contentRef = action.payload.contentRef;
-  if (!id) {
-    return state;
-  }
-
-  // TODO: Record the last execute request for this cell
-
-  // * Clear outputs
-  // * Set status to queued, as all we've done is submit the execution request
-  // FIXME: This is a weird pattern. We're basically faking a dispatch here
-  // inside a reducer and then appending to the result. I think that both of
-  // these reducers should just handle the original action.
-  return clearOutputs(state, {
-    type: "CLEAR_OUTPUTS",
-    payload: {
-      id,
-      contentRef
-    }
-  }).setIn(["transient", "cellMap", id, "status"], "queued");
-}
-
 function setInCell(
   state: NotebookModel,
   action: actionTypes.SetInCell<string>
@@ -1010,8 +984,6 @@ export function notebook(
   switch (action.type) {
     case actionTypes.TOGGLE_TAG_IN_CELL:
       return toggleTagInCell(state, action);
-    case actionTypes.SEND_EXECUTE_REQUEST:
-      return sendExecuteRequest(state, action);
     case actionTypes.SAVE_FULFILLED:
       return setNotebookCheckpoint(state);
     case actionTypes.FOCUS_CELL:

--- a/packages/reducers/src/core/entities/index.ts
+++ b/packages/reducers/src/core/entities/index.ts
@@ -7,6 +7,7 @@ import { contents } from "./contents";
 import { hosts } from "./hosts";
 import { kernels } from "./kernels";
 import { kernelspecs } from "./kernelspecs";
+import { messages } from "./messages";
 import { modals } from "./modals";
 import { transforms } from "./transforms";
 
@@ -16,6 +17,7 @@ export const entities = combineReducers(
     hosts,
     kernels,
     kernelspecs,
+    messages,
     modals,
     transforms
   },

--- a/packages/reducers/src/core/entities/messages.ts
+++ b/packages/reducers/src/core/entities/messages.ts
@@ -1,0 +1,26 @@
+import * as actions from "@nteract/actions";
+import { makeMessagesRecord } from "@nteract/types";
+import { List } from "immutable";
+import { Action, AnyAction, Reducer } from "redux";
+import { combineReducers } from "redux-immutable";
+
+const messageQueue = (
+    state: List<AnyAction> = List<AnyAction>(),
+    action: actions.EnqueueAction | actions.ClearMessageQueue
+): List<AnyAction> => {
+    switch(action.type) {
+        case actions.ENQUEUE_ACTION:
+            return state.push(action);
+        case actions.CLEAR_MESSAGE_QUEUE:
+            return state.clear()
+        default:
+            return state;
+    }
+};
+
+export const messages: Reducer<
+    {
+        messageQueue: List<AnyAction>
+    },
+    Action<any>
+> = combineReducers({ messageQueue }, makeMessagesRecord as any)

--- a/packages/reducers/src/core/entities/messages.ts
+++ b/packages/reducers/src/core/entities/messages.ts
@@ -5,22 +5,22 @@ import { Action, AnyAction, Reducer } from "redux";
 import { combineReducers } from "redux-immutable";
 
 const messageQueue = (
-    state: List<AnyAction> = List<AnyAction>(),
-    action: actions.EnqueueAction | actions.ClearMessageQueue
+  state: List<AnyAction> = List<AnyAction>(),
+  action: actions.EnqueueAction | actions.ClearMessageQueue
 ): List<AnyAction> => {
-    switch(action.type) {
-        case actions.ENQUEUE_ACTION:
-            return state.push(action);
-        case actions.CLEAR_MESSAGE_QUEUE:
-            return state.clear()
-        default:
-            return state;
-    }
+  switch (action.type) {
+    case actions.ENQUEUE_ACTION:
+      return state.push(action);
+    case actions.CLEAR_MESSAGE_QUEUE:
+      return state.clear();
+    default:
+      return state;
+  }
 };
 
 export const messages: Reducer<
-    {
-        messageQueue: List<AnyAction>
-    },
-    Action<any>
-> = combineReducers({ messageQueue }, makeMessagesRecord as any)
+  {
+    messageQueue: List<AnyAction>;
+  },
+  Action<any>
+> = combineReducers({ messageQueue }, makeMessagesRecord as any);

--- a/packages/selectors/src/index.ts
+++ b/packages/selectors/src/index.ts
@@ -22,3 +22,10 @@ export * from "./config";
  */
 export const modalType = (state: AppState) =>
   state.core.entities.modals.modalType;
+
+/**
+ * Returns the list of ENQUEUE_ACTION actions that are waiting for the
+ * kernel to successfully launch before executing.
+ */
+export const messageQueue = (state: AppState) =>
+  state.core.entities.messages.messageQueue;

--- a/packages/types/src/entities/index.ts
+++ b/packages/types/src/entities/index.ts
@@ -4,6 +4,7 @@ import { ContentsRecordProps, makeContentsRecord } from "./contents";
 import { HostsRecordProps, makeHostsRecord } from "./hosts";
 import { KernelsRecordProps, makeKernelsRecord } from "./kernels";
 import { KernelspecsRecordProps, makeKernelspecsRecord } from "./kernelspecs";
+import { makeMessagesRecord, MessagesRecordProps } from "./messages";
 import { makeModalsRecord, ModalsRecordProps } from "./modals";
 import { makeTransformsRecord, TransformsRecordProps } from "./transforms";
 
@@ -12,6 +13,7 @@ export * from "./hosts";
 export * from "./kernels";
 export * from "./kernel-info";
 export * from "./kernelspecs";
+export * from "./messages";
 export * from "./modals";
 export * from "./transforms";
 
@@ -22,6 +24,7 @@ export interface EntitiesRecordProps {
   kernelspecs: Immutable.RecordOf<KernelspecsRecordProps>;
   modals: Immutable.RecordOf<ModalsRecordProps>;
   transforms: Immutable.RecordOf<TransformsRecordProps>;
+  messages: Immutable.RecordOf<MessagesRecordProps>;
 }
 
 export type EntitiesRecord = Immutable.RecordOf<EntitiesRecordProps>;
@@ -32,5 +35,6 @@ export const makeEntitiesRecord = Immutable.Record<EntitiesRecordProps>({
   kernels: makeKernelsRecord(),
   kernelspecs: makeKernelspecsRecord(),
   modals: makeModalsRecord(),
-  transforms: makeTransformsRecord()
+  transforms: makeTransformsRecord(),
+  messages: makeMessagesRecord()
 });

--- a/packages/types/src/entities/messages.ts
+++ b/packages/types/src/entities/messages.ts
@@ -8,5 +8,5 @@ export interface MessagesRecordProps {
 export type MessagesRecord = Immutable.RecordOf<MessagesRecordProps>;
 
 export const makeMessagesRecord = Immutable.Record<MessagesRecordProps>({
-    messageQueue: Immutable.List<AnyAction>()
+  messageQueue: Immutable.List<AnyAction>()
 });

--- a/packages/types/src/entities/messages.ts
+++ b/packages/types/src/entities/messages.ts
@@ -1,0 +1,12 @@
+import * as Immutable from "immutable";
+import { AnyAction } from "redux";
+
+export interface MessagesRecordProps {
+  messageQueue: Immutable.List<AnyAction>;
+}
+
+export type MessagesRecord = Immutable.RecordOf<MessagesRecordProps>;
+
+export const makeMessagesRecord = Immutable.Record<MessagesRecordProps>({
+    messageQueue: Immutable.List<AnyAction>()
+});


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [✓] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
The goal of this PR is to launch the kernel only when user attempts to execute a cell instead of immediately launching the kernel when user opens a notebook.

- `ExecuteFocusedCell`, `ExecuteAllCells`, and `ExecuteAllCellsBelow` are mapped to `ExecuteCell`.
- `ExecuteCell` now checks if the kernel exists:
  - If it doesn't, `launchKernelByName` and `enqueueAction` actions are emitted.
  - If it does, but the kernel status is not fully ready (e.g. the kernel status is `starting`), then `enqueueAction` is emitted.
  - If the kernel is fully ready, then `sendExecuteRequest` action is emitted which executes the cell like what `executeCell` used to do.
- When the kernel doesn't exist or isn't fully ready, the pending actions are stored in a message queue which is an Immutable.List of actions that represents a FIFO queue.
  - The message queue's path in the state object is: **state.core.entities.messages**
-  A new epic which listens to the `LAUNCH_KERNEL_SUCCESSFUL` action is added. It checks whether the kernel is ready and emits an `executeCell` action for each pending action in the message queue. The message queue is then cleared.

References:
 - RFC by @captainsafia :https://github.com/nteract/nteract/issues/4762
 - Action flowchart: ![image](https://user-images.githubusercontent.com/56978073/72197846-f389c180-33da-11ea-8d74-6f7fe05fd649.png)