### PR TITLE
Add ansi-{decoration} classes to Ansi component

### DIFF
--- a/packages/ansi-to-react/__tests__/index.spec.ts
+++ b/packages/ansi-to-react/__tests__/index.spec.ts
@@ -5,6 +5,7 @@ import Ansi from "../src/index";
 
 const GREEN_FG = "\u001b[32m";
 const YELLOW_BG = "\u001b[43m";
+const BOLD = "\u001b[1m";
 const RESET = "\u001b[0;m";
 
 describe("Ansi", () => {
@@ -147,6 +148,21 @@ describe("Ansi", () => {
       expect(el.text()).toBe("hello world");
       expect(el.html()).toBe(
         "<code><span>hello </span><span class=\"ansi-yellow-bg ansi-green-fg\">world</span></code>"
+      );
+    });
+
+    test("can add text decoration classes", () => {
+      const el = shallow(
+        React.createElement(
+          Ansi,
+          { useClasses: true },
+          `hello ${GREEN_FG}${BOLD}world${RESET}!`,
+        )
+      );
+      expect(el).not.toBeNull();
+      expect(el.text()).toBe("hello world!");
+      expect(el.html()).toBe(
+        "<code><span>hello </span><span class=\"ansi-green-fg ansi-bold\">world</span><span>!</span></code>"
       );
     });
 

--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -35,9 +35,6 @@ function ansiToJSON(
 function createClass(bundle: AnserJsonEntry): string | null {
   let classNames: string = "";
 
-  if (!bundle.bg && !bundle.fg) {
-    return null;
-  }
   if (bundle.bg) {
     classNames += `${bundle.bg}-bg `;
   }
@@ -46,6 +43,10 @@ function createClass(bundle: AnserJsonEntry): string | null {
   }
   if (bundle.decoration) {
     classNames += `ansi-${bundle.decoration} `;
+  }
+
+  if (classNames === "") {
+    return null;
   }
 
   classNames = classNames.substring(0, classNames.length - 1);

--- a/packages/ansi-to-react/src/index.ts
+++ b/packages/ansi-to-react/src/index.ts
@@ -44,6 +44,9 @@ function createClass(bundle: AnserJsonEntry): string | null {
   if (bundle.fg) {
     classNames += `${bundle.fg}-fg `;
   }
+  if (bundle.decoration) {
+    classNames += `ansi-${bundle.decoration} `;
+  }
 
   classNames = classNames.substring(0, classNames.length - 1);
   return classNames;


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

Followup to #4816.

This adds classes like `ansi-bold` to the output of the `<Ansi />` component when using CSS classes. The declaration for `decoration` is
```ts
export interface AnserJsonEntry {
  // ...
  decoration: null | 'bold' | 'dim' | 'italic' | 'underline' | 'blink' | 'reverse' | 'hidden' | 'strikethrough';
  // ...
}
```