### PR TITLE
Resolve navigating cells with arrow keys to close #5196

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -87,7 +87,7 @@ type Mode = {
 export default class CodeMirrorEditor extends React.Component<
   CodeMirrorEditorProps,
   CodeMirrorEditorState
-> {
+  > {
   static defaultProps: Partial<CodeMirrorEditorProps> = {
     value: "",
     channels: null,
@@ -407,7 +407,7 @@ export default class CodeMirrorEditor extends React.Component<
       this.cm &&
       this.props.value !== undefined &&
       normalizeLineEndings(this.cm.getValue()) !==
-        normalizeLineEndings(this.props.value)
+      normalizeLineEndings(this.props.value)
     ) {
       if (this.props.preserveScrollPosition) {
         const prevScrollPosition = this.cm.getScrollInfo();
@@ -474,10 +474,9 @@ export default class CodeMirrorEditor extends React.Component<
   goLineDownOrEmit(editor: Editor & Doc): void {
     const cursor: Position = editor.getCursor();
     const lastLineNumber: number = editor.lastLine();
-    const lastLine: string = editor.getLine(lastLineNumber);
+
     if (
       cursor.line === lastLineNumber &&
-      cursor.ch === lastLine.length &&
       !editor.somethingSelected()
     ) {
       CodeMirror.signal(editor, "bottomBoundary");
@@ -528,13 +527,13 @@ export default class CodeMirrorEditor extends React.Component<
         />
         {tooltipNode
           ? ReactDOM.createPortal(
-              <Tooltip
-                bundle={bundle}
-                cursorCoords={cursorCoords}
-                deleteTip={this.deleteTip}
-              />,
-              tooltipNode
-            )
+            <Tooltip
+              bundle={bundle}
+              cursorCoords={cursorCoords}
+              deleteTip={this.deleteTip}
+            />,
+            tooltipNode
+          )
           : null}
       </React.Fragment>
     );

--- a/packages/stateful-components/src/inputs/connected-editors/codemirror.tsx
+++ b/packages/stateful-components/src/inputs/connected-editors/codemirror.tsx
@@ -1,7 +1,8 @@
-import { AppState, ContentRef, selectors } from "@nteract/core";
+import { AppState, ContentRef, selectors, actions } from "@nteract/core";
 import CodeMirrorEditor from "@nteract/editor";
 import { createConfigCollection, createDeprecatedConfigOption, defineConfigOption, HasPrivateConfigurationState } from "@nteract/mythic-configuration";
 import { connect } from "react-redux";
+import { Dispatch } from "redux";
 
 const codeMirrorConfig = createConfigCollection({
   key: "codeMirror",
@@ -15,16 +16,16 @@ createDeprecatedConfigOption({
 });
 
 const BOOLEAN = [
-  {label: "Yes", value: true},
-  {label: "No", value: false},
+  { label: "Yes", value: true },
+  { label: "No", value: false },
 ];
 
 defineConfigOption({
   label: "Blink Editor Cursor",
   key: "codeMirror.cursorBlinkRate",
   values: [
-    {label: "Yes", value: 530},
-    {label: "No", value: 0},
+    { label: "Yes", value: 530 },
+    { label: "No", value: 0 },
   ],
   defaultValue: 0,
 });
@@ -61,9 +62,9 @@ defineConfigOption({
   label: "Tab Size",
   key: "codeMirror.tabSize",
   values: [
-    {label: "2 Spaces", value: 2},
-    {label: "3 Spaces", value: 3},
-    {label: "4 Spaces", value: 4},
+    { label: "2 Spaces", value: 2 },
+    { label: "3 Spaces", value: 3 },
+    { label: "4 Spaces", value: 4 },
   ],
   defaultValue: 4,
 });
@@ -93,6 +94,11 @@ interface ComponentProps {
   id: string;
   contentRef: ContentRef;
   editorType: string;
+}
+
+interface DispatchProps {
+  focusAbove: () => void;
+  focusBelow: () => void;
 }
 
 const makeMapStateToProps = (state: AppState & HasPrivateConfigurationState, ownProps: ComponentProps) => {
@@ -147,4 +153,24 @@ const makeMapStateToProps = (state: AppState & HasPrivateConfigurationState, own
   return mapStateToProps;
 };
 
-export default connect(makeMapStateToProps)(CodeMirrorEditor);
+export const makeMapDispatchToProps = (
+  initialDispatch: Dispatch,
+  ownProps: ComponentProps
+) => {
+  const { id, contentRef } = ownProps;
+  const mapDispatchToProps = (dispatch: Dispatch) => {
+    return {
+      focusBelow: () => {
+        dispatch(actions.focusNextCell({ id, contentRef, createCellIfUndefined: true }));
+        dispatch(actions.focusNextCellEditor({ id, contentRef }));
+      },
+      focusAbove: () => {
+        dispatch(actions.focusPreviousCell({ id, contentRef }));
+        dispatch(actions.focusPreviousCellEditor({ id, contentRef }));
+      }
+    }
+  };
+  return mapDispatchToProps;
+};
+
+export default connect(makeMapStateToProps, makeMapDispatchToProps)(CodeMirrorEditor);


### PR DESCRIPTION
Closes #5196.

- Passes focusBelow and focusAbove methods to editor
- Removes unnecessary check on line length