### PR TITLE
Fix: Set kernel execution state after launch

### DIFF
--- a/applications/desktop/src/notebook/epics/zeromq-kernels.ts
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.ts
@@ -30,7 +30,7 @@ import {
 } from "rxjs/operators";
 import { launchSpec } from "spawnteract";
 
-import { KernelspecInfo, Kernelspecs } from "@nteract/types";
+import { KernelspecInfo, Kernelspecs, KernelStatus } from "@nteract/types";
 
 import {
   Channels,
@@ -134,7 +134,7 @@ export function launchKernelObservable(
             cwd,
             kernelSpecName: kernelSpec.name,
             lastActivity: null,
-            status: "launched"
+            status: KernelStatus.Launched
           };
 
           observer.next(
@@ -146,7 +146,7 @@ export function launchKernelObservable(
             })
           );
           observer.next(
-            actions.setExecutionState({ kernelStatus: "launched", kernelRef })
+            actions.setExecutionState({ kernelStatus: KernelStatus.Launched, kernelRef })
           );
           observer.complete();
         }
@@ -429,7 +429,7 @@ export const killKernelEpic = (
             // Inform about the state
             of(
               actions.setExecutionState({
-                kernelStatus: "shutting down",
+                kernelStatus: KernelStatus.ShuttingDown,
                 kernelRef
               })
             )

--- a/applications/desktop/src/notebook/native-window.ts
+++ b/applications/desktop/src/notebook/native-window.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { Store } from "redux";
 import { combineLatest, EMPTY, Observable, of } from "rxjs";
 import { debounceTime, distinctUntilChanged, map, mergeMap, switchMap } from "rxjs/operators";
+import { KernelStatus } from "@nteract/types";
 
 const HOME = remote.app.getPath("home");
 
@@ -99,7 +100,7 @@ export function createTitleFeed(
     (state: AppState, kernelRef: KernelRef) => {
       const kernel = selectors.kernel(state, { kernelRef });
       if (!kernel) {
-        return "not connected";
+        return KernelStatus.NotConnected;
       } else {
         return kernel.status;
       }

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -110,7 +110,7 @@ Provide a bulleted list of new features or improvements and a reference to the P
 
 #### Bug Fixes
 
-Provide a bulleted list of bug fixes and a reference to the PR(s) containing the changes.
+- Update kernel execution state after receiving a `kernel_request_reply` message ([PR#5331](https://github.com/nteract/nteract/pull/5331))
 
 ### @nteract/fixtures ([publish-version-here])
 

--- a/packages/actions/__tests__/actions-spec.ts
+++ b/packages/actions/__tests__/actions-spec.ts
@@ -1,4 +1,4 @@
-import { createContentRef, createKernelRef } from "@nteract/types";
+import { createContentRef, createKernelRef, KernelStatus } from "@nteract/types";
 import * as actionTypes from "../src";
 
 const actions = actionTypes;
@@ -183,10 +183,10 @@ describe("setExecutionState", () => {
   test("creates a SET_EXECUTION_STATE action", () => {
     const kernelRef = createKernelRef();
     expect(
-      actions.setExecutionState({ kernelStatus: "idle", kernelRef })
+      actions.setExecutionState({ kernelStatus: KernelStatus.Idle, kernelRef })
     ).toEqual({
       type: actionTypes.SET_EXECUTION_STATE,
-      payload: { kernelStatus: "idle", kernelRef }
+      payload: { kernelStatus: KernelStatus.Idle, kernelRef }
     });
   });
 });

--- a/packages/epics/__tests__/kernel-lifecycle.spec.ts
+++ b/packages/epics/__tests__/kernel-lifecycle.spec.ts
@@ -195,6 +195,13 @@ describe("acquireKernelInfo", () => {
       },
       {
         payload: {
+          kernelRef: "fakeKernelRef",
+          kernelStatus: "launched"
+        },
+        type: "SET_EXECUTION_STATE"
+      },
+      {
+        payload: {
           contentRef: "fakeContentRef",
           kernelInfo: stateModule.makeKernelspec()
         },
@@ -371,6 +378,13 @@ describe("acquireKernelInfo", () => {
           },
           kernelRef: "fakeKernelRef"
         }
+      },
+      {
+        payload: {
+          kernelRef: "fakeKernelRef",
+          kernelStatus: "launched"
+        },
+        type: "SET_EXECUTION_STATE"
       }
     ]);
 
@@ -407,7 +421,7 @@ describe("watchExecutionStateEpic", () => {
       () => done()
     );
   });
-  
+
   test("on kernel error returns executeFailed action", done => {
     const sent = new Subject();
     const received = new Subject();
@@ -437,11 +451,11 @@ describe("watchExecutionStateEpic", () => {
             type: actionsModule.EXECUTE_FAILED,
             error: true,
             payload: {
-              code:"EXEC_WEBSOCKET_ERROR",
+              code: "EXEC_WEBSOCKET_ERROR",
               contentRef: "fakeContentRef",
               error: new Error(
                 "The WebSocket connection has unexpectedly disconnected."
-                )
+              )
             }
           }
         ]);

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -67,13 +67,13 @@ export const watchExecutionStateEpic = (
           catchError((error: Error) => {
             return of(
               actions.executeFailed({
-                  error: new Error(
+                error: new Error(
                   "The WebSocket connection has unexpectedly disconnected."
-                  ),
-                  code: errors.EXEC_WEBSOCKET_ERROR,
-                  contentRef: (action as actions.NewKernelAction).payload.contentRef  
+                ),
+                code: errors.EXEC_WEBSOCKET_ERROR,
+                contentRef: (action as actions.NewKernelAction).payload.contentRef
               })
-          );
+            );
           })
         )
     )
@@ -139,7 +139,8 @@ export function acquireKernelInfo(
           actions.setKernelInfo({
             kernelRef,
             info
-          })
+          }),
+          actions.setExecutionState({ kernelStatus: "launched", kernelRef })
         ];
 
         if (kernelSpecName) {

--- a/packages/epics/src/kernel-lifecycle.ts
+++ b/packages/epics/src/kernel-lifecycle.ts
@@ -25,7 +25,7 @@ import {
 
 import * as actions from "@nteract/actions";
 import * as selectors from "@nteract/selectors";
-import { AppState, ContentRef, KernelInfo, KernelRef } from "@nteract/types";
+import { AppState, ContentRef, KernelInfo, KernelRef, KernelStatus } from "@nteract/types";
 import { createKernelRef, errors } from "@nteract/types";
 
 const path = require("path");
@@ -140,7 +140,7 @@ export function acquireKernelInfo(
             kernelRef,
             info
           }),
-          actions.setExecutionState({ kernelStatus: "launched", kernelRef })
+          actions.setExecutionState({ kernelStatus: KernelStatus.Launched, kernelRef })
         ];
 
         if (kernelSpecName) {

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -2,7 +2,7 @@
 
 import { appendCellToNotebook, emptyCodeCell, emptyMarkdownCell, emptyNotebook, ImmutableNotebook, JSONObject, monocellNotebook } from "@nteract/commutable";
 import { core } from "@nteract/reducers";
-import { AppState, createContentRef, createKernelRef, makeAppRecord, makeCommsRecord, makeContentsRecord, makeDocumentRecord, makeEntitiesRecord, makeKernelsRecord, makeNotebookContentRecord, makeRemoteKernelRecord, makeStateRecord } from "@nteract/types";
+import { AppState, createContentRef, createKernelRef, KernelStatus, makeAppRecord, makeCommsRecord, makeContentsRecord, makeDocumentRecord, makeEntitiesRecord, makeKernelsRecord, makeNotebookContentRecord, makeRemoteKernelRecord, makeStateRecord } from "@nteract/types";
 import * as Immutable from "immutable";
 import { combineReducers, createStore, Store } from "redux";
 import { Subject } from "rxjs";
@@ -107,7 +107,7 @@ export const mockAppState = (config: JSONObject): AppState => {
             [kernelRef]: makeRemoteKernelRecord({
               sessionId: "aSessionId",
               channels,
-              status: "not connected"
+              status: KernelStatus.NotConnected
             })
           })
         })

