### PR TITLE
Hide cell toolbar in exported PDF / print

### DIFF
--- a/packages/stateful-components/src/cells/toolbar.tsx
+++ b/packages/stateful-components/src/cells/toolbar.tsx
@@ -4,6 +4,7 @@ import { Dispatch } from "redux";
 
 import { ContentRef, actions, AppState, selectors } from "@nteract/core";
 import { CellType } from "@nteract/commutable";
+import styled from "styled-components";
 
 export interface ComponentProps {
   id: string;
@@ -38,16 +39,24 @@ export const CellToolbarContext = React.createContext({});
 
 export type CellToolbarProps = DispatchProps & StateProps;
 
+const CellToolbarRegion = styled.div`
+  @media print {
+    display: none;
+  }
+`;
+
 class CellToolbar extends React.Component<
   ComponentProps & StateProps & DispatchProps
 > {
   render() {
     return (
-      <div className="nteract-cell-toolbar">
-        <CellToolbarContext.Provider value={this.props}>
-          {this.props.children}
-        </CellToolbarContext.Provider>
-      </div>
+      <CellToolbarRegion>
+        <div className="nteract-cell-toolbar">
+          <CellToolbarContext.Provider value={this.props}>
+            {this.props.children}
+          </CellToolbarContext.Provider>
+        </div>
+      </CellToolbarRegion>
     );
   }
 }

--- a/packages/styles/themes/default.css
+++ b/packages/styles/themes/default.css
@@ -131,11 +131,6 @@
   opacity: 1;
 }
 
-@media print {
-  .nteract-cell-toolbar {
-    display: none;
-  }
-}
 
 .nteract-cell-toolbar button {
   display: inline-block;


### PR DESCRIPTION
This PR fixes #5062 

The `@media print` rule for `.nteract-cell-toolbar` in the default theme is overridden by something, and is not applied when exporting to pdf. Using `display: none !important` works too.

Other components have this rule in the component using `styled.div`, so this is more consistent with that.