### PR TITLE
Collapse cells by default

### DIFF
--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -24,8 +24,8 @@ export const makeCodeCell = Record<CodeCellParams>({
   cell_type: "code",
   execution_count: null,
   metadata: ImmutableMap({
-    collapsed: false,
-    outputExpanded: true,
+    collapsed: true,
+    outputExpanded: false,
     jupyter: ImmutableMap({
       source_hidden: false,
       outputs_hidden: false


### PR DESCRIPTION
This changes the cell creator so that it has cell outputs collapsed by default
