### PR TITLE
Add support for image drag-and-drop or paste

### DIFF
--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -159,6 +159,7 @@
     "@types/lodash.sample": "^4.2.6",
     "@types/lodash.sortby": "^4.7.6",
     "@types/lodash.throttle": "^4.1.6",
+    "@types/plist": "^3.0.2",
     "electron": "7.3.3",
     "electron-notarize": "^1.0.0",
     "file-loader": "^6.0.0",

--- a/applications/desktop/package.json
+++ b/applications/desktop/package.json
@@ -151,6 +151,7 @@
     "lodash.throttle": "^4.1.1",
     "mathjax-electron": "^3.0.0",
     "nteract-assets": "^4.0.0",
+    "plist": "^3.0.1",
     "rxjs": "^6.6.0"
   },
   "devDependencies": {

--- a/applications/desktop/src/notebook/insert-images.ts
+++ b/applications/desktop/src/notebook/insert-images.ts
@@ -1,0 +1,209 @@
+import { actions } from "@nteract/core";
+import { selectors } from "@nteract/core";
+import { ContentRef } from "@nteract/core";
+import { sendNotification } from "@nteract/mythic-notifications";
+import { DesktopStore } from "./store";
+import * as path from "path";
+import * as fs from 'fs';
+import { emptyMarkdownCell, emptyCodeCell, createImmutableOutput } from "@nteract/commutable";
+import * as Immutable from "immutable";
+
+interface InsertImagesParameters {
+  imagePaths?: Array<string>;
+  base64ImageSource?: string;
+  embedImagesInNotebook?: boolean;
+  linkImagesAndKeepAtOriginalPath?: boolean;
+  copyImagesToNotebookDirectory?: boolean;
+  contentRef: ContentRef;
+  store: DesktopStore;
+};
+
+export function insertImages({
+  imagePaths = [],
+  base64ImageSource,
+  embedImagesInNotebook,
+  linkImagesAndKeepAtOriginalPath,
+  copyImagesToNotebookDirectory,
+  contentRef,
+  store
+}: InsertImagesParameters)
+{
+  if (embedImagesInNotebook) {
+    if (base64ImageSource) {
+      createMarkdownCellWithImages({imageSources: [base64ImageSource], store, contentRef});
+    } else {
+      for (let imagePath of imagePaths) {
+        let fileExtension = path.extname(imagePath).slice(1);
+        let base64Image = fs.readFileSync(imagePath).toString('base64');
+        createCodeCellWithImageOutput({
+          base64Image,
+          imageType: `image/${fileExtension}`,
+          imagePath,
+          store,
+          contentRef
+        });
+      }
+    }
+  }
+
+  const notebookPath = selectors.filepath(store.getState(), {contentRef: contentRef});
+  const notebookDirectory = (notebookPath) ? path.dirname(notebookPath) : null;
+
+  if (copyImagesToNotebookDirectory || linkImagesAndKeepAtOriginalPath) {
+    if (notebookDirectory) {
+      if (copyImagesToNotebookDirectory) {
+        imagePaths = copyImagesToDirectoryAndReturnNewPaths({
+          imagePaths,
+          destinationDirectory: notebookDirectory,
+          store,
+          contentRef
+        })
+      }
+
+      imagePaths = makePathsRelativeWithinDirectory({
+        imagePaths,
+        directory: notebookDirectory
+      });
+    }
+
+    createMarkdownCellWithImages({
+      imageSources: imagePaths,
+      store,
+      contentRef
+    });
+  }
+};
+
+interface CreateMarkdownCellWithImagesParameters {
+  imageSources: Array<string>;
+  store: DesktopStore;
+  contentRef: ContentRef;
+}
+
+function createMarkdownCellWithImages({
+  imageSources,
+  store,
+  contentRef
+}: CreateMarkdownCellWithImagesParameters)
+{
+  let newCell = emptyMarkdownCell.set("source",
+    imageSources.map((src) => `<img src=\"${src}\" />`).join("\n")
+  );
+
+  store.dispatch(
+    actions.createCellAbove({
+      cellType: "markdown",
+      contentRef,
+      cell: newCell
+    })
+  );
+}
+
+interface CreateCodeCellWithImageOutputParameters {
+  base64Image: string;
+  imageType: string;
+  imagePath: string;
+  store: DesktopStore;
+  contentRef: ContentRef;
+}
+
+function createCodeCellWithImageOutput({
+  base64Image,
+  imageType,
+  imagePath,
+  store,
+  contentRef
+}: CreateCodeCellWithImageOutputParameters) {
+
+  let newCell = emptyCodeCell
+    .set("outputs", Immutable.List([
+      createImmutableOutput({
+        "output_type": "display_data",
+        "data": {
+          [imageType]: [
+            base64Image + "\n"
+          ]
+        },
+        "metadata": {}
+      })
+    ]))
+    .set("metadata", Immutable.fromJS({
+      "collapsed": false,
+      "jupyter": {
+        "source_hidden": true,
+        "output_hidden": false
+      }
+    }))
+  ;
+
+  store.dispatch(
+    actions.createCellAbove({
+      cellType: "code",
+      contentRef,
+      cell: newCell
+    })
+  );
+}
+
+interface CopyImagesToDirectoryAndReturnNewPathsParameters {
+  imagePaths: Array<string>;
+  destinationDirectory: string;
+  store: DesktopStore;
+  contentRef: ContentRef;
+}
+
+function copyImagesToDirectoryAndReturnNewPaths({
+  imagePaths,
+  destinationDirectory,
+  store,
+  contentRef
+}: CopyImagesToDirectoryAndReturnNewPathsParameters)
+{
+  let destinationImagePaths = []
+  for (let sourceImagePath of imagePaths) {
+    let imageBaseName = path.basename(sourceImagePath);
+    let destinationImagePath = `${destinationDirectory}/${imageBaseName}`;
+    destinationImagePaths.push(destinationImagePath);
+    let performCopy = () => { fs.copyFile(sourceImagePath, destinationImagePath, () => {}) };
+    if (! fs.existsSync(destinationImagePath)) {
+      performCopy()
+    } else {
+      store.dispatch(
+        sendNotification.create({
+          key: `insert-images-file-${imageBaseName}-already-exists`,
+          title: "File already exists",
+          message: `The image ${destinationImagePath} already exists.`,
+          level: "warning",
+          action: {
+            label: "Replace",
+            callback: () => performCopy()
+          }
+        })
+      );
+    }
+  }
+  return destinationImagePaths;
+}
+
+interface MakePathsRelativeWithinDirectoryParameters {
+  imagePaths: Array<string>;
+  directory: string;
+}
+
+// For all image paths within the given directory, use relative paths,
+// for image paths outside the directory, use absolute paths.
+//
+function makePathsRelativeWithinDirectory({
+  imagePaths,
+  directory
+}: MakePathsRelativeWithinDirectoryParameters)
+{
+  return imagePaths.map(imagePath => {
+    let relativePath = path.relative(directory, imagePath);
+    if (relativePath.startsWith("../")) {
+      return imagePath;
+    } else {
+      return relativePath;
+    }
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,6 +2517,17 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@nteract/actions@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@nteract/actions/-/actions-5.0.1.tgz#5744926e503d70e0e493bb28a3cc9144f2337a77"
+  integrity sha512-gXKuANoGmB2oFRGpPbHUW0J9j81nsl8iENauVm+Cmljgeq8QKN9b68N5M2gOW6OdvzcUNn823xB0EiM3wWBu8w==
+  dependencies:
+    "@nteract/commutable" "^7.2.11"
+    "@nteract/messaging" "^7.0.6"
+    "@nteract/types" "^6.0.6"
+    immutable "^4.0.0-rc.12"
+    rx-jupyter "^5.5.8"
+
 "@nteract/actions@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@nteract/actions/-/actions-6.0.0.tgz#89f7dbe5a398350264df9add664a4bb4f2da737b"
@@ -2532,6 +2543,19 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@nteract/any-vega/-/any-vega-1.0.1.tgz#d790774bdc453bc5af663455747637a2100f634a"
   integrity sha512-RjECjm2bdQpEHuhpWyIjAg8dA8t5iWGDmx2VuStBhVSffciNrCn0WxhJiK5TSkyuBgk4rB4eAOspJ8UnfjOAyA==
+
+"@nteract/core@^13.0.0":
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/@nteract/core/-/core-13.1.1.tgz#08304dad6707e9945f51666d79f5480134c717bb"
+  integrity sha512-zAgVgkxJsNEKPojyj9mf6nWacP07FEItSc3Vb0REnRcasQxFtDhnAbh5y7OcER2NtrCbQqHWxVPaUIOqXGTSpA==
+  dependencies:
+    "@nteract/actions" "^5.0.1"
+    "@nteract/commutable" "^7.2.11"
+    "@nteract/epics" "^4.0.8"
+    "@nteract/reducers" "^3.2.1"
+    "@nteract/selectors" "^2.8.9"
+    "@nteract/types" "^6.0.6"
+    redux-logger "^3.0.6"
 
 "@nteract/core@^14.0.0":
   version "14.0.0"
@@ -2579,7 +2603,7 @@
   dependencies:
     react-hot-loader "^4.1.2"
 
-"@nteract/epics@^4.0.9":
+"@nteract/epics@^4.0.8", "@nteract/epics@^4.0.9":
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/@nteract/epics/-/epics-4.0.9.tgz#d5c30e2f08fcdf9f524b096def987f175c3a8393"
   integrity sha512-Sd0t4SHSzDWPAUM+h/UWEmgMfx8Snvkv7+f/Og1q0qRXeEH6gPJxZLUQ8l0q612wB4XmAMG7M3xk26N41SSt4A==
@@ -2680,6 +2704,21 @@
     ansi-to-react "^6.0.5"
     react-json-tree "^0.11.0"
 
+"@nteract/reducers@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@nteract/reducers/-/reducers-3.2.1.tgz#456e3b555ab3b2549950d0139aaa3b250c661266"
+  integrity sha512-bKA1Qy1jnbEJOhXZTIrbNc6BkHFnxbWE4ieJr5Vp4fNBs8oGGBV5xUCqBezdRKXLQsghGmsOl2sfVn4vydF0CQ==
+  dependencies:
+    "@nteract/actions" "^5.0.1"
+    "@nteract/commutable" "^7.2.11"
+    "@nteract/types" "^6.0.6"
+    escape-carriage "^1.3.0"
+    immutable "^4.0.0-rc.12"
+    lodash.has "^4.5.2"
+    redux "^4.0.1"
+    redux-immutable "^4.0.0"
+    uuid "^7.0.0"
+
 "@nteract/reducers@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@nteract/reducers/-/reducers-4.0.0.tgz#25e50cee37556e690680f4b06b4b2835a607a49a"
@@ -2695,7 +2734,7 @@
     redux-immutable "^4.0.0"
     uuid "^8.0.0"
 
-"@nteract/selectors@^2.8.10":
+"@nteract/selectors@^2.8.10", "@nteract/selectors@^2.8.9":
   version "2.8.10"
   resolved "https://registry.yarnpkg.com/@nteract/selectors/-/selectors-2.8.10.tgz#ef5afd1460ddb748e9c09cf623b1185f8ae43a9f"
   integrity sha512-CJUmuYL76ThY7E57/XCfb9i3le8JQ2cKCqBqvULFPkCx9qcmKqWjMp47EJxUvRdRYyVBkqhpnTF0FgGi7LPPGg==
@@ -2743,7 +2782,7 @@
     "@nteract/any-vega" "^1.0.1"
     "@nteract/presentational-components" "^3.3.7"
 
-"@nteract/types@^6.0.7":
+"@nteract/types@^6.0.6", "@nteract/types@^6.0.7":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@nteract/types/-/types-6.0.7.tgz#5a9b458c376cb81feca875b684696c32a9769642"
   integrity sha512-sv4X97iXVHXVoPBl2m/xxO396GwujUSfm+7Cx6W5ziGUxSBjs4ydGTn2Uy6zv1MRa7Gwv9uJ/Sl8hgm7vY80Tw==
@@ -3419,6 +3458,14 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/pidusage/-/pidusage-2.0.1.tgz#45eb309be947dcfa177957ef662ce2a0a2311d48"
   integrity sha512-tYYcz/+5v/EGYT83C0pIXrJGOiVBLksQvxgJboG4nGqx/gZTvq0Ro4SkAjECqMk7L4Ww58VWB4j48qeYh4/YJg==
+
+"@types/plist@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/plist/-/plist-3.0.2.tgz#61b3727bba0f5c462fe333542534a0c3e19ccb01"
+  integrity sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==
+  dependencies:
+    "@types/node" "*"
+    xmlbuilder ">=11.0.1"
 
 "@types/prettier@^2.0.0":
   version "2.0.1"
@@ -7602,6 +7649,24 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.4, es-abstrac
     string.prototype.trimleft "^2.1.1"
     string.prototype.trimright "^2.1.1"
 
+es-abstract@^1.18.0-next.0, es-abstract@^1.18.0-next.1:
+  version "1.18.0-next.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
+  integrity sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -9885,6 +9950,11 @@ is-callable@^1.1.4, is-callable@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
+is-callable@^1.2.0, is-callable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
+  integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -10037,6 +10107,11 @@ is-interactive@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-npm@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
@@ -10124,6 +10199,13 @@ is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.0.tgz#ece38e389e490df0dc21caea2bd596f987f767ff"
   integrity sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
+  dependencies:
+    has-symbols "^1.0.1"
+
+is-regex@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
+  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
 
@@ -12364,17 +12446,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-<<<<<<< HEAD
-node-abi@^2.7.0:
+node-abi@2.19.1, node-abi@^2.7.0:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
   integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
-=======
-node-abi@2.18.0, node-abi@^2.7.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
-  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
->>>>>>> Add back plist dependency
   dependencies:
     semver "^5.4.1"
 
@@ -12679,7 +12754,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
@@ -12718,6 +12793,16 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.entries@^1.1.1, object.entries@^1.1.2:
   version "1.1.2"
@@ -16362,6 +16447,14 @@ string.prototype.trimend@^1.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
+string.prototype.trimend@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz#6ddd9a8796bc714b489a3ae22246a208f37bfa46"
+  integrity sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+
 string.prototype.trimleft@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
@@ -16387,6 +16480,14 @@ string.prototype.trimstart@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
+
+string.prototype.trimstart@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz#22d45da81015309cd0cdd79787e8919fc5c613e7"
+  integrity sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -18420,6 +18521,11 @@ xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
+xmlbuilder@>=11.0.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
 xmlbuilder@^9.0.7:
   version "9.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4710,7 +4710,7 @@ base64-inline-loader@^1.1.1:
     loader-utils "^1.1.0"
     mime-types "^2.1.18"
 
-base64-js@^1.0.2, base64-js@^1.2.1:
+base64-js@^1.0.2, base64-js@^1.2.1, base64-js@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -12364,10 +12364,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+<<<<<<< HEAD
 node-abi@^2.7.0:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.19.1.tgz#6aa32561d0a5e2fdb6810d8c25641b657a8cea85"
   integrity sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
+=======
+node-abi@2.18.0, node-abi@^2.7.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.18.0.tgz#1f5486cfd7d38bd4f5392fa44a4ad4d9a0dffbf4"
+  integrity sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
+>>>>>>> Add back plist dependency
   dependencies:
     semver "^5.4.1"
 
@@ -13368,6 +13375,15 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+plist@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
+  integrity sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^9.0.7"
+    xmldom "0.1.x"
 
 plotly.js-dist@^1.51.3:
   version "1.54.1"
@@ -18405,10 +18421,20 @@ xml@^1.0.1:
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
+xmlbuilder@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
 xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldom@0.1.x:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
+  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,13 +222,13 @@
     regexpu-core "^4.7.0"
 
 "@babel/helper-create-regexp-features-plugin@^7.8.3":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz#fdd60d88524659a0b6959c0579925e425714f3b8"
-  integrity sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.0.tgz#858cef57039f3b3a9012273597288a71e1dff8ca"
+  integrity sha512-YBqH+3wLcom+tko8/JLgRcG8DMqORgmjqNRNI751gTioJSZHWFybO1mRoLtJtWIlYSHY+zT9LqqnbbK1c3KIVQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-regex" "^7.10.4"
-    regexpu-core "^4.7.0"
+    regexpu-core "^4.7.1"
 
 "@babel/helper-define-map@^7.10.1":
   version "7.10.1"
@@ -4608,10 +4608,10 @@ babel-plugin-istanbul@^6.0.0:
     istanbul-lib-instrument "^4.0.0"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^26.2.0:
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz#bdd0011df0d3d513e5e95f76bd53b51147aca2dd"
-  integrity sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==
+babel-plugin-jest-hoist@^26.5.0:
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz#3916b3a28129c29528de91e5784a44680db46385"
+  integrity sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -4646,10 +4646,10 @@ babel-plugin-transform-react-remove-prop-types@0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
-babel-preset-current-node-syntax@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz#b4b547acddbf963cba555ba9f9cbbb70bfd044da"
-  integrity sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==
+babel-preset-current-node-syntax@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz#826f1f8e7245ad534714ba001f84f7e906c3b615"
+  integrity sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==
   dependencies:
     "@babel/plugin-syntax-async-generators" "^7.8.4"
     "@babel/plugin-syntax-bigint" "^7.8.3"
@@ -4664,12 +4664,12 @@ babel-preset-current-node-syntax@^0.1.2:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
 babel-preset-jest@^26.0.0:
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.2.0.tgz#f198201a4e543a43eb40bc481e19736e095fd3e0"
-  integrity sha512-R1k8kdP3R9phYQugXeNnK/nvCGlBzG4m3EoIIukC80GXb6wCv2XiwPhK6K9MAkQcMszWBYvl2Wm+yigyXFQqXg==
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz#f1b166045cd21437d1188d29f7fba470d5bdb0e7"
+  integrity sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==
   dependencies:
-    babel-plugin-jest-hoist "^26.2.0"
-    babel-preset-current-node-syntax "^0.1.2"
+    babel-plugin-jest-hoist "^26.5.0"
+    babel-preset-current-node-syntax "^0.1.3"
 
 babel-runtime@^6.6.1:
   version "6.26.0"
@@ -9880,7 +9880,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
-is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.0:
+is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
@@ -14939,6 +14939,18 @@ regexpu-core@^4.5.4, regexpu-core@^4.6.0, regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+regexpu-core@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.1.tgz#2dea5a9a07233298fbf0db91fa9abc4c6e0f8ad6"
+  integrity sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.2.0"
+    regjsgen "^0.5.1"
+    regjsparser "^0.6.4"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.2.0"
+
 registry-auth-token@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.0.tgz#1d37dffda72bbecd0f581e4715540213a65eb7da"
@@ -16326,7 +16338,7 @@ string.prototype.trim@^1.2.1:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
 
-string.prototype.trimend@^1.0.0, string.prototype.trimend@^1.0.1:
+string.prototype.trimend@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
@@ -16352,7 +16364,7 @@ string.prototype.trimright@^2.1.1:
     es-abstract "^1.17.5"
     string.prototype.trimend "^1.0.0"
 
-string.prototype.trimstart@^1.0.0, string.prototype.trimstart@^1.0.1:
+string.prototype.trimstart@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
   integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==


### PR DESCRIPTION
* Adding basic event handler for dropping images into the notebook.

The images are displayed using a new markdown cell.

https://github.com/nteract/nteract/issues/5081

* Dropping images: When holding the alt key, copy the images to the notebook directory.

https://github.com/nteract/nteract/issues/5081

* Dropping images: Use relative paths in the markdown cells for images that are within the notebook directory.

https://github.com/nteract/nteract/issues/5081

* Dropping images: Extract implementation to separate file

https://github.com/nteract/nteract/issues/5081

* Dropping images: Holding down the ctrl key also copies the images

to the notebook path.

As far as I know, holding down the alt/options key is the default "copy" modifier key for drag-and-drop operations in macOS. Holding down the ctrl key is the default "copy" modified key for drag-and-drop operations in linux and windows. I did not find a more abstract way to implement this, e.g. with Electron's accelerators.

https://github.com/nteract/nteract/issues/5081

* Dropping images: Make the hotkey-operating-system switch more explicit

by using "option" on macOS, "ctrl" otherwiese.

https://github.com/fiedl/nteract/commit/5842de36c766c1361d16683d085bb693f337d087

https://github.com/nteract/nteract/issues/5081

* Add feature to insert pasted image files as images in new markdown cells

This early version only works on macOS and requires the `plist` npm package.
https://github.com/nteract/nteract/issues/4963#issuecomment-627561034

The files are not embedded in the ipynb file, but the markdown images just refer to their original file paths. If the image paths are within the notebook directory, relative paths are used to refer to the image files.

https://github.com/nteract/nteract/issues/4963
https://github.com/nteract/nteract/issues/5081

* Dropping images: Adding notification when trying to overwrite existing files.

https://github.com/nteract/nteract/issues/5081

* Dropping images: use native `effectAllowed` to determine whether to copy, link, or embed inserted images

https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#drageffects

https://github.com/nteract/nteract/issues/5081

* Dropping images: support embedding images in notebooks as base64 string

as suggested by https://github.com/nteract/nteract/issues/4963#issuecomment-628275602

https://github.com/nteract/nteract/issues/5081

* Pasting images: Paste image blob from the clipboard and embed it as base64 source in the notebook

as suggested by https://github.com/nteract/nteract/issues/4963#issuecomment-628275602.

https://github.com/nteract/nteract/issues/5081

* Dropping images: fixing issues suggested by `yarn build:all:ci`

https://circleci.com/gh/nteract/nteract/7627?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

https://github.com/nteract/nteract/issues/5081

* Dropping images: Adopt new interface of `createCellBelow`

from https://github.com/nteract/nteract/pull/5102.

See also:
- https://github.com/nteract/nteract/pull/5113#issuecomment-633040612
- https://github.com/nteract/nteract/issues/5081#issuecomment-627090928

* Dropping images: Create cell above rather than below current cell

This now works due to https://github.com/nteract/nteract/pull/5102.

See also:
- https://github.com/nteract/nteract/issues/5081#issuecomment-626919405
- https://github.com/nteract/nteract/issues/5081#issuecomment-627090928

* Dropping images: Embed base64 images as `display_data` output

rather than strings in a markdown cell.

https://github.com/nteract/nteract/pull/5113#issuecomment-632085169

https://github.com/nteract/nteract/pull/5113#issuecomment-632721377

https://github.com/nteract/nteract/issues/4963#issuecomment-628275602

* Dropping images: fixing typescript issues suggested by `yarn build:all:ci`

See also: https://github.com/nteract/nteract/pull/5113#issuecomment-629888271

* Dropping images: remove unused imports and images

as suggested by lgtm:
- https://github.com/nteract/nteract/pull/5113#issuecomment-636334076
- https://lgtm.com/projects/g/nteract/nteract/rev/pr-c3c56d12d5830c333a4b84508d6595a2b6b86f43

* Dropping images: removing deprecated flag `outputExpanded`

as suggested by review https://github.com/nteract/nteract/pull/5113#discussion_r435628297

* Dropping images: moving `event.preventDefault()` to the top

as suggested by review https://github.com/nteract/nteract/pull/5113#discussion_r435614990

* Dropping images: using shorthand for named function arguments

if they argument key is the same as the local variable name.

Suggested by review https://github.com/nteract/nteract/pull/5113#discussion_r435614436.

* Dropping images: fixing named-parameter issue

introduced by
https://github.com/nteract/nteract/pull/5113/commits/8def04b46002284db4ed9640996a5e07109760bf

discovered by
https://github.com/nteract/nteract/pull/5113#issuecomment-639495467
