### PR TITLE
Support "addCloseObserver" as configurable property in JupyterHostRecord

### DIFF
--- a/packages/epics/__tests__/websocket-kernel.spec.ts
+++ b/packages/epics/__tests__/websocket-kernel.spec.ts
@@ -41,12 +41,14 @@ describe("launchWebSocketKernelEpic", () => {
     const contentRef = "fakeContentRef";
     const kernelRef = "fake";
     const hostRef = "fakeHostRef";
+    const closeObserver = { next: () => {} }
     const value = {
       app: stateModule.makeAppRecord({
         host: stateModule.makeJupyterHostRecord({
           type: "jupyter",
           token: "eh",
-          basePath: "http://localhost:8888/"
+          basePath: "http://localhost:8888/",
+          closeObserver
         }),
         notificationSystem: { addNotification: jest.fn() }
       }),
@@ -75,7 +77,8 @@ describe("launchWebSocketKernelEpic", () => {
               [hostRef]: stateModule.makeJupyterHostRecord({
                 type: "jupyter",
                 token: "eh",
-                basePath: "http://localhost:8888/"
+                basePath: "http://localhost:8888/",
+                closeObserver
               })
             })
           })

--- a/packages/rx-jupyter/src/kernels.ts
+++ b/packages/rx-jupyter/src/kernels.ts
@@ -147,7 +147,8 @@ export const connect = (
 ): Subject<any> => {
   const wsSubject = webSocket<JupyterMessage>({
     url: formWebSocketURL(serverConfig, kernelID, sessionID),
-    protocol: serverConfig.wsProtocol
+    protocol: serverConfig.wsProtocol,
+    closeObserver: serverConfig.closeObserver
   });
 
   // Create a subject that does some of the handling inline for the session

--- a/packages/selectors/src/core/hosts.ts
+++ b/packages/selectors/src/core/hosts.ts
@@ -22,7 +22,8 @@ export const serverConfig = (host: JupyterHostRecord): ServerConfig => {
     crossDomain: host.crossDomain ? host.crossDomain : undefined,
     token: host.token ? host.token : undefined,
     ajaxOptions: host.ajaxOptions ? host.ajaxOptions : undefined,
-    wsProtocol: host.wsProtocol ? host.wsProtocol : undefined
+    wsProtocol: host.wsProtocol ? host.wsProtocol : undefined,
+    closeObserver: host.closeObserver ? host.closeObserver : undefined
   };
 };
 

--- a/packages/types/src/entities/hosts/remote-jupyter.ts
+++ b/packages/types/src/entities/hosts/remote-jupyter.ts
@@ -39,7 +39,8 @@ export const makeJupyterHostRecord = Immutable.Record<JupyterHostRecordProps>({
   ajaxOptions: undefined,
   wsProtocol: undefined,
   bookstoreEnabled: false,
-  showHeaderEditor: false
+  showHeaderEditor: false,
+  closeObserver: undefined
 });
 
 export type JupyterHostRecord = Immutable.RecordOf<JupyterHostRecordProps>;

--- a/packages/types/src/entities/hosts/remote-jupyter.ts
+++ b/packages/types/src/entities/hosts/remote-jupyter.ts
@@ -1,4 +1,5 @@
 import * as Immutable from "immutable";
+import { NextObserver } from "rxjs";
 import { AjaxRequest } from "rxjs/ajax";
 
 import { BaseHostProps } from "./base";
@@ -11,6 +12,7 @@ export interface ServerConfig {
   xsrfToken?: string;
   ajaxOptions?: Partial<AjaxRequest>;
   wsProtocol?: string | string[];
+  closeObserver?: NextObserver<CloseEvent>;
 }
 
 export type JupyterHostRecordProps = BaseHostProps & {
@@ -23,6 +25,7 @@ export type JupyterHostRecordProps = BaseHostProps & {
   crossDomain?: boolean | null;
   ajaxOptions?: Partial<AjaxRequest>;
   wsProtocol?: string | string[];
+  closeObserver?: NextObserver<CloseEvent>;
 };
 
 export const makeJupyterHostRecord = Immutable.Record<JupyterHostRecordProps>({


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

Add closeObserver pass to rxjs, so consumer application can detect web socket connection failure.

