### PR TITLE
Resurrect parameterized cell header

### DIFF
--- a/packages/notebook-app-component/src/decorators/cell-banner/index.tsx
+++ b/packages/notebook-app-component/src/decorators/cell-banner/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { connect } from "react-redux";
+import Immutable from "immutable";
+
+import { selectors, ContentRef, AppState } from "@nteract/core";
+
+import styled from "styled-components";
+
+interface ComponentProps {
+    id: string;
+    contentRef: ContentRef;
+}
+
+interface StateProps {
+    tags: Immutable.Set<string>;
+}
+
+
+type Props = ComponentProps & StateProps;
+
+const Banner = styled.div`
+  background-color: darkblue;
+  color: ghostwhite;
+  padding: 9px 16px;
+  font-size: 12px;
+  line-height: 20px;
+`;
+
+Banner.displayName = "CellBanner";
+
+export class CellBanner extends React.Component<Props> {
+    render() {
+        return <>
+            {this.props.tags?.has("parameters") ? (
+                <Banner>Papermill - Parametrized</Banner>
+            ) : null}
+            {this.props.tags?.has("default parameters") ? (
+                <Banner>Papermill - Default Parameters</Banner>
+            ) : null}
+        </>;
+    }
+}
+
+const makeMapStateToProps = (
+    initialState: AppState,
+    ownProps: ComponentProps
+) => {
+    const mapStateToProps = (state: AppState) => {
+        const { id, contentRef } = ownProps;
+        const model = selectors.model(state, { contentRef });
+        let tags = Immutable.Set<string>();
+
+        if (model && model.type === "notebook") {
+            const cellMap = selectors.notebook.cellMap(model);
+            const cell = cellMap.get(ownProps.id);
+            if (cell) {
+                tags = cell.getIn(["metadata", "tags"]);
+            }
+        }
+
+        return {
+            tags
+        };
+    };
+    return mapStateToProps;
+};
+
+export default connect(
+    makeMapStateToProps
+)(CellBanner);

--- a/packages/notebook-app-component/src/decorators/cell-banner/index.tsx
+++ b/packages/notebook-app-component/src/decorators/cell-banner/index.tsx
@@ -15,7 +15,6 @@ interface StateProps {
     tags: Immutable.Set<string>;
 }
 
-
 type Props = ComponentProps & StateProps;
 
 const Banner = styled.div`
@@ -52,7 +51,7 @@ const makeMapStateToProps = (
 
         if (model && model.type === "notebook") {
             const cellMap = selectors.notebook.cellMap(model);
-            const cell = cellMap.get(ownProps.id);
+            const cell = cellMap.get(id);
             if (cell) {
                 tags = cell.getIn(["metadata", "tags"]);
             }

--- a/packages/notebook-app-component/src/notebook-apps/draggable-with-cell-creator.tsx
+++ b/packages/notebook-app-component/src/notebook-apps/draggable-with-cell-creator.tsx
@@ -21,6 +21,7 @@ import HijackScroll from "../decorators/hijack-scroll";
 import KeyboardShortcuts from "../decorators/kbd-shortcuts";
 import UndoableCellDelete from "../decorators/undoable/undoable-cell-delete";
 import EditorLoader from "../decorators/editor-loader";
+import CellBanner from "../decorators/cell-banner";
 
 interface ComponentProps {
   contentRef: ContentRef;
@@ -35,6 +36,7 @@ const decorate = (
   const Cell = () => (
     <DraggableCell id={id} contentRef={contentRef}>
       <HijackScroll id={id} contentRef={contentRef}>
+        <CellBanner id={id} contentRef={contentRef} />
         <UndoableCellDelete id={id} contentRef={contentRef}>
           {children}
         </UndoableCellDelete>


### PR DESCRIPTION
This PR brings back the parameterized cell header that can be toggled by setting the parameterized toggle in the cell menu.

<img width="776" alt="Screen Shot 2020-11-04 at 7 31 34 PM" src="https://user-images.githubusercontent.com/1857993/98194682-c57aee00-1ed4-11eb-8382-bd8907dd4e73.png">

