### PR TITLE
Don't pass kernelRefGenerator via dependency injection

### DIFF
--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -18,6 +18,8 @@ import {
 const buildScheduler = () =>
   new TestScheduler((actual, expected) => expect(actual).toEqual(expected));
 
+stateModule.createKernelRef = () => "newKernelRef";
+
 describe("acquireKernelInfo", () => {
   test("sends a kernel_info_request and processes kernel_info_reply", async done => {
     const sent = new Subject();
@@ -460,12 +462,12 @@ describe("restartKernelEpic", () => {
         d: actionsModule.launchKernelByName({
           kernelSpecName: undefined,
           cwd: ".",
-          kernelRef: newKernelRef,
+          kernelRef: expect.any(String),
           selectNextKernel: true,
           contentRef
         }),
         e: actionsModule.restartKernelSuccessful({
-          kernelRef: newKernelRef,
+          kernelRef: expect.any(String),
           contentRef
         }),
         n: sendNotification.create({
@@ -479,11 +481,7 @@ describe("restartKernelEpic", () => {
       const outputMarbles = "(cdn)e|";
 
       const inputAction$ = hot(inputMarbles, inputActions);
-      const outputAction$ = restartKernelEpic(
-        inputAction$,
-        { value: state },
-        () => newKernelRef
-      );
+      const outputAction$ = restartKernelEpic(inputAction$, { value: state });
 
       expectObservable(outputAction$).toBe(outputMarbles, outputActions);
     });
@@ -542,12 +540,12 @@ describe("restartKernelEpic", () => {
         d: actionsModule.launchKernelByName({
           kernelSpecName: undefined,
           cwd: ".",
-          kernelRef: newKernelRef,
+          kernelRef: expect.any(String),
           selectNextKernel: true,
           contentRef: "contentRef"
         }),
         e: actionsModule.restartKernelSuccessful({
-          kernelRef: newKernelRef,
+          kernelRef: expect.any(String),
           contentRef: "contentRef"
         }),
         f: actionsModule.executeAllCells({ contentRef: "contentRef" }),
@@ -562,11 +560,7 @@ describe("restartKernelEpic", () => {
       const outputMarbles = "(cdn)(ef)|";
 
       const inputAction$ = hot(inputMarbles, inputActions);
-      const outputAction$ = restartKernelEpic(
-        inputAction$,
-        { value: state },
-        () => newKernelRef
-      );
+      const outputAction$ = restartKernelEpic(inputAction$, { value: state });
 
       expectObservable(outputAction$).toBe(outputMarbles, outputActions);
     });

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -267,8 +267,7 @@ export const launchKernelWhenNotebookSetEpic = (
  */
 export const restartKernelEpic = (
   action$: ActionsObservable<actions.RestartKernel | actions.NewKernelAction>,
-  state$: any,
-  kernelRefGenerator: () => KernelRef = createKernelRef
+  state$: any
 ) =>
   action$.pipe(
     ofType(actions.RESTART_KERNEL),
@@ -305,7 +304,7 @@ export const restartKernelEpic = (
         );
       }
 
-      const newKernelRef = kernelRefGenerator();
+      const newKernelRef = createKernelRef();
       const initiatingContentRef = action.payload.contentRef;
       const successNotification = sendNotification.create({
         title: "Kernel Restarting...",


### PR DESCRIPTION
Closes #4952 

Now that we pass the contentProvider in via dependency injection, the value of the kernelRefGenerator passed in to the restartEpic is overriden by the dependency injection set in the root epic.

This PR removes the `kernelRefGenerator` and instead relies on the `createKernelRef` method directly.