### PR TITLE
Introduce mythic-windowing and move splash screen logic there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ site/
 applications/jupyter-extension/pip-wheel-metadata/
 
 applications/desktop/**/*.d.ts
-/.python-version
+
+# pyenv config
+.python-version
 
 applications/desktop/.env

--- a/applications/desktop/src/main/index.ts
+++ b/applications/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import { ConfigurationOption, defineConfigOption, setConfigFile } from "@nteract/mythic-configuration";
+import { closeWindow, electronBackend, setWindowingBackend, showWindow } from "@nteract/mythic-windowing";
 import { KernelspecInfo, Kernelspecs } from "@nteract/types";
 import { app, BrowserWindow, dialog, Event, ipcMain as ipc, IpcMainEvent, Menu, Tray } from "electron";
 import initContextMenu from "electron-context-menu";
@@ -11,7 +12,6 @@ import { join, resolve } from "path";
 import { forkJoin, fromEvent, Observable, Subscriber, zip } from "rxjs";
 import { buffer, first, mergeMap, skipUntil, takeUntil } from "rxjs/operators";
 import yargs from "yargs/yargs";
-import { closeWindow, showWindow } from "../../../../packages/mythic-windowing/src";
 import { QUITTING_STATE_NOT_STARTED, QUITTING_STATE_QUITTING, setKernelSpecs, setQuittingState } from "./actions";
 import { initAutoUpdater } from "./auto-updater";
 import { defaultKernel } from "./config-options";
@@ -109,6 +109,8 @@ const appAndKernelSpecsReady = zip(
   windowReady$,
   kernelSpecsPromise,
 );
+
+store.dispatch(setWindowingBackend.create(electronBackend));
 
 electronReady$
   .pipe(takeUntil(appAndKernelSpecsReady))

--- a/applications/desktop/src/main/store.ts
+++ b/applications/desktop/src/main/store.ts
@@ -1,13 +1,16 @@
 import { Kernelspecs, middlewares as coreMiddlewares } from "@nteract/core";
 import { configuration } from "@nteract/mythic-configuration";
+import { windowing } from "@nteract/mythic-windowing";
 import { makeConfigureStore } from "@nteract/myths";
 import { AnyAction } from "redux";
 import { QUITTING_STATE_NOT_STARTED, QuittingState } from "./actions";
 import { MainStateProps } from "./reducers";
 
