### PR TITLE
Remove caching of output in TransformMedia

### DIFF
--- a/packages/stateful-components/__tests__/outputs/transform-media.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/transform-media.spec.tsx
@@ -1,11 +1,14 @@
+import { mount } from "enzyme";
 import Immutable from "immutable";
+import React from "react";
 
 import { makeDisplayData } from "@nteract/commutable";
-import { makeContentsRecord, state as types } from "@nteract/core";
+import { state as types } from "@nteract/core";
 import { mockAppState } from "@nteract/fixtures";
 
 import {
   mapStateToProps,
+  PureTransformMedia,
   richestMediaType
 } from "../../src/outputs/transform-media";
 
@@ -95,5 +98,12 @@ describe("mapStateToProps", () => {
     const ownProps = { output_type: "display_data", output };
     const result = mapStateToProps(state, ownProps);
     expect(result.Media).toBe(transform);
+  });
+});
+
+describe("PureTransformMedia", () => {
+  it("renders nothing if there is no mediaType provided", () => {
+    const component = mount(<PureTransformMedia />);
+    expect(component.isEmptyRender()).toBe(true);
   });
 });

--- a/packages/stateful-components/__tests__/outputs/transform-media.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/transform-media.spec.tsx
@@ -5,7 +5,7 @@ import { makeContentsRecord, state as types } from "@nteract/core";
 import { mockAppState } from "@nteract/fixtures";
 
 import {
-  makeMapStateToProps,
+  mapStateToProps,
   richestMediaType
 } from "../../src/outputs/transform-media";
 
@@ -52,11 +52,11 @@ describe("richestMediaType", () => {
   });
 });
 
-describe("makeMapStateToProps", () => {
+describe("mapStateToProps", () => {
   it("returns empty Media component for invalid output_types", () => {
     const state = mockAppState({});
     const ownProps = { output_type: "stream" };
-    const result = makeMapStateToProps(state, ownProps)(state);
+    const result = mapStateToProps(state, ownProps);
     expect(result.Media()).toBeNull();
   });
   it("returns an empty Media component for unregistered transforms", () => {
@@ -68,7 +68,7 @@ describe("makeMapStateToProps", () => {
       }
     });
     const ownProps = { output_type: "display_data", output };
-    const result = makeMapStateToProps(state, ownProps)(state);
+    const result = mapStateToProps(state, ownProps);
     expect(result.Media()).toBeNull();
   });
   it("returns an empty Media component for unregistered transforms", () => {
@@ -93,7 +93,7 @@ describe("makeMapStateToProps", () => {
       }
     });
     const ownProps = { output_type: "display_data", output };
-    const result = makeMapStateToProps(state, ownProps)(state);
+    const result = mapStateToProps(state, ownProps);
     expect(result.Media).toBe(transform);
   });
 });

--- a/packages/stateful-components/src/outputs/transform-media.tsx
+++ b/packages/stateful-components/src/outputs/transform-media.tsx
@@ -10,8 +10,6 @@ import {
 } from "@nteract/commutable";
 import { actions, AppState, ContentRef, selectors } from "@nteract/core";
 
-import memoizeOne from "memoize-one";
-
 interface ComponentProps {
   output_type: string;
   id: string;
@@ -35,7 +33,7 @@ interface DispatchProps {
   };
 }
 
-const PureTransformMedia = (
+export const PureTransformMedia = (
   props: ComponentProps & StateProps & DispatchProps
 ) => {
   const {

--- a/packages/stateful-components/src/outputs/transform-media.tsx
+++ b/packages/stateful-components/src/outputs/transform-media.tsx
@@ -84,56 +84,48 @@ export const richestMediaType = (
   return mediaType;
 };
 
-export const makeMapStateToProps = (
-  initialState: AppState,
+export const mapStateToProps = (
+  state: AppState,
   ownProps: ComponentProps
-) => {
-  const { output_type, output } = ownProps;
-
-  const memoizedMetadata = memoizeOne(immutableMetadata =>
-    immutableMetadata ? immutableMetadata.toJS() : {}
-  );
-
-  const mapStateToProps = (state: AppState): StateProps => {
-    // This component should only be used with display data and execute result
-    if (
-      !output ||
-      !(output_type === "display_data" || output_type === "execute_result")
-    ) {
-      console.warn(
-        "connected transform media managed to get a non media bundle output"
-      );
-      return {
-        Media: () => null
-      };
-    }
-
-    const handlers = selectors.transformsById(state);
-    const order = selectors.displayOrder(state);
-    const theme = selectors.userTheme(state);
-
-    const mediaType = richestMediaType(output, order, handlers);
-
-    if (mediaType) {
-      const metadata = memoizedMetadata(output.metadata.get(mediaType));
-      const data = output.data[mediaType];
-      const Media = selectors.transform(state, { id: mediaType });
-      return {
-        Media,
-        mediaType,
-        data,
-        metadata,
-        theme
-      };
-    }
+): StateProps => {
+  const { output, output_type } = ownProps;
+  // This component should only be used with display data and execute result
+  if (
+    !output ||
+    !(output_type === "display_data" || output_type === "execute_result")
+  ) {
+    console.warn(
+      "connected transform media managed to get a non media bundle output"
+    );
     return {
-      Media: () => null,
+      Media: () => null
+    };
+  }
+
+  const handlers = selectors.transformsById(state);
+  const order = selectors.displayOrder(state);
+  const theme = selectors.userTheme(state);
+
+  const mediaType = richestMediaType(output, order, handlers);
+
+  if (mediaType) {
+    const metadata = output.metadata.get(mediaType);
+    const data = output.data[mediaType];
+    const Media = selectors.transform(state, { id: mediaType });
+    return {
+      Media,
       mediaType,
-      output,
+      data,
+      metadata,
       theme
     };
+  }
+  return {
+    Media: () => null,
+    mediaType,
+    output,
+    theme
   };
-  return mapStateToProps;
 };
 
 const makeMapDispatchToProps = (
@@ -167,7 +159,7 @@ const TransformMedia = connect<
   ComponentProps,
   AppState
 >(
-  makeMapStateToProps,
+  mapStateToProps,
   makeMapDispatchToProps
 )(PureTransformMedia);
 


### PR DESCRIPTION
Closes #4951 

This output was being updated correctly by the updateDisplayEpic but was being cached when mapped to the display component.

I removed the caching to allow the component to re-render when the state was changed.