### PR TITLE
[Fix] Fix the outgrow of DragHandle

### DIFF
--- a/packages/notebook-app-component/src/decorators/draggable/index.tsx
+++ b/packages/notebook-app-component/src/decorators/draggable/index.tsx
@@ -106,9 +106,13 @@ const DragArea = styled.div.attrs<DragAreaProps>(props => ({
         : "3px transparent solid"
   }
 }))`
-  position: relative;
   padding: 10px;
 ` as StyledComponent<"div", any, DragAreaProps, never>; // Somehow setting the type on `attrs` isn't propagating properly;
+
+// This is the div that DragHandle's absolute position will anchor
+const DragHandleAnchor = styled.div`
+  position: relative;
+`;
 
 export function isDragUpper(
   props: Props,
@@ -213,13 +217,15 @@ export class DraggableCellView extends React.Component<
             this.el = el;
           }}
         >
-          {this.props.connectDragSource(
-            // Same thing with connectDragSource... It also needs a React Element that matches a DOM element
-            <div>
-              <DragHandle onClick={this.selectCell} />
-            </div>
-          )}
-          {this.props.children}
+          <DragHandleAnchor>
+            {this.props.connectDragSource(
+              // Same thing with connectDragSource... It also needs a React Element that matches a DOM element
+              <div>
+                <DragHandle onClick={this.selectCell} />
+              </div>
+            )}
+            {this.props.children}
+          </DragHandleAnchor>
         </DragArea>
       </div>
     );


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

**Problem**
The DragHandle area expand outside of the drag area, see screenshot below (the DragHandle is colored as red, and the cell's DragArea is colored in blue)
![image](https://user-images.githubusercontent.com/41454397/75406606-b82d4e80-58c5-11ea-80cb-06b5458aec40.png)

The cause is that DragHandle is set to use absolute position and 100% height, so it finds the nearest base - the DragArea, and set its height to be DragArea's height subtract border width. However the 10px padding on DragArea push down the DragHandle to outgrow the DragArea.

**Solution**
Add a layer of div called DragHandleAnchor with position set to relative. So DragHandle's position and height is based on it, DragHandleAnchor doesn't have padding so DragHandle won't outgrow it. 
After the fix:
![image](https://user-images.githubusercontent.com/41454397/75406630-c7ac9780-58c5-11ea-9bbd-dcb813682259.png)



<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
