### PR TITLE
Fix CSS for collapsed cell and remove outputExpanded

### DIFF
--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -6,7 +6,7 @@ import {
   List as ImmutableList,
   Map as ImmutableMap,
   Record,
-  RecordOf
+  RecordOf,
 } from "immutable";
 
 /* CodeCell Record Boilerplate */
@@ -25,19 +25,18 @@ export const makeCodeCell = Record<CodeCellParams>({
   execution_count: null,
   metadata: ImmutableMap({
     collapsed: true,
-    outputExpanded: false,
     jupyter: ImmutableMap({
       source_hidden: false,
-      outputs_hidden: false
+      outputs_hidden: false,
     }),
     nteract: ImmutableMap({
       transient: ImmutableMap({
-        deleting: false
-      })
-    })
+        deleting: false,
+      }),
+    }),
   }),
   source: "",
-  outputs: ImmutableList()
+  outputs: ImmutableList(),
 });
 
 export type ImmutableCodeCell = RecordOf<CodeCellParams>;
@@ -55,11 +54,11 @@ export const makeMarkdownCell = Record<MarkdownCellParams>({
   metadata: ImmutableMap({
     nteract: ImmutableMap({
       transient: ImmutableMap({
-        deleting: false
-      })
-    })
+        deleting: false,
+      }),
+    }),
   }),
-  source: ""
+  source: "",
 });
 
 export type ImmutableMarkdownCell = RecordOf<MarkdownCellParams>;
@@ -77,11 +76,11 @@ export const makeRawCell = Record<RawCellParams>({
   metadata: ImmutableMap({
     nteract: ImmutableMap({
       transient: ImmutableMap({
-        deleting: false
-      })
-    })
+        deleting: false,
+      }),
+    }),
   }),
-  source: ""
+  source: "",
 });
 
 export type ImmutableRawCell = RecordOf<RawCellParams>;

--- a/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
+++ b/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
@@ -8,7 +8,7 @@ import {
   makeDisplayData,
   makeErrorOutput,
   makeExecuteResult,
-  makeStreamOutput
+  makeStreamOutput,
 } from "@nteract/commutable";
 import * as Immutable from "immutable";
 import uuid from "uuid/v4";
@@ -19,7 +19,7 @@ import { makeDocumentRecord } from "@nteract/types";
 import {
   cleanCellTransient,
   notebook as reducers,
-  reduceOutputs
+  reduceOutputs,
 } from "../../../../src/core/entities/contents/notebook";
 
 const initialDocument = Immutable.Map();
@@ -37,13 +37,13 @@ describe("reduceOutputs", () => {
         output_type: "error",
         ename: "well",
         evalue: "actually",
-        traceback: Immutable.List()
-      })
+        traceback: Immutable.List(),
+      }),
     ]);
     const newOutputs = reduceOutputs(outputs, {
       output_type: "display_data",
       data: {},
-      metadata: {}
+      metadata: {},
     });
 
     expect(newOutputs).toEqual(
@@ -51,31 +51,31 @@ describe("reduceOutputs", () => {
         makeStreamOutput({
           output_type: "stream",
           name: "stdout",
-          text: "Woo"
+          text: "Woo",
         }),
         makeErrorOutput({
           output_type: "error",
           ename: "well",
           evalue: "actually",
-          traceback: Immutable.List()
+          traceback: Immutable.List(),
         }),
         makeDisplayData({
           output_type: "display_data",
           data: {},
-          metadata: Immutable.Map()
-        })
+          metadata: Immutable.Map(),
+        }),
       ])
     );
   });
 
   test("handles the case of a single stream output", () => {
     const outputs = Immutable.List([
-      makeStreamOutput({ name: "stdout", text: "hello" })
+      makeStreamOutput({ name: "stdout", text: "hello" }),
     ]);
     const newOutputs = reduceOutputs(outputs, {
       name: "stdout",
       text: " world",
-      output_type: "stream"
+      output_type: "stream",
     });
 
     expect(newOutputs).toEqual(
@@ -83,8 +83,8 @@ describe("reduceOutputs", () => {
         makeStreamOutput({
           name: "stdout",
           text: "hello world",
-          output_type: "stream"
-        })
+          output_type: "stream",
+        }),
       ])
     );
   });
