### PR TITLE
Move save timestamp workaround to JupyterContentProvider

### DIFF
--- a/packages/rx-jupyter/__tests__/contents-spec.ts
+++ b/packages/rx-jupyter/__tests__/contents-spec.ts
@@ -94,7 +94,7 @@ describe("contents", () => {
         path: "save/to/this/path"
       };
       const create$ = JupyterContentProvider.save(serverConfig, "/path/to/content", model);
-      const request = (create$ as AjaxObservable).request;
+      const request = (create$.source as AjaxObservable).request; // Because of a workaround the AjaxObservable is source
       expect(request.url).toBe(
         "http://localhost:8888/api/contents/path/to/content"
       );


### PR DESCRIPTION
1. Move the poll workaround to `JupyterContentProvider` since it is specific to Jupyter. This doesn't force this logic on other content providers.
2. Tweaked the polling logic to stop as soon as a newer timestamp is found. This prevents doing GET calls 4 times every time.