+
 export const configureStore = makeConfigureStore<MainStateProps>()({
   packages: [
     configuration,
+    windowing,
   ],
   reducers: {
     kernelSpecs: (state: Kernelspecs = {}, action: AnyAction) =>

--- a/applications/desktop/tsconfig.json
+++ b/applications/desktop/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "../../packages/editor" },
     { "path": "../../packages/mythic-configuration" },
     { "path": "../../packages/mythic-notifications" },
+    { "path": "../../packages/mythic-windowing" },
     { "path": "../../packages/myths" },
     { "path": "../../packages/notebook-app-component" },
     { "path": "../../packages/presentational-components" },

--- a/applications/desktop/webpack.prod.js
+++ b/applications/desktop/webpack.prod.js
@@ -3,9 +3,9 @@ const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
 
 const { commonMainConfig, commonRendererConfig } = require("./webpack.common");
 
-const mainConfig = merge(commonMainConfig, { mode: "production" });
+const mainConfig = merge.merge(commonMainConfig, { mode: "production" });
 
-const rendererConfig = merge(commonRendererConfig, {
+const rendererConfig = merge.merge(commonRendererConfig, {
   plugins: [new LodashModuleReplacementPlugin()],
   mode: "production"
 });

--- a/applications/desktop/webpack.prod.js
+++ b/applications/desktop/webpack.prod.js
@@ -3,9 +3,9 @@ const LodashModuleReplacementPlugin = require("lodash-webpack-plugin");
 
 const { commonMainConfig, commonRendererConfig } = require("./webpack.common");
 
-const mainConfig = merge.merge(commonMainConfig, { mode: "production" });
+const mainConfig = merge(commonMainConfig, { mode: "production" });
 
-const rendererConfig = merge.merge(commonRendererConfig, {
+const rendererConfig = merge(commonRendererConfig, {
   plugins: [new LodashModuleReplacementPlugin()],
   mode: "production"
 });

--- a/packages/mythic-windowing/README.md
+++ b/packages/mythic-windowing/README.md
@@ -1,0 +1,71 @@
+# @nteract/mythic-notifications
+
+This package implements a notification system based on `blueprintjs`, using the `myths` framework.
+
+## Installation
+
+```
+$ yarn add @nteract/mythic-notifications
+```
+
+```
+$ npm install --save @nteract/mythic-notifications
+```
+
+## Usage
+
+Initialize the package by including the `notifications` package in your store and rendering the `<NotificationsRoot/>`:
+
+```javascript
+import { notifications, NotificationRoot } from "@nteract/mythic-notifications";
+import { makeConfigureStore } from "@nteract/myths";
+
+export const configureStore = makeConfigureStore({
+  packages: [notifications],
+});
+
+export const App = () =>
+    <>
+      {/* ... */}
+      <NotificationRoot darkTheme={false} />
+    </>
+```
+
+Then dispatch actions made by `sendNotification.create`:
+
+```javascript
+import { sendNotification } from "@nteract/mythic-notifications";
+
+store.dispatch(sendNotification.create({
+  title: "Hello World!",
+  message: <em>Hi out there!</em>,
+  level: "info",
+}));
+```
+
+## API
+
+```typescript
+import { IconName } from "@blueprintjs/core";
+
+export interface NotificationMessage {
+  key?: string;
+  icon?: IconName;
+  title?: string;
+  message: string | JSX.Element;
+  level: "error" | "warning" | "info" | "success" | "in-progress";
+  action?: {
+    icon?: IconName;
+    label: string;
+    callback: () => void;
+  };
+}
+```
+
+## Support
+
+If you experience an issue while using this package or have a feature request, please file an issue on the [issue board](https://github.com/nteract/nteract/issues/new/choose) and add the `pkg:mythic-notifications` label.
+
+## License
+
+[BSD-3-Clause](https://choosealicense.com/licenses/bsd-3-clause/)

--- a/packages/mythic-windowing/README.md
+++ b/packages/mythic-windowing/README.md
@@ -1,70 +1,60 @@
-# @nteract/mythic-notifications
+# @nteract/mythic-windowing
 
-This package implements a notification system based on `blueprintjs`, using the `myths` framework.
+This package implements a windowing system based on `electron`, using the `myths` framework.
 
 ## Installation
 
 ```
-$ yarn add @nteract/mythic-notifications
+$ yarn add @nteract/mythic-windowing
 ```
 
 ```
-$ npm install --save @nteract/mythic-notifications
+$ npm install --save @nteract/mythic-windowing
 ```
 
 ## Usage
 
-Initialize the package by including the `notifications` package in your store and rendering the `<NotificationsRoot/>`:
+Initialize the package by including the `windowing` package in your store:
 
 ```javascript
-import { notifications, NotificationRoot } from "@nteract/mythic-notifications";
+import { windowing, setWindowingBackend, electronBackend } from "@nteract/mythic-windowing";
 import { makeConfigureStore } from "@nteract/myths";
 
 export const configureStore = makeConfigureStore({
-  packages: [notifications],
+  packages: [windowing],
 });
 
-export const App = () =>
-    <>
-      {/* ... */}
-      <NotificationRoot darkTheme={false} />
-    </>
-```
+store.dispatch(setWindowingBackend.create(electronBackend));
 
-Then dispatch actions made by `sendNotification.create`:
+const electronReady$ = new Observable((observer) => {
+  (app as any).on("ready", launchInfo => observer.next(launchInfo));
+});
 
-```javascript
-import { sendNotification } from "@nteract/mythic-notifications";
-
-store.dispatch(sendNotification.create({
-  title: "Hello World!",
-  message: <em>Hi out there!</em>,
-  level: "info",
-}));
+electronReady$
+  .subscribe(
+    () => store.dispatch(
+      showWindow.create({
+        id: "splash",
+        kind: "splash",
+        width: 565,
+        height: 233,
+        path: join(__dirname, "..", "static", "splash.html"),
+      })
+    ),
+    (err) => console.error(err),
+    () => store.dispatch(
+      closeWindow.create("splash")
+    ),
+  );
 ```
 
 ## API
 
-```typescript
-import { IconName } from "@blueprintjs/core";
-
-export interface NotificationMessage {
-  key?: string;
-  icon?: IconName;
-  title?: string;
-  message: string | JSX.Element;
-  level: "error" | "warning" | "info" | "success" | "in-progress";
-  action?: {
-    icon?: IconName;
-    label: string;
-    callback: () => void;
-  };
-}
-```
+TBD
 
 ## Support
 
-If you experience an issue while using this package or have a feature request, please file an issue on the [issue board](https://github.com/nteract/nteract/issues/new/choose) and add the `pkg:mythic-notifications` label.
+If you experience an issue while using this package or have a feature request, please file an issue on the [issue board](https://github.com/nteract/nteract/issues/new/choose) and add the `pkg:mythic-windowing` label.
 
 ## License
 

--- a/packages/mythic-windowing/package.json
+++ b/packages/mythic-windowing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nteract/mythic-windowing",
   "version": "0.1.0",
-  "description": "TODO",
+  "description": "A windowing system based on electron and the myths redux framework",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",

--- a/packages/mythic-windowing/package.json
+++ b/packages/mythic-windowing/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@nteract/mythic-windowing",
+  "version": "0.1.0",
+  "description": "TODO",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "nteractDesktop": "src/index.ts",
+  "scripts": {},
+  "repository": "https://github.com/nteract/nteract/tree/master/packages/mythic-windowing",
+  "keywords": [
+    "nteract"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+  },
+  "dependencies": {
+    "@nteract/myths": "^0.2.0",
+    "electron": "7.3.2"
+  },
+  "peerDependencies": {
+  },
+  "author": "nteract contributers",
+  "license": "BSD-3-Clause"
+}

--- a/packages/mythic-windowing/src/backends/electron/index.ts
+++ b/packages/mythic-windowing/src/backends/electron/index.ts
@@ -1,0 +1,30 @@
+import { BrowserWindow } from "electron";
+import { of } from "rxjs";
+import { deregisterWindow, registerWindow } from "../../myths/window-registry";
+import { WindowingBackend, WindowProps } from "../../types";
+
+
+export const electronBackend: WindowingBackend<BrowserWindow> = {
+  showWindow: ({id, width, height, path, kind}: WindowProps) => {
+    const window = new BrowserWindow({
+      width,
+      height,
+      useContentSize: true,
+      title: "loading",
+      frame: false,
+      show: false,
+    });
+
+    window.loadURL(`file://${path}`);
+    window.once("ready-to-show", () => {
+      window.show();
+    });
+
+    return of(registerWindow<BrowserWindow>().create({ id, window }));
+  },
+
+  closeWindow: (id: string, window?: BrowserWindow) => {
+    window?.close();
+    return of(deregisterWindow.create(id));
+  }
+}

--- a/packages/mythic-windowing/src/backends/electron/index.ts
+++ b/packages/mythic-windowing/src/backends/electron/index.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from "electron";
 import { of } from "rxjs";
-import { deregisterWindow, registerWindow } from "../../myths/window-registry";
-import { WindowingBackend, WindowProps } from "../../types";
+import { forgetWindow, rememberWindow } from "../../myths/window-registry";
+import { WindowingBackend, WindowProps, WindowRef } from "../../types";
 
 
 export const electronBackend: WindowingBackend<BrowserWindow> = {
@@ -20,11 +20,11 @@ export const electronBackend: WindowingBackend<BrowserWindow> = {
       window.show();
     });
 
-    return of(registerWindow.create({ id, window }));
+    return of(rememberWindow.create({ id, window }));
   },
 
-  closeWindow: (id: string, window?: BrowserWindow) => {
+  closeWindow: (id: WindowRef, window?: BrowserWindow) => {
     window?.close();
-    return of(deregisterWindow.create(id));
+    return of(forgetWindow.create(id));
   }
 }

--- a/packages/mythic-windowing/src/backends/electron/index.ts
+++ b/packages/mythic-windowing/src/backends/electron/index.ts
@@ -20,7 +20,7 @@ export const electronBackend: WindowingBackend<BrowserWindow> = {
       window.show();
     });
 
-    return of(registerWindow<BrowserWindow>().create({ id, window }));
+    return of(registerWindow.create({ id, window }));
   },
 
   closeWindow: (id: string, window?: BrowserWindow) => {

--- a/packages/mythic-windowing/src/index.ts
+++ b/packages/mythic-windowing/src/index.ts
@@ -1,3 +1,8 @@
+export { electronBackend } from "./backends/electron";
+
 export * from "./types";
-export { windowing } from "./package";
+
 export { showWindow, closeWindow } from "./myths/window-lifecycle";
+export { setWindowingBackend } from "./myths/window-registry";
+
+export { windowing } from "./package";

--- a/packages/mythic-windowing/src/index.ts
+++ b/packages/mythic-windowing/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export { windowing } from "./package";
+export { showWindow, closeWindow } from "./myths/window-lifecycle";

--- a/packages/mythic-windowing/src/myths/window-lifecycle.ts
+++ b/packages/mythic-windowing/src/myths/window-lifecycle.ts
@@ -1,0 +1,22 @@
+import { windowing } from "../package";
+import { WindowProps } from "../types";
+
+
+export const showWindow =
+  windowing.createMyth("showWindow")<WindowProps>({
+    thenDispatch: [
+      (action, state) =>
+        state.backend.showWindow(action.payload),
+    ],
+  });
+
+export const closeWindow =
+  windowing.createMyth("closeWindow")<string>({
+    thenDispatch: [
+      (action, state) =>
+        state.backend.closeWindow(
+          action.payload,
+          state.windows.get(action.payload),
+        ),
+    ],
+  });

--- a/packages/mythic-windowing/src/myths/window-lifecycle.ts
+++ b/packages/mythic-windowing/src/myths/window-lifecycle.ts
@@ -1,5 +1,5 @@
 import { windowing } from "../package";
-import { WindowProps } from "../types";
+import { WindowProps, WindowRef } from "../types";
 
 
 export const showWindow =
@@ -11,7 +11,7 @@ export const showWindow =
   });
 
 export const closeWindow =
-  windowing.createMyth("closeWindow")<string>({
+  windowing.createMyth("closeWindow")<WindowRef>({
     thenDispatch: [
       (action, state) =>
         state.backend.closeWindow(

--- a/packages/mythic-windowing/src/myths/window-registry.ts
+++ b/packages/mythic-windowing/src/myths/window-registry.ts
@@ -1,0 +1,14 @@
+import { windowing } from "../package";
+
+
+export const registerWindow = <T>() =>
+  windowing.createMyth("registerWindow")<{ id: string; window: T }>({
+    reduce: (state, action) =>
+      state.setIn(["windows", action.payload.id], action.payload.window),
+  });
+
+export const deregisterWindow =
+  windowing.createMyth("deregisterWindow")<string>({
+    reduce: (state, action) =>
+      state.deleteIn(["windows", action.payload]),
+  });

--- a/packages/mythic-windowing/src/myths/window-registry.ts
+++ b/packages/mythic-windowing/src/myths/window-registry.ts
@@ -1,8 +1,15 @@
 import { windowing } from "../package";
+import { Window, WindowingBackend } from "../types";
 
 
-export const registerWindow = <T>() =>
-  windowing.createMyth("registerWindow")<{ id: string; window: T }>({
+export const setWindowingBackend =
+  windowing.createMyth("setWindowingBackend")<WindowingBackend<Window>>({
+    reduce: (state, action) =>
+      state.set("backend", action.payload),
+  });
+
+export const registerWindow =
+  windowing.createMyth("registerWindow")<{ id: string; window: Window }>({
     reduce: (state, action) =>
       state.setIn(["windows", action.payload.id], action.payload.window),
   });

--- a/packages/mythic-windowing/src/myths/window-registry.ts
+++ b/packages/mythic-windowing/src/myths/window-registry.ts
@@ -1,5 +1,5 @@
 import { windowing } from "../package";
-import { Window, WindowingBackend } from "../types";
+import { Window, WindowingBackend, WindowRef } from "../types";
 
 
 export const setWindowingBackend =
@@ -8,14 +8,14 @@ export const setWindowingBackend =
       state.set("backend", action.payload),
   });
 
-export const registerWindow =
-  windowing.createMyth("registerWindow")<{ id: string; window: Window }>({
+export const rememberWindow =
+  windowing.createMyth("rememberWindow")<{ id: WindowRef; window: Window }>({
     reduce: (state, action) =>
       state.setIn(["windows", action.payload.id], action.payload.window),
   });
 
-export const deregisterWindow =
-  windowing.createMyth("deregisterWindow")<string>({
+export const forgetWindow =
+  windowing.createMyth("forgetWindow")<WindowRef>({
     reduce: (state, action) =>
       state.deleteIn(["windows", action.payload]),
   });

--- a/packages/mythic-windowing/src/package.ts
+++ b/packages/mythic-windowing/src/package.ts
@@ -1,0 +1,15 @@
+import { createMythicPackage } from "@nteract/myths";
+import { BrowserWindow } from "electron";
+import * as Immutable from "immutable";
+import { electronBackend } from "./backends/electron";
+import { WindowingState } from "./types";
+
+
+export const windowing = createMythicPackage("windowing")<
+  WindowingState<BrowserWindow>
+>({
+  initialState: {
+    backend: electronBackend,
+    windows: Immutable.Map<string, BrowserWindow>(),
+  },
+});

--- a/packages/mythic-windowing/src/package.ts
+++ b/packages/mythic-windowing/src/package.ts
@@ -1,15 +1,11 @@
 import { createMythicPackage } from "@nteract/myths";
-import { BrowserWindow } from "electron";
 import * as Immutable from "immutable";
-import { electronBackend } from "./backends/electron";
-import { WindowingState } from "./types";
+import { Window, Windowing, WindowingBackend } from "./types";
 
 
-export const windowing = createMythicPackage("windowing")<
-  WindowingState<BrowserWindow>
->({
+export const windowing: Windowing = createMythicPackage("windowing")({
   initialState: {
-    backend: electronBackend,
-    windows: Immutable.Map<string, BrowserWindow>(),
+    backend: null as unknown as WindowingBackend<Window>,
+    windows: Immutable.Map<string, Window>(),
   },
 });

--- a/packages/mythic-windowing/src/package.ts
+++ b/packages/mythic-windowing/src/package.ts
@@ -1,11 +1,11 @@
 import { createMythicPackage } from "@nteract/myths";
 import * as Immutable from "immutable";
-import { Window, Windowing, WindowingBackend } from "./types";
+import { Window, Windowing, WindowingBackend, WindowRef } from "./types";
 
 
 export const windowing: Windowing = createMythicPackage("windowing")({
   initialState: {
     backend: null as unknown as WindowingBackend<Window>,
-    windows: Immutable.Map<string, Window>(),
+    windows: Immutable.Map<WindowRef, Window>(),
   },
 });

--- a/packages/mythic-windowing/src/types.ts
+++ b/packages/mythic-windowing/src/types.ts
@@ -5,20 +5,21 @@ import { Observable } from "rxjs";
 
 
 export type Window = BrowserWindow;
+export type WindowRef = string;
 export type Windowing = MythicPackage<"windowing", WindowingState>;
 
 export interface WindowingState {
   backend: WindowingBackend<Window>;
-  windows: Immutable.Map<string, Window>;
+  windows: Immutable.Map<WindowRef, Window>;
 }
 
 export interface WindowingBackend<WINDOW> {
   showWindow: (props: WindowProps) => Observable<MythicAction>;
-  closeWindow: (id: string, window?: WINDOW) => Observable<MythicAction>;
+  closeWindow: (id: WindowRef, window?: WINDOW) => Observable<MythicAction>;
 }
 
 export interface WindowProps {
-  id: string;
+  id: WindowRef;
   kind?: "normal" | "splash";
   width: number;
   height: number;

--- a/packages/mythic-windowing/src/types.ts
+++ b/packages/mythic-windowing/src/types.ts
@@ -1,0 +1,22 @@
+import { MythicAction } from "@nteract/myths";
+import { BrowserWindow } from "electron";
+import * as Immutable from "immutable";
+import { Observable } from "rxjs";
+
+export interface WindowProps {
+  id: string;
+  kind?: "normal" | "splash";
+  width: number;
+  height: number;
+  path?: string;
+}
+
+export interface WindowingBackend<T> {
+  showWindow: (props: WindowProps) => Observable<MythicAction>;
+  closeWindow: (id: string, window?: T) => Observable<MythicAction>;
+}
+
+export interface WindowingState<T> {
+  backend: WindowingBackend<T>;
+  windows: Immutable.Map<string, T>;
+}

--- a/packages/mythic-windowing/src/types.ts
+++ b/packages/mythic-windowing/src/types.ts
@@ -1,7 +1,21 @@
-import { MythicAction } from "@nteract/myths";
+import { MythicAction, MythicPackage } from "@nteract/myths";
 import { BrowserWindow } from "electron";
 import * as Immutable from "immutable";
 import { Observable } from "rxjs";
+
+
+export type Window = BrowserWindow;
+export type Windowing = MythicPackage<"windowing", WindowingState>;
+
+export interface WindowingState {
+  backend: WindowingBackend<Window>;
+  windows: Immutable.Map<string, Window>;
+}
+
+export interface WindowingBackend<WINDOW> {
+  showWindow: (props: WindowProps) => Observable<MythicAction>;
+  closeWindow: (id: string, window?: WINDOW) => Observable<MythicAction>;
+}
 
 export interface WindowProps {
   id: string;
@@ -9,14 +23,4 @@ export interface WindowProps {
   width: number;
   height: number;
   path?: string;
-}
-
-export interface WindowingBackend<T> {
-  showWindow: (props: WindowProps) => Observable<MythicAction>;
-  closeWindow: (id: string, window?: T) => Observable<MythicAction>;
-}
-
-export interface WindowingState<T> {
-  backend: WindowingBackend<T>;
-  windows: Immutable.Map<string, T>;
 }

--- a/packages/mythic-windowing/tsconfig.json
+++ b/packages/mythic-windowing/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../myths" }
+  ]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "monaco-editor" },
     { "path": "mythic-configuration" },
     { "path": "mythic-notifications" },
+    { "path": "mythic-windowing" },
     { "path": "myths" },
     { "path": "notebook-app-component" },
     { "path": "presentational-components" },


### PR DESCRIPTION
Progress on #4799.

Plan is to move as much of the electron-related stuff out of desktop as possible, and make things based on actions/myths.

This PR introduces the general package infra for that and uses it to make the splash screen.