@@ -95,7 +95,7 @@ describe("reduceOutputs", () => {
     outputs = reduceOutputs(outputs, {
       name: "stdout",
       text: "hello",
-      output_type: "stream"
+      output_type: "stream",
     });
 
     expect(outputs).toEqual(
@@ -105,11 +105,11 @@ describe("reduceOutputs", () => {
     outputs = reduceOutputs(outputs, {
       name: "stdout",
       text: " world",
-      output_type: "stream"
+      output_type: "stream",
     });
     expect(outputs).toEqual(
       Immutable.List([
-        makeStreamOutput({ name: "stdout", text: "hello world" })
+        makeStreamOutput({ name: "stdout", text: "hello world" }),
       ])
     );
   });
@@ -119,19 +119,19 @@ describe("reduceOutputs", () => {
       makeStreamOutput({
         name: "stdout",
         text: "hello",
-        output_type: "stream"
+        output_type: "stream",
       }),
       makeStreamOutput({
         name: "stderr",
         text: "errors are",
-        output_type: "stream"
-      })
+        output_type: "stream",
+      }),
     ]);
 
     const newOutputs = reduceOutputs(outputs, {
       name: "stdout",
       text: " world",
-      output_type: "stream"
+      output_type: "stream",
     });
 
     expect(newOutputs).toEqual(
@@ -139,31 +139,31 @@ describe("reduceOutputs", () => {
         makeStreamOutput({
           name: "stdout",
           text: "hello world",
-          output_type: "stream"
+          output_type: "stream",
         }),
         makeStreamOutput({
           name: "stderr",
           text: "errors are",
-          output_type: "stream"
-        })
+          output_type: "stream",
+        }),
       ])
     );
 
     const evenNewerOutputs = reduceOutputs(newOutputs, {
       name: "stderr",
       text: " informative",
-      output_type: "stream"
+      output_type: "stream",
     });
     expect(evenNewerOutputs).toEqual(
       Immutable.fromJS([
         makeStreamOutput({
           name: "stdout",
-          text: "hello world"
+          text: "hello world",
         }),
         makeStreamOutput({
           name: "stderr",
-          text: "errors are informative"
-        })
+          text: "errors are informative",
+        }),
       ])
     );
   });
