### PR TITLE
Polish up interactions with cell execute button

### DIFF
--- a/packages/notebook-app-component/src/derived-components/toolbar.tsx
+++ b/packages/notebook-app-component/src/derived-components/toolbar.tsx
@@ -23,6 +23,7 @@ import {
   CircularButton,
 } from "@nteract/presentational-components";
 import { CellToolbar, CellToolbarContext } from "@nteract/stateful-components";
+import { ExecutionCount } from "../../../commutable/lib";
 
 const StyledDropdownContent = styled(DropdownContent)``;
 
@@ -37,6 +38,7 @@ interface ComponentState {
   checkOutput: boolean;
   checkExtendedOutput: boolean;
   checkParameterizedCell: boolean;
+  showExecuteButton: boolean;
 }
 
 export default class Toolbar extends React.PureComponent<
@@ -55,6 +57,7 @@ export default class Toolbar extends React.PureComponent<
       checkOutput: true,
       checkExtendedOutput: false,
       checkParameterizedCell: false,
+      showExecuteButton: false,
     };
 
     this.toggleMenuRef = React.createRef();
@@ -149,6 +152,14 @@ export default class Toolbar extends React.PureComponent<
     );
   };
 
+  showExecuteButton = () => {
+    this.setState({ showExecuteButton: true });
+  }
+
+  hideExecuteButton = (executionCount: ExecutionCount) => {
+    this.setState({ showExecuteButton: executionCount !== null ? false : true });
+  }
+
   render(): JSX.Element {
     return (
       <CellToolbar contentRef={this.props.contentRef} id={this.props.id}>
@@ -158,10 +169,12 @@ export default class Toolbar extends React.PureComponent<
               {context.type !== "markdown" ? (
                 <CircularButton
                   onClick={context.executeCell}
-                  title="execute cell"
+                  title="Execute this cell"
                   className="executeButton"
+                  onMouseEnter={this.showExecuteButton}
+                  onMouseLeave={() => this.hideExecuteButton(context.executionCount)}
                 >
-                  <Icons.Play />
+                  {context.executionCount == null ? <Icons.Play/> : (this.state.showExecuteButton ? <Icons.Play/> : context.executionCount)}
                 </CircularButton>
               ) : null}
               <div ref={this.dropdownRef}>

--- a/packages/stateful-components/src/cells/toolbar.tsx
+++ b/packages/stateful-components/src/cells/toolbar.tsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
 import { ContentRef, actions, AppState, selectors } from "@nteract/core";
-import { CellType } from "@nteract/commutable";
+import { CellType, ExecutionCount } from "@nteract/commutable";
 
 export interface ComponentProps {
   id: string;
@@ -13,6 +13,7 @@ export interface ComponentProps {
 
 export interface StateProps {
   type?: CellType;
+  executionCount?: ExecutionCount;
 }
 
 export interface DispatchProps {
@@ -62,14 +63,16 @@ const makeMapStateToProps = (
     const { id, contentRef } = ownProps;
     const model = selectors.model(state, { contentRef });
     let type: CellType = "code";
+    let executionCount: ExecutionCount = null;
 
     if (model && model.type === "notebook") {
       const cell = selectors.notebook.cellById(model, { id });
       if (cell) {
         type = cell.get<CellType>("cell_type", "code");
+        executionCount = cell.get<ExecutionCount>("execution_count", null);
       }
     }
-    return { type };
+    return { type, executionCount };
   };
   return mapStateToProps;
 };

--- a/packages/styles/cell-menu.css
+++ b/packages/styles/cell-menu.css
@@ -122,6 +122,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  font-family: var(--nt-font-family-normal);
 }
 
 .circular-button svg:not(.progress-ring) * {


### PR DESCRIPTION
This PR polishes up some of the interactions with the cell play button.

- It should always appear if the cell has not been executed yet
- If the cell has been executed it should only appear on hover