### PR TITLE
Tooltip Bugfix

### DIFF
--- a/packages/editor/src/components/tooltip.tsx
+++ b/packages/editor/src/components/tooltip.tsx
@@ -25,9 +25,10 @@ export const Tip: StyledComponent<"div", {}, TipProps> = styled.div`
   background-color: var(--theme-app-bg, #2b2b2b);
   box-shadow: 2px 2px 50px rgba(0, 0, 0, 0.2);
   float: right;
-  height: auto;
+  height: 50vh;
   left: ${(props: TipProps) => props.cursorCoords.left}px;
   margin: 30px 20px 50px 20px;
+  overflow-y: auto;
   padding: 20px 20px 50px 20px;
   position: absolute;
   top: ${(props: TipProps) => props.cursorCoords.top}px;

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -346,7 +346,7 @@ export default class CodeMirrorEditor extends React.Component<
    * re-renders triggered by the `Editor` parent component in the
    * @nteract/stateful-components package.
    */
-  shouldComponentUpdate(nextProps: CodeMirrorEditorProps): boolean {
+  shouldComponentUpdate(nextProps: CodeMirrorEditorProps, nextState: CodeMirrorEditorState): boolean {
     const valueChanged = this.props.value !== nextProps.value;
     const editorFocusedChanged =
       this.props.editorFocused !== nextProps.editorFocused;
@@ -356,7 +356,13 @@ export default class CodeMirrorEditor extends React.Component<
       nextProps.codeMirror
     );
 
-    return valueChanged || editorFocusedChanged || codeMirrorConfigChanged;
+    // Re-render the page when viewing the tip.
+    const bundleChanged = !isEqual(
+      this.state.bundle,
+      nextState.bundle
+    )
+
+    return valueChanged || editorFocusedChanged || codeMirrorConfigChanged || bundleChanged;
   }
 
   componentDidUpdate(prevProps: CodeMirrorEditorProps): void {


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

PR to address Issue #5122 

Function tooltip now pops up when pressing `ctrl + .` without pressing additional keys.

- Root cause was the `shouldComponentUpdate` conditions never passed when changing the state for the tool tip.
- Added a state comparison that looks at `bundle` which is only ever changed when the tooltip is activated or deactivated.

Function tooltip size now scales with the user screen size and scrolls for larger tooltips.

![image](https://user-images.githubusercontent.com/9558507/85725548-37d7f800-b6c3-11ea-850e-6125b4f23780.png)
