### PR TITLE
Added support for elm syntax highlighting

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -199,6 +199,7 @@ export default class CodeMirrorEditor extends React.PureComponent<
     require("codemirror/mode/python/python");
     require("codemirror/mode/ruby/ruby");
     require("codemirror/mode/javascript/javascript");
+    require("codemirror/mode/elm/elm");
     require("codemirror/mode/css/css");
     require("codemirror/mode/julia/julia");
     require("codemirror/mode/r/r");


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

I just added a line to add support for elm syntax highlighting.

https://github.com/nteract/nteract/issues/4884
