### PR TITLE
Map CodeMirror csharp language code to monaco language

### DIFF
--- a/packages/monaco-editor/src/converter.ts
+++ b/packages/monaco-editor/src/converter.ts
@@ -7,11 +7,12 @@ import * as monaco from "monaco-editor";
 export enum Mode {
   markdown = "markdown",
   raw = "plaintext",
-  python = "python"
+  python = "python",
+  csharp = "csharp"
 }
 
 /**
- * Maps Code Mirror mode to a valid Monaco Editor supported langauge
+ * Maps Code Mirror mode to a valid Monaco Editor supported language
  * defaults to plaintext if map not found.
  * @param mode Code Mirror mode
  * @returns Monaco language
@@ -35,7 +36,11 @@ export function mapCodeMirrorModeToMonaco(mode: any): string {
   // Need to handle "ipython" as a special case since it is not a registered language
   if (language === "ipython") {
     return Mode.python;
-  } else if (monaco.languages.getEncodedLanguageId(language) > 0) {
+  }
+  else if (language === "text/x-csharp") {
+    return Mode.csharp;
+  }
+  else if (monaco.languages.getEncodedLanguageId(language) > 0) {
     return language;
   }
   return Mode.raw;


### PR DESCRIPTION
When substituting the default CodeMirror editor in the cell input with the Monaco editor using the stateful components editor slot, syntax coloring for csharp kernels is not working.

The reason is that the monaco editor extracts the language from either [the running kernel info or the notebooks' metadata kernel info](https://github.com/nteract/nteract/blob/990fa64f9526b3bd022b777d4e44d7411ce15758/packages/stateful-components/src/inputs/connected-editors/monacoEditor.tsx#L55).
For CSharp kernels, the info in both cases is `"text/x-csharp"` which not recognized by monaco and therefore the converting method falls back to `Mode.raw` (`"plaintext"`): no syntax coloring.

Note 1:
There probably are other language name mismatches between codemirror and monaco, but I'm not able to test them.

Note 2:
There may be other ways to fix this by looking at the `language_info.name` field of the notebook metadata or the running kernel/session `name` field which seem to match the monaco language better. I don't know enough about how these fields are populated, so I assume the author of the code mentioned above chose to look at the codemirror code as the most reliable way to determine language. So adding a new case seemed to be the least risky way to fix.