### PR TITLE
Move from cloneElement to child render props

### DIFF
--- a/packages/stateful-components/__tests__/inputs/editor.spec.tsx
+++ b/packages/stateful-components/__tests__/inputs/editor.spec.tsx
@@ -50,8 +50,10 @@ describe("<Editor/>", () => {
   it("renders the matching child", () => {
     const component = mount(
       <Editor editorType="monaco">
-        <SubEditor editorType="monaco" />
-        <SubEditor editorType="codemirror" />
+        {{
+          monaco: () => <SubEditor editorType="monaco" />,
+          codemirror: () => <SubEditor editorType="codemirror" />
+        }}
       </Editor>
     );
     expect(component.find(".monaco")).toHaveLength(1);
@@ -60,8 +62,10 @@ describe("<Editor/>", () => {
   it("renders nothing if no matching child is found", () => {
     const component = mount(
       <Editor editorType="textarea">
-        <SubEditor editorType="monaco" />
-        <SubEditor editorType="codemirror" />
+        {{
+          monaco: () => <SubEditor editorType="monaco" />,
+          codemirror: () => <SubEditor editorType="codemirror" />
+        }}
       </Editor>
     );
     expect(component.isEmptyRender()).toBe(true);

--- a/packages/stateful-components/__tests__/outputs/index.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/index.spec.tsx
@@ -57,7 +57,7 @@ describe("makeMapStateToProps", () => {
       .first();
     const ownProps = { contentRef, id };
     const result = makeMapStateToProps(state, ownProps)(state);
-    expect(result.hidden).toBe(undefined);
+    expect(result.hidden).toBe(false);
     expect(result.expanded).toBe(true);
   });
 });

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -5,7 +5,7 @@ import { ContentRef } from "@nteract/core";
 import { KernelOutputError, Media, StreamText } from "@nteract/outputs";
 import { Source } from "@nteract/presentational-components";
 
-import Editor, { PassedEditorProps } from "../inputs/editor";
+import Editor, { PassedEditorProps, EditorSlots } from "../inputs/editor";
 import CodeMirrorEditor from "../inputs/connected-editors/codemirror";
 import Input from "../inputs/input";
 import Prompt, { PassedPromptProps } from "../inputs/prompt";
@@ -15,7 +15,7 @@ import Pagers from "../outputs/pagers";
 import TransformMedia from "../outputs/transform-media";
 
 interface NamedCodeCellSlots {
-  editor?: (props: { id: string; contentRef: string }) => JSX.Element;
+  editor?: EditorSlots;
   prompt?: (props: { id: string; contentRef: string }) => JSX.Element;
   pagers?: (props: { id: string; contentRef: string }) => JSX.Element;
   inputPrompts?: (props: { id: string; contentRef: string }) => JSX.Element;
@@ -58,11 +58,11 @@ export default class CodeCell extends React.Component<ComponentProps> {
           }}
         </Prompt>
       ),
-      editor: (props: { id: string; contentRef: string }) => ({
+      editor: {
         codemirror: (props: PassedEditorProps) => (
           <CodeMirrorEditor {...props} editorType={"codemirror"} />
         )
-      }),
+      },
       pagers: (props: any) => (
         <Pagers id={id} contentRef={contentRef}>
           <Media.Json />
@@ -110,7 +110,7 @@ export default class CodeCell extends React.Component<ComponentProps> {
           {prompt({ id, contentRef })}
           <Source className="nteract-cell-source">
             <Editor id={id} contentRef={contentRef}>
-              {editor({ id, contentRef })}
+              {editor}
             </Editor>
           </Source>
         </Input>

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -5,10 +5,10 @@ import { ContentRef } from "@nteract/core";
 import { KernelOutputError, Media, StreamText } from "@nteract/outputs";
 import { Source } from "@nteract/presentational-components";
 
-import Editor from "../inputs/editor";
+import Editor, { PassedEditorProps } from "../inputs/editor";
 import CodeMirrorEditor from "../inputs/connected-editors/codemirror";
 import Input from "../inputs/input";
-import Prompt from "../inputs/prompt";
+import Prompt, { PassedPromptProps } from "../inputs/prompt";
 import Outputs from "../outputs";
 import InputPrompts from "../outputs/input-prompts";
 import Pagers from "../outputs/pagers";
@@ -31,19 +31,6 @@ interface ComponentProps {
   children?: NamedCodeCellSlots;
 }
 
-const PromptText = (props: any) => {
-  if (props.status === "busy") {
-    return <React.Fragment>{"[*]"}</React.Fragment>;
-  }
-  if (props.status === "queued") {
-    return <React.Fragment>{"[…]"}</React.Fragment>;
-  }
-  if (typeof props.executionCount === "number") {
-    return <React.Fragment>{`[${props.executionCount}]`}</React.Fragment>;
-  }
-  return <React.Fragment>{"[ ]"}</React.Fragment>;
-};
-
 export default class CodeCell extends React.Component<ComponentProps> {
   static defaultProps = {
     cell_type: "code"
@@ -55,16 +42,27 @@ export default class CodeCell extends React.Component<ComponentProps> {
     const defaults = {
       prompt: (props: { id: string; contentRef: string }) => (
         <Prompt id={props.id} contentRef={props.contentRef}>
-          <PromptText />
+          {(props: PassedPromptProps) => {
+            if (props.status === "busy") {
+              return <React.Fragment>{"[*]"}</React.Fragment>;
+            }
+            if (props.status === "queued") {
+              return <React.Fragment>{"[…]"}</React.Fragment>;
+            }
+            if (typeof props.executionCount === "number") {
+              return (
+                <React.Fragment>{`[${props.executionCount}]`}</React.Fragment>
+              );
+            }
+            return <React.Fragment>{"[ ]"}</React.Fragment>;
+          }}
         </Prompt>
       ),
-      editor: (props: { id: string; contentRef: string }) => (
-        <CodeMirrorEditor
-          id={props.id}
-          contentRef={props.contentRef}
-          editorType="codemirror"
-        />
-      ),
+      editor: (props: { id: string; contentRef: string }) => ({
+        codemirror: (props: PassedEditorProps) => (
+          <CodeMirrorEditor {...props} editorType={"codemirror"} />
+        )
+      }),
       pagers: (props: any) => (
         <Pagers id={id} contentRef={contentRef}>
           <Media.Json />

--- a/packages/stateful-components/src/cells/markdown-cell.tsx
+++ b/packages/stateful-components/src/cells/markdown-cell.tsx
@@ -6,13 +6,13 @@ import { actions, AppState, ContentRef, selectors } from "@nteract/core";
 import { MarkdownPreviewer } from "@nteract/markdown";
 import { Source } from "@nteract/presentational-components";
 
-import Editor from "../inputs/editor";
+import Editor, { EditorSlots, PassedEditorProps } from "../inputs/editor";
 import CodeMirrorEditor from "../inputs/connected-editors/codemirror";
 
 import { ImmutableCell } from "@nteract/commutable/src";
 
 interface NamedMDCellSlots {
-  editor?: (props: { id: string; contentRef: string }) => JSX.Element;
+  editor?: EditorSlots;
   toolbar?: () => JSX.Element;
 }
 
@@ -52,13 +52,11 @@ export class PureMarkdownCell extends React.Component<
     } = this.props;
 
     const defaults = {
-      editor: (props: { id: string; contentRef: string }) => (
-        <CodeMirrorEditor
-          id={props.id}
-          contentRef={props.contentRef}
-          editorType="codemirror"
-        />
-      )
+      editor: {
+        codemirror: (props: PassedEditorProps) => (
+          <CodeMirrorEditor {...props} editorType={"codemirror"} />
+        )
+      }
     };
 
     const editor = children?.editor || defaults.editor;
@@ -80,7 +78,7 @@ export class PureMarkdownCell extends React.Component<
         >
           <Source className="nteract-cell-source">
             <Editor id={id} contentRef={contentRef}>
-              {editor({ id, contentRef })}
+              {editor}
             </Editor>
           </Source>
         </MarkdownPreviewer>

--- a/packages/stateful-components/src/cells/raw-cell.tsx
+++ b/packages/stateful-components/src/cells/raw-cell.tsx
@@ -6,11 +6,11 @@ import { ImmutableCell } from "@nteract/commutable";
 import { actions, AppState, ContentRef } from "@nteract/core";
 import { Source } from "@nteract/presentational-components";
 
-import Editor from "../inputs/editor";
+import Editor, { PassedEditorProps, EditorSlots } from "../inputs/editor";
 import CodeMirrorEditor from "../inputs/connected-editors/codemirror";
 
 interface NamedRawCellSlots {
-  editor?: (props: { id: string; contentRef: string }) => JSX.Element;
+  editor?: EditorSlots;
   toolbar?: () => JSX.Element;
 }
 
@@ -34,13 +34,11 @@ export class PureRawCell extends React.Component<
     const { id, contentRef, children } = this.props;
 
     const defaults = {
-      editor: (props: { id: string; contentRef: string }) => (
-        <CodeMirrorEditor
-          id={props.id}
-          contentRef={props.contentRef}
-          editorType="codemirror"
-        />
-      )
+      editor: {
+        codemirror: (props: PassedEditorProps) => (
+          <CodeMirrorEditor {...props} editorType={"codemirror"} />
+        )
+      }
     };
 
     const editor = children?.editor || defaults.editor;
@@ -51,7 +49,7 @@ export class PureRawCell extends React.Component<
         {toolbar && toolbar()}
         <Source className="nteract-cell-source">
           <Editor id={id} contentRef={contentRef}>
-            {editor({ id, contentRef })}
+            {editor}
           </Editor>
         </Source>
       </div>

--- a/packages/stateful-components/src/inputs/editor.tsx
+++ b/packages/stateful-components/src/inputs/editor.tsx
@@ -18,7 +18,7 @@ export interface PassedEditorProps {
   className: string;
 }
 
-interface EditorSlots {
+export interface EditorSlots {
   [key: string]: (props: PassedEditorProps) => React.ReactNode;
 }
 

--- a/packages/stateful-components/src/inputs/prompt.tsx
+++ b/packages/stateful-components/src/inputs/prompt.tsx
@@ -3,10 +3,17 @@ import { connect } from "react-redux";
 
 import { AppState, ContentRef, selectors } from "@nteract/core";
 
+export interface PassedPromptProps {
+  id: string;
+  contentRef: ContentRef;
+  status?: string;
+  executionCount?: number;
+}
+
 interface ComponentProps {
   id: string;
   contentRef: ContentRef;
-  children: React.ReactElement;
+  children: (props: PassedPromptProps) => React.ReactNode;
 }
 
 interface StateProps {
@@ -14,27 +21,17 @@ interface StateProps {
   executionCount?: number;
 }
 
-export class Prompt extends React.Component<ComponentProps, StateProps> {
+type Props = StateProps & ComponentProps;
+
+export class Prompt extends React.Component<Props> {
   render() {
     return (
       <div className="nteract-cell-prompt">
-        {React.Children.map(this.props.children, child => {
-          if (!child) {
-            return;
-          }
-          if (
-            typeof child === "string" ||
-            typeof child === "number" ||
-            typeof child === "boolean"
-          ) {
-            return;
-          }
-
-          if (typeof child !== "object" || !("props" in child)) {
-            return;
-          }
-
-          return React.cloneElement(child, this.props);
+        {this.props.children({
+          id: this.props.id,
+          contentRef: this.props.contentRef,
+          status: this.props.status,
+          executionCount: this.props.executionCount
         })}
       </div>
     );

--- a/packages/stateful-components/src/outputs/index.tsx
+++ b/packages/stateful-components/src/outputs/index.tsx
@@ -22,8 +22,9 @@ export class Outputs extends React.PureComponent<ComponentProps & StateProps> {
     const { outputs, children, hidden, expanded } = this.props;
     return (
       <div
-        className={`nteract-cell-outputs ${hidden && "hidden"} ${expanded &&
-          "expanded"}`}
+        className={`nteract-cell-outputs ${hidden ? "hidden" : ""} ${
+          expanded ? "expanded" : ""
+        }`}
       >
         {outputs.map((output, index) => (
           <Output output={output} key={index}>
@@ -53,7 +54,7 @@ export const makeMapStateToProps = (
         outputs = cell.get("outputs", Immutable.List());
         hidden =
           cell.cell_type === "code" &&
-          cell.getIn(["metadata", "jupyter", "output_hidden"]);
+          cell.getIn(["metadata", "jupyter", "outputs_hidden"]);
         expanded =
           cell.cell_type === "code" &&
           (cell.getIn(["metadata", "outputExpanded"]) ||


### PR DESCRIPTION
Move from `React.cloneElement` to render props for the selection of Editors and the override of the Prompt sub-contents.

This has the benefits of improving the experience when working with TypeScript and reducing aggressive renders.