### PR TITLE
Clean up auto-save epic

### DIFF
--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -1,13 +1,37 @@
 import { stringifyNotebook } from "@nteract/commutable";
-import { actions, AppState, ContentRecord, createContentRef, createKernelspecsRef, makeAppRecord, makeCommsRecord, makeContentsRecord, makeDummyContentRecord, makeEntitiesRecord, makeHostsRecord, makeJupyterHostRecord, makeNotebookContentRecord, makeStateRecord, makeTransformsRecord } from "@nteract/core";
+import {
+  actions,
+  AppState,
+  ContentRecord,
+  createContentRef,
+  createKernelspecsRef,
+  makeAppRecord,
+  makeCommsRecord,
+  makeContentsRecord,
+  makeDummyContentRecord,
+  makeEntitiesRecord,
+  makeHostsRecord,
+  makeJupyterHostRecord,
+  makeNotebookContentRecord,
+  makeStateRecord,
+  makeTransformsRecord
+} from "@nteract/core";
 import { fixtureJSON, mockAppState } from "@nteract/fixtures";
 import FileSaver from "file-saver";
 import * as Immutable from "immutable";
 import { ActionsObservable, StateObservable } from "redux-observable";
 import { contents } from "rx-jupyter";
 import { of, Subject } from "rxjs";
