### PR TITLE
Fix height on collapsed outputs

### DIFF
--- a/packages/styles/themes/base.css
+++ b/packages/styles/themes/base.css
@@ -15,7 +15,7 @@
   outline: none;
   /* When expanded, this is overtaken to 100% */
   text-overflow: ellipsis;
-  height: 300px;
+  max-height: 300px;
 }
 
 .nteract-cell-outputs.expanded {


### PR DESCRIPTION
The height on the collapsed input should be set via `max-height` instead of `height`.