### PR TITLE
css: set `max-height` and `overflow-y` for expanded output

### DIFF
--- a/packages/styles/themes/base.css
+++ b/packages/styles/themes/base.css
@@ -20,6 +20,8 @@
 
 .nteract-cell-outputs.expanded {
   height: 100%;
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 .nteract-cell-outputs:empty {

--- a/packages/styles/themes/base.css
+++ b/packages/styles/themes/base.css
@@ -11,7 +11,7 @@
 .nteract-cell-outputs {
   padding: 10px 10px 10px calc(var(--prompt-width, 50px) + 10px);
   word-wrap: break-word;
-  overflow-y: scroll;
+  overflow-y: auto;
   outline: none;
   /* When expanded, this is overtaken to 100% */
   text-overflow: ellipsis;
@@ -21,7 +21,6 @@
 .nteract-cell-outputs.expanded {
   height: 100%;
   max-height: 100%;
-  overflow-y: auto;
 }
 
 .nteract-cell-outputs:empty {


### PR DESCRIPTION
![Bildschirmfoto 2020-05-30 um 13 08 58](https://user-images.githubusercontent.com/1679688/83328252-f306a000-a281-11ea-9e38-1a6fbd6d22a0.png)

fixes https://github.com/nteract/nteract/issues/5132.

> Even though the output is expanded the content is cut off.
>
> Clicking "Toggle Expanded Output" in the ui of the cell does not help. When having the output expanded, the `.nteract-cell-outputs` element does get an extra `expanded` class. But, according to the inspector, the `.nteract-cell-outputs.expanded` element still has `max-height: 300px`, which seems to overrule the `height: 100%`.

original context: https://github.com/nteract/nteract/pull/5113#issuecomment-636254454