### PR TITLE
Fix error handling when saving

### DIFF
--- a/applications/desktop/src/notebook/local-content-provider.ts
+++ b/applications/desktop/src/notebook/local-content-provider.ts
@@ -9,9 +9,6 @@ import { catchError, map, mergeMap } from "rxjs/operators";
 
 // A Content provider which reads/writes to local disk
 export class LocalContentProvider implements IContentProvider {
-
-  constructor() {}
-
   public remove(serverConfig: ServerConfig, path: string): Observable<AjaxResponse> {
     throw new Error("Not implemented");
   }

--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -1,39 +1,13 @@
+import { stringifyNotebook } from "@nteract/commutable";
+import { actions, AppState, ContentRecord, createContentRef, createKernelspecsRef, makeAppRecord, makeCommsRecord, makeContentsRecord, makeDummyContentRecord, makeEntitiesRecord, makeHostsRecord, makeJupyterHostRecord, makeNotebookContentRecord, makeStateRecord, makeTransformsRecord } from "@nteract/core";
+import { fixtureJSON, mockAppState } from "@nteract/fixtures";
 import FileSaver from "file-saver";
 import Immutable from "immutable";
 import { ActionsObservable, StateObservable } from "redux-observable";
-import { of, Subject } from "rxjs";
-import { toArray, map } from "rxjs/operators";
-
-import { stringifyNotebook } from "@nteract/commutable";
-import {
-  actions,
-  ContentRecord,
-  createContentRef,
-  createKernelspecsRef,
-  makeAppRecord,
-  makeCommsRecord,
-  makeContentsRecord,
-  makeDummyContentRecord,
-  makeEntitiesRecord,
-  makeHostsRecord,
-  makeJupyterHostRecord,
-  makeNotebookContentRecord,
-  makeStateRecord,
-  makeTransformsRecord,
-  makeLocalHostRecord,
-  AppState
-} from "@nteract/core";
-
-import { fixtureJSON, mockAppState } from "@nteract/fixtures";
-import {
-  downloadString,
-  saveAsContentEpic,
-  saveContentEpic,
-  closeNotebookEpic,
-  fetchContentEpic,
-  updateContentEpic
-} from "../src/contents";
 import { contents } from "rx-jupyter";
+import { of, Subject } from "rxjs";
+import { map, toArray } from "rxjs/operators";
+import { closeNotebookEpic, downloadString, fetchContentEpic, saveAsContentEpic, saveContentEpic, updateContentEpic } from "../src/contents";
 
 jest.mock("rx-jupyter", () => ({
   contents: {
@@ -351,33 +325,6 @@ describe("closeNotebookEpic", () => {
 });
 
 describe("fetchContentEpic", () => {
-  it("returns an error if no filepath is provided", done => {
-    const state = mockAppState({});
-    const contentRef: string = state.core.entities.contents.byRef
-      .keySeq()
-      .first();
-    const action$ = ActionsObservable.of(
-      actions.fetchContent({
-        contentRef
-      })
-    );
-    const state$ = new StateObservable<AppState>(new Subject(), state);
-    const obs = fetchContentEpic(action$, state$, { contentProvider: contents.JupyterContentProvider });
-    obs.pipe(toArray()).subscribe(
-      action => {
-        expect(action).toEqual([
-          actions.fetchContentFailed({
-            error: new Error("fetching content needs a payload"),
-            filepath: undefined,
-            contentRef,
-            kernelRef: undefined
-          })
-        ]);
-      },
-      err => done.fail(err), // It should not error in the stream
-      () => done()
-    );
-  });
   it("emits FETCH_CONTENT_FULFILLED action on successful completion", done => {
     const state = {
       ...mockAppState({}),
@@ -408,27 +355,6 @@ describe("fetchContentEpic", () => {
 });
 
 describe("updateContentEpic", () => {
-  it("throws an error if there is no filepath provided", done => {
-    const state = mockAppState({});
-    const contentRef: string = state.core.entities.contents.byRef
-      .keySeq()
-      .first();
-    const action$ = ActionsObservable.of(
-      actions.changeContentName({
-        contentRef
-      })
-    );
-    const state$ = new StateObservable<AppState>(new Subject(), state);
-    const obs = updateContentEpic(action$, state$, { contentProvider: contents.JupyterContentProvider });
-    obs.pipe(toArray()).subscribe(
-      action => {
-        const types = action.map(({ type }) => type);
-        expect(types).toEqual([actions.CHANGE_CONTENT_NAME_FAILED]);
-      },
-      err => done.fail(err), // It should not error in the stream
-      () => done()
-    );
-  });
   it("changes the content name on valid details", done => {
     const state = {
       ...mockAppState({}),

--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -2,45 +2,49 @@ import { stringifyNotebook } from "@nteract/commutable";
 import { actions, AppState, ContentRecord, createContentRef, createKernelspecsRef, makeAppRecord, makeCommsRecord, makeContentsRecord, makeDummyContentRecord, makeEntitiesRecord, makeHostsRecord, makeJupyterHostRecord, makeNotebookContentRecord, makeStateRecord, makeTransformsRecord } from "@nteract/core";
 import { fixtureJSON, mockAppState } from "@nteract/fixtures";
 import FileSaver from "file-saver";
-import Immutable from "immutable";
+import * as Immutable from "immutable";
 import { ActionsObservable, StateObservable } from "redux-observable";
 import { contents } from "rx-jupyter";
 import { of, Subject } from "rxjs";
 import { map, toArray } from "rxjs/operators";
 import { closeNotebookEpic, downloadString, fetchContentEpic, saveAsContentEpic, saveContentEpic, updateContentEpic } from "../src/contents";
 
-jest.mock("rx-jupyter", () => ({
-  contents: {
-    JupyterContentProvider: {
-      save: (severConfig, filepath, model) => {
-        return of({ response: {} });
-      },
-      update: (serverConfig, prevFilePath, object) => {
-        return of({ status: 200, response: {} });
-      },
-      get: jest
-        .fn()
-        .mockReturnValue(
-          of({
-            status: 200,
-            response: { last_modified: "some_stable_value" }
-          })
-        )
-        .mockReturnValueOnce(
-          of({
-            status: 200,
-            response: { last_modified: "one_value" }
-          })
-        )
-        .mockReturnValueOnce(
-          of({
-            status: 200,
-            response: { last_modified: "one_value" }
-          })
-        )
+jest.mock("rx-jupyter", () => {
+  const { of } = require("rxjs");
+
+  return {
+    contents: {
+      JupyterContentProvider: {
+        save: (severConfig, filepath, model) => {
+          return of({ response: {} });
+        },
+        update: (serverConfig, prevFilePath, object) => {
+          return of({ status: 200, response: {} });
+        },
+        get: jest
+          .fn()
+          .mockReturnValue(
+            of({
+              status: 200,
+              response: { last_modified: "some_stable_value" }
+            })
+          )
+          .mockReturnValueOnce(
+            of({
+              status: 200,
+              response: { last_modified: "one_value" }
+            })
+          )
+          .mockReturnValueOnce(
+            of({
+              status: 200,
+              response: { last_modified: "one_value" }
+            })
+          )
+      }
     }
   }
-}));
+});
 
 describe("downloadString", () => {
   it("calls FileSaver.saveAs with notebook and filename", () => {

--- a/packages/epics/__tests__/kernelspecs.spec.ts
+++ b/packages/epics/__tests__/kernelspecs.spec.ts
@@ -1,8 +1,8 @@
+import { fetchKernelspecs } from "@nteract/actions";
+import { JupyterHostRecordProps } from "@nteract/types";
 import { ActionsObservable } from "redux-observable";
 import { toArray } from "rxjs/operators";
-
-import { fetchKernelspecs } from "@nteract/actions";
-import { fetchKernelspecsEpic } from "../src/kernelspecs";
+import { fetchKernelspecsEpic } from "../src";
 
 describe("fetchKernelspecsEpic", () => {
   test("calls kernelspecs.list with appropriate jupyter host config", done => {
@@ -16,16 +16,12 @@ describe("fetchKernelspecsEpic", () => {
         app: {
           host: {
             type: "jupyter",
-            kernelRef: null,
-            id: null,
-            selectedKernelRef: null,
-            kernelspecsRef: null,
-            defaultKernelName: null,
-            activeKernelRefs: [],
             token: "x-x-x",
-            serverUrl: "http://localhost:8888/",
-            crossDomain: false
-          }
+            origin: "http://localhost:8888/",
+            basePath: "",
+            bookstoreEnabled: false,
+            showHeaderEditor: false,
+          } as JupyterHostRecordProps
         }
       }
     };

--- a/packages/epics/src/hosts.ts
+++ b/packages/epics/src/hosts.ts
@@ -1,22 +1,12 @@
-// Vendor modules
 import * as actions from "@nteract/actions";
 import { toJS } from "@nteract/commutable";
 import { NotebookV4 } from "@nteract/commutable/lib/v4";
 import * as selectors from "@nteract/selectors";
-import {
-  AppState,
-  DirectoryContentRecordProps,
-  DummyContentRecordProps,
-  FileContentRecordProps,
-  NotebookContentRecordProps,
-  ServerConfig,
-  IContentProvider
-} from "@nteract/types";
+import { AppState, DirectoryContentRecordProps, DummyContentRecordProps, FileContentRecordProps, IContentProvider, NotebookContentRecordProps, ServerConfig } from "@nteract/types";
 import { RecordOf } from "immutable";
-import { ofType } from "redux-observable";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { ActionsObservable, ofType, StateObservable } from "redux-observable";
 import { bookstore } from "rx-jupyter";
-import { empty, Observable, of } from "rxjs";
+import { EMPTY, Observable, of } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, switchMap, tap } from "rxjs/operators";
 
@@ -53,7 +43,7 @@ export function publishToBookstore(
 
       // Dismiss any usage that isn't targeting a jupyter server
       if (host.type !== "jupyter") {
-        return empty();
+        return EMPTY;
       }
 
       const content:

--- a/packages/epics/src/kernelspecs.ts
+++ b/packages/epics/src/kernelspecs.ts
@@ -1,12 +1,10 @@
-import { ofType } from "redux-observable";
-import { ActionsObservable } from "redux-observable";
-import { kernelspecs } from "rx-jupyter";
-import { empty, of } from "rxjs";
-import { catchError, map, mergeMap } from "rxjs/operators";
-
 import * as actions from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
 import { KernelspecProps, ServerConfig } from "@nteract/types";
+import { ActionsObservable, ofType } from "redux-observable";
+import { kernelspecs } from "rx-jupyter";
+import { EMPTY, of } from "rxjs";
+import { catchError, map, mergeMap } from "rxjs/operators";
 
 export const fetchKernelspecsEpic = (
   action$: ActionsObservable<actions.FetchKernelspecs>,
@@ -23,7 +21,7 @@ export const fetchKernelspecsEpic = (
       const host = selectors.currentHost(state);
       if (host.type !== "jupyter") {
         // Dismiss any usage that isn't targeting a jupyter server
-        return empty();
+        return EMPTY;
       }
       const serverConfig: ServerConfig = selectors.serverConfig(host);
 


### PR DESCRIPTION
Follow up to an issue raised in #4871.

I looked at the logic, and it seems like the "open in another tab" error is supposed to prevent saving when the local and on-disk modified timestamps mismatched by more than 600 ms. It was apparently added to prevent files in multiple tabs from interfering, but I think this is extremely surprising behaviour, and it can prevent saving a file completely, e.g. for the test I `chmod 000`-ed a file, then `chmod 666`-ed it back, and I still couldn't save over it. I removed the behaviour entirely.

Additionally, the save epic didn't check the contents of the fake-XHR for an error response, so the actual `EACCES` didn't get through. I added that check.

![save failed](https://user-images.githubusercontent.com/5156808/74249486-845d0100-4ce9-11ea-9789-ed48a0fd3912.png)

I also fixed warnings in the file, which lead to removal of several guards that were guaranteed to never fail by the typechecker. This led to tests failing that provided malformed actions to the epic. I removed those tests; I don't think they make much sense with the typechecker.