### PR TITLE
Remove createExecuteRequest functions from @nteract/messaging | issue #4780

### DIFF
--- a/packages/epics/__tests__/execute.spec.ts
+++ b/packages/epics/__tests__/execute.spec.ts
@@ -1,6 +1,6 @@
 import * as actions from "@nteract/actions";
 import { mockAppState } from "@nteract/fixtures";
-import { createExecuteRequest, createMessage } from "@nteract/messaging";
+import { executeRequest, createMessage } from "@nteract/messaging";
 import * as stateModule from "@nteract/types";
 import { ActionsObservable, StateObservable } from "redux-observable";
 import { empty, from, of, Subject } from "rxjs";
@@ -244,7 +244,7 @@ describe("createExecuteCellStream", () => {
       }
     };
     const action$ = ActionsObservable.from([]);
-    const message = createExecuteRequest("source");
+    const message = executeRequest("source");
 
     const observable = createExecuteCellStream(
       action$,

--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -1,7 +1,7 @@
 import {
   Channels,
   childOf,
-  createExecuteRequest,
+  executeRequest,
   ExecuteRequest,
   executionCounts,
   inputReply,
@@ -512,7 +512,7 @@ export function sendExecuteRequestEpic(
           if ((cell as any).get("cell_type") === "code") {
             const source = cell.get("source", "");
 
-            const message = createExecuteRequest(source);
+            const message = executeRequest(source);
 
             return createExecuteCellStream(
               action$,

--- a/packages/messaging/__tests__/messaging-spec.ts
+++ b/packages/messaging/__tests__/messaging-spec.ts
@@ -5,7 +5,7 @@ import { count, map, tap, toArray } from "rxjs/operators";
 import {
   childOf,
   convertOutputMessageToNotebookFormat,
-  createExecuteRequest,
+  executeRequest,
   createMessage,
   createCommMessage,
   createCommOpenMessage,
@@ -40,10 +40,10 @@ describe("createMessage", () => {
   });
 });
 
-describe("createExecuteRequest", () => {
+describe("executeRequest", () => {
   it("creates an execute_request message", () => {
     const code = 'print("test")';
-    const executeRequest = createExecuteRequest(code);
+    const executeRequest = executeRequest(code);
 
     expect(executeRequest.content.code).toEqual(code);
     expect(executeRequest.header.msg_type).toEqual("execute_request");

--- a/packages/messaging/__tests__/messaging-spec.ts
+++ b/packages/messaging/__tests__/messaging-spec.ts
@@ -43,10 +43,10 @@ describe("createMessage", () => {
 describe("executeRequest", () => {
   it("creates an execute_request message", () => {
     const code = 'print("test")';
-    const executeRequest = executeRequest(code);
+    const executeReq = executeRequest(code);
 
-    expect(executeRequest.content.code).toEqual(code);
-    expect(executeRequest.header.msg_type).toEqual("execute_request");
+    expect(executeReq.content.code).toEqual(code);
+    expect(executeReq.header.msg_type).toEqual("execute_request");
   });
 });
 

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -18,11 +18,6 @@ export function createMessage<MT extends MessageType>(
   return { ...message({ msg_type }), ...fields };
 }
 
-// TODO: Deprecate
-export function createExecuteRequest(code: string = ""): ExecuteRequest {
-  return executeRequest(code, {});
-}
-
 /**
  * creates a comm open message
  * @param  {string} comm_id       uuid


### PR DESCRIPTION
Remove `createExecuteRequest` functions from @nteract/messaging.



> [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

