### PR TITLE
Cells created using commutable have outputs collapsed by default

### DIFF
--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -24,8 +24,8 @@ export const makeCodeCell = Record<CodeCellParams>({
   cell_type: "code",
   execution_count: null,
   metadata: ImmutableMap({
-    collapsed: false,
-    outputExpanded: true,
+    collapsed: true,
+    outputExpanded: false,
     jupyter: ImmutableMap({
       source_hidden: false,
       outputs_hidden: false

--- a/packages/stateful-components/__tests__/outputs/index.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/index.spec.tsx
@@ -71,7 +71,7 @@ describe("makeMapStateToProps", () => {
       .first();
     const ownProps = { contentRef, id };
     const result = makeMapStateToProps(state, ownProps)(state);
-    expect(result.hidden).toBe(false);
-    expect(result.expanded).toBe(true);
+    expect(result.hidden).toBe(true);
+    expect(result.expanded).toBe(false);
   });
 });

--- a/packages/stateful-components/__tests__/outputs/index.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/index.spec.tsx
@@ -71,7 +71,7 @@ describe("makeMapStateToProps", () => {
       .first();
     const ownProps = { contentRef, id };
     const result = makeMapStateToProps(state, ownProps)(state);
-    expect(result.hidden).toBe(true);
+    expect(result.hidden).toBe(false);
     expect(result.expanded).toBe(false);
   });
 });


### PR DESCRIPTION
This changes the cell creator so that it has cell outputs collapsed by default
