### PR TITLE
[testMigration] Add missing properties in <Manager> test

### DIFF
--- a/packages/jupyter-widgets/__tests__/manager/index.spec.tsx
+++ b/packages/jupyter-widgets/__tests__/manager/index.spec.tsx
@@ -1,9 +1,17 @@
 import * as React from "react";
 
 import Manager from "../../src/manager/index";
+import { WidgetModel } from "@jupyter-widgets/base";
+
+let manager: WidgetModel;
+let modelById: (id: string) => Promise<WidgetModel>;
 
 describe("Manager", () => {
   it("can be rendered", () => {
-    expect(<Manager />).not.toBeNull();
+    expect(<Manager model_id="" 
+                    contentRef="" id="" 
+                    model={manager} 
+                    modelById={modelById} 
+                />).not.toBeNull();
   });
 });


### PR DESCRIPTION
For issue #3997. This is to resolve the test error in `manager` test.

### Before

![DeepinScreenshot_select-area_20200311062835](https://user-images.githubusercontent.com/29037312/76372059-41329400-6362-11ea-8657-59109e004535.png)


### After 

![DeepinScreenshot_select-area_20200311063424](https://user-images.githubusercontent.com/29037312/76372113-63c4ad00-6362-11ea-8580-28a16f02e18a.png)
