### PR TITLE
Add codemirror for powershell, FSharp and go

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -220,6 +220,9 @@ export default class CodeMirrorEditor extends React.Component<
     require("codemirror/mode/sql/sql");
     require("codemirror/mode/markdown/markdown");
     require("codemirror/mode/gfm/gfm");
+    require("codemirror/mode/go/go");
+    require("codemirror/mode/powershell/powershell");
+    require("codemirror/mode/mllike/mllike");
 
     require("./mode/ipython");
 


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

Fix #5055
Add the CodeMirror libs for PowerShell, FSharp and go.

- https://github.com/codemirror/CodeMirror/blob/master/mode/mllike/mllike.js
- https://github.com/codemirror/CodeMirror/blob/master/mode/powershell/powershell.js
- https://github.com/codemirror/CodeMirror/blob/master/mode/go/go.js

---------

@captainsafia Same question:
I found that `codemirror/mode/clike/clike` is already there, which should cover c# (https://codemirror.net/mode/clike/). Why is c# still not properly syntax colored on macOS (didn't try on other plats)?