### PR TITLE
Don't relaunch kernel for notebooks that already have kernels

### DIFF
--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -14,7 +14,6 @@ import {
   watchExecutionStateEpic,
   launchKernelWhenNotebookSetEpic
 } from "../src/kernel-lifecycle";
-import { makeNotebookRecord } from "@nteract/commutable";
 
 const buildScheduler = () =>
   new TestScheduler((actual, expected) => expect(actual).toEqual(expected));

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -14,6 +14,7 @@ import {
   watchExecutionStateEpic,
   launchKernelWhenNotebookSetEpic
 } from "../src/kernel-lifecycle";
+import { makeNotebookRecord } from "@nteract/commutable";
 
 const buildScheduler = () =>
   new TestScheduler((actual, expected) => expect(actual).toEqual(expected));
@@ -109,8 +110,7 @@ describe("acquireKernelInfo", () => {
           })
         })
       }),
-      app: stateModule.makeAppRecord({
-      }),
+      app: stateModule.makeAppRecord({}),
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     };
@@ -259,8 +259,7 @@ describe("restartKernelEpic", () => {
           })
         })
       }),
-      app: stateModule.makeAppRecord({
-      })
+      app: stateModule.makeAppRecord({})
     };
 
     const testScheduler = buildScheduler();
@@ -300,11 +299,11 @@ describe("restartKernelEpic", () => {
         n: sendNotification.create({
           title: "Kernel Restarting...",
           message: "Kernel unknown is restarting.",
-          level: "success",
+          level: "success"
         })
       };
 
-      const inputMarbles  = "a----b|";
+      const inputMarbles = "a----b|";
       const outputMarbles = "(cdn)e|";
 
       const inputAction$ = hot(inputMarbles, inputActions);
@@ -342,8 +341,7 @@ describe("restartKernelEpic", () => {
           })
         })
       }),
-      app: stateModule.makeAppRecord({
-      })
+      app: stateModule.makeAppRecord({})
     };
 
     const testScheduler = buildScheduler();
@@ -384,11 +382,11 @@ describe("restartKernelEpic", () => {
         n: sendNotification.create({
           title: "Kernel Restarting...",
           message: "Kernel unknown is restarting.",
-          level: "success",
+          level: "success"
         })
       };
 
-      const inputMarbles  = "a----b---|";
+      const inputMarbles = "a----b---|";
       const outputMarbles = "(cdn)(ef)|";
 
       const inputAction$ = hot(inputMarbles, inputActions);
@@ -428,8 +426,7 @@ describe("restartKernelEpic", () => {
           })
         })
       }),
-      app: stateModule.makeAppRecord({
-      })
+      app: stateModule.makeAppRecord({})
     };
 
     const responses = await restartKernelEpic(
@@ -471,8 +468,8 @@ describe("launchKernelWhenNotebookSet", () => {
       () => done()
     );
   });
-  it("emits a LAUNCH_KERNEL_BY_NAME action for valid notebook", done => {
-    const state = mockAppState({});
+  it("does nothing if content already has a kernel", done => {
+    let state = mockAppState({});
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
@@ -480,9 +477,44 @@ describe("launchKernelWhenNotebookSet", () => {
     const action$ = ActionsObservable.of(
       actionsModule.fetchContentFulfilled({
         contentRef,
-        filepath: "my-file.txt",
+        filepath: "my-notebook",
         model: {},
         kernelRef
+      })
+    );
+    const state$ = new StateObservable(new Subject(), state);
+    const obs = launchKernelWhenNotebookSetEpic(action$, state$);
+    obs.pipe(toArray()).subscribe(
+      actions => {
+        const types = actions.map(({ type }) => type);
+        expect(types).toEqual([]);
+      },
+      err => done.fail(err), // It should not error in the stream
+      () => done()
+    );
+  });
+  it("emits a LAUNCH_KERNEL_BY_NAME action for valid notebook and unlaunched kernel", done => {
+    const contentRef = stateModule.createContentRef();
+    const state = {
+      core: {
+        entities: stateModule.makeEntitiesRecord({
+          contents: stateModule.makeContentsRecord({
+            byRef: Immutable.Map({
+              [contentRef]: stateModule.makeNotebookContentRecord({
+                model: stateModule.makeDocumentRecord({
+                  kernelRef: null
+                })
+              })
+            })
+          })
+        })
+      }
+    };
+    const action$ = ActionsObservable.of(
+      actionsModule.fetchContentFulfilled({
+        contentRef,
+        filepath: "my-file.txt",
+        model: {}
       })
     );
     const state$ = new StateObservable(new Subject(), state);

--- a/packages/epics/mkdocs.yml
+++ b/packages/epics/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: nteract/epics
 
 nav:
   - Overview: "overview.md"
-  - Conmms Epics: "comms.md"
+  - Comms Epics: "comms.md"
   - Contents Epics: "contents.md"
   - Execution Epics: "execute.md"
   - Kernel Epics: "kernels.md"

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -9,7 +9,7 @@ import {
 import { sendNotification } from "@nteract/mythic-notifications";
 import { AnyAction } from "redux";
 import { ActionsObservable, ofType, StateObservable } from "redux-observable";
-import { EMPTY, empty, merge, Observable, Observer, of } from "rxjs";
+import { EMPTY, merge, Observable, Observer, of } from "rxjs";
 import {
   catchError,
   concatMap,
@@ -218,7 +218,7 @@ export const launchKernelWhenNotebookSetEpic = (
         content.model.type !== "notebook"
       ) {
         // This epic only handles notebook content
-        return empty();
+        return EMPTY;
       }
 
       /**
@@ -230,7 +230,7 @@ export const launchKernelWhenNotebookSetEpic = (
           kernelRef: content.model.kernelRef
         });
         if (kernel && kernel.channels) {
-          return empty();
+          return EMPTY;
         }
       }
       const filepath = content.filepath;

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -132,10 +132,12 @@ export function acquireKernelInfo(
 
         const kernelspec = selectors.kernelspecByName(state, { name: l.name });
         if (kernelspec) {
-            result.push(actions.setKernelMetadata({
-                contentRef,
-                kernelInfo: kernelspec
-            }));
+          result.push(
+            actions.setKernelMetadata({
+              contentRef,
+              kernelInfo: kernelspec
+            })
+          );
         }
       }
 
@@ -219,6 +221,18 @@ export const launchKernelWhenNotebookSetEpic = (
         return empty();
       }
 
+      /**
+       * Avoid relaunching kernels for notebooks that have already
+       * launched their content.
+       */
+      if (content.model.kernelRef) {
+        const kernel = selectors.kernel(state, {
+          kernelRef: content.model.kernelRef
+        });
+        if (kernel && kernel.channels) {
+          return empty();
+        }
+      }
       const filepath = content.filepath;
       const notebook = content.model.notebook;
 
@@ -260,7 +274,7 @@ export const restartKernelEpic = (
             title: "Failure to Restart",
             message: "Unable to restart kernel, please select a new kernel.",
             level: "error"
-          }),
+          })
         );
       }
 


### PR DESCRIPTION
@lbarons and I were working through a core SDK integration scenario where the notebook contents were reloaded via a dispatch of `actions.FetchContent`. When the `launchKernelWhenNotebookSetEpic` is registered in the epic middleware, this causes the kernel for that notebook to be relaunched.

This PR adds logic to the `launchKernelWhenNotebookSetEpic` to check if a kernel is already launched for that content associated with a given content ref. If so, it does nothing.

Also, I went ahead and replaced all the uses of `empty()` in favor of the recommended `EMPTY` in this file.