@@ -181,7 +181,7 @@ describe("setLanguageInfo", () => {
     const kernelInfo = {
       name: "french",
       language: "french",
-      displayName: "français"
+      displayName: "français",
     };
     const state = reducers(
       initialDocument,
@@ -240,7 +240,7 @@ describe("focusNextCell", () => {
       "notebook",
       "cellMap",
       newCellId,
-      "cell_type"
+      "cell_type",
     ]);
 
     expect(state.cellFocused).not.toBeNull();
@@ -263,7 +263,7 @@ describe("focusNextCell", () => {
       "notebook",
       "cellMap",
       newCellId,
-      "cell_type"
+      "cell_type",
     ]);
 
     expect(state.cellFocused).not.toBeNull();
@@ -364,7 +364,7 @@ describe("moveCell", () => {
       actions.createCellBelow({
         id: fixtureCommutable.get("cellOrder").first(),
         cellType: "markdown",
-        source: "# Woo\n*Yay*"
+        source: "# Woo\n*Yay*",
       })
     );
 
@@ -375,13 +375,13 @@ describe("moveCell", () => {
       actions.moveCell({
         id: cellOrder.get(0),
         destinationId: cellOrder.get(1),
-        above: false
+        above: false,
       })
     );
     expect(state.getIn(["notebook", "cellOrder"]).toJS()).toEqual([
       cellOrder.get(1),
       cellOrder.get(0),
-      cellOrder.get(2)
+      cellOrder.get(2),
     ]);
 
     const state2 = reducers(
@@ -389,13 +389,13 @@ describe("moveCell", () => {
       actions.moveCell({
         id: cellOrder.get(0),
         destinationId: cellOrder.get(1),
-        above: true
+        above: true,
       })
     );
     expect(state2.getIn(["notebook", "cellOrder"]).toJS()).toEqual([
       cellOrder.get(0),
       cellOrder.get(1),
-      cellOrder.get(2)
+      cellOrder.get(2),
     ]);
   });
 });
@@ -435,7 +435,7 @@ describe("clearOutputs", () => {
 
     const originalState = makeDocumentRecord({
       notebook,
-      filename: "test.ipynb"
+      filename: "test.ipynb",
     });
 
     const id = originalState.getIn(["notebook", "cellOrder"]).last();
@@ -455,7 +455,7 @@ describe("clearOutputs", () => {
     originalState = originalState.set(
       "cellPrompts",
       Immutable.Map({
-        [id]: Immutable.List([{ prompt: "Test: ", password: false }])
+        [id]: Immutable.List([{ prompt: "Test: ", password: false }]),
       })
     );
 
@@ -528,7 +528,7 @@ describe("overwriteMetadataField", () => {
       originalState,
       actions.overwriteMetadataField({
         field: "name",
-        value: "javascript"
+        value: "javascript",
       })
     );
     expect(state.getIn(["notebook", "metadata", "name"])).toBe("javascript");
@@ -553,8 +553,8 @@ describe("toggleCellOutputVisibility", () => {
   test("changes the visibility on a single cell", () => {
     const originalState = monocellDocument.updateIn(
       ["notebook", "cellMap"],
-      cells =>
-        cells.map(value =>
+      (cells) =>
+        cells.map((value) =>
           value.setIn(["metadata", "jupyter", "outputs_hidden"], false)
         )
     );
@@ -571,7 +571,7 @@ describe("toggleCellOutputVisibility", () => {
         id,
         "metadata",
         "jupyter",
-        "outputs_hidden"
+        "outputs_hidden",
       ])
     ).toBe(true);
   });
@@ -581,8 +581,8 @@ describe("toggleCellInputVisibility", () => {
   test("changes the input visibility on a single cell", () => {
     const originalState = monocellDocument.updateIn(
       ["notebook", "cellMap"],
-      cells =>
-        cells.map(value =>
+      (cells) =>
+        cells.map((value) =>
           value.setIn(["metadata", "jupyter", "source_hidden"], false)
         )
     );
@@ -590,7 +590,7 @@ describe("toggleCellInputVisibility", () => {
     const state = reducers(
       originalState,
       actions.toggleCellInputVisibility({
-        id
+        id,
       })
     );
     expect(
@@ -600,7 +600,7 @@ describe("toggleCellInputVisibility", () => {
         id,
         "metadata",
         "jupyter",
-        "source_hidden"
+        "source_hidden",
       ])
     ).toBe(true);
   });
@@ -654,11 +654,11 @@ describe("copyCell", () => {
         cellMap: {
           [firstId]: emptyCodeCell.set("source", "data"),
           [secondId]: emptyCodeCell,
-          [thirdId]: emptyCodeCell
-        }
+          [thirdId]: emptyCodeCell,
+        },
       }),
       cellFocused: secondId,
-      copied: null
+      copied: null,
     });
 
     const state = reducers(originalState, actions.copyCell({ id: firstId }));
@@ -671,8 +671,8 @@ describe("copyCell", () => {
         cellMap: {
           [firstId]: emptyCodeCell.set("source", "data"),
           [secondId]: emptyCodeCell,
-          [thirdId]: emptyCodeCell
-        }
+          [thirdId]: emptyCodeCell,
+        },
       })
     );
   });
@@ -690,11 +690,11 @@ describe("cutCell", () => {
         cellMap: {
           [firstId]: emptyCodeCell.set("source", "data"),
           [secondId]: emptyCodeCell,
-          [thirdId]: emptyCodeCell
-        }
+          [thirdId]: emptyCodeCell,
+        },
       }),
       cellFocused: secondId,
-      copied: null
+      copied: null,
     });
 
     const state = reducers(originalState, actions.cutCell({ id: firstId }));
@@ -716,11 +716,11 @@ describe("pasteCell", () => {
         cellMap: {
           [firstId]: emptyCodeCell,
           [secondId]: emptyCodeCell,
-          [thirdId]: emptyCodeCell
-        }
+          [thirdId]: emptyCodeCell,
+        },
       }),
       cellFocused: secondId,
-      copied: emptyCodeCell.set("source", "COPY PASTA")
+      copied: emptyCodeCell.set("source", "COPY PASTA"),
     });
 
     // We will paste the cell after the focused cell
@@ -780,24 +780,17 @@ describe("changeCellType", () => {
 });
 
 describe("toggleOutputExpansion", () => {
-  test("changes outputExpanded set", () => {
+  test("toggles value of collapsed property", () => {
     const originalState = monocellDocument.updateIn(
       ["notebook", "cellMap"],
-      cells =>
-        cells.map(value =>
-          value
-            .setIn(["metadata", "outputExpanded"], false)
-            .setIn(["metadata", "collapsed"], true)
-        )
+      (cells) =>
+        cells.map((value) => value.setIn(["metadata", "collapsed"], true))
     );
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
     const state = reducers(
       originalState,
       actions.toggleOutputExpansion({ id })
     );
-    expect(
-      state.getIn(["notebook", "cellMap", id, "metadata", "outputExpanded"])
-    ).toBe(true);
     expect(
       state.getIn(["notebook", "cellMap", id, "metadata", "collapsed"])
     ).toBe(false);
@@ -813,8 +806,8 @@ describe("appendOutput", () => {
       id,
       output: {
         output_type: "display_data",
-        data: { "text/html": "<marquee>wee</marquee>" }
-      }
+        data: { "text/html": "<marquee>wee</marquee>" },
+      },
     });
 
     const state = reducers(originalState, action);
@@ -822,8 +815,8 @@ describe("appendOutput", () => {
       Immutable.List([
         makeDisplayData({
           output_type: "display_data",
-          data: { "text/html": "<marquee>wee</marquee>" }
-        })
+          data: { "text/html": "<marquee>wee</marquee>" },
+        }),
       ])
     );
 
@@ -841,23 +834,23 @@ describe("appendOutput", () => {
       output: {
         output_type: "display_data",
         data: { "text/html": "<marquee>wee</marquee>" },
-        transient: { display_id: "1234" }
-      }
+        transient: { display_id: "1234" },
+      },
     });
 
     const state = reducers(originalState, action);
     expect(state.getIn(["notebook", "cellMap", cellId, "outputs"])).toEqual(
       Immutable.List([
         makeDisplayData({
-          data: { "text/html": "<marquee>wee</marquee>" }
-        })
+          data: { "text/html": "<marquee>wee</marquee>" },
+        }),
       ])
     );
 
     expect(state.getIn(["transient", "keyPathsForDisplays", "1234"])).toEqual(
       // we expect a list of keypaths (which are lists of strings + numbers)
       Immutable.List([
-        Immutable.List(["notebook", "cellMap", cellId, "outputs", 0])
+        Immutable.List(["notebook", "cellMap", cellId, "outputs", 0]),
       ])
     );
   });
@@ -874,9 +867,9 @@ describe("updateDisplay", () => {
         output_type: "update_display_data",
         data: { "text/html": "🐱😼😹" },
         metadata: {},
-        transient: { display_id: "1234" }
+        transient: { display_id: "1234" },
       },
-      contentRef: undefined
+      contentRef: undefined,
     });
 
     const state = reducers(originalState, action);
