### PR TITLE
Add back support for Ctrl + Enter keyboard shortcut

### DIFF
--- a/packages/notebook-app-component/__tests__/decorators/kbd-shortcuts.spec.tsx
+++ b/packages/notebook-app-component/__tests__/decorators/kbd-shortcuts.spec.tsx
@@ -79,7 +79,7 @@ describe("KeyboardShortcuts", () => {
     expect(component).not.toBeNull();
     map.keydown({
       keyCode: 13,
-      ctrlKey: true,
+      ctrlKey: false,
       metaKey: true,
       shiftKey: true,
       preventDefault: () => {}
@@ -115,7 +115,7 @@ describe("KeyboardShortcuts", () => {
     expect(component).not.toBeNull();
     map.keydown({
       keyCode: 13,
-      ctrlKey: true,
+      ctrlKey: false,
       metaKey: true,
       shiftKey: true,
       preventDefault: () => {}

--- a/packages/notebook-app-component/__tests__/decorators/kbd-shortcuts.spec.tsx
+++ b/packages/notebook-app-component/__tests__/decorators/kbd-shortcuts.spec.tsx
@@ -1,0 +1,130 @@
+import { mount, shallow } from "enzyme";
+import Immutable from "immutable";
+import React from "react";
+
+import { KeyboardShortcuts } from "../../src/decorators/kbd-shortcuts";
+
+describe("KeyboardShortcuts", () => {
+  const map = {};
+  beforeEach(() => {
+    /**
+     * This is to written here to enable testing global key handlers
+     * on individual events in React components. For more information,
+     * checkout this link.
+     *
+     * https://github.com/airbnb/enzyme/issues/426#issuecomment-228601631
+     */
+    document.addEventListener = jest.fn((event, cb) => {
+      map[event] = cb;
+    });
+  });
+  it("renders without crashing", () => {
+    const component = shallow(
+      <KeyboardShortcuts contentRef={"test"}>
+        <p>test</p>
+      </KeyboardShortcuts>
+    );
+    expect(component).not.toBeNull();
+  });
+  it("does nothing if enter is not pressed", () => {
+    const executeFocusedCell = jest.fn();
+    const component = shallow(
+      <KeyboardShortcuts
+        contentRef={"test"}
+        executeFocusedCell={executeFocusedCell}
+      >
+        <p>test</p>
+      </KeyboardShortcuts>
+    );
+    expect(component).not.toBeNull();
+    map.keydown({ keyCode: 14 });
+
+    expect(executeFocusedCell).not.toBeCalled();
+  });
+  it("does nothing if a meta key is not pressed", () => {
+    const executeFocusedCell = jest.fn();
+    const component = shallow(
+      <KeyboardShortcuts
+        contentRef={"test"}
+        executeFocusedCell={executeFocusedCell}
+      >
+        <p>test</p>
+      </KeyboardShortcuts>
+    );
+    expect(component).not.toBeNull();
+    map.keydown({ keyCode: 13, ctrlKey: false });
+    expect(executeFocusedCell).not.toBeCalled();
+  });
+  it("executes focused cell if the correct key combination is pressed", () => {
+    const executeFocusedCell = jest.fn();
+    const focusNextCell = jest.fn();
+    const focusNextCellEditor = jest.fn();
+
+    const component = mount(
+      <KeyboardShortcuts
+        contentRef={"test"}
+        executeFocusedCell={executeFocusedCell}
+        focusNextCell={focusNextCell}
+        focusNextCellEditor={focusNextCellEditor}
+        focusedCell={"cellId"}
+        cellOrder={Immutable.List(["cellId", "cellId1"])}
+        cellMap={Immutable.Map({
+          cellId: Immutable.Map({ cell_type: "code" }),
+          cellId1: Immutable.Map({ cell_type: "code" })
+        })}
+      >
+        <p>test</p>
+      </KeyboardShortcuts>
+    );
+    expect(component).not.toBeNull();
+    map.keydown({
+      keyCode: 13,
+      ctrlKey: true,
+      metaKey: true,
+      shiftKey: true,
+      preventDefault: () => {}
+    });
+    // Should execute the currently focused cell
+    expect(executeFocusedCell).toBeCalled();
+    // Should focus the next cell
+    expect(focusNextCell).toBeCalled();
+    // Should focus the next cell editor since it is a code cell
+    expect(focusNextCellEditor).toBeCalled();
+  });
+  it("should not focus next cell's editor if it is markdown", () => {
+    const executeFocusedCell = jest.fn();
+    const focusNextCell = jest.fn();
+    const focusNextCellEditor = jest.fn();
+
+    const component = mount(
+      <KeyboardShortcuts
+        contentRef={"test"}
+        executeFocusedCell={executeFocusedCell}
+        focusNextCell={focusNextCell}
+        focusNextCellEditor={focusNextCellEditor}
+        focusedCell={"cellId"}
+        cellOrder={Immutable.List(["cellId", "cellId1"])}
+        cellMap={Immutable.Map({
+          cellId: Immutable.Map({ cell_type: "code" }),
+          cellId1: Immutable.Map({ cell_type: "markdown" })
+        })}
+      >
+        <p>test</p>
+      </KeyboardShortcuts>
+    );
+    expect(component).not.toBeNull();
+    map.keydown({
+      keyCode: 13,
+      ctrlKey: true,
+      metaKey: true,
+      shiftKey: true,
+      preventDefault: () => {}
+    });
+    // Should execute the currently focused cell
+    expect(executeFocusedCell).toBeCalled();
+    // Should focus the next cell
+    expect(focusNextCell).toBeCalled();
+    // Should focus the next cell editor since it is a code cell
+    expect(focusNextCellEditor).not.toBeCalled();
+  });
+});

--- a/packages/notebook-app-component/__tests__/decorators/kbd-shortcuts.spec.tsx
+++ b/packages/notebook-app-component/__tests__/decorators/kbd-shortcuts.spec.tsx
@@ -37,7 +37,7 @@ describe("KeyboardShortcuts", () => {
       </KeyboardShortcuts>
     );
     expect(component).not.toBeNull();
-    map.keydown({ keyCode: 14 });
+    map.keydown({ key: "Not Enter" });
 
     expect(executeFocusedCell).not.toBeCalled();
   });
@@ -52,7 +52,7 @@ describe("KeyboardShortcuts", () => {
       </KeyboardShortcuts>
     );
     expect(component).not.toBeNull();
-    map.keydown({ keyCode: 13, ctrlKey: false });
+    map.keydown({ key: "Enter", ctrlKey: false });
     expect(executeFocusedCell).not.toBeCalled();
   });
   it("executes focused cell if the correct key combination is pressed", () => {
@@ -78,7 +78,7 @@ describe("KeyboardShortcuts", () => {
     );
     expect(component).not.toBeNull();
     map.keydown({
-      keyCode: 13,
+      key: "Enter",
       ctrlKey: false,
       metaKey: true,
       shiftKey: true,
@@ -114,7 +114,7 @@ describe("KeyboardShortcuts", () => {
     );
     expect(component).not.toBeNull();
     map.keydown({
-      keyCode: 13,
+      key: "Enter",
       ctrlKey: false,
       metaKey: true,
       shiftKey: true,

--- a/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
+++ b/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
@@ -48,7 +48,7 @@ export class KeyboardShortcuts extends React.PureComponent<Props> {
 
   keyDown(e: KeyboardEvent): void {
     // If enter is not pressed, do nothing
-    if (e.keyCode !== 13) {
+    if (e.key !== "Enter") {
       return;
     }
 

--- a/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
+++ b/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
@@ -100,7 +100,7 @@ export class KeyboardShortcuts extends React.PureComponent<Props> {
           nextCell === undefined ||
           (nextCell && nextCell.get("cell_type") === "code")
         ) {
-          focusNextCellEditor({ id: focusedCell || undefined, contentRef });
+          focusNextCellEditor({ id: focusedCell, contentRef });
         }
       }
     }

--- a/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
+++ b/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
@@ -1,0 +1,153 @@
+import Immutable from "immutable";
+import React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+
+import { CellId } from "@nteract/commutable";
+import { actions, AppState, ContentRef, selectors } from "@nteract/core";
+
+interface ComponentProps {
+  contentRef: ContentRef;
+  children: React.ReactNode;
+}
+
+interface StateProps {
+  cellMap: Immutable.Map<string, any>;
+  cellOrder: Immutable.List<string>;
+  focusedCell?: string | null;
+}
+
+interface DispatchProps {
+  executeFocusedCell: (payload: { contentRef: ContentRef }) => void;
+  focusNextCell: (payload: {
+    id?: CellId;
+    createCellIfUndefined: boolean;
+    contentRef: ContentRef;
+  }) => void;
+  focusNextCellEditor: (payload: {
+    id?: CellId;
+    contentRef: ContentRef;
+  }) => void;
+}
+
+export class KeyboardShortcuts extends React.Component<
+  ComponentProps & StateProps & DispatchProps
+> {
+  constructor(props: ComponentProps & StateProps & DispatchProps) {
+    super(props);
+    this.keyDown = this.keyDown.bind(this);
+  }
+
+  componentDidMount(): void {
+    document.addEventListener("keydown", this.keyDown);
+  }
+
+  componentWillUnmount(): void {
+    document.removeEventListener("keydown", this.keyDown);
+  }
+
+  keyDown(e: KeyboardEvent): void {
+    // If enter is not pressed, do nothing
+    if (e.keyCode !== 13) {
+      return;
+    }
+
+    const {
+      executeFocusedCell,
+      focusNextCell,
+      focusNextCellEditor,
+      contentRef,
+      cellOrder,
+      focusedCell,
+      cellMap
+    } = this.props;
+
+    let ctrlKeyPressed = e.ctrlKey;
+    // Allow cmd + enter (macOS) to operate like ctrl + enter
+    if (process.platform === "darwin") {
+      ctrlKeyPressed = (e.metaKey || e.ctrlKey) && !(e.metaKey && e.ctrlKey);
+    }
+
+    const shiftXORctrl =
+      (e.shiftKey || ctrlKeyPressed) && !(e.shiftKey && ctrlKeyPressed);
+    if (!shiftXORctrl) {
+      return;
+    }
+
+    e.preventDefault();
+
+    if (focusedCell) {
+      // NOTE: Order matters here because we need it to execute _before_ we
+      // focus the next cell
+      executeFocusedCell({ contentRef });
+
+      if (e.shiftKey) {
+        /** Get the next cell and check if it is a markdown cell. */
+        const focusedCellIndex = cellOrder.indexOf(focusedCell);
+        const nextCellId = cellOrder.get(focusedCellIndex + 1);
+        const nextCell = nextCellId ? cellMap.get(nextCellId) : undefined;
+
+        /** Always focus the next cell. */
+        focusNextCell({
+          id: undefined,
+          createCellIfUndefined: true,
+          contentRef
+        });
+
+        /** Only focus the next editor if it is a code cell or a cell
+         * created at the bottom of the notebook. */
+        if (
+          nextCell === undefined ||
+          (nextCell && nextCell.get("cell_type") === "code")
+        ) {
+          focusNextCellEditor({ id: focusedCell || undefined, contentRef });
+        }
+      }
+    }
+  }
+
+  render() {
+    return <React.Fragment>{this.props.children}</React.Fragment>;
+  }
+}
+
+const makeMapStateToProps = (state: AppState, ownProps: ComponentProps) => {
+  const { contentRef } = ownProps;
+  const mapStateToProps = (state: AppState) => {
+    const model = selectors.model(state, { contentRef });
+
+    let cellOrder = Immutable.List();
+    let cellMap = Immutable.Map<string, any>();
+    let focusedCell;
+
+    if (model && model.type === "notebook") {
+      cellOrder = model.notebook.cellOrder;
+      cellMap = selectors.notebook.cellMap(model);
+      focusedCell = selectors.notebook.cellFocused(model);
+    }
+
+    return {
+      cellOrder,
+      cellMap,
+      focusedCell
+    };
+  };
+  return mapStateToProps;
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  executeFocusedCell: (payload: { contentRef: ContentRef }) =>
+    dispatch(actions.executeFocusedCell(payload)),
+  focusNextCell: (payload: {
+    id?: CellId;
+    createCellIfUndefined: boolean;
+    contentRef: ContentRef;
+  }) => dispatch(actions.focusNextCell(payload)),
+  focusNextCellEditor: (payload: { id?: CellId; contentRef: ContentRef }) =>
+    dispatch(actions.focusNextCellEditor(payload))
+});
+
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(KeyboardShortcuts);

--- a/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
+++ b/packages/notebook-app-component/src/decorators/kbd-shortcuts/index.tsx
@@ -30,10 +30,10 @@ interface DispatchProps {
   }) => void;
 }
 
-export class KeyboardShortcuts extends React.Component<
-  ComponentProps & StateProps & DispatchProps
-> {
-  constructor(props: ComponentProps & StateProps & DispatchProps) {
+type Props = ComponentProps & StateProps & DispatchProps;
+
+export class KeyboardShortcuts extends React.PureComponent<Props> {
+  constructor(props: Props) {
     super(props);
     this.keyDown = this.keyDown.bind(this);
   }

--- a/packages/notebook-app-component/src/notebook-apps/draggable-with-cell-creator.tsx
+++ b/packages/notebook-app-component/src/notebook-apps/draggable-with-cell-creator.tsx
@@ -1,22 +1,23 @@
-import React from "react";
+import { CellType } from "@nteract/commutable";
+import { ContentRef } from "@nteract/core";
 import {
   Cells,
   CodeCell,
   MarkdownCell,
   RawCell
 } from "@nteract/stateful-components";
-import { ContentRef } from "@nteract/core";
-import { CellType } from "@nteract/commutable";
+import React from "react";
 
-import CellToolbar from "../derived-components/toolbar";
 import StatusBar from "../derived-components/status-bar";
+import CellToolbar from "../derived-components/toolbar";
 
 import { DragDropContext as dragDropContext } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 
+import CellCreator from "../decorators/cell-creator";
 import DraggableCell from "../decorators/draggable";
 import HijackScroll from "../decorators/hijack-scroll";
-import CellCreator from "../decorators/cell-creator";
+import KeyboardShortcuts from "../decorators/kbd-shortcuts";
 import Themer from "../decorators/themer";
 import UndoableCellDelete from "../decorators/undoable/undoable-cell-delete";
 
@@ -51,71 +52,73 @@ export class NotebookApp extends React.Component<ComponentProps> {
     return (
       <React.Fragment>
         <Themer>
-          <Cells contentRef={this.props.contentRef}>
-            {{
-              code: (props: { id: string; contentRef: ContentRef }) =>
-                decorate(
-                  props.id,
-                  props.contentRef,
-                  "code",
-                  <CodeCell
-                    id={props.id}
-                    contentRef={props.contentRef}
-                    cell_type="code"
-                  >
-                    {{
-                      toolbar: () => (
-                        <CellToolbar
-                          id={props.id}
-                          contentRef={props.contentRef}
-                        />
-                      )
-                    }}
-                  </CodeCell>
-                ),
-              markdown: (props: { id: string; contentRef: ContentRef }) =>
-                decorate(
-                  props.id,
-                  props.contentRef,
-                  "markdown",
-                  <MarkdownCell
-                    id={props.id}
-                    contentRef={props.contentRef}
-                    cell_type="markdown"
-                  >
-                    {{
-                      toolbar: () => (
-                        <CellToolbar
-                          id={props.id}
-                          contentRef={props.contentRef}
-                        />
-                      )
-                    }}
-                  </MarkdownCell>
-                ),
-              raw: (props: { id: string; contentRef: ContentRef }) =>
-                decorate(
-                  props.id,
-                  props.contentRef,
-                  "raw",
-                  <RawCell
-                    id={props.id}
-                    contentRef={props.contentRef}
-                    cell_type="raw"
-                  >
-                    {{
-                      toolbar: () => (
-                        <CellToolbar
-                          id={props.id}
-                          contentRef={props.contentRef}
-                        />
-                      )
-                    }}
-                  </RawCell>
-                )
-            }}
-          </Cells>
-          <StatusBar contentRef={this.props.contentRef} />
+          <KeyboardShortcuts contentRef={this.props.contentRef}>
+            <Cells contentRef={this.props.contentRef}>
+              {{
+                code: (props: { id: string; contentRef: ContentRef }) =>
+                  decorate(
+                    props.id,
+                    props.contentRef,
+                    "code",
+                    <CodeCell
+                      id={props.id}
+                      contentRef={props.contentRef}
+                      cell_type="code"
+                    >
+                      {{
+                        toolbar: () => (
+                          <CellToolbar
+                            id={props.id}
+                            contentRef={props.contentRef}
+                          />
+                        )
+                      }}
+                    </CodeCell>
+                  ),
+                markdown: (props: { id: string; contentRef: ContentRef }) =>
+                  decorate(
+                    props.id,
+                    props.contentRef,
+                    "markdown",
+                    <MarkdownCell
+                      id={props.id}
+                      contentRef={props.contentRef}
+                      cell_type="markdown"
+                    >
+                      {{
+                        toolbar: () => (
+                          <CellToolbar
+                            id={props.id}
+                            contentRef={props.contentRef}
+                          />
+                        )
+                      }}
+                    </MarkdownCell>
+                  ),
+                raw: (props: { id: string; contentRef: ContentRef }) =>
+                  decorate(
+                    props.id,
+                    props.contentRef,
+                    "raw",
+                    <RawCell
+                      id={props.id}
+                      contentRef={props.contentRef}
+                      cell_type="raw"
+                    >
+                      {{
+                        toolbar: () => (
+                          <CellToolbar
+                            id={props.id}
+                            contentRef={props.contentRef}
+                          />
+                        )
+                      }}
+                    </RawCell>
+                  )
+              }}
+            </Cells>
+            <StatusBar contentRef={this.props.contentRef} />
+          </KeyboardShortcuts>
         </Themer>
       </React.Fragment>
     );


### PR DESCRIPTION
Adds back support for Ctrl+Enter keyboard shortcut for cell execution as a component decorator.

And also some tests. 🎉 🌮  