### PR TITLE
Add directory touched by pip to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ dist/
 test/*.ipynb
 
 applications/desktop/bin/nteract-env
+applications/jupyter-extension/pip-wheel-metadata/*
 
 # Ignore lerna lock
 packages/*/yarn.lock


### PR DESCRIPTION
When cloning nteract for the first time and downloading depedencies, I had
changes within applications/jupyter-extension/pip-wheel-metadata/*. Because
this was done by pip, there is no need to have these files in the repo.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