@@ -897,17 +890,17 @@ describe("updateDisplay", () => {
         output: {
           output_type: "display_data",
           data: { "text/html": "<marquee>wee</marquee>" },
-          transient: { display_id: "1234" }
-        }
+          transient: { display_id: "1234" },
+        },
       }),
       actions.appendOutput({
         id,
         output: {
           output_type: "execute_result",
           data: { "text/plain": "shennagins afoot" },
-          transient: { display_id: "1234" }
-        }
-      })
+          transient: { display_id: "1234" },
+        },
+      }),
     ];
 
     const state = actionArray.reduce(
@@ -920,13 +913,13 @@ describe("updateDisplay", () => {
         makeDisplayData({
           output_type: "display_data",
           data: { "text/plain": "shennagins afoot" },
-          metadata: Immutable.Map({})
+          metadata: Immutable.Map({}),
         }),
         makeExecuteResult({
           output_type: "execute_result",
           data: { "text/plain": "shennagins afoot" },
-          metadata: Immutable.Map({})
-        })
+          metadata: Immutable.Map({}),
+        }),
       ])
     );
 
@@ -935,9 +928,9 @@ describe("updateDisplay", () => {
         content: {
           output_type: "update_display_data",
           data: { "text/html": "<marquee>WOO</marquee>" },
-          transient: { display_id: "1234" }
-        }
-      })
+          transient: { display_id: "1234" },
+        },
+      }),
     ];
 
     const moreState = moreActionArray.reduce(
@@ -950,13 +943,13 @@ describe("updateDisplay", () => {
         makeDisplayData({
           output_type: "display_data",
           data: { "text/html": "<marquee>WOO</marquee>" },
-          metadata: Immutable.Map({})
+          metadata: Immutable.Map({}),
         }),
         makeExecuteResult({
           output_type: "execute_result",
           data: { "text/html": "<marquee>WOO</marquee>" },
-          metadata: Immutable.Map({})
-        })
+          metadata: Immutable.Map({}),
+        }),
       ])
     );
   });
