### PR TITLE
Update createCell APIs to take ImmutableCell

### DIFF
--- a/packages/actions/src/actionTypes/cell_structure.ts
+++ b/packages/actions/src/actionTypes/cell_structure.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-line-length
-import { CellId, CellType } from "@nteract/commutable";
+import { CellId, CellType, ImmutableCell } from "@nteract/commutable";
 import { Action, HasCell, HasContent, makeActionFunction, MaybeHasCell } from "../utils";
 
 export const CREATE_CELL_BELOW    = "CREATE_CELL_BELOW";
@@ -11,9 +11,9 @@ export const CUT_CELL             = "CUT_CELL";
 export const COPY_CELL            = "COPY_CELL";
 export const PASTE_CELL           = "PASTE_CELL";
 
-export type CreateCellBelow       = Action<typeof CREATE_CELL_BELOW,  MaybeHasCell & { cellType: CellType; source: string }>;
-export type CreateCellAbove       = Action<typeof CREATE_CELL_ABOVE,  MaybeHasCell & { cellType: CellType }>;
-export type CreateCellAppend      = Action<typeof CREATE_CELL_APPEND, HasContent   & { cellType: CellType }>;
+export type CreateCellBelow       = Action<typeof CREATE_CELL_BELOW,  MaybeHasCell & { cellType: CellType; cell?: ImmutableCell }>;
+export type CreateCellAbove       = Action<typeof CREATE_CELL_ABOVE,  MaybeHasCell & { cellType: CellType; cell?: ImmutableCell }>;
+export type CreateCellAppend = Action<typeof CREATE_CELL_APPEND, HasContent & { cellType: CellType; cell?: ImmutableCell }>;
 export type MoveCell              = Action<typeof MOVE_CELL,          HasCell      & { destinationId: CellId; above: boolean }>;
 export type DeleteCell            = Action<typeof DELETE_CELL,        MaybeHasCell>;
 export type CutCell               = Action<typeof CUT_CELL,           MaybeHasCell>;

--- a/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
+++ b/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
@@ -493,6 +493,18 @@ describe("createCellAbove", () => {
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
     expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(id);
   });
+  test("creates new cell given cell contents", () => {
+    const originalState = initialDocument.set("notebook", fixtureCommutable);
+    const id = originalState.getIn(["notebook", "cellOrder"]).last();
+    const state = reducers(
+      originalState,
+      actions.createCellAbove({ cellType: "markdown", id, cell: emptyMarkdownCell.set("source", "test contents") })
+    );
+    expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
+    expect(state.getIn(["notebook", "cellOrder"]).last()).toBe(id);
+    const insertedCellId = state.getIn(["notebook", "cellOrder", 1]);
+    expect(state.getIn(["notebook", "cellMap", insertedCellId, "source"])).toEqual("test contents")
+  })
 });
 
 describe("newCellAppend", () => {

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -500,17 +500,17 @@ function createCellBelow(
     return state;
   }
 
-  const { cellType, source } = action.payload;
-  const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  const { cellType } = action.payload;
+  let cell: ImmutableCell =
+    cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  if (action.payload.cell) {
+    cell = action.payload.cell;
+  }
+
   const cellId = uuid();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
     const index = notebook.get("cellOrder", List()).indexOf(id) + 1;
-    return insertCellAt(
-      notebook,
-      (cell as ImmutableMarkdownCell).set("source", source),
-      cellId,
-      index
-    );
+    return insertCellAt(notebook, cell, cellId, index);
   });
 }
 
@@ -524,7 +524,11 @@ function createCellAbove(
   }
 
   const { cellType } = action.payload;
-  const cell = cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  let cell: ImmutableCell =
+    cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  if (action.payload.cell) {
+    cell = action.payload.cell;
+  }
   const cellId = uuid();
   return state.update("notebook", (notebook: ImmutableNotebook) => {
     const cellOrder: List<CellId> = notebook.get("cellOrder", List());
@@ -573,8 +577,7 @@ function acceptPayloadMessage(
         type: actionTypes.CREATE_CELL_BELOW,
         payload: {
           cellType: "code",
-          // TODO: is payload.text guaranteed to be defined?
-          source: payload.text || "",
+          cell: emptyCodeCell.setIn("source", payload.text || ""),
           id,
           contentRef: action.payload.contentRef,
         },

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -10,7 +10,6 @@ import {
   emptyNotebook,
   ImmutableCell,
   ImmutableCodeCell,
-  ImmutableMarkdownCell,
   ImmutableNotebook,
   ImmutableOutput,
   insertCellAfter,


### PR DESCRIPTION
The createCellAbove/Below APIs now take the entire `ImmutableCell` as an optional property to allow setting the source, metadata, and outputs before inserting the cell.