### PR TITLE
Add catchError to all persistent kernel susbcribers

### DIFF
--- a/packages/epics/__tests__/comm.spec.ts
+++ b/packages/epics/__tests__/comm.spec.ts
@@ -3,7 +3,7 @@ import { toArray } from "rxjs/operators";
 import Immutable from "immutable";
 
 import * as actions from "@nteract/actions";
-import { COMM_MESSAGE, COMM_OPEN } from "@nteract/actions";
+import { COMM_MESSAGE, COMM_OPEN, EXECUTE_FAILED } from "@nteract/actions";
 import { ActionsObservable, StateObservable } from "redux-observable";
 import { commListenEpic } from "../src/comm";
 
@@ -106,6 +106,104 @@ describe("commActionObservable", () => {
               buffers: new Uint8Array([])
             }
           ]);
+        },
+        err => done.fail(err),
+        () => done()
+      ); // It should not error in the stream
+  });
+
+  test("on kernel error executeFailed action is returned", done => {
+
+    const contentRef = "fakeContentRef";
+    const kernelspecsRef = createKernelspecsRef();
+
+    const state = {
+      app: makeAppRecord({
+        version: "test"
+      }),
+      comms: makeCommsRecord(),
+      config: Immutable.Map({
+        theme: "light"
+      }),
+      core: makeStateRecord({
+        currentKernelspecsRef: kernelspecsRef,
+        entities: makeEntitiesRecord({
+          hosts: makeHostsRecord({}),
+          contents: makeContentsRecord({
+            byRef: Immutable.Map<string, ContentRecord>().set(
+              contentRef,
+              makeDummyContentRecord({
+                filepath: "test.ipynb"
+              })
+            )
+          }),
+          transforms: makeTransformsRecord({
+            displayOrder: Immutable.List([]),
+            byId: Immutable.Map({})
+          })
+        })
+      })
+    };
+
+    const sent = new Subject();
+    const received = new Subject();
+    received.hasError = true;
+
+    const mockSocket = Subject.create(sent, received);
+
+    const action = ActionsObservable.of(
+      actions.launchKernelSuccessful({
+        kernel: {
+          channels: mockSocket,
+          cwd: "/home/tester",
+          type: "websocket"
+        },
+        kernelRef: "fakeKernelRef",
+        contentRef: "fakeContentRef",
+        selectNextKernel: false
+      })
+    );
+
+    commListenEpic(action, new StateObservable(new Subject(), state))
+      .pipe(toArray())
+      .subscribe(
+        actions => {
+          expect(actions).toEqual([
+            {
+              type: EXECUTE_FAILED,
+              error: true,
+              payload: {
+                code:"EXEC_WEBSOCKET_ERROR",
+                contentRef: "fakeContentRef",
+                error: new Error(
+                  "The WebSocket connection has unexpectedly disconnected."
+                  )  
+              }
+            },
+            {
+              type: EXECUTE_FAILED,
+              error: true,
+              payload: {
+                code:"EXEC_WEBSOCKET_ERROR", 
+                contentRef: "fakeContentRef",
+                error: new Error(
+                  "The WebSocket connection has unexpectedly disconnected."
+                  )
+              }
+            },
+            {
+              type: EXECUTE_FAILED,
+              error: true,
+              payload: {
+                code:"EXEC_WEBSOCKET_ERROR",
+                contentRef: "fakeContentRef",
+                error: new Error(
+                  "The WebSocket connection has unexpectedly disconnected."
+                  )  
+              }
+            }
+          ]
+          );
         },
         err => done.fail(err),
         () => done()

--- a/packages/epics/src/comm.ts
+++ b/packages/epics/src/comm.ts
@@ -1,7 +1,7 @@
 import { ofMessageType } from "@nteract/messaging";
 import { ofType, StateObservable } from "redux-observable";
 import { ActionsObservable } from "redux-observable";
-import { merge, empty, of } from "rxjs";
+import { merge, of } from "rxjs";
 import { map, switchMap, takeUntil, filter, catchError } from "rxjs/operators";
 
 import {

--- a/packages/epics/src/comm.ts
+++ b/packages/epics/src/comm.ts
@@ -1,7 +1,7 @@
 import { ofMessageType } from "@nteract/messaging";
 import { ofType, StateObservable } from "redux-observable";
 import { ActionsObservable } from "redux-observable";
-import { merge, empty } from "rxjs";
+import { merge, empty, of } from "rxjs";
 import { map, switchMap, takeUntil, filter, catchError } from "rxjs/operators";
 
 import {
@@ -10,10 +10,11 @@ import {
   KILL_KERNEL_SUCCESSFUL,
   LAUNCH_KERNEL_SUCCESSFUL,
   NewKernelAction,
-  KillKernelSuccessful
+  KillKernelSuccessful,
+  executeFailed
 } from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
-import { AppState } from "@nteract/types";
+import { AppState, errors } from "@nteract/types";
 
 import { ipywidgetsModel$ } from "./ipywidgets";
 
@@ -59,7 +60,15 @@ export const commListenEpic = (
           )
         ),
         catchError((error: Error) => {
-          return empty();
+          return of(
+            executeFailed({
+                error: new Error(
+                "The WebSocket connection has unexpectedly disconnected."
+                ),
+                code: errors.EXEC_WEBSOCKET_ERROR,
+                contentRef
+            })
+        );
         })
       );
 
@@ -76,7 +85,15 @@ export const commListenEpic = (
           )
         ),
         catchError((error: Error) => {
-          return empty();
+          return of(
+            executeFailed({
+                error: new Error(
+                "The WebSocket connection has unexpectedly disconnected."
+                ),
+                code: errors.EXEC_WEBSOCKET_ERROR,
+                contentRef
+            })
+        );
         })
       );
 

--- a/packages/epics/src/comm.ts
+++ b/packages/epics/src/comm.ts
@@ -1,8 +1,8 @@
 import { ofMessageType } from "@nteract/messaging";
 import { ofType, StateObservable } from "redux-observable";
 import { ActionsObservable } from "redux-observable";
-import { merge } from "rxjs";
-import { map, switchMap, takeUntil, filter } from "rxjs/operators";
+import { merge, empty } from "rxjs";
+import { map, switchMap, takeUntil, filter, catchError } from "rxjs/operators";
 
 import {
   commMessageAction,
@@ -57,7 +57,10 @@ export const commListenEpic = (
                 action.payload.kernelRef === kernelRef
             )
           )
-        )
+        ),
+        catchError((error: Error) => {
+          return empty();
+        })
       );
 
       const commMessageAction$ = kernel.channels.pipe(
@@ -71,7 +74,10 @@ export const commListenEpic = (
                 action.payload.kernelRef === kernelRef
             )
           )
