### PR TITLE
Improve resizing performance for Monaco Editor component by replacing extra layout calls with CSS

### DIFF
--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { completionProvider } from "./completions/completionItemProvider";
 import { ContentRef } from "@nteract/core";
 import { DocumentUri } from "./documentUri";
+import "./style.css";
 
 export type IModelContentChangedEvent = monaco.editor.IModelContentChangedEvent;
 
@@ -266,7 +267,8 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
    * Tells editor to check the surrounding container size and resize itself appropriately
    */
   resize() {
-    if (this.editor) {
+    // We call layout only for the focussed editor and resize other instances using CSS
+    if (this.editor && this.props.editorFocused) {
       this.editor.layout();
     }
   }

--- a/packages/monaco-editor/src/style.css
+++ b/packages/monaco-editor/src/style.css
@@ -1,0 +1,20 @@
+/*
+For the following components, we use the inherited width values from monaco-container.
+On resizing the browser, the width of monaco-container will be calculated
+and we just use the calculated width for the following components
+So we don't need to use Monaco editor's layout() function which is expensive operation and causes performance issues on resizing.
+*/
+
+.monaco-container .monaco-editor {
+  width: inherit !important;
+}
+  
+.monaco-container .monaco-editor .overflow-guard {
+  width: inherit !important;
+}
+  
+/* 26px is the left margin for .monaco-scrollable-element  */
+.monaco-container .monaco-editor .monaco-scrollable-element.editor-scrollable.vs {
+  width: calc(100% - 26px) !important;
+}
+  


### PR DESCRIPTION
<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

Closes issue #5298 
<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