-import { map, toArray } from "rxjs/operators";
-import { closeNotebookEpic, downloadString, fetchContentEpic, saveAsContentEpic, saveContentEpic, updateContentEpic } from "../src/contents";
+import { map, take, toArray } from "rxjs/operators";
+import {
+  autoSaveCurrentContentEpic,
+  closeNotebookEpic,
+  downloadString,
+  fetchContentEpic,
+  saveAsContentEpic,
+  saveContentEpic,
+  updateContentEpic
+} from "../src/contents";
 
 jest.mock("rx-jupyter", () => {
   const { of } = require("rxjs");
@@ -43,7 +67,7 @@ jest.mock("rx-jupyter", () => {
           )
       }
     }
-  }
+  };
 });
 
 describe("downloadString", () => {
@@ -346,7 +370,9 @@ describe("fetchContentEpic", () => {
       })
     );
     const state$ = new StateObservable<AppState>(new Subject(), state);
-    const obs = fetchContentEpic(action$, state$, { contentProvider: contents.JupyterContentProvider });
+    const obs = fetchContentEpic(action$, state$, {
+      contentProvider: contents.JupyterContentProvider
+    });
     obs.pipe(toArray()).subscribe(
       action => {
         const types = action.map(({ type }) => type);
@@ -376,7 +402,9 @@ describe("updateContentEpic", () => {
       })
     );
     const state$ = new StateObservable<AppState>(new Subject(), state);
-    const obs = updateContentEpic(action$, state$, { contentProvider: contents.JupyterContentProvider });
+    const obs = updateContentEpic(action$, state$, {
+      contentProvider: contents.JupyterContentProvider
+    });
     obs.pipe(toArray()).subscribe(
       action => {
         const types = action.map(({ type }) => type);
@@ -388,5 +416,99 @@ describe("updateContentEpic", () => {
       }, // It should not error in the stream
       () => done()
     );
+  });
+});
+
+describe("autoSaveContentEpic", () => {
+  it("returns a valid Observable", () => {
+    const action$ = ActionsObservable.from([]);
+    const state$ = new StateObservable(new Subject(), mockAppState({}));
+    expect(autoSaveCurrentContentEpic(action$, state$)).not.toBeNull();
+  });
+  it("dispatches a save action on content change", async () => {
+    const action$ = ActionsObservable.from([]);
+    const stateSubject$ = new Subject();
+    const state = {
+      app: {},
+      config: Immutable.Map({
+        autoSaveInterval: 100
+      }),
+      core: {
+        entities: {
+          kernels: {},
+          contents: {
+            byRef: Immutable.Map({
+              aContentRef: {
+                type: "notebook",
+                filepath: "test.ipynb",
+                model: {
+                  notebook: { key: "to be cleared" }
+                }
+              }
+            })
+          }
+        }
+      }
+    };
+    const state$ = new StateObservable(stateSubject$, state);
+    const newState = {
+      app: {},
+      config: Immutable.Map({
+        autoSaveInterval: 100
+      }),
+      core: {
+        entities: {
+          kernels: {},
+          contents: {
+            byRef: Immutable.Map({
+              aContentRef: {
+                type: "notebook",
+                filepath: "test.ipynb",
+                model: {
+                  notebook: { key: Math.random().toString() }
+                }
+              }
+            })
+          }
+        }
+      }
+    };
+    stateSubject$.next(newState);
+    const results = await autoSaveCurrentContentEpic(action$, state$)
+      .pipe(take(2), toArray())
+      .toPromise();
+    expect(results.map(a => a.type)).toContain(actions.SAVE);
+  });
+  it("dispatches nothing on no content change", async () => {
+    const action$ = ActionsObservable.from([]);
+    const stateSubject$ = new Subject();
+    const state = {
+      app: {},
+      config: Immutable.Map({
+        autoSaveInterval: 0
+      }),
+      core: {
+        entities: {
+          contents: makeContentsRecord({
+            byRef: Immutable.Map({
+              aContentRef: {
+                type: "notebook",
+                filepath: "test.ipynb",
+                model: {
+                  notebook: { key: "to be cleared" }
+                }
+              }
+            })
+          }),
+          kernels: {}
+        }
+      }
+    };
+    const state$ = new StateObservable(stateSubject$, state);
+    stateSubject$.next(state);
+    const results = await autoSaveCurrentContentEpic(action$, state$)
+      .pipe(take(2), toArray())
+      .toPromise();
+    expect(results.map(a => a.type)).toContain(actions.SAVE);
   });
 });

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -139,10 +139,10 @@ export function autoSaveCurrentContentEpic(
   action$: ActionsObservable<Action>,
   state$: StateObservable<AppState>
 ): Observable<actions.Save> {
-  const state = state$.value;
-  const duration = selectors.autoSaveInterval(state);
+  const duration = selectors.autoSaveInterval(state$.value);
   return interval(duration).pipe(
     mergeMap(() => {
+      const state = state$.value;
       return from(
         selectors
           .contentByRef(state)

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -1,7 +1,18 @@
 import * as actions from "@nteract/actions";
 import { Notebook, stringifyNotebook, toJS } from "@nteract/commutable";
 import * as selectors from "@nteract/selectors";
-import { AppState, ContentRef, DirectoryContentRecordProps, DummyContentRecordProps, FileContentRecordProps, IContent, IContentProvider, JupyterHostRecord, NotebookContentRecordProps, ServerConfig } from "@nteract/types";
+import {
+  AppState,
+  ContentRef,
+  DirectoryContentRecordProps,
+  DummyContentRecordProps,
+  FileContentRecordProps,
+  IContent,
+  IContentProvider,
+  JupyterHostRecord,
+  NotebookContentRecordProps,
+  ServerConfig
+} from "@nteract/types";
 import FileSaver from "file-saver";
 import { existsSync } from "fs";
 import { RecordOf } from "immutable";
@@ -9,7 +20,15 @@ import { Action } from "redux";
 import { ActionsObservable, ofType, StateObservable } from "redux-observable";
 import { EMPTY, from, interval, Observable, of } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
-import { catchError, concatMap, distinctUntilChanged, map, mergeMap, pluck, switchMap, take, tap } from "rxjs/operators";
+import {
+  catchError,
+  distinctUntilChanged,
+  map,
+  mergeMap,
+  switchMap,
+  take,
+  tap
+} from "rxjs/operators";
 import urljoin from "url-join";
 
 export function updateContentEpic(
@@ -22,7 +41,7 @@ export function updateContentEpic(
     switchMap(action => {
       const state = state$.value;
       const { filepath, prevFilePath } = action.payload;
-      
+
       const host = selectors.currentHost(state) as JupyterHostRecord;
       const serverConfig: ServerConfig = selectors.serverConfig(host);
 
@@ -153,27 +172,16 @@ export function autoSaveCurrentContentEpic(
              */
             content =>
               (content.type === "file" || content.type === "notebook") &&
-              content.filepath !== "" &&
-              selectors.isCurrentKernelZeroMQ(state)
-                ? existsSync(content.filepath)
-                : true
+              content.filepath !== ""
           )
           .keys()
       );
     }),
     mergeMap((contentRef: ContentRef) =>
       state$.pipe(
-        pluck(
-          "core",
-          "entities",
-          "contents",
-          "byRef",
-          contentRef,
-          "model",
-          "notebook"
-        ),
+        map(state => selectors.model(state, { contentRef })),
         distinctUntilChanged(),
-        concatMap(() => of(actions.save({ contentRef })))
+        switchMap(() => of(actions.save({ contentRef })))
       )
     )
   );
@@ -187,8 +195,8 @@ function serializeContent(
     | RecordOf<FileContentRecordProps>
     | RecordOf<DirectoryContentRecordProps>
 ): {
-  saveModel: Partial<IContent<"file" | "notebook">> | null,
-  serializedData: Notebook | string | null,
+  saveModel: Partial<IContent<"file" | "notebook">> | null;
+  serializedData: Notebook | string | null;
 } {
   // This could be object for notebook, or string for files
   let serializedData: Notebook | string;
@@ -327,9 +335,9 @@ export function saveContentEpic(
                   return of(
                     actions.saveFailed({
                       contentRef: action.payload.contentRef,
-                      error: saveXhr.response,
+                      error: saveXhr.response
                     })
-                  )
+                  );
                 }
 
                 const pollIntervalMs = 500;
@@ -450,21 +458,21 @@ export function saveAsContentEpic(
       return dependencies.contentProvider
         .save(serverConfig, filepath, saveModel)
         .pipe(
-        map((xhr: AjaxResponse) => {
-          return actions.saveAsFulfilled({
-            contentRef: action.payload.contentRef,
-            model: xhr.response
-          });
-        }),
-        catchError((error: Error) =>
-          of(
-            actions.saveAsFailed({
-              error,
-              contentRef: action.payload.contentRef
-            })
+          map((xhr: AjaxResponse) => {
+            return actions.saveAsFulfilled({
+              contentRef: action.payload.contentRef,
+              model: xhr.response
+            });
+          }),
+          catchError((error: Error) =>
+            of(
+              actions.saveAsFailed({
+                error,
+                contentRef: action.payload.contentRef
+              })
+            )
           )
-        )
-      );
+        );
     })
   );
 }

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -14,7 +14,6 @@ import {
   ServerConfig
 } from "@nteract/types";
 import FileSaver from "file-saver";
-import { existsSync } from "fs";
 import { RecordOf } from "immutable";
 import { Action } from "redux";
 import { ActionsObservable, ofType, StateObservable } from "redux-observable";
@@ -158,8 +157,9 @@ export function autoSaveCurrentContentEpic(
   action$: ActionsObservable<Action>,
   state$: StateObservable<AppState>
 ): Observable<actions.Save> {
-  const duration = selectors.autoSaveInterval(state$.value);
-  return interval(duration).pipe(
+  return state$.pipe(
+    map(state => selectors.autoSaveInterval(state)),
+    switchMap(time => interval(time)),
     mergeMap(() => {
       const state = state$.value;
       return from(


### PR DESCRIPTION
In [this commit](https://github.com/nteract/nteract/commit/fac12544f9befa1cf3dc17e0b3d6bd9c453700bf), the line `const state = state$.value` is moved outside of the `pipe` operator. This means that we are no longer getting the latest value of state which will cause problems once multi-tab is supported. The state will not be updated when we open/close tabs so auto-save will not work properly.

The fix is to simply move the line back inside `pipe` so we are always getting the latest value of state.