--- a/packages/messaging/__tests__/messaging-spec.ts
+++ b/packages/messaging/__tests__/messaging-spec.ts
@@ -24,6 +24,9 @@ import {
   message,
   status
 } from "../src/messages";
+import {
+  KernelStatus
+} from "@nteract/types";
 
 describe("createMessage", () => {
   it("makes a msg", () => {
@@ -264,10 +267,10 @@ describe("convertOutputMessageToNotebookFormat", () => {
 describe("outputs", () => {
   it("extracts outputs as nbformattable contents", () => {
     const hacking = of(
-      status("busy"),
+      status(KernelStatus.Busy),
       displayData({ data: { "text/plain": "woo" } }),
       displayData({ data: { "text/plain": "hoo" } }),
-      status("idle")
+      status(KernelStatus.Idle)
     );
 
     return hacking
@@ -295,8 +298,8 @@ describe("outputs", () => {
 describe("payloads", () => {
   it("extracts payloads from execute_reply messages", () => {
     return of(
-      status("idle"),
-      status("busy"),
+      status(KernelStatus.Idle),
+      status(KernelStatus.Busy),
       executeReply({ payload: [{ c: "d" }] }),
       executeReply({ payload: [{ a: "b" }, { g: "6" }] }),
       executeReply({ status: "ok" }),
@@ -317,9 +320,9 @@ describe("payloads", () => {
 describe("executionCounts", () => {
   it("extracts all execution counts from a session", () => {
     return of(
-      status("starting"),
-      status("idle"),
-      status("busy"),
+      status(KernelStatus.Starting),
+      status(KernelStatus.Idle),
+      status(KernelStatus.Busy),
       executeInput({
         code: "display('woo')\ndisplay('hoo')",
         execution_count: 0
@@ -330,7 +333,7 @@ describe("executionCounts", () => {
         code: "",
         execution_count: 1
       }),
-      status("idle")
+      status(KernelStatus.Idle)
     )
       .pipe(executionCounts(), toArray())
       .toPromise()
@@ -340,20 +343,20 @@ describe("executionCounts", () => {
   });
   it("extracts all execution counts from a session", () => {
     return of(
-      status("starting"),
-      status("idle"),
-      status("busy"),
+      status(KernelStatus.Starting),
+      status(KernelStatus.Idle),
+      status(KernelStatus.Busy),
       executeReply({
-        status: "idle",
+        status: KernelStatus.Idle,
         execution_count: 0
       }),
       displayData({ data: { "text/plain": "woo" } }),
       displayData({ data: { "text/plain": "hoo" } }),
       executeReply({
-        status: "idle",
+        status: KernelStatus.Idle,
         execution_count: 1
       }),
-      status("idle")
+      status(KernelStatus.Idle)
     )
       .pipe(executionCounts(), toArray())
       .toPromise()
@@ -366,17 +369,17 @@ describe("executionCounts", () => {
 describe("kernelStatuses", () => {
   it("extracts all the execution states from status messages", () => {
     return of(
-      status("starting"),
-      status("idle"),
-      status("busy"),
+      status(KernelStatus.Starting),
+      status(KernelStatus.Idle),
+      status(KernelStatus.Busy),
       displayData({ data: { "text/plain": "woo" } }),
       displayData({ data: { "text/plain": "hoo" } }),
-      status("idle")
+      status(KernelStatus.Idle)
     )
       .pipe(kernelStatuses(), toArray())
       .toPromise()
       .then(arr => {
-        expect(arr).toEqual(["starting", "idle", "busy", "idle"]);
+        expect(arr).toEqual([KernelStatus.Starting, KernelStatus.Idle, KernelStatus.Busy, KernelStatus.Idle]);
       });
   });
 });

--- a/packages/messaging/src/messages.ts
+++ b/packages/messaging/src/messages.ts
@@ -1,3 +1,4 @@
+import { KernelStatus } from "@nteract/types";
 import { v4 as uuid } from "uuid";
 import {
   BasicOutputMessageContent,
@@ -314,14 +315,14 @@ export function stream(content: { name: "stdout" | "stderr"; text: string }) {
 
 export interface ExecuteReplyError {
   status: string;
-  execution_count : number;
-  ename : string;
-  evalue : string;
-  traceback : string[];
+  execution_count: number;
+  ename: string;
+  evalue: string;
+  traceback: string[];
 }
 export interface ExecuteReplyOk {
   status: string;
-  execution_count : number;
+  execution_count: number;
   payload?: object[];
   user_expressions?: object;
 
@@ -342,7 +343,7 @@ export function executeReply(
  *
  * @param execution_state The kernel's execution state
  */
-export function status(execution_state: "busy" | "idle" | "starting") {
+export function status(execution_state: KernelStatus.Busy | KernelStatus.Idle | KernelStatus.Starting) {
   return message(
     {
       msg_type: "status"

--- a/packages/reducers/src/core/entities/kernels.ts
+++ b/packages/reducers/src/core/entities/kernels.ts
@@ -37,7 +37,7 @@ const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
       typedAction = action as actionTypes.RestartKernel;
       return state.setIn(
         [typedAction.payload.kernelRef, "status"],
-        "restarting"
+        KernelStatus.Restarting
       );
     case actionTypes.LAUNCH_KERNEL:
       typedAction = action as actionTypes.LaunchKernelAction;
@@ -84,10 +84,10 @@ const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
 
       const helpLinks = typedAction.payload.info.helpLinks
         ? List(
-            (typedAction.payload.info.helpLinks as HelpLink[]).map(
-              makeHelpLinkRecord
-            )
+          (typedAction.payload.info.helpLinks as HelpLink[]).map(
+            makeHelpLinkRecord
           )
+        )
         : List();
 
       return state.setIn(

--- a/packages/selectors/src/core/kernels.ts
+++ b/packages/selectors/src/core/kernels.ts
@@ -1,3 +1,4 @@
+import { KernelStatus } from "@nteract/types";
 import { AppState, KernelRef } from "@nteract/types";
 
 import { createSelector } from "reselect";
@@ -71,6 +72,6 @@ export const currentKernelStatus = createSelector(
     if (kernel && kernel.status) {
       return kernel.status;
     }
-    return "not connected";
+    return KernelStatus.NotConnected;
   }
 );


### PR DESCRIPTION
- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

This fix is meant to set the execution state of a kernel after receiving a `kernel_info_reply` message. See: https://github.com/nteract/nteract/discussions/5324

**The problem:** In cases where kernels take a long time to boot, calls to the Jupyter Server's sessions API would return an `execution_state` of `starting`. Once in this state, we never go back to update the status of the kernel, even after establishing a websocket with the server and receiving a `kernel_info_reply`. For UI actions that switch on particular kernel execution states, the only resolution to this was to refresh the page.

**The fix:** The code here simply updates the execution state of the kernel to `launched`, much like what we do in `zeromq-kernels.ts`. In the event of a long boot, this will ensure that the state does eventually get set to something.