### PR TITLE
Add support for configuring keyboard shortcuts

### DIFF
--- a/applications/desktop/src/main/launch.ts
+++ b/applications/desktop/src/main/launch.ts
@@ -31,7 +31,7 @@ export function launch(filename?: string) {
     icon: iconPath,
     title: "nteract",
     show: false,
-    webPreferences: { nodeIntegration: true }
+    webPreferences: { nodeIntegration: true },
   });
 
   win.once("ready-to-show", () => {
@@ -41,7 +41,7 @@ export function launch(filename?: string) {
   win.loadURL(`file://${index}`);
 
   win.webContents.on("did-finish-load", () => {
-    const menu = loadFullMenu();
+    const menu = loadFullMenu((global as any).CONFIG.keyboardShortcuts);
     Menu.setApplicationMenu(menu);
     if (filename !== undefined) {
       win.webContents.send("main:load", filename);
@@ -52,18 +52,18 @@ export function launch(filename?: string) {
   win.webContents.on("will-navigate", deferURL);
 
   win.on("focus", () => {
-    const menu = loadFullMenu();
+    const menu = loadFullMenu((global as any).CONFIG.keyboardShortcuts);
     Menu.setApplicationMenu(menu);
   });
 
   win.on("show", () => {
-    const menu = loadFullMenu();
+    const menu = loadFullMenu((global as any).CONFIG.keyboardShortcuts);
     Menu.setApplicationMenu(menu);
   });
 
   // Emitted when the window is closed.
   win.on("closed", () => {
-    const menu = loadFullMenu();
+    const menu = loadFullMenu((global as any).CONFIG.keyboardShortcuts);
     Menu.setApplicationMenu(menu);
   });
   return win;

--- a/applications/desktop/src/main/menu.ts
+++ b/applications/desktop/src/main/menu.ts
@@ -18,6 +18,34 @@ import { installShellCommand } from "./cli";
 import { launch, launchNewNotebook } from "./launch";
 import { addRightClickMenu } from "./newfile-entry";
 
+interface KeyboardShortcuts {
+  new: string;
+  open: string;
+  save: string;
+  saveAs: string;
+  publish: string;
+  exportPDF: string;
+  selectAll: string;
+  newCodeCellAbove: string;
+  newCodeCellBelow: string;
+  newTextCellBelow: string;
+  copyCell: string;
+  cutCell: string;
+  pasteCell: string;
+  deleteCell: string;
+  changeToCodeCell: string;
+  changeToMarkdownCell: string;
+  runAllCells: string;
+  runAllCellsBelow: string;
+  clearAllOutputs: string;
+  expandContents: string;
+  killKernel: string;
+  interruptKernel: string;
+  restartKernel: string;
+  restartAndRunAll: string;
+  restartAndClearAll: string;
+}
+
 function send(
   focusedWindow: BrowserWindow,
   eventName: string,
@@ -323,7 +351,10 @@ export const named = {
   ],
 };
 
-export function loadFullMenu(store = global.store) {
+export function loadFullMenu(
+  keyboardShortcuts: KeyboardShortcuts,
+  store = global.store
+) {
   // NOTE for those looking for selectors -- this state is not the same as the
   //      "core" state -- it's a main process side model in the electron app
   const state = store.getState();
@@ -373,7 +404,7 @@ export function loadFullMenu(store = global.store) {
   const fileSubMenus = {
     new: {
       label: "&New",
-      accelerator: "CmdOrCtrl+N",
+      accelerator: keyboardShortcuts.new || "CmdOrCtrl+N",
     },
     open: {
       label: "&Open",
@@ -400,14 +431,14 @@ export function loadFullMenu(store = global.store) {
           }
         });
       },
-      accelerator: "CmdOrCtrl+O",
+      accelerator: keyboardShortcuts.open || "CmdOrCtrl+O",
     },
     openExampleNotebooks,
     save: {
       label: "&Save",
       enabled: BrowserWindow.getAllWindows().length > 0,
       click: createSender("menu:save"),
-      accelerator: "CmdOrCtrl+S",
+      accelerator: keyboardShortcuts.save || "CmdOrCtrl+S",
     },
     saveAs: {
       label: "Save &As",
@@ -436,11 +467,12 @@ export function loadFullMenu(store = global.store) {
           send(focusedWindow, "menu:save-as", `${filename}${ext}`);
         });
       },
-      accelerator: "CmdOrCtrl+Shift+S",
+      accelerator: keyboardShortcuts.saveAs || "CmdOrCtrl+Shift+S",
     },
     publish: {
       label: "&Publish",
       enabled: BrowserWindow.getAllWindows().length > 0,
+      accelerator: keyboardShortcuts.publish,
       submenu: [
         {
           label: "&Gist",
@@ -452,6 +484,7 @@ export function loadFullMenu(store = global.store) {
     exportPDF: {
       label: "Export &PDF",
       enabled: BrowserWindow.getAllWindows().length > 0,
+      accelerator: keyboardShortcuts.exportPDF,
       click: createSender("menu:exportPDF"),
     },
   };
@@ -513,7 +546,7 @@ export function loadFullMenu(store = global.store) {
       },
       {
         label: "Select All",
-        accelerator: "CmdOrCtrl+A",
+        accelerator: keyboardShortcuts.selectAll || "CmdOrCtrl+A",
         role: "selectall",
       },
       {
@@ -522,18 +555,19 @@ export function loadFullMenu(store = global.store) {
       {
         label: "Insert Code Cell Above",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+A",
+        accelerator: keyboardShortcuts.newCodeCellAbove || "CmdOrCtrl+Shift+A",
         click: createSender("menu:new-code-cell-above"),
       },
       {
         label: "Insert Code Cell Below",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+B",
+        accelerator: keyboardShortcuts.newCodeCellBelow || "CmdOrCtrl+Shift+B",
         click: createSender("menu:new-code-cell-below"),
       },
       {
         label: "Insert Text Cell Below",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.newTextCellBelow,
         click: createSender("menu:new-text-cell-below"),
       },
       {
@@ -547,13 +581,13 @@ export function loadFullMenu(store = global.store) {
       {
         label: "Copy Cell",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+C",
+        accelerator: keyboardShortcuts.copyCell || "CmdOrCtrl+Shift+C",
         click: createSender("menu:copy-cell"),
       },
       {
         label: "Cut Cell",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+X",
+        accelerator: keyboardShortcuts.cutCell || "CmdOrCtrl+Shift+X",
         click: createSender("menu:cut-cell"),
       },
       {
@@ -596,13 +630,14 @@ export function loadFullMenu(store = global.store) {
       {
         label: "Change Cell Type to Code",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+Y",
+        accelerator: keyboardShortcuts.changeToCodeCell || "CmdOrCtrl+Shift+Y",
         click: createSender("menu:change-cell-to-code"),
       },
       {
         label: "Change Cell Type to Text",
         enabled: BrowserWindow.getAllWindows().length > 0,
-        accelerator: "CmdOrCtrl+Shift+M",
+        accelerator:
+          keyboardShortcuts.changeToMarkdownCell || "CmdOrCtrl+Shift+M",
         click: createSender("menu:change-cell-to-text"),
       },
       {
@@ -611,21 +646,25 @@ export function loadFullMenu(store = global.store) {
       {
         label: "Run All",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.runAllCells,
         click: createSender("menu:run-all"),
       },
       {
         label: "Run All Below",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.runAllCellsBelow,
         click: createSender("menu:run-all-below"),
       },
       {
         label: "Clear All Outputs",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.clearAllOutputs,
         click: createSender("menu:clear-all"),
       },
       {
         label: "Unhide Input and Output in all Cells",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.expandContents,
         click: createSender("menu:unhide-all"),
       },
     ],
@@ -715,26 +754,31 @@ export function loadFullMenu(store = global.store) {
       {
         label: "&Kill",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.killKernel,
         click: createSender("menu:kill-kernel"),
       },
       {
         label: "&Interrupt",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.interruptKernel,
         click: createSender("menu:interrupt-kernel"),
       },
       {
         label: "&Restart",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.restartKernel,
         click: createSender("menu:restart-kernel"),
       },
       {
         label: "Restart and &Clear All Cells",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.restartAndClearAll,
         click: createSender("menu:restart-and-clear-all"),
       },
       {
         label: "Restart and Run &All Cells",
         enabled: BrowserWindow.getAllWindows().length > 0,
+        accelerator: keyboardShortcuts.restartAndRunAll,
         click: createSender("menu:restart-and-run-all"),
       },
       {

--- a/docs/configuring-kbd-shortcuts.md
+++ b/docs/configuring-kbd-shortcuts.md
@@ -1,0 +1,60 @@
+# Customizing keyboard shortcuts
+
+The nteract desktop app supports overriding the default keymappings defining in [the keyboard shortcuts documentation](./kbd-shortcuts) using nteract's [configuration system](./desktop-config).
+
+In order to configure your own keyboard shortcuts, you will need to ensure that you have created an `nteract.json` file in the `~/.jupyter` directory on your machine. The nteract desktop app will look for custom keyboard shortcut mappings under the `keyboardShortcuts` property in this file.
+
+```
+{
+    "keyboardShortcuts": {
+        // Your keyboard shortcut mappings here
+    }
+}
+```
+
+Keyboard shortcut mappings are defined in a key-value pair where the key is the shortcut name and the value is an [Electron-supported keyboard accelerator](https://www.electronjs.org/docs/api/accelerator).
+
+```
+{
+    "keyboardShortcuts": {
+        "new": "CmdOrCtrl+M",
+        "newCodeCellBelow": "CmdOrCtrl+Shift+J"
+  }
+}
+```
+
+The table below outlines all the available configurations and their defaults.
+
+| Action                 | Default Keyboard Shortcut    |
+| ---------------------- | ---------------------------- |
+| `new`                  | <kbd>CmdOrCtrl+N</kbd>       |
+| `open`                 | <kbd>CmdOrCtrl+O</kbd>       |
+| `save`                 | <kbd>CmdOrCtrl+S</kbd>       |
+| `saveAs`               | <kbd>CmdOrCtrl+Shift+S</kbd> |
+| `publish`              | None                         |
+| `exportPDF`            | None                         |
+| `selectAll`            | <kbd>CmdOrCtrl+A</kbd>       |
+| `newCodeCellAbove`     | <kbd>CmdOrCtrl+Shift+A</kbd> |
+| `newCodeCellBelow`     | <kbd>CmdOrCtrl+Shift+B</kbd> |
+| `newTextCellBelow`     | None                         |
+| `copyCell`             | <kbd>CmdOrCtrl+Shift+C</kbd> |
+| `cutCell`              | <kbd>CmdOrCtrl+Shift+X</kbd> |
+| `pasteCell`            | <kbd>CmdOrCtrl+Shift+V</kbd> |
+| `deleteCell`           | <kbd>CmdOrCtrl+Shift+D</kbd> |
+| `changeToCodeCell`     | <kbd>CmdOrCtrl+Shift+Y</kbd> |
+| `changeToMarkdownCell` | <kbd>CmdOrCtrl+Shift+M</kbd> |
+| `runAllCells`          | None                         |
+| `runAllCellsBelow`     |                              |
+| `clearAllOutputs`      | None                         |
+| `expandContents`       | None                         |
+| `killKernel`           | None                         |
+| `interruptKernel`      | None                         |
+| `restartKernel`        | None                         |
+| `restartAndRunAll`     | None                         |
+| `restartAndClearAll`   | None                         |
+
+When configuring custom keyboard shortcuts, remember:
+
+- You can have keyboard shortcuts that don't need modifiers like <kbd>Cmd</kbd> and <kbd>Alt</kbd> but you'll need to make sure that you are not focused on any cell editors before using the keyboard shortcuts (typically by pressing <kbd>Esc</kbd>).
+- Be sure that the keyboard shortcuts you define don't conflict with any other keyboard shortcuts.
+- Keyboard shortcuts must be configured before the nteract application is launched.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
       - "Creating data visualizations in nteract": "creating-data-visualizations-in-nteract.md"
       - "nteract Desktop Keyboard Shortcuts": "kbd-shortcuts.md"
       - "Configuring the nteract desktop app": "desktop-config.md"
+      - "Configuring keyboard shortcuts in nteract": "configuring-kbd-shortcuts.md"
   - User Guides for Core SDK:
       - "@nteract/actions": "!include ./packages/actions/mkdocs.yml"
       - "@nteract/commutable": "!include ./packages/commutable/mkdocs.yml"


### PR DESCRIPTION
This PR adds support for configuring keyboard shortcuts for different actions in the nteract desktop app. The configurable actions are documented in docs/configuring-kbd-shortcuts.md.

When the nteract application launches, we store the config the user provides in the `nteract.json` file under a global CONFIG attribute in the main process of the application. The configuration system expects the custom keymaps to be configured under the `keyboardShortcuts` map as read from in applications/desktop/src/main/index.ts.

When we build the menu in applications/desktop/src/main/index.ts, we first look for accelerators defined by the user's config before using our own defaults.

This PR also exposes configuration for actions that aren't currently tied to a keyboard shortcut.

Closes #5092 #4781 (ish)