### PR TITLE
Add 'markdownOptions' as a state config to tweak react-markdown behavior

### DIFF
--- a/packages/stateful-components/package.json
+++ b/packages/stateful-components/package.json
@@ -22,9 +22,11 @@
     "@nteract/commutable": "^7.2.10-alpha.0",
     "@nteract/core": "^13.1.0-alpha.0",
     "@nteract/fixtures": "^2.3.5-alpha.0",
+    "@nteract/markdown": "4.4.0",
     "@nteract/outputs": "^3.0.9",
     "@nteract/presentational-components": "^3.3.12-alpha.0",
     "immutable": "^4.0.0-rc.12",
+    "react-markdown": "^4.3.1",
     "redux": "^4.0.4"
   }
 }

--- a/packages/stateful-components/package.json
+++ b/packages/stateful-components/package.json
@@ -26,7 +26,9 @@
     "@nteract/outputs": "^3.0.9",
     "@nteract/presentational-components": "^3.3.12-alpha.0",
     "immutable": "^4.0.0-rc.12",
-    "react-markdown": "^4.3.1",
     "redux": "^4.0.4"
+  },
+  "devDependencies": {
+    "react-markdown": "^4.3.1"
   }
 }

--- a/packages/stateful-components/src/cells/markdown-cell.tsx
+++ b/packages/stateful-components/src/cells/markdown-cell.tsx
@@ -10,6 +10,7 @@ import Editor, { EditorSlots, PassedEditorProps } from "../inputs/editor";
 import CodeMirrorEditor from "../inputs/connected-editors/codemirror";
 
 import { ImmutableCell } from "@nteract/commutable/src";
+import { ReactMarkdownProps } from "react-markdown";
 
 interface NamedMDCellSlots {
   editor?: EditorSlots;
@@ -27,6 +28,7 @@ interface StateProps {
   isCellFocused: boolean;
   isEditorFocused: boolean;
   cell?: ImmutableCell;
+  markdownOptions: ReactMarkdownProps;
 }
 
 interface DispatchProps {
@@ -42,7 +44,7 @@ export class PureMarkdownCell extends React.Component<
   render() {
     const { contentRef, id, cell, children } = this.props;
 
-    const { isEditorFocused, isCellFocused } = this.props;
+    const { isEditorFocused, isCellFocused, markdownOptions } = this.props;
 
     const {
       focusAboveCell,
@@ -75,6 +77,7 @@ export class PureMarkdownCell extends React.Component<
           editorFocused={isEditorFocused}
           unfocusEditor={unfocusEditor}
           source={source}
+          markdownOptions={markdownOptions}
         >
           <Source className="nteract-cell-source">
             <Editor id={id} contentRef={contentRef}>
@@ -104,10 +107,22 @@ export const makeMapStateToProps = (
       isEditorFocused = model.editorFocused === id;
     }
 
+    const markdownOptionsDefaults = {
+      linkTarget: "_blank"
+    };
+    const currentMarkdownOptions = state.config.get("markdownOptions");
+
+    const markdownOptions = Object.assign(
+      {},
+      markdownOptionsDefaults,
+      currentMarkdownOptions
+    );
+
     return {
       cell,
       isCellFocused,
-      isEditorFocused
+      isEditorFocused,
+      markdownOptions
     };
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,6 +2323,15 @@
   resolved "https://registry.yarnpkg.com/@nteract/logos/-/logos-1.0.0.tgz#e17ca29f41a5282fe32fa5e4e69a5a3a9839d378"
   integrity sha512-6f675p3gzs7ZMAovzfOx+QOMNu1TGVT2aV5lPOwnPxJCM/APLpDRFcSoURwLA26CROlTTDEe10XweFzJgQ+VEQ==
 
+"@nteract/markdown@4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@nteract/markdown/-/markdown-4.4.0.tgz#01b00ba7938c9620bb4962b215745979e451bcca"
+  integrity sha512-Xd8sxPmW42HW2Nq0pz2XrFBARt4wmgA0IbLQ23pg7FRMzpt2Ed4EjfuJkcm9ylTreAt1NJcljIpN47vzBUIehQ==
+  dependencies:
+    "@nteract/mathjax" "^4.0.7"
+    "@nteract/presentational-components" "^3.3.11"
+    react-markdown "^4.0.0"
+
 "@nteract/markdown@^4.3.10-alpha.0":
   version "4.3.12"
   resolved "https://registry.yarnpkg.com/@nteract/markdown/-/markdown-4.3.12.tgz#81a654392aa98818824c1f8ac4ec908f0aceeb3f"
@@ -13060,7 +13069,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-markdown@^4.0.0:
+react-markdown@^4.0.0, react-markdown@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
   integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==


### PR DESCRIPTION
1. Update @nteract/markdown to 4.4.0
2. Expose `markdownOptions` as state config. This is plumbed down to `react-markdown` to tweak markdown rendering.
3. Add default for `linkTarget`. This forces all markdown hyperlinks to open in new tab.