@@ -968,40 +961,40 @@ describe("cleanCellTransient", () => {
       1234: [
         ["notebook", "cellMap", "0000", "outputs", 0],
         ["notebook", "cellMap", "XYZA", "outputs", 0],
-        ["notebook", "cellMap", "0000", "outputs", 1]
+        ["notebook", "cellMap", "0000", "outputs", 1],
       ],
-      5678: [["notebook", "cellMap", "XYZA", "outputs", 1]]
+      5678: [["notebook", "cellMap", "XYZA", "outputs", 1]],
     });
     const state = new Immutable.Map({
       transient: new Immutable.Map({
-        keyPathsForDisplays
-      })
+        keyPathsForDisplays,
+      }),
     });
 
     expect(
       cleanCellTransient(state, "0000").getIn([
         "transient",
-        "keyPathsForDisplays"
+        "keyPathsForDisplays",
       ])
     ).toEqual(
       Immutable.fromJS({
         1234: [["notebook", "cellMap", "XYZA", "outputs", 0]],
-        5678: [["notebook", "cellMap", "XYZA", "outputs", 1]]
+        5678: [["notebook", "cellMap", "XYZA", "outputs", 1]],
       })
     );
 
     expect(
       cleanCellTransient(state, "XYZA").getIn([
         "transient",
-        "keyPathsForDisplays"
+        "keyPathsForDisplays",
       ])
     ).toEqual(
       Immutable.fromJS({
         1234: [
           ["notebook", "cellMap", "0000", "outputs", 0],
-          ["notebook", "cellMap", "0000", "outputs", 1]
+          ["notebook", "cellMap", "0000", "outputs", 1],
         ],
-        5678: []
+        5678: [],
       })
     );
   });
@@ -1013,7 +1006,7 @@ describe("acceptPayloadMessage", () => {
     const initialState = makeDocumentRecord({
       filename: "test.ipynb",
       notebook,
-      cellPagers: Immutable.Map({})
+      cellPagers: Immutable.Map({}),
     });
     const state = reducers(
       initialState,
@@ -1021,8 +1014,8 @@ describe("acceptPayloadMessage", () => {
         id: firstCellId,
         payload: {
           source: "page",
-          data: { well: "alright" }
-        }
+          data: { well: "alright" },
+        },
       })
     );
 
@@ -1037,8 +1030,8 @@ describe("acceptPayloadMessage", () => {
         payload: {
           source: "set_next_input",
           replace: true,
-          text: "this is now the text"
-        }
+          text: "this is now the text",
+        },
       })
     );
 
@@ -1068,13 +1061,13 @@ describe("updateOutputMetadata", () => {
         id,
         metadata: newOutputMetadata,
         index: 0,
-        mediaType: "test/mediatype"
+        mediaType: "test/mediatype",
       })
     );
     expect(state.getIn(["notebook", "cellMap", id, "outputs", 0])).toEqual(
       Immutable.Map({
         empty: "output",
-        metadata: Immutable.Map({ "test/mediatype": newOutputMetadata })
+        metadata: Immutable.Map({ "test/mediatype": newOutputMetadata }),
       })
     );
   });