-        )
+        ),
+        catchError((error: Error) => {
+          return empty();
+        })
       );
 
       return merge(

--- a/packages/epics/src/ipywidgets.ts
+++ b/packages/epics/src/ipywidgets.ts
@@ -11,8 +11,8 @@ import {
   DirectoryModelRecordProps
 } from "@nteract/types";
 
-import { of } from "rxjs";
-import { filter, switchMap } from "rxjs/operators";
+import { of, empty } from "rxjs";
+import { filter, switchMap, catchError } from "rxjs/operators";
 import { RecordOf } from "immutable";
 
 /**
@@ -86,5 +86,8 @@ export const ipywidgetsModel$ = (
             })
           : null
       );
+    }),
+    catchError((error: Error) => {
+      return empty();
     })
   );

--- a/packages/epics/src/ipywidgets.ts
+++ b/packages/epics/src/ipywidgets.ts
@@ -1,5 +1,5 @@
 import { ofMessageType, JupyterMessage } from "@nteract/messaging";
-import { commOpenAction, appendOutput } from "@nteract/actions";
+import { commOpenAction, appendOutput, executeFailed } from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
 import {
   ContentRef,
@@ -8,7 +8,8 @@ import {
   DocumentRecordProps,
   EmptyModelRecordProps,
   FileModelRecordProps,
-  DirectoryModelRecordProps
+  DirectoryModelRecordProps,
+  errors
 } from "@nteract/types";
 
 import { of, empty } from "rxjs";
@@ -88,6 +89,14 @@ export const ipywidgetsModel$ = (
       );
     }),
     catchError((error: Error) => {
-      return empty();
+      return of(
+        executeFailed({
+            error: new Error(
+            "The WebSocket connection has unexpectedly disconnected."
+            ),
+            code: errors.EXEC_WEBSOCKET_ERROR,
+            contentRef
+        })
+    );
     })
   );

--- a/packages/epics/src/ipywidgets.ts
+++ b/packages/epics/src/ipywidgets.ts
@@ -12,7 +12,7 @@ import {
   errors
 } from "@nteract/types";
 
-import { of, empty } from "rxjs";
+import { of } from "rxjs";
 import { filter, switchMap, catchError } from "rxjs/operators";
 import { RecordOf } from "immutable";
 

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -9,7 +9,7 @@ import {
 import { sendNotification } from "@nteract/mythic-notifications";
 import { AnyAction } from "redux";
 import { ActionsObservable, ofType, StateObservable } from "redux-observable";
-import { EMPTY, merge, Observable, Observer, of } from "rxjs";
+import { EMPTY, merge, Observable, Observer, of, empty } from "rxjs";
 import {
   catchError,
   concatMap,
@@ -20,7 +20,7 @@ import {
   switchMap,
   take,
   takeUntil,
-  timeout
+  timeout  
 } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
@@ -63,7 +63,10 @@ export const watchExecutionStateEpic = (
                 ) => killAction.payload.kernelRef === action.payload.kernelRef
               )
             )
-          )
+          ),
+          catchError((error: Error) => {
+            return empty();
+          })
         )
     )
   );

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -9,7 +9,7 @@ import {
 import { sendNotification } from "@nteract/mythic-notifications";
 import { AnyAction } from "redux";
 import { ActionsObservable, ofType, StateObservable } from "redux-observable";
-import { EMPTY, merge, Observable, Observer, of, empty } from "rxjs";
+import { EMPTY, merge, Observable, Observer, of } from "rxjs";
 import {
   catchError,
   concatMap,
@@ -26,7 +26,7 @@ import {
 import * as actions from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
 import { AppState, ContentRef, KernelInfo, KernelRef } from "@nteract/types";
-import { createKernelRef } from "@nteract/types";
+import { createKernelRef, errors } from "@nteract/types";
 
 const path = require("path");
 
@@ -65,7 +65,15 @@ export const watchExecutionStateEpic = (
             )
           ),
           catchError((error: Error) => {
-            return empty();
+            return of(
+              actions.executeFailed({
+                  error: new Error(
+                  "The WebSocket connection has unexpectedly disconnected."
+                  ),
+                  code: errors.EXEC_WEBSOCKET_ERROR,
+                  contentRef: (action as actions.NewKernelAction).payload.contentRef  
+              })
+          );
           })
         )
     )

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -20,7 +20,7 @@ import {
   switchMap,
   take,
   takeUntil,
-  timeout  
+  timeout
 } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";


### PR DESCRIPTION
When unclean websocket close event is thrown (e.g. 1006 websocket close error code), this error percolates to each of the subscribers of the websocket subject. If any of these subscribers don't handle this error, all the source observable streams are getting shutdown resulting in unresponsive application. This change adds catchError to the kernel channel subscribers to ensure the websocket error doesn't percolate to the root and crash the app.