### PR TITLE
Set config in Redux state after loading

### DIFF
--- a/packages/actions/src/actionTypes/config.ts
+++ b/packages/actions/src/actionTypes/config.ts
@@ -4,29 +4,38 @@ import { Action, makeActionFunction } from "../utils";
 // FIXME: probably belongs somewhere else
 interface ConfigPayload {
   config: {
-    [key: string]: string;
+    [key: string]: string | number;
   };
 }
 
-export const LOAD_CONFIG            = "LOAD_CONFIG";
-export const CONFIG_LOADED          = "CONFIG_LOADED";
-export const SAVE_CONFIG            = "SAVE_CONFIG";
-export const DONE_SAVING_CONFIG     = "DONE_SAVING_CONFIG";
-export const MERGE_CONFIG           = "MERGE_CONFIG";
-export const SET_CONFIG_AT_KEY      = "SET_CONFIG_AT_KEY";
+export const LOAD_CONFIG = "LOAD_CONFIG";
+export const CONFIG_LOADED = "CONFIG_LOADED";
+export const SAVE_CONFIG = "SAVE_CONFIG";
+export const DONE_SAVING_CONFIG = "DONE_SAVING_CONFIG";
+export const MERGE_CONFIG = "MERGE_CONFIG";
+export const SET_CONFIG_AT_KEY = "SET_CONFIG_AT_KEY";
 
-export type LoadConfigAction        = Action<typeof LOAD_CONFIG>;
-export type ConfigLoadedAction      = Action<typeof CONFIG_LOADED,        ConfigPayload>;
-export type SaveConfigAction        = Action<typeof SAVE_CONFIG>;
-export type DoneSavingConfigAction  = Action<typeof DONE_SAVING_CONFIG>;
-export type MergeConfigAction       = Action<typeof MERGE_CONFIG,         ConfigPayload>;
-export type SetConfigAction     <T> = Action<typeof SET_CONFIG_AT_KEY,    { key: string; value: T }>;
+export type LoadConfigAction = Action<typeof LOAD_CONFIG>;
+export type ConfigLoadedAction = Action<typeof CONFIG_LOADED, ConfigPayload>;
+export type SaveConfigAction = Action<typeof SAVE_CONFIG>;
+export type DoneSavingConfigAction = Action<typeof DONE_SAVING_CONFIG>;
+export type MergeConfigAction = Action<typeof MERGE_CONFIG, ConfigPayload>;
+export type SetConfigAction<T> = Action<
+  typeof SET_CONFIG_AT_KEY,
+  { key: string; value: T }
+>;
 
-export const loadConfig             = makeActionFunction<LoadConfigAction>      (LOAD_CONFIG);
-export const configLoaded           = makeActionFunction<ConfigLoadedAction>    (CONFIG_LOADED);
-export const saveConfig             = makeActionFunction<SaveConfigAction>      (SAVE_CONFIG);
-export const doneSavingConfig       = makeActionFunction<DoneSavingConfigAction>(DONE_SAVING_CONFIG);
-export const mergeConfig            = makeActionFunction<MergeConfigAction>     (MERGE_CONFIG);
-export const setConfigAtKey         = <T>(key: string, value: T) => makeActionFunction<SetConfigAction<T>>(SET_CONFIG_AT_KEY)({key, value});
-export const setTheme               = (theme: string) => setConfigAtKey("theme", theme);
-export const setCursorBlink         = (value: string) => setConfigAtKey("cursorBlinkRate", value);
+export const loadConfig = makeActionFunction<LoadConfigAction>(LOAD_CONFIG);
+export const configLoaded = makeActionFunction<ConfigLoadedAction>(
+  CONFIG_LOADED
+);
+export const saveConfig = makeActionFunction<SaveConfigAction>(SAVE_CONFIG);
+export const doneSavingConfig = makeActionFunction<DoneSavingConfigAction>(
+  DONE_SAVING_CONFIG
+);
+export const mergeConfig = makeActionFunction<MergeConfigAction>(MERGE_CONFIG);
+export const setConfigAtKey = <T>(key: string, value: T) =>
+  makeActionFunction<SetConfigAction<T>>(SET_CONFIG_AT_KEY)({ key, value });
+export const setTheme = (theme: string) => setConfigAtKey("theme", theme);
+export const setCursorBlink = (value: string) =>
+  setConfigAtKey("cursorBlinkRate", value);

--- a/packages/reducers/__tests__/config.spec.ts
+++ b/packages/reducers/__tests__/config.spec.ts
@@ -29,4 +29,12 @@ describe("mergeConfig", () => {
     });
     expect(state.get("theme")).toBe("dark");
   });
+  test("sets the config on config loaded action", () => {
+    const initialState = Map({ autoSaveInterval: 20000 });
+    const action = actionTypes.configLoaded({
+      config: { autoSaveInterval: 0 }
+    });
+    const state = reducers(initialState, action);
+    expect(state.get("autoSaveInterval")).toBe(0);
+  });
 });

--- a/packages/reducers/src/config.ts
+++ b/packages/reducers/src/config.ts
@@ -1,13 +1,16 @@
 // Vendor modules
-import { MergeConfigAction, SetConfigAction } from "@nteract/actions";
+import * as actions from "@nteract/actions";
 import { ConfigState } from "@nteract/types";
 import { Map } from "immutable";
 
-type ConfigAction = SetConfigAction<any> | MergeConfigAction;
+type ConfigAction =
+  | actions.SetConfigAction<any>
+  | actions.MergeConfigAction
+  | actions.ConfigLoadedAction;
 
 export function setConfigAtKey(
   state: ConfigState,
-  action: SetConfigAction<any>
+  action: actions.SetConfigAction<any>
 ): Map<string, any> {
   const { key, value } = action.payload;
   return state.set(key, value);
@@ -15,7 +18,7 @@ export function setConfigAtKey(
 
 export function mergeConfig(
   state: ConfigState,
-  action: MergeConfigAction
+  action: actions.MergeConfigAction | actions.ConfigLoadedAction
 ): Map<string, any> {
   const { config } = action.payload;
   return state.merge(config);
@@ -26,9 +29,10 @@ export default function handleConfig(
   action: ConfigAction
 ): Map<string, any> {
   switch (action.type) {
-    case "SET_CONFIG_AT_KEY":
+    case actions.SET_CONFIG_AT_KEY:
       return setConfigAtKey(state, action);
-    case "MERGE_CONFIG":
+    case actions.MERGE_CONFIG:
+    case actions.CONFIG_LOADED:
       return mergeConfig(state, action);
     default:
       return state;


### PR DESCRIPTION
Closes #4888 

The action being dispatched when the desktop app loaded the configuration file from the filesystem (`CONFIG_LOADED`) was not the same action used to set config elsewhere (`MERGE_CONFIG`). This PR updates config reducers to update the state when the `CONFIG_LOADED` action is dispatched.