@@ -1088,15 +1081,15 @@ describe("interruptKernelSuccessful", () => {
         cellMap: {
           cell1: { status: "" },
           cell2: { status: "" },
-          cell3: { status: "" }
-        }
-      }
+          cell3: { status: "" },
+        },
+      },
     });
     const state = reducers(
       originalState,
       actions.interruptKernelSuccessful({
         kernelRef: "testKernelRef",
-        contentRef: "testContentRef"
+        contentRef: "testContentRef",
       })
     );
     expect(state.getIn(["transient", "cellMap", "cell1", "status"])).toEqual(
@@ -1116,15 +1109,15 @@ describe("interruptKernelSuccessful", () => {
         cellMap: {
           cell1: { status: "queued" },
           cell2: { status: "running" },
-          cell3: { status: "" }
-        }
-      }
+          cell3: { status: "" },
+        },
+      },
     });
     const state = reducers(
       originalState,
       actions.interruptKernelSuccessful({
         kernelRef: "testKernelRef",
-        contentRef: "testContentRef"
+        contentRef: "testContentRef",
       })
     );
     expect(state.getIn(["transient", "cellMap", "cell1", "status"])).toEqual(
@@ -1161,8 +1154,8 @@ describe("unhideAll", () => {
             .setIn(["metadata", "jupyter", "outputs_hidden"], false),
           [cellOrder[3]]: emptyCodeCell
             .setIn(["metadata", "jupyter", "source_hidden"], true)
-            .setIn(["metadata", "jupyter", "outputs_hidden"], false)
-        }
+            .setIn(["metadata", "jupyter", "outputs_hidden"], false),
+        },
       })
     );
   });
