### PR TITLE
Add support for notarizing nteract desktop app on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ applications/jupyter-extension/pip-wheel-metadata/
 
 applications/desktop/**/*.d.ts
 /.python-version
+
+applications/desktop/.env

--- a/applications/desktop/build/entitlements.mac.plist
+++ b/applications/desktop/build/entitlements.mac.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+  </dict>
+</plist>

--- a/applications/desktop/build/notarize.js
+++ b/applications/desktop/build/notarize.js
@@ -1,0 +1,18 @@
+require('dotenv').config();
+const { notarize } = require('electron-notarize');
+
+exports.default = async function notarizing(context) {
+    const { electronPlatformName, appOutDir } = context;
+    if (electronPlatformName !== 'darwin') {
+        return;
+    }
+
+    const appName = context.packager.appInfo.productFilename;
+
+    return await notarize({
+        appBundleId: 'com.yourcompany.yourAppId',
+        appPath: `${appOutDir}/${appName}.app`,
+        appleId: process.env.APPLEID,
+        appleIdPassword: process.env.APPLEIDPASS,
+    });
+};

--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -73,7 +73,15 @@
       "target": [
         "dmg",
         "zip"
-      ]
+      ],
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist"
+    },
+    "afterSign": "build/notarize.js",
+    "dmg": {
+      "sign": false
     },
     "asar": true,
     "asarUnpack": [
@@ -94,14 +102,7 @@
       "maintainer": "nteract contributors <jupyter@googlegroups.com>",
       "synopsis": "The nteract desktop application allows you to quickly view, edit, and publish notebooks from your desktop. It  is a great tool for first-time and veteran notebook users, alike.",
       "target": [
-        {
-          "target": "deb",
-          "arch": [
-            "arm64",
-            "x64"
-          ]
-        },
-        "snap",
+        "deb",
         "AppImage",
         "tar.gz"
       ],
@@ -158,6 +159,7 @@
     "@types/lodash.sortby": "^4.7.6",
     "@types/lodash.throttle": "^4.1.6",
     "electron": "7.3.3",
+    "electron-notarize": "^1.0.0",
     "file-loader": "^6.0.0",
     "monaco-editor-webpack-plugin": "1.7.0",
     "utility-types": "^3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2662,19 +2662,10 @@
     "@nteract/presentational-components" "^3.3.11"
     react-markdown "^4.0.0"
 
-"@nteract/mathjax@4.0.11", "@nteract/mathjax@^4.0.11":
+"@nteract/mathjax@4.0.11", "@nteract/mathjax@^4.0.11", "@nteract/mathjax@^4.0.7":
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/@nteract/mathjax/-/mathjax-4.0.11.tgz#48c66fa0d26bd9caa54d231e2562bf690aeba785"
   integrity sha512-W+MIjPAA/CFaXJIubSod/ANK6iNpRR21mGFh0Z7Dde7fHLEM2gwCjqdzbxjvCMl82zRMGFPNuZ1bMyX4JArO2g==
-  dependencies:
-    load-script "^1.0.0"
-    react "^16.13.0"
-    react-dom "^16.13.0"
-
-"@nteract/mathjax@^4.0.7":
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@nteract/mathjax/-/mathjax-4.0.9.tgz#f7cdb758931f185d9f353b2d89960eec44322703"
-  integrity sha512-/RWipkAdg2LeC/0UBSFyo1l7xQR1pfPPC6teeVmEevj4Ukfi3S+RY1kdeDV5mRj7n68LVJEa7s0yx/nA6J6jsA==
   dependencies:
     load-script "^1.0.0"
     react "^16.13.0"
@@ -6737,6 +6728,11 @@ date-fns@^2.0.0, date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
   integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
 
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -7338,6 +7334,14 @@ electron-log@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.2.1.tgz#a5e9f5b7a9c8cffb6ae5af78b76e68012d5e68da"
   integrity sha512-tUI9w3kUP3qhwXJ92RDUPFVZfwtBwKCy/1TsSHndXYLlNCB/7+vkiQG0uxv9D2Leuxc/DJKfYyrdEBpzi/vyZg==
+
+electron-notarize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-1.0.0.tgz#bc925b1ccc3f79e58e029e8c4706572b01a9fd8f"
+  integrity sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
 
 electron-publish@22.7.0:
   version "22.7.0"
@@ -12380,9 +12384,9 @@ nice-try@^1.0.4:
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-abi@^2.7.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
-  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
+  integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
   dependencies:
     semver "^5.4.1"
 


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/4915.

This adds some scripts and configuration to support notarizing the nteract desktop app for macOS.

Note: in order for this to work, the person executing the release will need to have an `applications/desktop/.env` file with the following info.

```
APPLEID="foo@apple-account.com"
APPLEIDPASS="uniquepassword" 
```

This also removes the snap-based configurations for Linux. They were causing some strange issues with the build.