### PR TITLE
Fix syntax highlighting getting lost on CodeMirror mode update

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -349,7 +349,11 @@ export default class CodeMirrorEditor extends React.Component<
       if (
         this.props.codeMirror[optionName] !== prevProps.codeMirror[optionName]
       ) {
-        this.cm.setOption(optionName, this.props.codeMirror[optionName]);
+        if (optionName === "mode") {
+          this.cm.setOption(optionName, this.cleanMode());
+        } else {
+          this.cm.setOption(optionName, this.props.codeMirror[optionName]);
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #5093.

The issue was that the mode becomes an `Immutable.Map` after receiving mode info from the kernel, and that map was only properly converted to a JS object on the initial setting of editor options, while the code for updating the options passed it through unchanged.
