### PR TITLE
Restore Save-As kernel prompt

### DIFF
--- a/applications/desktop/__tests__/renderer/menu.spec.ts
+++ b/applications/desktop/__tests__/renderer/menu.spec.ts
@@ -722,35 +722,6 @@ describe("initMenuHandlers", () => {
   });
 });
 
-describe("triggerWindowRefresh", () => {
-  test("does nothing if no filename is given", () => {
-    const store = {
-      dispatch: jest.fn()
-    };
-
-    expect(menu.triggerWindowRefresh(store, null)).toBeUndefined();
-  });
-  test("sends a SAVE_AS action if given filename", () => {
-    const props = {
-      contentRef: "123"
-    };
-
-    const store = {
-      dispatch: jest.fn()
-    };
-    const filepath = "dummy-nb.ipynb";
-
-    menu.triggerWindowRefresh(props, store, filepath);
-
-    expect(store.dispatch).toHaveBeenCalledWith(
-      actions.saveAs({
-        filepath,
-        contentRef: "123"
-      })
-    );
-  });
-});
-
 describe("exportPDF", () => {
   test("it notifies a user upon successful write", () => {
     const state = mockAppState({});
@@ -918,23 +889,5 @@ describe("showSaveAsDialog", () => {
     menu.showSaveAsDialog().then(filepath => {
       expect(remote.dialog.showSaveAsDialog).toBeCalled();
     });
-  });
-});
-
-describe("promptUserAboutNewKernel", () => {
-  it("shows a message box for restarting a new kernel", () => {
-    const state = mockAppState({});
-    const contentRef: string = state.core.entities.contents.byRef
-      .keySeq()
-      .first();
-    const store = {
-      dispatch: jest.fn(),
-      getState: jest.fn(() => state)
-    };
-    menu
-      .promptUserAboutNewKernel({ contentRef }, store, "file.ipynb")
-      .then(filepath => {
-        expect(remote.dialog.showMessageBox).toBeCalled();
-      });
   });
 });

--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -185,6 +185,10 @@ describe("saveAs", () => {
       .toPromise();
 
     expect(responses).toEqual([
+      actions.changeFilename({
+        contentRef,
+        filepath: "test.ipynb"
+      }),
       actions.saveAsFulfilled({
         contentRef,
         model: {}

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -460,8 +460,7 @@ export function saveAsContentEpic(
       const host = selectors.currentHost(state) as JupyterHostRecord;
       const serverConfig = selectors.serverConfig(host);
 
-      const kernelRef = selectors.kernelRefByContentRef(
-        store.getState(), { contentRef } );
+      const kernelRef = selectors.kernelRefByContentRef( state, { contentRef } );
       const kernel = selectors.kernel( state, { kernelRef } );
       if ( kernel ) {
         const cwd = filepath

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -460,11 +460,17 @@ export function saveAsContentEpic(
       return dependencies.contentProvider
         .save(serverConfig, filepath, saveModel)
         .pipe(
-          map((xhr: AjaxResponse) => {
-            return actions.saveAsFulfilled({
-              contentRef: action.payload.contentRef,
-              model: xhr.response
-            });
+          mergeMap((xhr: AjaxResponse) => {
+            return of(
+              actions.changeFilename({
+                contentRef: action.payload.contentRef,
+                filepath
+              }),
+              actions.saveAsFulfilled({
+                contentRef: action.payload.contentRef,
+                model: xhr.response
+              })
+            );
           }),
           catchError((error: Error) =>
             of(

--- a/packages/reducers/src/core/entities/contents/index.ts
+++ b/packages/reducers/src/core/entities/contents/index.ts
@@ -256,6 +256,7 @@ export const byRef = (
           })
       );
     }
+    case actionTypes.SAVE_AS_FULFILLED:
     case actionTypes.SAVE_FULFILLED: {
       const saveFulfilledAction = action as actionTypes.SaveFulfilled;
       return state


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

This PR does the following things:
 - Issue #4587 asks for a feature that was added way back in #721 but that somehow disappeared in the intervening work; this PR puts that feature back in.
 - That feature had previously used a popup dialog, but @captainsafia said to use `sendNotification()` this time instead, so that's a small upgrade.
 - In order to do that stuff, it was also necessary to fix #4968, so this PR fixes that one, too.
 - The code in `applications/desktop/src/notebook/menu.tsx` had some vestigial stuff that needed to be cleaned out; I did that while I was in there.