@@ -1173,7 +1166,7 @@ describe("unhideAll", () => {
       initialState,
       actions.unhideAll({
         inputHidden: false,
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1181,7 +1174,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(true);
@@ -1189,7 +1182,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).toEqual([false, true, false, false]);
@@ -1201,7 +1194,7 @@ describe("unhideAll", () => {
       initialState,
       actions.unhideAll({
         inputHidden: true,
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1209,7 +1202,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(false);
@@ -1217,7 +1210,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).toEqual([false, true, false, false]);
@@ -1229,7 +1222,7 @@ describe("unhideAll", () => {
       initialState,
       actions.unhideAll({
         outputHidden: false,
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1237,7 +1230,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(true);
@@ -1245,7 +1238,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).toEqual([false, false, false, true]);
@@ -1257,7 +1250,7 @@ describe("unhideAll", () => {
       initialState,
       actions.unhideAll({
         outputHidden: true,
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1265,7 +1258,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(false);
@@ -1273,7 +1266,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).toEqual([false, false, false, true]);
@@ -1286,7 +1279,7 @@ describe("unhideAll", () => {
       actions.unhideAll({
         inputHidden: false,
         outputHidden: false,
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1294,7 +1287,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(true);
@@ -1302,7 +1295,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(true);
@@ -1315,7 +1308,7 @@ describe("unhideAll", () => {
       actions.unhideAll({
         inputHidden: true,
         outputHidden: true,
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1323,7 +1316,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(false);
@@ -1331,7 +1324,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).not.toContain(false);
@@ -1342,7 +1335,7 @@ describe("unhideAll", () => {
     const actualState = reducers(
       initialState,
       actions.unhideAll({
-        contentRef: undefined
+        contentRef: undefined,
       })
     );
 
@@ -1350,7 +1343,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "source_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "source_hidden"]))
         .toList()
         .toArray()
     ).toEqual([false, false, false, true]);
@@ -1358,7 +1351,7 @@ describe("unhideAll", () => {
     expect(
       actualState
         .getIn(["notebook", "cellMap"])
-        .map(cell => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
+        .map((cell) => cell.getIn(["metadata", "jupyter", "outputs_hidden"]))
         .toList()
         .toArray()
     ).toEqual([false, true, false, false]);

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -23,14 +23,14 @@ import {
   OnDiskDisplayData,
   OnDiskExecuteResult,
   OnDiskOutput,
-  OnDiskStreamOutput
+  OnDiskStreamOutput,
 } from "@nteract/commutable";
 import { UpdateDisplayDataContent } from "@nteract/messaging";
 import {
   DocumentRecordProps,
   makeDocumentRecord,
   NotebookModel,
-  PayloadMessage
+  PayloadMessage,
 } from "@nteract/types";
 import { escapeCarriageReturnSafe } from "escape-carriage";
 import { fromJS, List, Map, RecordOf, Set } from "immutable";
@@ -162,7 +162,7 @@ function toggleTagInCell(
 
   return state.updateIn(
     ["notebook", "cellMap", id, "metadata", "tags"],
-    tags => {
+    (tags) => {
       if (tags) {
         return tags.has(tag) ? tags.remove(tag) : tags.add(tag);
       } else {
@@ -193,7 +193,7 @@ function clearAllOutputs(
       if ((cell as any).get("cell_type") === "code") {
         return (cell as ImmutableCodeCell).merge({
           outputs: List(),
-          execution_count: null
+          execution_count: null,
         });
       }
       return cell;
@@ -202,7 +202,7 @@ function clearAllOutputs(
   // Clear all the transient data too
   const transient = Map({
     keyPathsForDisplays: Map(),
-    cellMap: cellMap.map(() => Map())
+    cellMap: cellMap.map(() => Map()),
   });
 
   return state
@@ -229,7 +229,7 @@ function updateAllDisplaysWithID(
     state.getIn([
       "transient",
       "keyPathsForDisplays",
-      content.transient.display_id
+      content.transient.display_id,
     ]) || List();
 
   const updateOutput = (output: any) => {
@@ -237,14 +237,14 @@ function updateAllDisplaysWithID(
       // We already have something here, don't change the other fields
       return output.merge({
         data: createFrozenMediaBundle(content.data),
-        metadata: fromJS(content.metadata || {})
+        metadata: fromJS(content.metadata || {}),
       });
     } else if (content.output_type === "update_display_data") {
       // Nothing here and we have no valid output, just create a basic output
       return {
         data: createFrozenMediaBundle(content.data),
         metadata: fromJS(content.metadata || {}),
-        output_type: "display_data"
+        output_type: "display_data",
       };
     } else {
       // Nothing here, but we have a valid output
@@ -310,7 +310,7 @@ function appendOutput(
     "cellMap",
     cellId,
     "outputs",
-    outputIndex
+    outputIndex,
   ]);
 
   const keyPaths: KeyPaths = (
@@ -556,7 +556,7 @@ function acceptPayloadMessage(
 
   if (payload.source === "page") {
     // append pager
-    return state.updateIn(["cellPagers", id], l =>
+    return state.updateIn(["cellPagers", id], (l) =>
       (l || List()).push(payload.data)
     );
   } else if (payload.source === "set_next_input") {
@@ -576,8 +576,8 @@ function acceptPayloadMessage(
           // TODO: is payload.text guaranteed to be defined?
           source: payload.text || "",
           id,
-          contentRef: action.payload.contentRef
-        }
+          contentRef: action.payload.contentRef,
+        },
       });
     }
   }
@@ -612,7 +612,7 @@ function toggleCellOutputVisibility(
       id,
       "metadata",
       "jupyter",
-      "outputs_hidden"
+      "outputs_hidden",
     ])
   );
 }
@@ -631,7 +631,7 @@ function unhideAll(
     metadataMixin = metadataMixin.set("source_hidden", inputHidden);
   }
 
-  return state.updateIn(["notebook", "cellMap"], cellMap =>
+  return state.updateIn(["notebook", "cellMap"], (cellMap) =>
     cellMap.map((cell: ImmutableCell) => {
       if ((cell as any).get("cell_type") === "code") {
         return cell.mergeIn(["metadata", "jupyter"], metadataMixin);
@@ -658,7 +658,7 @@ function toggleCellInputVisibility(
       id,
       "metadata",
       "jupyter",
-      "source_hidden"
+      "source_hidden",
     ])
   );
 }
@@ -682,7 +682,7 @@ function updateOutputMetadata(
     item.set(
       "metadata",
       fromJS({
-        [mediaType]: metadata
+        [mediaType]: metadata,
       })
     )
   );
@@ -710,7 +710,7 @@ function setKernelMetadata(
         fromJS({
           name: kernelInfo.name,
           language: kernelInfo.language,
-          display_name: kernelInfo.displayName
+          display_name: kernelInfo.displayName,
         })
       )
       .setIn(["notebook", "metadata", "kernel_info", "name"], kernelInfo.name);
@@ -824,21 +824,21 @@ function changeCellType(
       return nextState.setIn(
         ["notebook", "cellMap", id],
         makeCodeCell({
-          source: cell.source
+          source: cell.source,
         })
       );
     case "markdown":
       return nextState.setIn(
         ["notebook", "cellMap", id],
         makeMarkdownCell({
-          source: cell.source
+          source: cell.source,
         })
       );
     case "raw":
       return nextState.setIn(
         ["notebook", "cellMap", id],
         makeRawCell({
-          source: cell.source
+          source: cell.source,
         })
       );
   }
@@ -860,15 +860,10 @@ function toggleOutputExpansion(
   return state.updateIn(
     ["notebook", "cellMap"],
     (cells: Map<CellId, ImmutableCell>) =>
-      cells
-        .setIn(
-          [id, "metadata", "collapsed"],
-          !cells.getIn([id, "metadata", "collapsed"])
-        )
-        .setIn(
-          [id, "metadata", "outputExpanded"],
-          !cells.getIn([id, "metadata", "outputExpanded"])
-        )
+      cells.setIn(
+        [id, "metadata", "collapsed"],
+        !cells.getIn([id, "metadata", "collapsed"])
+      )
   );
 }
 
@@ -877,10 +872,10 @@ function promptInputRequest(
   action: actionTypes.PromptInputRequest
 ): RecordOf<DocumentRecordProps> {
   const { id, password, prompt } = action.payload;
-  return state.updateIn(["cellPrompts", id], prompts =>
+  return state.updateIn(["cellPrompts", id], (prompts) =>
     prompts.push({
       prompt,
-      password
+      password,
     })
   );
 }
@@ -889,7 +884,7 @@ function interruptKernelSuccessful(
   state: NotebookModel,
   action: actionTypes.InterruptKernelSuccessful
 ): RecordOf<DocumentRecordProps> {
-  return state.updateIn(["transient", "cellMap"], cells =>
+  return state.updateIn(["transient", "cellMap"], (cells) =>
     cells.map((cell: Map<string, string>) => {
       if (cell.get("status") === "queued" || cell.get("status") === "running") {
         return cell.set("status", "");
@@ -941,7 +936,7 @@ type DocumentAction =
   | actionTypes.InterruptKernelSuccessful;
 
 const defaultDocument: NotebookModel = makeDocumentRecord({
-  notebook: emptyNotebook
+  notebook: emptyNotebook,
 });
 
 export function notebook(

--- a/packages/stateful-components/src/outputs/index.tsx
+++ b/packages/stateful-components/src/outputs/index.tsx
@@ -57,8 +57,7 @@ export const makeMapStateToProps = (
           cell.getIn(["metadata", "jupyter", "outputs_hidden"]);
         expanded =
           cell.cell_type === "code" &&
-          (cell.getIn(["metadata", "collapsed"]) === false ||
-            cell.getIn(["metadata", "outputExpanded"]));
+          cell.getIn(["metadata", "collapsed"]) === false;
       }
     }
 

--- a/packages/styles/themes/base.css
+++ b/packages/styles/themes/base.css
@@ -11,10 +11,15 @@
 .nteract-cell-outputs {
   padding: 10px 10px 10px calc(var(--prompt-width, 50px) + 10px);
   word-wrap: break-word;
-  overflow-y: hidden;
+  overflow-y: scroll;
   outline: none;
   /* When expanded, this is overtaken to 100% */
   text-overflow: ellipsis;
+  height: 300px;
+}
+
+.nteract-cell-outputs.expanded {
+  height: 100%;
 }
 
 .nteract-cell-outputs:empty {


### PR DESCRIPTION
Resolves #4448 

As it turns out, we already had the toggle expanded property in the cell menu but we were missing the CSS for it. This is implemented now.

![image](https://user-images.githubusercontent.com/1857993/81131126-f7e46800-8efe-11ea-9056-b05e5e0b8139.png)
