### PR TITLE
Fix the logic getting the default kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ site/
 applications/jupyter-extension/pip-wheel-metadata/
 
 applications/desktop/**/*.d.ts
+/.python-version

--- a/applications/desktop/src/main/index.ts
+++ b/applications/desktop/src/main/index.ts
@@ -245,7 +245,7 @@ openFile$
 
         if (passedKernel && passedKernel in specs) {
           kernel = passedKernel;
-        } else if (!kernel && !(kernel in specs)) {
+        } else if (!kernel || !(kernel in specs)) {
           const specList = Object.keys(specs);
           specList.sort();
           kernel = specList[0];
@@ -253,6 +253,8 @@ openFile$
 
         if (kernel && specs[kernel]) {
           launchNewNotebook(filepath, specs[kernel]);
+        } else {
+          log.error(`can't find kernel "${kernel}" in:`, specs);
         }
       });
     };


### PR DESCRIPTION
Maybe fix for #5190?

If the default kernel for the config system isn't found, it'll currently hang at the splash screen due to wrong logic. This fixes that.