### PR TITLE
update cell UI directly after converting cell type (#5053)

### DIFF
--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -19,7 +19,15 @@ type Props = ComponentProps & StateProps;
 
 export class Cell extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
-    return nextProps.selected !== this.props.selected;
+    // Update cell directly after converting between markdown and code
+    if (this.props.cell.cell_type !== nextProps.cell.cell_type) {
+      return true;
+    }
+    // Update cell when selecting or de-selecting it
+    if (nextProps.selected !== this.props.selected) {
+      return true
+    }
+    return false
   }
 
   render(): JSX.Element | null {

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -20,7 +20,8 @@ type Props = ComponentProps & StateProps;
 export class Cell extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     // Update cell directly after converting between markdown and code
-    if (this.props.cell.cell_type !== nextProps.cell.cell_type) {
+    if (this.props.cell?.cell_type !== nextProps.cell?.cell_type) {
+
       return true;
     }
     // Update cell when selecting or de-selecting it

--- a/packages/stateful-components/src/cells/cell.tsx
+++ b/packages/stateful-components/src/cells/cell.tsx
@@ -25,7 +25,8 @@ export class Cell extends React.Component<Props> {
       return true;
     }
     // Update cell when selecting or de-selecting it
-    if (nextProps.selected !== this.props.selected) {
+    if (nextProps?.selected !== this.props?.selected) {
+
       return true
     }
     return false


### PR DESCRIPTION
This PR proposes a fix for  #5053 

Using _Convert to Markdown  Cell_ and _Convert to Code Cell_ work as in earlier versions, clicking the menu instantly updates the cell as well.