### PR TITLE
Add support for auto-complete on Tab

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -434,9 +434,14 @@ export default class CodeMirrorEditor extends React.PureComponent<
   }
 
   executeTab(editor: Editor & Doc): void {
-    editor.somethingSelected()
-      ? editor.execCommand("indentMore")
-      : editor.execCommand("insertSoftTab");
+    const { line, ch } = editor.getCursor();
+    if (editor.somethingSelected()) {
+      editor.execCommand("indentMore");
+    } else if (line && ch !== 0) {
+      editor.execCommand("autocomplete");
+    } else {
+      editor.execCommand("insertSoftTab");
+    }
   }
 
   codemirrorValueChanged(doc: Editor, change: EditorChangeLinkedList): void {


### PR DESCRIPTION
Closes #4817 .

This allows Tab to be used for auto-complete when it is not at the beginning of the line for compatibility with Jupyter classic and other UIs. 
