### PR TITLE
Fix performance issues in editor components

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -312,7 +312,9 @@ export default class CodeMirrorEditor extends React.Component<
     const valueChanged = this.props.value !== nextProps.value;
     const editorFocusedChanged =
       this.props.editorFocused !== nextProps.editorFocused;
-    return valueChanged || editorFocusedChanged;
+    const cursorBlinkRateChanged =
+      this.props.cursorBlinkRate !== nextProps.cursorBlinkRate;
+    return valueChanged || editorFocusedChanged || cursorBlinkRateChanged;
   }
 
   componentDidUpdate(prevProps: CodeMirrorEditorProps): void {

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -78,7 +78,7 @@ interface CodeCompletionEvent {
   debounce: boolean;
 }
 
-export default class CodeMirrorEditor extends React.PureComponent<
+export default class CodeMirrorEditor extends React.Component<
   CodeMirrorEditorProps,
   CodeMirrorEditorState
 > {
@@ -303,6 +303,18 @@ export default class CodeMirrorEditor extends React.PureComponent<
     );
   }
 
+  /**
+   * Only update the component if certain values change to avoid
+   * re-renders triggered by the `Editor` parent component in the
+   * @nteract/stateful-components package.
+   */
+  shouldComponentUpdate(nextProps: CodeMirrorEditorProps): boolean {
+    const valueChanged = this.props.value !== nextProps.value;
+    const editorFocusedChanged =
+      this.props.editorFocused !== nextProps.editorFocused;
+    return valueChanged || editorFocusedChanged;
+  }
+
   componentDidUpdate(prevProps: CodeMirrorEditorProps): void {
     if (!this.cm) {
       return;
@@ -475,8 +487,6 @@ export default class CodeMirrorEditor extends React.PureComponent<
               tooltipNode
             )
           : null}
-        <CodeMirrorCSS />
-        <ShowHintCSS />
       </React.Fragment>
     );
   }

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -17,7 +17,7 @@ interface StateProps {
 
 type Props = ComponentProps & StateProps;
 
-export class Cell extends React.Component<ComponentProps & StateProps> {
+export class Cell extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     return nextProps.selected !== this.props.selected;
   }

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -15,7 +15,13 @@ interface StateProps {
   selected: boolean;
 }
 
-export class Cell extends React.PureComponent<ComponentProps & StateProps> {
+type Props = ComponentProps & StateProps;
+
+export class Cell extends React.Component<ComponentProps & StateProps> {
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return nextProps.selected !== this.props.selected;
+  }
+
   render(): JSX.Element | null {
     // We must pick only one child to render
     let chosenOne: React.ReactNode | null = null;

--- a/packages/stateful-components/src/inputs/editor.tsx
+++ b/packages/stateful-components/src/inputs/editor.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
-import { AppState, ContentRef, actions, selectors } from "@nteract/core";
+import { actions, AppState, ContentRef, selectors } from "@nteract/core";
 
 interface ComponentProps {
   id: string;
@@ -19,8 +19,15 @@ interface StateProps {
   theme: string;
 }
 
-export class Editor extends React.Component<ComponentProps & StateProps> {
-  render() {
+interface DispatchProps {
+  onChange: (text: string) => void;
+  onFocusChange: (focused: boolean) => void;
+}
+
+type Props = ComponentProps & StateProps & DispatchProps;
+
+export class Editor extends React.PureComponent<Props> {
+  render(): JSX.Element | null {
     const { editorType } = this.props;
 
     let chosenOne: React.ReactChild | null = null;
@@ -63,7 +70,14 @@ export class Editor extends React.Component<ComponentProps & StateProps> {
 
     // Render the output component that handles this output type
     return React.cloneElement(chosenOne, {
-      ...this.props,
+      editorType: this.props.editorType,
+      value: this.props.value,
+      editorFocused: this.props.editorFocused,
+      channels: this.props.channels,
+      kernelStatus: this.props.kernelStatus,
+      theme: this.props.theme,
+      onChange: this.props.onChange,
+      onFocusChange: this.props.onFocusChange,
       className: "nteract-cell-editor"
     });
   }
@@ -81,8 +95,8 @@ export const makeMapStateToProps = (
     let channels = null;
     let kernelStatus = "not connected";
     let value = "";
-    let editorType = "codemirror";
-    let theme = selectors.userTheme(state);
+    const editorType = "codemirror";
+    const theme = selectors.userTheme(state);
 
     if (model && model.type === "notebook") {
       const cell = selectors.notebook.cellById(model, { id });


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/4885.

For more information on the changes in `packages/editor/src/index.tsx` and `packages/stateful-components/src/inputs/editor.tsx` please see [this comment](https://github.com/nteract/nteract/issues/4885#issuecomment-581191883).

The changes in `packages/stateful-components/src/cells/cell.tsx` were made to resolve an issue I noticed where the `Cell` parent component was re-rendered every time anything in the cell changed since the `Cell` component takes the entire ImmutableCell object as a prop.