### PR TITLE
Fix IContent definition for "directory" type

### DIFF
--- a/packages/types/src/content-provider.ts
+++ b/packages/types/src/content-provider.ts
@@ -31,7 +31,7 @@ export interface IContent<FT extends FileType = FileType>
     : FT extends "notebook"
     ? Notebook
     : FT extends "directory"
-    ? Array<IEmptyContent<FT>>
+    ? Array<IEmptyContent<FileType>>
     : null;
 }
 


### PR DESCRIPTION
According to current definition of `IContent<"directory">` the content property is of type `Array<IEmptyContent<"directory">>`. However this is not correct and the directory content can contain any type of file. So this change updates the content property type to `Array<IEmptyContent<FileType>>` instead.