### PR TITLE
Lazy kernel launch fixes

### DIFF
--- a/packages/epics/__tests__/execute.spec.ts
+++ b/packages/epics/__tests__/execute.spec.ts
@@ -508,9 +508,9 @@ describe("executeCellAfterKernelLaunchEpic", () => {
     );
   });
 
-  test("do nothing if kernel is still starting", done => {
+  test("do nothing if kernel is shutting down", done => {
     const fakeKernel = stateModule.makeRemoteKernelRecord({
-      status: "starting"
+      status: "shutting down"
     });
     const fakeContent = stateModule
       .makeNotebookContentRecord()


### PR DESCRIPTION
This PR includes two fixes for my previous [lazy kernel launch](https://github.com/nteract/nteract/pull/4822) change:
1. In `lazyLaunchKernelEpic`, using the `first` operator prevents the kernel to be launched in multi-tab senario. Instead of using `first`, we should use `distinct` and compare the `contentRef` from the payload. This will still prevent the kernel from being launched more than once within the same notebook, but allow other tabs to lazy launch kernel as well.
2. In `executeCellAfterKernelLaunchEpic`, if the kernel status is still "starting", then the requests in the message queue will never be executed because the `LAUNCH_KERNEL_SUCESSFUL` action is only emitted once. Since we have existing logic that queues the execute requests if the kernel is still starting, we can relax the status check to only filter out "not connected" and "shutting down" status.
