### PR TITLE
Don't resubscribe to source execution on error

### DIFF
--- a/packages/epics/src/execute.ts
+++ b/packages/epics/src/execute.ts
@@ -521,15 +521,14 @@ export function sendExecuteRequestEpic(
               id,
               action.payload.contentRef
             ).pipe(
-              catchError((error, source) =>
+              catchError((error) =>
                 merge(
                   of(
                     actions.executeFailed({
                       error,
                       contentRef: action.payload.contentRef
                     })
-                  ),
-                  source
+                  )
                 )
               )
             );


### PR DESCRIPTION
When an error occurs during the lifecycle of a cell execution (like a dropped WebSocket connection), we continuously resubscribe to the broken stream causing a flurry of `ExecuteFailed` actions to be dispatched.