### PR TITLE
Change acceptPayloadMessage to take JupyterMessage

### DIFF
--- a/packages/actions/src/actionTypes/cell_io.ts
+++ b/packages/actions/src/actionTypes/cell_io.ts
@@ -1,6 +1,6 @@
 // tslint:disable:max-line-length
 import { JSONObject, OnDiskOutput } from "@nteract/commutable";
-import { PayloadMessage } from "@nteract/types";
+import { JupyterMessage } from "@nteract/messaging";
 import { Action, HasCell, HasContent, makeActionFunction, MaybeHasCell } from "../utils";
 
 export const PROMPT_INPUT_REQUEST           = "PROMPT_INPUT_REQUEST";
@@ -24,7 +24,7 @@ export type ToggleCellOutputVisibility      = Action<typeof TOGGLE_CELL_OUTPUT_V
 export type ClearOutputs                    = Action<typeof CLEAR_OUTPUTS,                  MaybeHasCell>;
 export type UpdateOutputMetadata            = Action<typeof UPDATE_OUTPUT_METADATA,         HasCell & { metadata: JSONObject; index: number; mediaType: string }>;
 export type AppendOutput                    = Action<typeof APPEND_OUTPUT,                  HasCell &  { output: OnDiskOutput }>;
-export type AcceptPayloadMessage            = Action<typeof ACCEPT_PAYLOAD_MESSAGE,         HasCell &  { payload: PayloadMessage }>;
+export type AcceptPayloadMessage            = Action<typeof ACCEPT_PAYLOAD_MESSAGE,         HasCell &  { payload: JupyterMessage }>;
 export type ToggleCellExpansion             = Action<typeof TOGGLE_OUTPUT_EXPANSION,        HasCell>;
 
 export const promptInputRequest             = makeActionFunction<PromptInputRequest>        (PROMPT_INPUT_REQUEST);

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -42,8 +42,7 @@ import {
   AppState,
   ContentRef,
   InputRequestMessage,
-  KernelStatus,
-  PayloadMessage
+  KernelStatus
 } from "@nteract/types";
 import { List } from "immutable";
 
