### PR TITLE
Upgrade redux-observable to 2.0.0-alpha.0

### DIFF
--- a/applications/desktop/__tests__/renderer/epics/close-notebook.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/close-notebook.spec.ts
@@ -5,7 +5,8 @@ import {
   state as stateModule
 } from "@nteract/core";
 import * as Immutable from "immutable";
-import { ActionsObservable } from "redux-observable";
+import { of } from "rxjs";
+
 import { toArray } from "rxjs/operators";
 import { TestScheduler } from "rxjs/testing";
 
@@ -70,7 +71,7 @@ describe("closeNotebookEpic", () => {
 
       const state = buildState(true);
       const responses = await closeNotebookEpic(
-        ActionsObservable.of(
+        of(
           actions.closeNotebook({ contentRef: "contentRef1" })
         ),
         { value: state }
@@ -110,7 +111,7 @@ describe("closeNotebookEpic", () => {
 
       const state = buildState(true);
       const responses = await closeNotebookEpic(
-        ActionsObservable.of(
+        of(
           actions.closeNotebook({ contentRef: "contentRef1" })
         ),
         { value: state }

--- a/applications/desktop/__tests__/renderer/epics/config.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/config.spec.ts
@@ -1,10 +1,11 @@
-import { ActionsObservable } from "redux-observable";
 
+
+import { of } from "rxjs";
 import { saveConfigOnChangeEpic } from "../../../src/notebook/epics/config";
 
 describe("saveConfigOnChangeEpic", () => {
   test("invokes a SAVE_CONFIG when the SET_CONFIG action happens", done => {
-    const action$ = ActionsObservable.of({ type: "SET_CONFIG" });
+    const action$ = of({ type: "SET_CONFIG" });
     const responseActions = saveConfigOnChangeEpic(action$);
     responseActions.subscribe(
       x => {

--- a/applications/desktop/__tests__/renderer/epics/github-publish.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/github-publish.spec.ts
@@ -1,14 +1,14 @@
 import { actions, makeAppRecord } from "@nteract/core";
 import { mockAppState } from "@nteract/fixtures";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { publishEpic } from "../../../src/notebook/epics/github-publish";
 
-import { Subject } from "rxjs";
+import { of, Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 describe("publishEpic", () => {
   it("does nothing if no content ref is provided", done => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.publishGist({ contentRef: undefined })
     );
     const state$ = new StateObservable(new Subject(), {});
@@ -23,7 +23,7 @@ describe("publishEpic", () => {
     );
   });
   it("does nothing if there is no content", done => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.publishGist({ contentRef: "" })
     );
     const state$ = new StateObservable(new Subject(), {});
@@ -37,12 +37,12 @@ describe("publishEpic", () => {
       () => done()
     );
   });
-  it("emits an error if no GitHub token is provided", done => {
+  it("emits an error if no GitHub token is provided", (done) => {
     const state = mockAppState({});
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(actions.publishGist({ contentRef }));
+    const action$ = of(actions.publishGist({ contentRef }));
     const state$ = new StateObservable(new Subject(), state);
     const obs = publishEpic(action$, state$);
     obs.pipe(toArray()).subscribe(

--- a/applications/desktop/__tests__/renderer/epics/index.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/index.spec.ts
@@ -1,5 +1,5 @@
-import { Subject } from "rxjs";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { Observable, Subject } from "rxjs";
+import { StateObservable } from "redux-observable";
 
 import { mockAppState } from "@nteract/fixtures";
 
@@ -9,7 +9,7 @@ describe("epics", () => {
   test("is an array of epics", () => {
     expect(Array.isArray(epics)).toBe(true);
 
-    const action$ = new ActionsObservable();
+    const action$ = new Observable();
     const state$ = new StateObservable(new Subject(), mockAppState({}));
     const mapped = epics.map(epic => epic(action$, state$));
     expect(Array.isArray(mapped)).toBe(true);

--- a/applications/desktop/__tests__/renderer/epics/kernel-launch.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/kernel-launch.spec.ts
@@ -1,5 +1,6 @@
 import { actions as actionsModule, makeStateRecord } from "@nteract/core";
-import { ActionsObservable } from "redux-observable";
+import { of } from "rxjs";
+
 import { toArray } from "rxjs/operators";
 
 import {
@@ -17,7 +18,7 @@ describe("launchKernelObservable", () => {
 
 describe("launchKernelEpic", () => {
   test("throws an error if given a bad action", async () => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       {
         type: actionsModule.LAUNCH_KERNEL,
         payload: {
@@ -56,7 +57,7 @@ describe("launchKernelEpic", () => {
   });
 
   test("calls launchKernelObservable if given the correct action", async () => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actionsModule.launchKernel({
         kernelSpec: { spec: "hokey", name: "woohoo" },
         contentRef: "abc",
@@ -108,7 +109,7 @@ describe("launchKernelEpic", () => {
 
 describe("launchKernelByNameEpic", () => {
   test("creates a LAUNCH_KERNEL action in response to a LAUNCH_KERNEL_BY_NAME action", done => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actionsModule.launchKernelByName({
         kernelSpecName: "python3",
         cwd: "~"

--- a/applications/desktop/__tests__/renderer/epics/loading.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/loading.spec.ts
@@ -1,8 +1,8 @@
 import { monocellNotebook, toJS } from "@nteract/commutable";
 import { actions } from "@nteract/core";
 import { fixtureCommutable, mockAppState } from "@nteract/fixtures";
-import { ActionsObservable, StateObservable } from "redux-observable";
-import { Subject } from "rxjs";
+import { StateObservable } from "redux-observable";
+import { of, Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 import {
@@ -24,7 +24,7 @@ describe("extractNewKernel", () => {
 
 describe("newNotebookEpic", () => {
   test("calls new Kernel after creating a new notebook", async () => {
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actions.NEW_NOTEBOOK,
       payload: {
         filepath: null,
@@ -74,7 +74,7 @@ describe("newNotebookEpic", () => {
 
 describe("newNotebookEpicNamed", () => {
   test("calls new Kernel after creating a new notebook with given name", async () => {
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actions.NEW_NOTEBOOK,
       payload: {
         filepath: "/home/whatever2/some.ipynb",
@@ -125,7 +125,7 @@ describe("newNotebookEpicNamed", () => {
 describe("launchKernelWhenNotebookSetEpic", () => {
   it("does nothing for non-notebook files", done => {
     const state = mockAppState({});
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.fetchContentFulfilled({ contentRef: "test" })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -142,7 +142,7 @@ describe("launchKernelWhenNotebookSetEpic", () => {
   it("launches a kernel for a given content", done => {
     const state = mockAppState({});
     const contentRef = state.core.entities.contents.byRef.keySeq().first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.fetchContentFulfilled({ contentRef })
     );
     const state$ = new StateObservable(new Subject(), state);

--- a/applications/desktop/__tests__/renderer/epics/zeromq-kernels.spec.ts
+++ b/applications/desktop/__tests__/renderer/epics/zeromq-kernels.spec.ts
@@ -11,14 +11,14 @@ import {
   makeRemoteKernelRecord,
   makeStateRecord
 } from "@nteract/core";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { toArray } from "rxjs/operators";
 
 import { doneSavingConfig } from "@nteract/actions";
 import { mockAppState } from "@nteract/fixtures";
 import { displayName } from "@nteract/selectors/lib/core/contents/notebook";
 import Immutable from "immutable";
-import { Subject } from "rxjs";
+import { of, Subject } from "rxjs";
 import {
   interruptKernelEpic,
   killKernelEpic,
@@ -27,7 +27,7 @@ import {
 
 describe("killKernelEpic", () => {
   it("does nothing if there is no kernelRef", done => {
-    const action$ = ActionsObservable.of(actions.killKernel({}));
+    const action$ = of(actions.killKernel({}));
     const obs = killKernelEpic(action$);
     obs.pipe(toArray()).subscribe(
       action => {
@@ -40,7 +40,7 @@ describe("killKernelEpic", () => {
   });
   it("does nothing if there is no kernel", done => {
     const state = mockAppState({});
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.killKernel({ kernelRef: "not real" })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -57,7 +57,7 @@ describe("killKernelEpic", () => {
   it("does nothing if the kernel is not a zeromq kernel", done => {
     const state = mockAppState({});
     const kernelRef = state.core.entities.kernels.byRef.keySeq().first();
-    const action$ = ActionsObservable.of(actions.killKernel({ kernelRef }));
+    const action$ = of(actions.killKernel({ kernelRef }));
     const state$ = new StateObservable(new Subject(), state);
     const obs = killKernelEpic(action$, state$);
     obs.pipe(toArray()).subscribe(
@@ -73,7 +73,7 @@ describe("killKernelEpic", () => {
 
 describe("interruptKernel", () => {
   it("returns an error if there is no kernel to interrupt", done => {
-    const action$ = ActionsObservable.of(actions.interruptKernel({}));
+    const action$ = of(actions.interruptKernel({}));
     const state$ = new StateObservable(new Subject(), mockAppState({}));
     const obs = interruptKernelEpic(action$, state$);
     obs.pipe(toArray()).subscribe(
@@ -88,7 +88,7 @@ describe("interruptKernel", () => {
   it("does nothing if the kernel is not a zeromq kernel", done => {
     const state = mockAppState({});
     const contentRef = state.core.entities.contents.byRef.keySeq().first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.interruptKernel({ contentRef })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -104,7 +104,7 @@ describe("interruptKernel", () => {
       () => done()
     );
   });
-  it("calls kill with a SIGINT on the kernel", () => {
+  it("calls kill with a SIGINT on the kernel", (done) => {
     const kill = jest.fn();
     const state = {
       ...mockAppState({}),
@@ -131,7 +131,7 @@ describe("interruptKernel", () => {
         })
       })
     };
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.interruptKernel({ contentRef: "content" })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -150,7 +150,7 @@ describe("interruptKernel", () => {
 
 describe("watchSpawn", () => {
   it("throws error if kernel type is not zeromq", done => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.launchKernelSuccessful({
         kernelRef: createKernelRef(),
         contentRef: createContentRef(),
@@ -169,7 +169,7 @@ describe("watchSpawn", () => {
     );
   });
   it("throws error if no spawn object is not available to watch", done => {
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.launchKernelSuccessful({
         kernelRef: createKernelRef(),
         contentRef: createContentRef(),

--- a/applications/desktop/src/notebook/epics/close-notebook.ts
+++ b/applications/desktop/src/notebook/epics/close-notebook.ts
@@ -5,7 +5,7 @@ import {
 } from "@nteract/core";
 import { ipcRenderer as ipc } from "electron";
 import { RecordOf } from "immutable";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
 import { concat, empty, Observable, Observer, of, zip } from "rxjs";
 import {
   catchError,
@@ -29,20 +29,11 @@ import { KernelRecord, KernelRef } from "@nteract/types";
 import { Actions } from "../actions";
 
 export const closeNotebookEpic = (
-  action$: ActionsObservable<
-    | CloseNotebook
-    | coreActions.KillKernelFailed
-    | coreActions.KillKernelSuccessful
-  >,
+  action$: Observable<any>,
   state$: StateObservable<DesktopNotebookAppState>
 ) =>
   action$.pipe(
-    ofType<
-      | CloseNotebook
-      | coreActions.KillKernelFailed
-      | coreActions.KillKernelSuccessful,
-      ReturnType<typeof actions.closeNotebook>
-    >(CLOSE_NOTEBOOK),
+    ofType(CLOSE_NOTEBOOK),
     exhaustMap((action: CloseNotebook) => {
       const contentRef = action.payload.contentRef;
       const state = state$.value;
@@ -91,15 +82,7 @@ export const closeNotebookEpic = (
 
             killKernelAwaits.push(
               action$.pipe(
-                ofType<
-                  | CloseNotebook
-                  | coreActions.KillKernelFailed
-                  | coreActions.KillKernelSuccessful,
-                  ReturnType<
-                    | typeof coreActions.killKernelSuccessful
-                    | typeof coreActions.killKernelFailed
-                  >
-                >(
+                ofType(
                   coreActions.KILL_KERNEL_SUCCESSFUL,
                   coreActions.KILL_KERNEL_FAILED
                 ),

--- a/applications/desktop/src/notebook/epics/config.ts
+++ b/applications/desktop/src/notebook/epics/config.ts
@@ -1,7 +1,8 @@
 import { actions } from "@nteract/core";
 import { remote } from "electron";
 import { readFileObservable, writeFileObservable } from "fs-observable";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
+import { Observable } from "rxjs";
 import { map, mapTo, mergeMap, switchMap } from "rxjs/operators";
 import { DesktopNotebookAppState } from "../state";
 
@@ -16,7 +17,7 @@ export const CONFIG_FILE_PATH = path.join(HOME, ".jupyter", "nteract.json");
 /**
  * An epic that loads the configuration.
  */
-export const loadConfigEpic = (action$: ActionsObservable<Actions>) =>
+export const loadConfigEpic = (action$: Observable<Actions>) =>
   action$.pipe(
     ofType(actions.LOAD_CONFIG),
     switchMap(() =>
@@ -29,7 +30,7 @@ export const loadConfigEpic = (action$: ActionsObservable<Actions>) =>
 /**
  * An epic that saves the configuration if it has been changed.
  */
-export const saveConfigOnChangeEpic = (action$: ActionsObservable<Actions>) =>
+export const saveConfigOnChangeEpic = (action$: Observable<Actions>) =>
   action$.pipe(
     ofType(actions.SET_CONFIG),
     mapTo({ type: actions.SAVE_CONFIG })
@@ -39,7 +40,7 @@ export const saveConfigOnChangeEpic = (action$: ActionsObservable<Actions>) =>
  * An epic that saves the configuration.
  */
 export const saveConfigEpic = (
-  action$: ActionsObservable<Actions>,
+  action$: Observable<Actions>,
   state$: StateObservable<DesktopNotebookAppState>
 ) =>
   action$.pipe(

--- a/applications/desktop/src/notebook/epics/github-publish.ts
+++ b/applications/desktop/src/notebook/epics/github-publish.ts
@@ -3,7 +3,7 @@ import { sendNotification } from "@nteract/mythic-notifications";
 import { shell } from "electron";
 
 import * as path from "path";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
 import { concat, EMPTY, Observable, of } from "rxjs";
 import { ajax, AjaxResponse } from "rxjs/ajax";
 import { catchError, mergeMap } from "rxjs/operators";
@@ -50,7 +50,7 @@ function publishGist(
  * response from the Github API.
  */
 export const publishEpic = (
-  action$: ActionsObservable<actions.PublishGist>,
+  action$: Observable<actions.PublishGist>,
   state$: StateObservable<DesktopNotebookAppState>
 ) => {
   return action$.pipe(

--- a/applications/desktop/src/notebook/epics/index.ts
+++ b/applications/desktop/src/notebook/epics/index.ts
@@ -1,5 +1,5 @@
 import { epics as coreEpics } from "@nteract/core";
-import { ActionsObservable, Epic, StateObservable } from "redux-observable";
+import { Epic, StateObservable } from "redux-observable";
 import { Observable } from "rxjs";
 import { catchError, startWith } from "rxjs/operators";
 import { DesktopNotebookAppState } from "../state";
@@ -29,7 +29,7 @@ export function retryAndEmitError(err: Error, source: Observable<Actions>) {
 
 export const wrapEpic = (epic: Epic<Actions, Actions>) => (
   ...args: [
-    ActionsObservable<Actions>,
+    Observable<Actions>,
     StateObservable<DesktopNotebookAppState>,
     undefined
   ]

--- a/applications/desktop/src/notebook/epics/loading.ts
+++ b/applications/desktop/src/notebook/epics/loading.ts
@@ -6,8 +6,8 @@ import {
   toJS
 } from "@nteract/commutable";
 import { actions, AppState, selectors } from "@nteract/core";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
-import { empty, of } from "rxjs";
+import { ofType, StateObservable } from "redux-observable";
+import { empty, Observable, of } from "rxjs";
 import {
   map,
   mergeMap
@@ -38,7 +38,7 @@ export const extractNewKernel = (
 };
 
 export const launchKernelWhenNotebookSetEpic = (
-  action$: ActionsObservable<actions.FetchContentFulfilled>,
+  action$: Observable<actions.FetchContentFulfilled>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(
@@ -80,7 +80,7 @@ export const launchKernelWhenNotebookSetEpic = (
  * @param  {ActionObservable}  ActionObservable for NEW_NOTEBOOK action
  */
 export const newNotebookEpic = (
-  action$: ActionsObservable<actions.NewNotebook>
+  action$: Observable<actions.NewNotebook>
 ) =>
   action$.pipe(
     ofType(actions.NEW_NOTEBOOK),

--- a/applications/desktop/src/notebook/epics/zeromq-kernels.ts
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.ts
@@ -16,7 +16,7 @@ import {
 } from "enchannel-zmq-backend";
 import * as jmp from "jmp";
 import sample from "lodash.sample";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
 import { empty, merge, Observable, of, Subscriber } from "rxjs";
 import {
   catchError,
@@ -173,7 +173,7 @@ export const kernelSpecsObservable: Observable<Kernelspecs> = new Observable<
 });
 
 export const launchKernelByNameEpic = (
-  action$: ActionsObservable<actions.LaunchKernelByNameAction>
+  action$: Observable<actions.LaunchKernelByNameAction>
 ): Observable<Actions> =>
   action$.pipe(
     ofType(actions.LAUNCH_KERNEL_BY_NAME),
@@ -219,7 +219,7 @@ type LaunchKernelResponseActions =
  * @param  {ActionObservable} action$  ActionObservable for LAUNCH_KERNEL action
  */
 export const launchKernelEpic = (
-  action$: ActionsObservable<actions.LaunchKernelAction>,
+  action$: Observable<actions.LaunchKernelAction>,
   state$: StateObservable<AppState>
 ): Observable<Actions> => {
   const response$ = action$.pipe(
@@ -293,7 +293,7 @@ type InterruptActions =
   | actions.InterruptKernelSuccessful;
 
 export const interruptKernelEpic = (
-  action$: ActionsObservable<actions.InterruptKernel>,
+  action$: Observable<actions.InterruptKernel>,
   state$: StateObservable<AppState>
 ): Observable<InterruptActions> =>
   action$.pipe(
@@ -366,7 +366,7 @@ function killSpawn(spawn: ChildProcess): void {
 // shutdown by sending a shutdown msg to the kernel, and only if the kernel
 // doesn't respond promptly does it SIGKILL the kernel.
 export const killKernelEpic = (
-  action$: ActionsObservable<actions.KillKernelAction>,
+  action$: Observable<actions.KillKernelAction>,
   state$: StateObservable<AppState>
 ): Observable<Actions> =>
   action$.pipe(
@@ -451,7 +451,7 @@ export const killKernelEpic = (
   ) as Observable<Actions>;
 
 export function watchSpawn(
-  action$: ActionsObservable<actions.NewKernelAction>
+  action$: Observable<actions.NewKernelAction>
 ) {
   return action$.pipe(
     ofType(actions.LAUNCH_KERNEL_SUCCESSFUL),

--- a/applications/jupyter-extension/nteract_on_jupyter/package.json
+++ b/applications/jupyter-extension/nteract_on_jupyter/package.json
@@ -48,7 +48,7 @@
     "react-redux": "^6.0.0",
     "react-router-dom": "^5.0.0",
     "redux": "^4.0.0",
-    "redux-observable": "^1.0.0",
+    "redux-observable": "^2.0.0-alpha.0",
     "rx-jupyter": "^5.5.8",
     "rxjs": "^6.3.3",
     "url-join": "^4.0.0",

--- a/applications/web/package.json
+++ b/applications/web/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^16.12.0",
     "react-redux": "^6.0.0",
     "redux": "^4.0.0",
-    "redux-observable": "^1.0.0",
+    "redux-observable": "^2.0.0-alpha.0",
     "rx-jupyter": "^5.5.8",
     "rxjs": "^6.3.3",
     "shortid": "^2.2.15"

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "react-test-renderer": "^16.2.0",
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
-    "redux-observable": "^1.0.0",
+    "redux-observable": "2.0.0-alpha.0",
     "regenerator-runtime": "^0.13.0",
     "remark-parse": "^8.0.0",
     "remark-stringify": "^8.0.0",

--- a/packages/epics/__tests__/comm.spec.ts
+++ b/packages/epics/__tests__/comm.spec.ts
@@ -4,7 +4,7 @@ import Immutable from "immutable";
 
 import * as actions from "@nteract/actions";
 import { COMM_MESSAGE, COMM_OPEN, EXECUTE_FAILED } from "@nteract/actions";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { commListenEpic } from "../src/comm";
 
 import {
@@ -72,7 +72,7 @@ describe("commActionObservable", () => {
       buffers: new Uint8Array([])
     };
 
-    const action = ActionsObservable.of(
+    const action = of(
       actions.launchKernelSuccessful({
         kernel: {
           channels: of(commOpenMessage, commMessage) as Subject<any>,
@@ -151,7 +151,7 @@ describe("commActionObservable", () => {
 
     const mockSocket = Subject.create(sent, received);
 
-    const action = ActionsObservable.of(
+    const action = of(
       actions.launchKernelSuccessful({
         kernel: {
           channels: mockSocket,

--- a/packages/epics/__tests__/contents.spec.ts
+++ b/packages/epics/__tests__/contents.spec.ts
@@ -20,9 +20,9 @@ import {
 import { fixtureJSON, mockAppState } from "@nteract/fixtures";
 import FileSaver from "file-saver";
 import * as Immutable from "immutable";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { contents } from "rx-jupyter";
-import { of, Subject } from "rxjs";
+import { from, of, Subject } from "rxjs";
 import { map, take, toArray } from "rxjs/operators";
 import {
   autoSaveCurrentContentEpic,
@@ -128,7 +128,7 @@ describe("saveAs", () => {
     };
 
     const responses = await saveAsContentEpic(
-      ActionsObservable.of(
+      of(
         actions.saveAs({ filepath: "test.ipynb", contentRef })
       ),
       new StateObservable(new Subject(), state),
@@ -175,7 +175,7 @@ describe("saveAs", () => {
     };
 
     const responses = await saveAsContentEpic(
-      ActionsObservable.of(
+      of(
         actions.saveAs({ filepath: "test.ipynb", contentRef })
       ),
       new StateObservable(new Subject(), state),
@@ -232,7 +232,7 @@ describe("save", () => {
 
     const responses = [];
     saveContentEpic(
-      ActionsObservable.of(
+      of(
         actions.save({ filepath: "test.ipynb", contentRef })
       ),
       new StateObservable(new Subject(), state),
@@ -286,7 +286,7 @@ describe("save", () => {
     };
 
     const responses = await saveContentEpic(
-      ActionsObservable.of(actions.downloadContent({ contentRef })),
+      of(actions.downloadContent({ contentRef })),
       new StateObservable(new Subject(), state),
       { contentProvider: contents.JupyterContentProvider }
     )
@@ -330,7 +330,7 @@ describe("save", () => {
     };
 
     const responses = await saveContentEpic(
-      ActionsObservable.of(actions.downloadContent({ contentRef })),
+      of(actions.downloadContent({ contentRef })),
       new StateObservable(new Subject(), state),
       { contentProvider: contents.JupyterContentProvider }
     )
@@ -350,7 +350,7 @@ describe("closeNotebookEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.closeNotebook({
         contentRef
       })
@@ -379,7 +379,7 @@ describe("fetchContentEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.fetchContent({
         contentRef,
         filepath: "my-file.ipynb"
@@ -408,7 +408,7 @@ describe("fetchContentEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.fetchContent({
         contentRef,
         filepath: "my-file.ipynb"
@@ -445,7 +445,7 @@ describe("updateContentEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.changeContentName({
         contentRef,
         filepath: "test.ipynb"
@@ -477,7 +477,7 @@ describe("updateContentEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.changeContentName({
         contentRef,
         filepath: "test.ipynb"
@@ -508,12 +508,12 @@ describe("updateContentEpic", () => {
 
 describe("autoSaveContentEpic", () => {
   it("returns a valid Observable", () => {
-    const action$ = ActionsObservable.from([]);
+    const action$ = from([]);
     const state$ = new StateObservable(new Subject(), mockAppState({}));
     expect(autoSaveCurrentContentEpic(action$, state$)).not.toBeNull();
   });
   it("dispatches a save action on content change", async done => {
-    const action$ = ActionsObservable.from([]);
+    const action$ = from([]);
     const stateSubject$ = new Subject();
     const state = {
       app: {},
@@ -580,7 +580,7 @@ describe("autoSaveContentEpic", () => {
     done();
   });
   it("dispatches nothing on no content change", async done => {
-    const action$ = ActionsObservable.from([]);
+    const action$ = from([]);
     const stateSubject$ = new Subject();
     const state = {
       app: {},

--- a/packages/epics/__tests__/execute/execute.spec.ts
+++ b/packages/epics/__tests__/execute/execute.spec.ts
@@ -4,8 +4,8 @@ import { executeRequest, createMessage } from "@nteract/messaging";
 import * as stateModule from "@nteract/types";
 
 import Immutable from "immutable";
-import { ActionsObservable, StateObservable } from "redux-observable";
-import { empty, Subject } from "rxjs";
+import { StateObservable } from "redux-observable";
+import { empty, from, Observable, of, Subject } from "rxjs";
 import { catchError, share, toArray } from "rxjs/operators";
 
 import {
@@ -162,7 +162,7 @@ describe("createExecuteCellStream", () => {
         app: {}
       }
     };
-    const action$ = ActionsObservable.from([]);
+    const action$ = from([]);
     const message = executeRequest("source");
 
     const observable = createExecuteCellStream(
@@ -206,9 +206,9 @@ describe("sendExecuteRequestEpic", () => {
 
   test("Errors on a bad action", done => {
     // Make one hot action
-    const badAction$ = ActionsObservable.of(
+    const badAction$ = of(
       actions.sendExecuteRequest({ id: "id", contentRef: "fakeContentRef" })
-    ).pipe(share()) as ActionsObservable<any>;
+    ).pipe(share()) as Observable<any>;
     const responseActions = sendExecuteRequestEpic(badAction$, state$).pipe(
       catchError(error => {
         expect(error.message).toEqual(
@@ -228,9 +228,9 @@ describe("sendExecuteRequestEpic", () => {
   });
 
   test("Errors on an action where source not a string", done => {
-    const badAction$ = ActionsObservable.of(
+    const badAction$ = of(
       actions.sendExecuteRequest({ id: "id", contentRef: "fakeContentRef" })
-    ).pipe(share()) as ActionsObservable<any>;
+    ).pipe(share()) as Observable<any>;
     const responseActions = sendExecuteRequestEpic(badAction$, state$).pipe(
       catchError(error => {
         expect(error.message).toEqual("execute cell needs source string");
@@ -273,7 +273,7 @@ describe("sendExecuteRequestEpic", () => {
       new Subject(),
       disconnectedState
     );
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: "first", contentRef: "fakeContentRef" })
     );
     const responses = await sendExecuteRequestEpic(action$, disconnectedState$)
@@ -307,7 +307,7 @@ describe("sendExecuteRequestEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: "first", contentRef: "fakeContent" })
     );
     let result = "";
@@ -347,7 +347,7 @@ describe("sendExecuteRequestEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: "first", contentRef: "fakeContent" })
     );
     let result = "";
@@ -391,7 +391,7 @@ describe("sendExecuteRequestEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: cellId, contentRef: "fakeContent" })
     );
     let result = "";
@@ -435,7 +435,7 @@ describe("sendExecuteRequestEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: cellId, contentRef: "fakeContent" })
     );
     let result = "";
@@ -480,7 +480,7 @@ describe("sendExecuteRequestEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: cellId, contentRef: "fakeContent" })
     );
     let result = "";
@@ -526,7 +526,7 @@ describe("sendExecuteRequestEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendExecuteRequest({ id: cellId, contentRef: "fakeContent" })
     );
     let result = "";

--- a/packages/epics/__tests__/execute/lazy-launch.spec.ts
+++ b/packages/epics/__tests__/execute/lazy-launch.spec.ts
@@ -1,7 +1,7 @@
 import * as actions from "@nteract/actions";
 import * as stateModule from "@nteract/types";
-import { ActionsObservable, StateObservable } from "redux-observable";
-import { Subject } from "rxjs";
+import { StateObservable } from "redux-observable";
+import { of, Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 import {
@@ -46,7 +46,7 @@ describe("executeCellAfterKernelLaunchEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.launchKernelSuccessful({
         contentRef: "fakeContentRef",
         kernel: fakeKernel,
@@ -110,7 +110,7 @@ describe("executeCellAfterKernelLaunchEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.launchKernelSuccessful({
         contentRef: "fakeContentRef",
         kernel: fakeKernel,
@@ -153,7 +153,7 @@ describe("lazyLaunchKernelEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.executeCell({ id: "0", contentRef: "fakeContentRef" }),
       actions.executeCell({ id: "1", contentRef: "fakeContentRef" }),
       actions.executeCell({ id: "2", contentRef: "fakeContentRef" })

--- a/packages/epics/__tests__/execute/map-to-execute.spec.ts
+++ b/packages/epics/__tests__/execute/map-to-execute.spec.ts
@@ -1,8 +1,8 @@
 import * as actions from "@nteract/actions";
 import * as stateModule from "@nteract/types";
 import { mockAppState } from "@nteract/fixtures";
-import { ActionsObservable, StateObservable } from "redux-observable";
-import { Subject } from "rxjs";
+import { StateObservable } from "redux-observable";
+import { of, Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 import { executeAllCellsEpic, executeCellEpic } from "../../src/execute";
@@ -12,7 +12,7 @@ const Immutable = require("immutable");
 describe("executeAllCellsEpic", () => {
   test("returns an error action if no content given", done => {
     const state = mockAppState({});
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.executeAllCells({ contentRef: "noContentForMe" })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -29,7 +29,7 @@ describe("executeAllCellsEpic", () => {
   test("does nothing if the model is not a notebook", done => {
     const state = mockAppState({ codeCellCount: 2 });
     const contentRef = state.core.entities.contents.byRef.keySeq().first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.executeAllCells({ contentRef })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -91,7 +91,7 @@ describe("executeCellEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.executeCell({ id: "0", contentRef: "fakeContentRef" })
     );
     const responses = await executeCellEpic(action$, state$)
@@ -119,7 +119,7 @@ describe("executeCellEpic", () => {
       })
     };
     const state$ = new StateObservable(new Subject(), state);
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.executeCell({ id: "0", contentRef: "fakeContentRef" })
     );
     const responses = await executeCellEpic(action$, state$)

--- a/packages/epics/__tests__/execute/process-msgs.spec.ts
+++ b/packages/epics/__tests__/execute/process-msgs.spec.ts
@@ -1,8 +1,8 @@
 import * as actions from "@nteract/actions";
 import { mockAppState } from "@nteract/fixtures";
 import * as stateModule from "@nteract/types";
-import { ActionsObservable, StateObservable } from "redux-observable";
-import { from, Subject } from "rxjs";
+import { StateObservable } from "redux-observable";
+import { from, of, Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 
 import { sendInputReplyEpic, updateDisplayEpic } from "../../src/execute";
@@ -42,7 +42,7 @@ describe("updateDisplayEpic", () => {
     ];
 
     const channels = from(messages);
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actions.LAUNCH_KERNEL_SUCCESSFUL,
       payload: {
         kernel: {
@@ -90,7 +90,7 @@ describe("updateDisplayEpic", () => {
 describe("sendInputReplyEpic", () => {
   it("does nothing if there is no active kernel", done => {
     const state = mockAppState({});
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendInputReply({ contentRef: "noKernelForMe" })
     );
     const state$ = new StateObservable(new Subject(), state);
@@ -129,7 +129,7 @@ describe("sendInputReplyEpic", () => {
       }
     };
     const contentRef = state.core.entities.contents.byRef.keySeq().first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.sendInputReply({ contentRef })
     );
     const state$ = new StateObservable(new Subject(), state);

--- a/packages/epics/__tests__/hosts.spec.ts
+++ b/packages/epics/__tests__/hosts.spec.ts
@@ -1,12 +1,13 @@
 import { actions, state as stateModule } from "@nteract/core";
 import Immutable from "immutable";
-import { ActionsObservable } from "redux-observable";
+import { of } from "rxjs";
+
 
 import { publishToBookstore } from "../src/hosts";
 
 describe("publishToBookstore", () => {
   test("throws an error if no payload is provided to action", () => {
-    const badAction$ = ActionsObservable.of({
+    const badAction$ = of({
       type: actions.PUBLISH_TO_BOOKSTORE,
       payload: undefined
     });
@@ -31,7 +32,7 @@ describe("publishToBookstore", () => {
     );
   });
   test("throws error if content type is not notebook", () => {
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actions.PUBLISH_TO_BOOKSTORE,
       payload: { contentRef: "contentRef" }
     });
@@ -78,7 +79,7 @@ describe("publishToBookstore", () => {
   });
 
   test("emits correct action after successful save", () => {
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actions.PUBLISH_TO_BOOKSTORE,
       payload: { contentRef: "contentRef" }
     });

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -3,7 +3,7 @@ import { mockAppState } from "@nteract/fixtures";
 import { createMessage, JupyterMessage, MessageType, payloads } from "@nteract/messaging";
 import { sendNotification } from "@nteract/mythic-notifications";
 import * as Immutable from "immutable";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { of, Subject } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { TestScheduler } from "rxjs/testing";
@@ -377,7 +377,7 @@ describe("acquireKernelInfo", () => {
 
 describe("watchExecutionStateEpic", () => {
   test("returns an Observable with an initial state of idle", done => {
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actionsModule.LAUNCH_KERNEL_SUCCESSFUL,
       payload: {
         kernel: {
@@ -412,7 +412,7 @@ describe("watchExecutionStateEpic", () => {
 
     const mockSocket = Subject.create(sent, received);
 
-    const action$ = ActionsObservable.of({
+    const action$ = of({
       type: actionsModule.LAUNCH_KERNEL_SUCCESSFUL,
       payload: {
         kernel: {
@@ -636,7 +636,7 @@ describe("restartKernelEpic", () => {
     };
 
     const responses = await restartKernelEpic(
-      ActionsObservable.of(
+      of(
         actionsModule.restartKernel({
           outputHandling: "Run All",
           kernelRef: "oldKernelRef",
@@ -672,7 +672,7 @@ describe("restartKernelEpic", () => {
     };
 
     const responses = await restartKernelEpic(
-      ActionsObservable.of(
+      of(
         actionsModule.restartKernel({
           outputHandling: "Run All",
           kernelRef: "oldKernelRef",
@@ -698,7 +698,7 @@ describe("launchKernelWhenNotebookSet", () => {
   it("does nothing if content is not a notebook", done => {
     const contentRef = stateModule.createContentRef();
     const kernelRef = stateModule.createKernelRef();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actionsModule.fetchContentFulfilled({
         contentRef,
         filepath: "my-file.txt",
@@ -722,7 +722,7 @@ describe("launchKernelWhenNotebookSet", () => {
       .keySeq()
       .first();
     const kernelRef = stateModule.createKernelRef();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actionsModule.fetchContentFulfilled({
         contentRef,
         filepath: "my-notebook",
@@ -758,7 +758,7 @@ describe("launchKernelWhenNotebookSet", () => {
         })
       }
     };
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actionsModule.fetchContentFulfilled({
         contentRef,
         filepath: "my-file.txt",

--- a/packages/epics/__tests__/kernelspecs.spec.ts
+++ b/packages/epics/__tests__/kernelspecs.spec.ts
@@ -1,6 +1,7 @@
 import { fetchKernelspecs } from "@nteract/actions";
 import { JupyterHostRecordProps } from "@nteract/types";
-import { ActionsObservable } from "redux-observable";
+import { of } from "rxjs";
+
 import { toArray } from "rxjs/operators";
 import { fetchKernelspecsEpic } from "../src";
 
@@ -10,7 +11,7 @@ describe("fetchKernelspecsEpic", () => {
       kernelspecsRef: "fake",
       hostRef: "alsoFake"
     });
-    const action$ = ActionsObservable.of(action);
+    const action$ = of(action);
     const state$ = {
       value: {
         app: {

--- a/packages/epics/__tests__/websocket-kernel.spec.ts
+++ b/packages/epics/__tests__/websocket-kernel.spec.ts
@@ -1,5 +1,5 @@
 import * as Immutable from "immutable";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { Subject, of } from "rxjs";
 import { toArray } from "rxjs/operators";
 
@@ -88,7 +88,7 @@ describe("launchWebSocketKernelEpic", () => {
       new Subject<stateModule.AppState>(),
       value
     );
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.launchKernelByName({
         contentRef,
         kernelRef,
@@ -155,7 +155,7 @@ describe("interruptKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.interruptKernel({ kernelRef: "fake" })
     );
 
@@ -206,7 +206,7 @@ describe("interruptKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.interruptKernel({ contentRef: "contentRef" })
     );
 
@@ -252,7 +252,7 @@ describe("restartKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.restartKernel({
         kernelRef: null,
         contentRef: "contentRef",
@@ -302,7 +302,7 @@ describe("restartKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.restartKernel({
         kernelRef: "fake",
         contentRef: "contentRef",
@@ -354,7 +354,7 @@ describe("restartKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.restartKernel({
         kernelRef: "fake",
         contentRef: "contentRef",
@@ -406,7 +406,7 @@ describe("restartKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.restartKernel({
         kernelRef: "fake",
         contentRef: "contentRef",
@@ -456,7 +456,7 @@ describe("restartKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.restartKernel({
         kernelRef: "fake",
         contentRef: "contentRef",
@@ -512,7 +512,7 @@ describe("restartKernelEpic", () => {
       comms: stateModule.makeCommsRecord(),
       config: Immutable.Map({})
     });
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.restartKernel({
         kernelRef: "fake",
         contentRef: "contentRef",
@@ -552,7 +552,7 @@ describe("changeWebSocketKernelEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.changeKernelByName({
         kernelSpecName: "julia",
         contentRef,
@@ -586,7 +586,7 @@ describe("changeWebSocketKernelEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.changeKernelByName({
         kernelSpecName: "julia",
         contentRef,
@@ -623,7 +623,7 @@ describe("killKernelEpic", () => {
     const contentRef: string = state.core.entities.contents.byRef
       .keySeq()
       .first();
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.killKernel({
         contentRef,
         kernelRef
@@ -650,7 +650,7 @@ describe("killKernelEpic", () => {
         host: stateModule.makeJupyterHostRecord({})
       })
     };
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.killKernel({
         contentRef: "none",
         kernelRef: "none"
@@ -695,7 +695,7 @@ describe("killKernelEpic", () => {
         })
       })
     };
-    const action$ = ActionsObservable.of(
+    const action$ = of(
       actions.killKernel({
         contentRef: "aContent",
         kernelRef: "aKernel"

--- a/packages/epics/package.json
+++ b/packages/epics/package.json
@@ -40,7 +40,7 @@
     "@nteract/types": "^6.0.6",
     "file-saver": "^2.0.0",
     "redux": "^4.0.1",
-    "redux-observable": "^1.0.0",
+    "redux-observable": "^2.0.0-alpha.0",
     "rx-jupyter": "^5.5.8",
     "rxjs": "^6.3.3"
   }

--- a/packages/epics/src/comm.ts
+++ b/packages/epics/src/comm.ts
@@ -1,7 +1,7 @@
 import { ofMessageType } from "@nteract/messaging";
 import { ofType, StateObservable } from "redux-observable";
-import { ActionsObservable } from "redux-observable";
-import { merge, of } from "rxjs";
+
+import { merge, Observable, of } from "rxjs";
 import { map, switchMap, takeUntil, filter, catchError } from "rxjs/operators";
 
 import {
@@ -20,12 +20,12 @@ import { ipywidgetsModel$ } from "./ipywidgets";
 
 /**
  * An epic that emits comm actions from the backend kernel
- * @param  {ActionsObservable} action$ Action Observable from redux-observable
+ * @param  {Observable} action$ Action Observable from redux-observable
  * @param  {redux.Store} store   the redux store
- * @return {ActionsObservable}         Comm actions
+ * @return {Observable}         Comm actions
  */
 export const commListenEpic = (
-  action$: ActionsObservable<NewKernelAction | KillKernelSuccessful>,
+  action$: Observable<NewKernelAction | KillKernelSuccessful>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(

--- a/packages/epics/src/contents.ts
+++ b/packages/epics/src/contents.ts
@@ -19,7 +19,7 @@ import FileSaver from "file-saver";
 import { RecordOf } from "immutable";
 import * as path from "path";
 import { Action } from "redux";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
 import { EMPTY, from, interval, Observable, of } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import {
@@ -35,7 +35,7 @@ import {
 import urljoin from "url-join";
 
 export function updateContentEpic(
-  action$: ActionsObservable<actions.ChangeContentName>,
+  action$: Observable<actions.ChangeContentName>,
   state$: StateObservable<AppState>,
   dependencies: { contentProvider: IContentProvider }
 ): Observable<unknown> {
@@ -91,7 +91,7 @@ export function updateContentEpic(
 }
 
 export function fetchContentEpic(
-  action$: ActionsObservable<
+  action$: Observable<
     | actions.FetchContent
     | actions.FetchContentFailed
     | actions.FetchContentFulfilled
@@ -158,7 +158,7 @@ export function downloadString(
 }
 
 export function autoSaveCurrentContentEpic(
-  action$: ActionsObservable<Action>,
+  action$: Observable<Action>,
   state$: StateObservable<AppState>
 ): Observable<actions.Save> {
   return state$.pipe(
@@ -236,7 +236,7 @@ function serializeContent(
 }
 
 export function saveContentEpic(
-  action$: ActionsObservable<actions.Save | actions.DownloadContent>,
+  action$: Observable<actions.Save | actions.DownloadContent>,
   state$: StateObservable<AppState>,
   dependencies: { contentProvider: IContentProvider }
 ): Observable<
@@ -414,7 +414,7 @@ export function saveContentEpic(
 }
 
 export function saveAsContentEpic(
-  action$: ActionsObservable<actions.SaveAs>,
+  action$: Observable<actions.SaveAs>,
   state$: StateObservable<AppState>,
   dependencies: { contentProvider: IContentProvider }
 ): Observable<actions.SaveAsFailed | actions.SaveAsFulfilled> {
@@ -529,7 +529,7 @@ export function saveAsContentEpic(
 }
 
 export function closeNotebookEpic(
-  action$: ActionsObservable<actions.CloseNotebook>,
+  action$: Observable<actions.CloseNotebook>,
   state$: StateObservable<AppState>
 ): Observable<actions.DisposeContent | actions.KillKernelAction> {
   return action$.pipe(

--- a/packages/epics/src/execute/execute.ts
+++ b/packages/epics/src/execute/execute.ts
@@ -13,7 +13,7 @@ import {
 } from "@nteract/messaging";
 import { AnyAction } from "redux";
 import { ofType } from "redux-observable";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { merge, Observable, of, Observer, GroupedObservable } from "rxjs";
 import {
   catchError,
@@ -197,7 +197,7 @@ type StopExecutionActions =
 type ExecuteStreamActions = StopExecutionActions | actions.SendExecuteRequest;
 
 export function createExecuteCellStream(
-  action$: ActionsObservable<ExecuteStreamActions>,
+  action$: Observable<ExecuteStreamActions>,
   channels: Channels,
   message: ExecuteRequest,
   id: string,
@@ -265,7 +265,7 @@ export function createExecuteCellStream(
  * creating inner observable streams of the running execution responses
  */
 export function sendExecuteRequestEpic(
-  action$: ActionsObservable<actions.SendExecuteRequest>,
+  action$: Observable<actions.SendExecuteRequest>,
   state$: StateObservable<AppState>
 ) {
   return action$.pipe(

--- a/packages/epics/src/execute/lazy-launch.ts
+++ b/packages/epics/src/execute/lazy-launch.ts
@@ -10,8 +10,8 @@
  * apps.
  */
 import { AnyAction } from "redux";
-import { ActionsObservable, StateObservable, ofType } from "redux-observable";
-import { of, merge } from "rxjs";
+import { StateObservable, ofType } from "redux-observable";
+import { of, merge, Observable } from "rxjs";
 import { switchMap, filter, distinct, withLatestFrom } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
@@ -25,7 +25,7 @@ import { extractNewKernel } from "../kernel-lifecycle";
  * the kernel is launched successfully and is ready to execute.
  */
 export const executeCellAfterKernelLaunchEpic = (
-  action$: ActionsObservable<actions.NewKernelAction>,
+  action$: Observable<actions.NewKernelAction>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(
@@ -65,7 +65,7 @@ export const executeCellAfterKernelLaunchEpic = (
  * being emitted more than once within the same notebook.
  */
 export function lazyLaunchKernelEpic(
-  action$: ActionsObservable<actions.ExecuteCell>,
+  action$: Observable<actions.ExecuteCell>,
   state$: StateObservable<AppState>
 ) {
   return action$.pipe(

--- a/packages/epics/src/execute/map-to-execute.ts
+++ b/packages/epics/src/execute/map-to-execute.ts
@@ -5,8 +5,8 @@
  * listen to.
  */
 import Immutable from "immutable";
-import { ActionsObservable, StateObservable, ofType } from "redux-observable";
-import { of } from "rxjs";
+import { StateObservable, ofType } from "redux-observable";
+import { Observable, of } from "rxjs";
 import { concatMap, mergeMap } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
@@ -23,7 +23,7 @@ import { AppState, KernelStatus, errors } from "@nteract/types";
  * @param state$   The stream of state changes
  */
 export function executeAllCellsEpic(
-  action$: ActionsObservable<
+  action$: Observable<
     actions.ExecuteAllCells | actions.ExecuteAllCellsBelow
   >,
   state$: StateObservable<AppState>
@@ -74,7 +74,7 @@ export function executeAllCellsEpic(
  * @param state$
  */
 export function executeFocusedCellEpic(
-  action$: ActionsObservable<actions.ExecuteFocusedCell>,
+  action$: Observable<actions.ExecuteFocusedCell>,
   state$: StateObservable<AppState>
 ) {
   return action$.pipe(
@@ -123,7 +123,7 @@ export function executeFocusedCellEpic(
  * by emitting the EnqueueAction action.
  */
 export function executeCellEpic(
-  action$: ActionsObservable<actions.ExecuteCell>,
+  action$: Observable<actions.ExecuteCell>,
   state$: StateObservable<AppState>
 ) {
   return action$.pipe(

--- a/packages/epics/src/execute/process-msgs.ts
+++ b/packages/epics/src/execute/process-msgs.ts
@@ -4,8 +4,8 @@
  * the Jupyter kernel.
  */
 
-import { ActionsObservable, StateObservable, ofType } from "redux-observable";
-import { EMPTY, of } from "rxjs";
+import { StateObservable, ofType } from "redux-observable";
+import { EMPTY, Observable, of } from "rxjs";
 import { switchMap, filter, map, takeUntil, catchError } from "rxjs/operators";
 
 import * as actions from "@nteract/actions";
@@ -22,7 +22,7 @@ import { AppState } from "@nteract/types";
  * @param action$   The stream of actions being dispatched on the Redux store
  */
 export const updateDisplayEpic = (
-  action$: ActionsObservable<
+  action$: Observable<
     actions.NewKernelAction | actions.KillKernelSuccessful
   >
 ) =>
@@ -73,7 +73,7 @@ export const updateDisplayEpic = (
  * @param state$    The stream of changes to the Redux store
  */
 export const sendInputReplyEpic = (
-  action$: ActionsObservable<actions.SendInputReply>,
+  action$: Observable<actions.SendInputReply>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(

--- a/packages/epics/src/hosts.ts
+++ b/packages/epics/src/hosts.ts
@@ -4,7 +4,7 @@ import { NotebookV4 } from "@nteract/commutable/lib/v4";
 import * as selectors from "@nteract/selectors";
 import { AppState, DirectoryContentRecordProps, DummyContentRecordProps, FileContentRecordProps, IContentProvider, NotebookContentRecordProps, ServerConfig } from "@nteract/types";
 import { RecordOf } from "immutable";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
 import { bookstore } from "rx-jupyter";
 import { EMPTY, Observable, of } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
@@ -20,7 +20,7 @@ import { catchError, map, switchMap, tap } from "rxjs/operators";
  * @param state$  Application state.
  */
 export function publishToBookstore(
-  action$: ActionsObservable<actions.PublishToBookstore>,
+  action$: Observable<actions.PublishToBookstore>,
   state$: StateObservable<AppState>,
   dependencies: { contentProvider: IContentProvider }
 ): Observable<unknown> {
@@ -116,7 +116,7 @@ export function publishToBookstore(
  * @param state$  Application state.
  */
 export function publishToBookstoreAfterSave(
-  action$: ActionsObservable<actions.PublishToBookstoreAfterSave>,
+  action$: Observable<actions.PublishToBookstoreAfterSave>,
   state$: StateObservable<AppState>
 ): Observable<void | actions.PublishToBookstoreFailed> {
   const state: any = state$.value;

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -8,7 +8,7 @@ import {
 } from "@nteract/messaging";
 import { sendNotification } from "@nteract/mythic-notifications";
 import { AnyAction } from "redux";
-import { ActionsObservable, ofType, StateObservable } from "redux-observable";
+import { ofType, StateObservable } from "redux-observable";
 import { EMPTY, merge, Observable, Observer, of } from "rxjs";
 import {
   catchError,
@@ -36,7 +36,7 @@ const path = require("path");
  * @oaram  {ActionObservable}  action$ ActionObservable for LAUNCH_KERNEL_SUCCESSFUL action
  */
 export const watchExecutionStateEpic = (
-  action$: ActionsObservable<
+  action$: Observable<
     actions.NewKernelAction | actions.KillKernelSuccessful
   >
 ) =>
@@ -174,7 +174,7 @@ export function acquireKernelInfo(
  * @param  {ActionObservable}  The action type
  */
 export const acquireKernelInfoEpic = (
-  action$: ActionsObservable<actions.NewKernelAction>,
+  action$: Observable<actions.NewKernelAction>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(
@@ -222,7 +222,7 @@ export const extractNewKernel = (
  *       We could always inject those dependencies separately...
  */
 export const launchKernelWhenNotebookSetEpic = (
-  action$: ActionsObservable<actions.FetchContentFulfilled>,
+  action$: Observable<actions.FetchContentFulfilled>,
   state$: any
 ) =>
   action$.pipe(
@@ -277,7 +277,7 @@ export const launchKernelWhenNotebookSetEpic = (
  * killing the existing kernel process and starting an ew one.
  */
 export const restartKernelEpic = (
-  action$: ActionsObservable<actions.RestartKernel | actions.NewKernelAction>,
+  action$: Observable<actions.RestartKernel | actions.NewKernelAction>,
   state$: any
 ) =>
   action$.pipe(

--- a/packages/epics/src/kernelspecs.ts
+++ b/packages/epics/src/kernelspecs.ts
@@ -1,13 +1,13 @@
 import * as actions from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
 import { KernelspecProps, ServerConfig } from "@nteract/types";
-import { ActionsObservable, ofType } from "redux-observable";
+import { ofType } from "redux-observable";
 import { kernelspecs } from "rx-jupyter";
-import { EMPTY, of } from "rxjs";
+import { EMPTY, Observable, of } from "rxjs";
 import { catchError, map, mergeMap } from "rxjs/operators";
 
 export const fetchKernelspecsEpic = (
-  action$: ActionsObservable<actions.FetchKernelspecs>,
+  action$: Observable<actions.FetchKernelspecs>,
   state$: any
 ) =>
   action$.pipe(

--- a/packages/epics/src/websocket-kernel.ts
+++ b/packages/epics/src/websocket-kernel.ts
@@ -1,8 +1,8 @@
 import { kernelInfoRequest } from "@nteract/messaging";
 import { ofType } from "redux-observable";
-import { ActionsObservable, StateObservable } from "redux-observable";
+import { StateObservable } from "redux-observable";
 import { kernels, sessions } from "rx-jupyter";
-import { empty, of } from "rxjs";
+import { empty, Observable, of } from "rxjs";
 import {
   catchError,
   concatMap,
@@ -23,7 +23,7 @@ import { AjaxResponse } from "rxjs/ajax";
 import { extractNewKernel } from "./kernel-lifecycle";
 
 export const launchWebSocketKernelEpic = (
-  action$: ActionsObservable<actions.LaunchKernelByNameAction>,
+  action$: Observable<actions.LaunchKernelByNameAction>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(
@@ -105,7 +105,7 @@ export const launchWebSocketKernelEpic = (
   );
 
 export const changeWebSocketKernelEpic = (
-  action$: ActionsObservable<actions.ChangeKernelByName>,
+  action$: Observable<actions.ChangeKernelByName>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(
@@ -202,7 +202,7 @@ export const changeWebSocketKernelEpic = (
   );
 
 export const interruptKernelEpic = (
-  action$: ActionsObservable<actions.InterruptKernel>,
+  action$: Observable<actions.InterruptKernel>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(
@@ -281,7 +281,7 @@ export const interruptKernelEpic = (
   );
 
 export const killKernelEpic = (
-  action$: ActionsObservable<actions.KillKernelAction>,
+  action$: Observable<actions.KillKernelAction>,
   state$: StateObservable<AppState>
 ) =>
   // TODO: Use the sessions API for this
@@ -374,7 +374,7 @@ export const killKernelEpic = (
   );
 
 export const restartWebSocketKernelEpic = (
-  action$: ActionsObservable<actions.RestartKernel>,
+  action$: Observable<actions.RestartKernel>,
   state$: StateObservable<AppState>
 ) =>
   action$.pipe(

--- a/packages/mythic-notifications/__tests__/notifications.spec.ts
+++ b/packages/mythic-notifications/__tests__/notifications.spec.ts
@@ -1,5 +1,4 @@
 import { notifications, sendNotification } from "@nteract/mythic-notifications";
-import { ActionsObservable } from "redux-observable";
 import { TestScheduler } from "rxjs/testing";
 
 const buildScheduler = () =>
@@ -60,9 +59,7 @@ describe("notifications", () => {
       const inputMarbles  = "ab|";
       const outputMarbles = "AB|";
 
-      const inputAction$ = new ActionsObservable(
-        hot(inputMarbles, inputActions),
-      );
+      const inputAction$ = hot(inputMarbles, inputActions);
       const outputAction$ = notifications.makeRootEpic()(
         inputAction$,
         null,

--- a/packages/myths/package.json
+++ b/packages/myths/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "react-redux": "^6.0.0",
     "redux": "^4.0.0",
-    "redux-observable": "^1.0.0",
+    "redux-observable": "^2.0.0-alpha.0",
     "rxjs": "^6.3.3"
   },
   "peerDependencies": {

--- a/packages/myths/src/epics.ts
+++ b/packages/myths/src/epics.ts
@@ -1,5 +1,5 @@
-import { ActionsObservable, combineEpics, Epic } from "redux-observable";
-import { EMPTY, of } from "rxjs";
+import { combineEpics, Epic } from "redux-observable";
+import { EMPTY, Observable, of } from "rxjs";
 import { filter, map, mergeMap } from "rxjs/operators";
 import { CreateEpicDefinition, EpicDefinition, MythicAction, Myths } from "./types";
 
@@ -19,7 +19,7 @@ export const makeEpics = <
       const def: CreateEpicDefinition<PROPS> = definition;
 
       epics.push(
-        (action$: ActionsObservable<MythicAction>) =>
+        (action$: Observable<MythicAction>) =>
           action$.pipe(
             filter(def.on),
             map(def.create),

--- a/packages/myths/src/store.ts
+++ b/packages/myths/src/store.ts
@@ -1,5 +1,5 @@
 import { applyMiddleware, combineReducers, createStore, Middleware, ReducersMapObject, Store } from "redux";
-import { ActionsObservable, combineEpics, createEpicMiddleware, Epic, StateObservable } from "redux-observable";
+import { combineEpics, createEpicMiddleware, Epic, StateObservable } from "redux-observable";
 import { Observable } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { MythicAction, MythicPackage } from "./types";
@@ -32,7 +32,7 @@ export const makeConfigureStore = <STATE>() => <DEPS>(
   });
 
   const rootEpic = (
-    action$: ActionsObservable<any>,
+    action$: Observable<any>,
     store$: StateObservable<any>,
     dependencies: any,
   ) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13509,10 +13509,10 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-observable@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-1.2.0.tgz#ff51b6c6be2598e9b5e89fc36639186bb0e669c7"
-  integrity sha512-yeR90RP2WzZzCxxnQPlh2uFzyfFLsfXu8ROh53jGDPXVqj71uNDMmvi/YKQkd9ofiVoO4OYb1snbowO49tCEMg==
+redux-observable@2.0.0-alpha.0, redux-observable@^2.0.0-alpha.0:
+  version "2.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-2.0.0-alpha.0.tgz#e2fbb9da1db722a581c861976958c3b5d58f49cd"
+  integrity sha512-w0RsVGprIFiYi1AhFCOATiv3ld2AtuobvbcVsLvX19p8eAwLowWl2OrKYcCq/QEeEpmSHTXutXfVfcBnzaWmdw==
 
 redux@^3.6.0:
   version "3.7.2"


### PR DESCRIPTION
Progress on #4799. Formerly part of #5031.

I ran into a bug in `redux-observable`, so I upgraded to latest (`1.0.0` → `2.0.0-alpha.0`, [Changelog](https://github.com/redux-observable/redux-observable/blob/master/CHANGELOG.md)) for a fix. **This means `ActionsObservable` is gone, it is just `Observable` now.**