### PR TITLE
Revert "Update dependency mkdirp to v1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "lerna": "^3.0.0",
     "lint-staged": "^10.0.0",
     "lodash-webpack-plugin": "^0.11.4",
-    "mkdirp": "^1.0.0",
+    "mkdirp": "^0.5.1",
     "node-fetch": "2.6.0",
     "portfinder": "^1.0.20",
     "prettier": "1.19.1",

--- a/packages/fs-observable/package.json
+++ b/packages/fs-observable/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "filewatcher": "^3.0.1",
-    "mkdirp": "^1.0.0"
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "@types/mkdirp": "^0.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10140,11 +10140,6 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.1.tgz#57828231711628a8a303f455bb7d79b32d9c9d4f"
-  integrity sha512-epSaAwmT1sXxKNHFtzxrNEepE0qneey1uVReE15tN3Zvba3ifzx01eStvvvyb8dQeI50CVuGZ5qnSk2wMtsysg==
-
 mock-require@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-3.0.3.tgz#ccd544d9eae81dd576b3f219f69ec867318a1946"


### PR DESCRIPTION
Reverts nteract/nteract#4859 due to it breaking `desktop`.