@@ -80,7 +79,7 @@ export function executeCellStream(
 
   const cellAction$ = merge(
     payloadStream.pipe(
-      map((payload: PayloadMessage) =>
+      map((payload: JupyterMessage) =>
         actions.acceptPayloadMessage({ id, payload, contentRef })
       )
     ),

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -1,4 +1,3 @@
-import { PayloadMessage } from "@nteract/types";
 import { from, Observable, Subscriber } from "rxjs";
 import { filter, map, mergeMap } from "rxjs/operators";
 import { executeRequest, message } from "./messages";
@@ -231,16 +230,12 @@ export const updatedOutputs = () => (source: Observable<JupyterMessage>) =>
  *     payloads()
  *   )
  */
-export const payloads = () => (
-  source: Observable<JupyterMessage>
-): Observable<PayloadMessage> =>
-  source.pipe(
-    ofMessageType("execute_reply"),
-    map(entry => entry.content.payload),
-    filter(p => !!p),
-    mergeMap((p: Observable<PayloadMessage>) => from(p))
-  );
-
+export const payloads = () => (source: Observable<JupyterMessage>):
+Observable<JupyterMessage> => source.pipe(
+  ofMessageType("execute_reply"),
+  mergeMap((p: Observable<JupyterMessage>) => from(p))
+);
+  
 /**
  * Get all the execution counts from an observable of jupyter messages
  */

--- a/packages/messaging/src/types.ts
+++ b/packages/messaging/src/types.ts
@@ -2,7 +2,7 @@ import { JSONObject, MediaBundle } from "@nteract/commutable";
 import { Subject } from "rxjs";
 
 export type MessageType =
-  | "execute_request"
+  "execute_request"
   | "inspect_request"
   | "inspect_reply"
   | "kernel_info_request"
@@ -35,7 +35,11 @@ export type MessageType =
   | "is_complete_reply"
   | "execute_reply"
   | "interrupt_request"
-  | "interrupt_reply";
+  | "interrupt_reply"
+  | "page"
+  | "set_next_input"
+  | "edit"
+  | "ask_exit";
 
 export interface JupyterMessageHeader<MT extends MessageType = MessageType> {
   msg_id: string;

--- a/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
+++ b/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
@@ -1008,36 +1008,223 @@ describe("acceptPayloadMessage", () => {
       notebook,
       cellPagers: Immutable.Map({})
     });
-    const state = reducers(
+    const statePage = reducers(
       initialState,
       actions.acceptPayloadMessage({
         id: firstCellId,
+        contentRef: undefined,    
         payload: {
-          source: "page",
-          data: { well: "alright" }
-        }
+          "header":{
+             "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+             "msg_type":"execute_reply",
+             "username":"username",
+             "session":"3e37709b-9eae434d4f21a1641a80a792",
+             "date":"2020-02-04T19:36:38.753971Z",
+             "version":"5.3"
+          },
+          "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+          "msg_type":"execute_reply",
+          "parent_header":{
+             "msg_id":"27ad5f9cecea41408e4ffea0fb126298",
+             "username":"username",
+             "session":"67f06f92bdf241728e2c602cc6d15bfe",
+             "msg_type":"execute_request",
+             "version":"5.2",
+             "date":"2020-02-04T19:36:38.749972Z"
+          },
+          "metadata":{
+             "started":"2020-02-04T19:36:38.749972Z",
+             "dependencies_met":true,
+             "engine":"9678b838-0f3c-4e59-ae18-0bd17bc15af3",
+             "status":"ok"
+          },
+          "content":{
+             "status":"ok",
+             "execution_count":2,
+             "user_expressions":{
+       
+             },
+             "payload":[
+                {
+                   "source":"page",
+                   "data":{ well: "alright" },
+                }
+             ]
+          },
+          "buffers":[
+          ],
+          "channel":"shell"
+       }
       })
     );
-
-    expect(state.getIn(["cellPagers", firstCellId])).toEqual(
+    
+    expect(statePage.getIn(["cellPagers", firstCellId])).toEqual(
       Immutable.List([{ well: "alright" }])
     );
 
-    const nextState = reducers(
-      state,
+    const stateSetNextInput = reducers(
+      statePage,
       actions.acceptPayloadMessage({
         id: firstCellId,
+        contentRef: undefined,
         payload: {
-          source: "set_next_input",
-          replace: true,
-          text: "this is now the text"
-        }
+          "header":{
+             "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+             "msg_type":"execute_reply",
+             "username":"username",
+             "session":"3e37709b-9eae434d4f21a1641a80a792",
+             "date":"2020-02-04T19:36:38.753971Z",
+             "version":"5.3"
+          },
+          "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+          "msg_type":"execute_reply",
+          "parent_header":{
+             "msg_id":"27ad5f9cecea41408e4ffea0fb126298",
+             "username":"username",
+             "session":"67f06f92bdf241728e2c602cc6d15bfe",
+             "msg_type":"execute_request",
+             "version":"5.2",
+             "date":"2020-02-04T19:36:38.749972Z"
+          },
+          "metadata":{
+             "started":"2020-02-04T19:36:38.749972Z",
+             "dependencies_met":true,
+             "engine":"9678b838-0f3c-4e59-ae18-0bd17bc15af3",
+             "status":"ok"
+          },
+          "content":{
+             "status":"ok",
+             "execution_count":2,
+             "user_expressions":{
+       
+             },
+             "payload":[
+                {
+                   "source":"set_next_input",
+                   "text":"this is now the test",
+                   "replace":true
+                }
+             ]
+          },
+          "buffers":[
+          ],
+          "channel":"shell"
+       }
       })
     );
 
     expect(
-      nextState.getIn(["notebook", "cellMap", firstCellId, "source"])
-    ).toEqual("this is now the text");
+      stateSetNextInput.getIn(["notebook", "cellMap", firstCellId, "source"])
+    ).toEqual("this is now the test");
+
+    const stateSetNextInputReplace = reducers(
+      statePage,
+      actions.acceptPayloadMessage({
+        id: firstCellId,
+        contentRef: undefined,
+        payload: {
+          "header":{
+             "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+             "msg_type":"execute_reply",
+             "username":"username",
+             "session":"3e37709b-9eae434d4f21a1641a80a792",
+             "date":"2020-02-04T19:36:38.753971Z",
+             "version":"5.3"
+          },
+          "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+          "msg_type":"execute_reply",
+          "parent_header":{
+             "msg_id":"27ad5f9cecea41408e4ffea0fb126298",
+             "username":"username",
+             "session":"67f06f92bdf241728e2c602cc6d15bfe",
+             "msg_type":"execute_request",
+             "version":"5.2",
+             "date":"2020-02-04T19:36:38.749972Z"
+          },
+          "metadata":{
+             "started":"2020-02-04T19:36:38.749972Z",
+             "dependencies_met":true,
+             "engine":"9678b838-0f3c-4e59-ae18-0bd17bc15af3",
+             "status":"ok"
+          },
+          "content":{
+             "status":"ok",
+             "execution_count":2,
+             "user_expressions":{
+       
+             },
+             "payload":[
+                {
+                   "source":"set_next_input",
+                   "text":"this is now the test",
+                   "replace":true
+                }
+             ]
+          },
+          "buffers":[
+          ],
+          "channel":"shell"
+       }
+      })
+    );
+
+    expect(
+      stateSetNextInputReplace.getIn(["notebook", "cellMap", firstCellId, "source"])
+    ).toEqual("this is now the test");
+
+    const unsupportedPayload = reducers(
+      statePage,
+      actions.acceptPayloadMessage({
+        id: firstCellId,
+        contentRef: undefined,
+        payload: {
+          "header":{
+             "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+             "msg_type":"execute_reply",
+             "username":"username",
+             "session":"3e37709b-9eae434d4f21a1641a80a792",
+             "date":"2020-02-04T19:36:38.753971Z",
+             "version":"5.3"
+          },
+          "msg_id":"82f36e0e-17af3c883025ae499dc1f660",
+          "msg_type":"execute_reply",
+          "parent_header":{
+             "msg_id":"27ad5f9cecea41408e4ffea0fb126298",
+             "username":"username",
+             "session":"67f06f92bdf241728e2c602cc6d15bfe",
+             "msg_type":"execute_request",
+             "version":"5.2",
+             "date":"2020-02-04T19:36:38.749972Z"
+          },
+          "metadata":{
+             "started":"2020-02-04T19:36:38.749972Z",
+             "dependencies_met":true,
+             "engine":"9678b838-0f3c-4e59-ae18-0bd17bc15af3",
+             "status":"ok"
+          },
+          "content":{
+             "status":"ok",
+             "execution_count":2,
+             "user_expressions":{
+       
+             },
+             "payload":[
+                {
+                   "source":"unsupported",
+                }
+             ]
+          },
+          "buffers":[
+          ],
+          "channel":"shell"
+       }
+      })
+    );
+  
+      expect(
+        unsupportedPayload.getIn(["notebook", "cellMap", firstCellId, "source"])
+      ).toEqual("this is now the test");  
+
   });
 });
 


### PR DESCRIPTION
Before, the function was taking a custom payload object. Typing now allows
JupyterMessage to be accepted as payload.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
