### PR TITLE
[WIP] Fix PDF export regressions

### DIFF
--- a/applications/desktop/.gitignore
+++ b/applications/desktop/.gitignore
@@ -1,2 +1,2 @@
 # the default file name when exporting unsaved notebook to pdf from the desktop app
-..pdf
+Untitled.pdf

--- a/applications/desktop/src/common/commands/by-menu/file.tsx
+++ b/applications/desktop/src/common/commands/by-menu/file.tsx
@@ -4,7 +4,6 @@ import { app, dialog, remote, shell } from "electron";
 import * as fs from "fs";
 import * as path from "path";
 import React from "react";
-import { promisify } from "util";
 import { launch, launchNewNotebook } from "../../../main/launch";
 import { dispatchCommandInRenderer } from "../dispatch";
 import { DesktopCommand, ElectronRoleCommand, ReqContent, ReqKernelSpec } from "../types";
@@ -168,10 +167,8 @@ export const ExportPDF: DesktopCommand<ReqContent> = {
     const basename = path.basename(notebookName, ".ipynb");
     const basepath = path.join(path.dirname(notebookName), basename);
     const pdfPath = `${basepath}.pdf`;
-    const model = selectors.notebookModel(state, props);
 
-    debugger;
-    let data : any
+    let data : any;
 
     data = await remote.getCurrentWindow().webContents.printToPDF({})
     await fs.writeFile(pdfPath, data, (error) =>  {
@@ -198,10 +195,6 @@ export const ExportPDF: DesktopCommand<ReqContent> = {
           },
         })
       );
-
     })
-
-
-
   },
 };

--- a/applications/desktop/src/common/commands/by-menu/file.tsx
+++ b/applications/desktop/src/common/commands/by-menu/file.tsx
@@ -170,22 +170,38 @@ export const ExportPDF: DesktopCommand<ReqContent> = {
     const pdfPath = `${basepath}.pdf`;
     const model = selectors.notebookModel(state, props);
 
-    let data: any;
-    data = await remote.getCurrentWindow().webContents.printToPDF({printBackground: true},);
+    debugger;
+    let data : any
 
-    await fs.writeFile(pdfPath, data, _erros_fs => {
-      /**RID:JK TODO: use more user-facing error message? What?*/
-      console.log('PDF export write failed');
+    data = await remote.getCurrentWindow().webContents.printToPDF({})
+    await fs.writeFile(pdfPath, data, (error) =>  {
+      if(error) {
+        console.log(`RID:JK:PDF writeFile FAILURE ${pdfPath}`)
+        store.dispatch(
+          sendNotification.create({
+            title: "PDF export error",
+            message: error.toString(),
+            level: "error",
+          })
+        );
+        return;
+      }
+      console.log(`RID:JK:PDF writeFile success ${pdfPath}`)
+      store.dispatch(
+        sendNotification.create({
+          title: "PDF exported",
+          message: <FilePathMessage filepath={pdfPath}/>,
+          level: "success",
+          action: {
+            label: "Open",
+            callback: () => shell.openItem(pdfPath),
+          },
+        })
+      );
 
-    });
-    yield sendNotification.create({
-      title: "PDF exported",
-      message: <FilePathMessage filepath={pdfPath}/>,
-      level: "success",
-      action: {
-        label: "Open",
-        callback: () => shell.openItem(pdfPath),
-      },
-    });
+    })
+
+
+
   },
 };


### PR DESCRIPTION
This PR is to fix a few issues with PDF exports in recent versions of nteract desktop:

- [x] fix PDFs not actually being exported when using the File > Export > PDF menuitem (#5277)
- [x] add user-facing notification for PDF export errors
- [x] ~fix~ remove cell expansion toggling logic when exporting pdf (#5119)
- [ ] expand cell outputs in cell `print` media rules instead
- [ ] fix PDF pagination. Currently all pdfs are single-page files with scroll bars rendered on the page (#5205)
- [ ] remove RID comments
- [ ] remove WIP tag

---


- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

