### PR TITLE
Fix desktop integration in AppImage package

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -90,7 +90,6 @@
         "Icon": "nteract",
         "MimeType": "application/x-ipynb+json;",
         "Name": "nteract",
-        "Path": "/opt/nteract/",
         "StartupNotify": "true",
         "Terminal": "false",
         "Type": "Application",


### PR DESCRIPTION
By removing the hardcoded reference to /opt/nteract in the configuration for electron-builder, this PR fixes #2661. It also fixes an issue with the .deb package, where Nteract would attempt to save unnamed notebooks to `/opt/nteract/Untitled.ipynb`, where the user does not have write permission, as described in https://github.com/nteract/nteract/issues/2661#issuecomment-575561001.

The hardcoded path existed in `build -> linux -> desktop -> Path` of `package.json`, and specifies the Path key  for the .desktop files generated by electron-builder. This Path key of .desktop files control the working directory where the application is launched, and is not necessary in our case because nteract does not need to be run with a specific working directory.

**Note:**
I have not replicated your build system in order to test this PR. I have, however, tested that removing the Path key from the .desktop files fixes AppImage installations, and improves .deb installations. It seems excessive to spend  lot of time setting up a correct build system for such a small PR, but feel free to let me know if it would be necessary before it could be accepted.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
