### PR TITLE
Fix high-order wrapping around DraggableCell

### DIFF
--- a/packages/notebook-app-component/src/decorators/draggable/index.tsx
+++ b/packages/notebook-app-component/src/decorators/draggable/index.tsx
@@ -247,6 +247,7 @@ export const makeMapDispatchToProps = (initialDispatch: Dispatch) => {
   return mapDispatchToProps;
 };
 
-export default source(
-  target(connect(null, makeMapDispatchToProps)(DraggableCellView))
-);
+export default connect(
+  null,
+  makeMapDispatchToProps
+)(source(target(DraggableCellView)));


### PR DESCRIPTION
This fixes the order of the wrapping of the DraggableCellView to resolve issues with the CellView in master.