### PR TITLE
Encapsulate calls to electron's shell

### DIFF
--- a/applications/desktop/src/common/commands/by-menu/file.tsx
+++ b/applications/desktop/src/common/commands/by-menu/file.tsx
@@ -1,6 +1,6 @@
 import { actions, createKernelRef, selectors } from "@nteract/core";
 import { sendNotification } from "@nteract/mythic-notifications";
-import { app, dialog, remote, shell } from "electron";
+import { app, dialog, remote } from "electron";
 import * as fs from "fs";
 import * as path from "path";
 import React from "react";
@@ -178,7 +178,7 @@ export const ExportPDF: DesktopCommand<ReqContent> = {
         level: "success",
         action: {
           label: "Open",
-          callback: () => shell.openItem(pdfPath),
+          file: pdfPath,
         },
       });
     } catch (error) {

--- a/applications/desktop/src/common/commands/utils/notifications.tsx
+++ b/applications/desktop/src/common/commands/utils/notifications.tsx
@@ -1,6 +1,7 @@
 import { Breadcrumbs } from "@blueprintjs/core";
-import { shell } from "electron";
+import { openExternalFile } from "@nteract/mythic-windowing";
 import React from "react";
+import { connect } from "react-redux";
 import styled from "styled-components";
 
 const Spacer = styled.div`
@@ -22,18 +23,27 @@ const NoWrap = styled.div`
 
 // Show the user the most important parts of the file path, as much as
 // they have space in the message.
-export const FilePathMessage = (props: { filepath: string }) =>
-  <>
-    <NoWrap>
-      <Breadcrumbs items={props.filepath.split("/").map((each, i) => ({
-        text: each,
-        icon: i === props.filepath.split("/").length - 1
-          ? "document"
-          : "folder-close",
-        onClick: i === props.filepath.split("/").length - 1
-          ? () => shell.openItem(props.filepath)
-          : undefined
-      }))}/>
-    </NoWrap>
-    <Spacer/>
-  </>;
+export const FilePathMessage =
+  connect(
+    undefined,
+    dispatch => ({
+      openExternalFile:
+        (filepath: string) => dispatch(openExternalFile.create(filepath)),
+    }),
+  )(
+    (props: { filepath: string, openExternalFile: (filepath: string) => void }) =>
+    <>
+      <NoWrap>
+        <Breadcrumbs items={props.filepath.split("/").map((each, i) => ({
+          text: each,
+          icon: i === props.filepath.split("/").length - 1
+            ? "document"
+            : "folder-close",
+          onClick: i === props.filepath.split("/").length - 1
+            ? () => props.openExternalFile(props.filepath)
+            : undefined
+        }))}/>
+      </NoWrap>
+      <Spacer/>
+    </>
+  );

--- a/applications/desktop/src/main/launch.ts
+++ b/applications/desktop/src/main/launch.ts
@@ -1,5 +1,6 @@
+import { openExternalUrl } from "@nteract/mythic-windowing";
 import { KernelspecInfo } from "@nteract/types";
-import { BrowserWindow, Menu, shell } from "electron";
+import { BrowserWindow, Menu } from "electron";
 import * as path from "path";
 import { loadFullMenu } from "./menu";
 
@@ -10,7 +11,7 @@ let launchIpynb: (path: string) => void;
 export function deferURL(event: Event, url: string) {
   event.preventDefault();
   if (!url.startsWith("file:")) {
-    shell.openExternal(url);
+    global.store.dispatch(openExternalUrl.create(url));
   } else if (url.endsWith(".ipynb")) {
     launchIpynb(url);
   }

--- a/applications/desktop/src/main/menu.ts
+++ b/applications/desktop/src/main/menu.ts
@@ -1,6 +1,8 @@
 import { manifest as examplesManifest } from "@nteract/examples";
 import { allConfigOptions, HasPrivateConfigurationState } from "@nteract/mythic-configuration";
-import { app, BrowserWindow, globalShortcut, Menu, MenuItemConstructorOptions, shell } from "electron";
+import { openExternalUrl } from "@nteract/mythic-windowing";
+import { MythicAction } from "@nteract/myths";
+import { app, BrowserWindow, globalShortcut, Menu, MenuItemConstructorOptions } from "electron";
 import sortBy from "lodash.sortby";
 import { Store } from "redux";
 import { accelerators } from "../common/accelerators";
@@ -66,7 +68,7 @@ const isEnabled = <PROPS>(command: ActionCommand<any, PROPS>) =>
   || !!BrowserWindow.getFocusedWindow();
 
 function buildMenuTemplate(
-  store: Store<MainStateRecord, MainAction>,
+  store: Store<MainStateRecord, MainAction | MythicAction>,
   structure: MenuDefinition,
 ) {
   const kernelspecs = sortBy(store.getState().kernelSpecs ?? {}, "spec.display_name");
@@ -99,7 +101,7 @@ function buildMenuTemplate(
 
     url: (label: string, url: string) => ({
       label: processString(label),
-      click: () => shell.openExternal(processString(url)),
+      click: () => store.dispatch(openExternalUrl.create(processString(url))),
     }),
 
     command: (label: string, options: MenuitemOptions, command: Command) =>

--- a/applications/desktop/src/notebook/epics/github-publish.ts
+++ b/applications/desktop/src/notebook/epics/github-publish.ts
@@ -1,6 +1,5 @@
 import { actions, selectors } from "@nteract/core";
 import { sendNotification } from "@nteract/mythic-notifications";
-import { shell } from "electron";
 
 import * as path from "path";
 import { ofType, StateObservable } from "redux-observable";
@@ -141,8 +140,7 @@ export const publishEpic = (
                 level: "success",
                 action: {
                   label: "Open",
-                  callback: () =>
-                    shell.openExternal(`https://nbviewer.jupyter.org/${xhr.response.id}`),
+                  url: `https://nbviewer.jupyter.org/${xhr.response.id}`,
                 },
               }),
             )

--- a/applications/desktop/src/notebook/index.tsx
+++ b/applications/desktop/src/notebook/index.tsx
@@ -25,6 +25,7 @@ import DataExplorer from "@nteract/data-explorer";
 import WidgetDisplay from "@nteract/jupyter-widgets";
 import * as MathJax from "@nteract/mathjax";
 import { allConfigOptionDefinitions } from "@nteract/mythic-configuration";
+import { electronBackend, setWindowingBackend } from "@nteract/mythic-windowing";
 import NotebookApp from "@nteract/notebook-app-component";
 import { Media } from "@nteract/outputs";
 
@@ -166,6 +167,8 @@ declare global {
   }
 }
 window.store = store;
+
+store.dispatch(setWindowingBackend.create(electronBackend));
 
 initNativeHandlers(contentRef, store);
 initMenuHandlers(contentRef, store);

--- a/applications/desktop/src/notebook/store.ts
+++ b/applications/desktop/src/notebook/store.ts
@@ -1,6 +1,7 @@
 import { middlewares as coreMiddlewares, reducers } from "@nteract/core";
 import { configuration } from "@nteract/mythic-configuration";
 import { notifications } from "@nteract/mythic-notifications";
+import { windowing } from "@nteract/mythic-windowing";
 import { makeConfigureStore } from "@nteract/myths";
 import epics from "./epics";
 import { LocalContentProvider } from "./local-content-provider";
@@ -11,6 +12,7 @@ export const configureStore = makeConfigureStore<DesktopNotebookAppState>()({
   packages: [
     configuration,
     notifications,
+    windowing,
   ],
   reducers: {
     app: reducers.app,

--- a/packages/mythic-notifications/package.json
+++ b/packages/mythic-notifications/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.7.0",
+    "@nteract/mythic-windowing": "^0.1.0",
     "@nteract/myths": "^0.2.4"
   },
   "peerDependencies": {

--- a/packages/mythic-notifications/src/index.ts
+++ b/packages/mythic-notifications/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./types";
 export { notifications } from "./package";
-export { NotificationRoot } from "./myths/initialize-system";
+export { NotificationRoot } from "./backends/blueprintjs";
 export { sendNotification } from "./myths/send-notification";

--- a/packages/mythic-notifications/src/myths/initialize-system.ts
+++ b/packages/mythic-notifications/src/myths/initialize-system.ts
@@ -1,4 +1,3 @@
-import React from "react";
 import { notifications } from "../package";
 import { NotificationSystem } from "../types";
 

--- a/packages/mythic-notifications/src/myths/initialize-system.tsx
+++ b/packages/mythic-notifications/src/myths/initialize-system.tsx
@@ -1,54 +1,9 @@
-import { Classes, Toaster } from "@blueprintjs/core";
-import { MythicComponent } from "@nteract/myths";
-import React, { RefObject } from "react";
-import styled from "styled-components";
-import { blueprintjsNotificationSystem } from "../backends/blueprintjs";
+import React from "react";
 import { notifications } from "../package";
 import { NotificationSystem } from "../types";
 
-const initializeSystem =
+export const initializeSystem =
   notifications.createMyth("initializeSystem")<NotificationSystem>({
     reduce: (state, action) =>
-      state.set("current", action.payload),
+      state.set("current", action.payload)
   });
-
-const DoNotPrint =
-  styled.div`
-    @media print {
-      display: none;
-    }
-  `;
-
-export const NotificationRoot =
-  initializeSystem.createConnectedComponent(
-    "NotificationRoot",
-    class extends MythicComponent<
-      typeof initializeSystem,
-      { darkTheme?: boolean }
-    > {
-      toaster?: RefObject<Toaster>;
-
-      postConstructor(): void {
-        this.toaster = React.createRef();
-      }
-
-      componentDidMount(): void {
-        this.props.initializeSystem(
-          blueprintjsNotificationSystem(this.toaster!.current!)
-        );
-      }
-
-      render(): JSX.Element {
-        return (
-          <DoNotPrint>
-            <Toaster
-              ref={this.toaster}
-              position={"top-right"}
-              className={this.props.darkTheme ? Classes.DARK : undefined}
-              usePortal={false}   // needed for the theme class to bubble down
-            />
-          </DoNotPrint>
-        );
-      }
-    },
-  );

--- a/packages/mythic-notifications/src/types.ts
+++ b/packages/mythic-notifications/src/types.ts
@@ -1,4 +1,13 @@
 import { IconName } from "@blueprintjs/core";
+import { MythicAction } from "@nteract/myths";
+
+
+export type NotificationAction =
+  | { callback: () => void }
+  | { dispatch: MythicAction }
+  | { url: string }
+  | { file: string }
+  ;
 
 export interface NotificationMessage {
   key?: string;
@@ -6,10 +15,9 @@ export interface NotificationMessage {
   title?: string;
   message: string | JSX.Element;
   level: "error" | "warning" | "info" | "success" | "in-progress";
-  action?: {
+  action?: NotificationAction & {
     icon?: IconName;
     label: string;
-    callback: () => void;
   };
 }
 

--- a/packages/mythic-notifications/tsconfig.json
+++ b/packages/mythic-notifications/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": ["src"],
   "references": [
+    { "path": "../mythic-windowing" },
     { "path": "../myths" }
   ]
 }

--- a/packages/mythic-windowing/package.json
+++ b/packages/mythic-windowing/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@nteract/myths": "^0.2.0",
-    "electron": "7.3.2"
+    "electron": "7.3.2",
+    "file-url": "^3.0.0"
   },
   "peerDependencies": {
   },

--- a/packages/mythic-windowing/src/backends/electron/index.ts
+++ b/packages/mythic-windowing/src/backends/electron/index.ts
@@ -1,5 +1,5 @@
-import { BrowserWindow } from "electron";
-import { of } from "rxjs";
+import { BrowserWindow, shell } from "electron";
+import { EMPTY, of } from "rxjs";
 import { forgetWindow, rememberWindow } from "../../myths/window-registry";
 import { WindowingBackend, WindowProps, WindowRef } from "../../types";
 
@@ -26,5 +26,10 @@ export const electronBackend: WindowingBackend<BrowserWindow> = {
   closeWindow: (id: WindowRef, window?: BrowserWindow) => {
     window?.close();
     return of(forgetWindow.create(id));
+  },
+
+  openExternalUrl: (url: string) => {
+    shell.openExternal(url).then();
+    return EMPTY;
   }
 }

--- a/packages/mythic-windowing/src/index.ts
+++ b/packages/mythic-windowing/src/index.ts
@@ -2,6 +2,7 @@ export { electronBackend } from "./backends/electron";
 
 export * from "./types";
 
+export { openExternalFile, openExternalUrl } from "./myths/open-external";
 export { showWindow, closeWindow } from "./myths/window-lifecycle";
 export { setWindowingBackend } from "./myths/window-registry";
 

--- a/packages/mythic-windowing/src/myths/open-external.ts
+++ b/packages/mythic-windowing/src/myths/open-external.ts
@@ -1,0 +1,20 @@
+import fileUrl from "file-url";
+import { of } from "rxjs";
+import { windowing } from "../package";
+
+export const openExternalUrl =
+  windowing.createMyth("openExternalUrl")<string>({
+    thenDispatch: [
+      (action, state) =>
+        state.backend.openExternalUrl(action.payload),
+    ],
+  });
+
+
+export const openExternalFile =
+  windowing.createMyth("openExternalFile")<string>({
+    thenDispatch: [
+      (action, _state) =>
+        of(openExternalUrl.create(fileUrl(action.payload))),
+    ],
+  });

--- a/packages/mythic-windowing/src/types.ts
+++ b/packages/mythic-windowing/src/types.ts
@@ -16,6 +16,7 @@ export interface WindowingState {
 export interface WindowingBackend<WINDOW> {
   showWindow: (props: WindowProps) => Observable<MythicAction>;
   closeWindow: (id: WindowRef, window?: WINDOW) => Observable<MythicAction>;
+  openExternalUrl: (url: string) => Observable<MythicAction>;
 }
 
 export interface WindowProps {

--- a/packages/myths/src/react.ts
+++ b/packages/myths/src/react.ts
@@ -28,7 +28,11 @@ export const makeCreateConnectedComponent =
       (componentName, cls, makeState) => {
         const component = connect(
           makeState ?? null,
-          { [myth.name]: myth.create },
+          (dispatch) => ({
+            [myth.name]:
+              (props: typeof myth.props) => dispatch(myth.create(props)),
+            dispatch,
+          }),
         )(cls as any);
         component.displayName = componentName;
         return component;

--- a/packages/myths/src/types.ts
+++ b/packages/myths/src/types.ts
@@ -1,7 +1,7 @@
 import { RecordOf } from "immutable";
 import { ComponentClass } from "react";
 import { ConnectedComponent } from "react-redux";
-import { Action, Reducer } from "redux";
+import { Action, Dispatch, Reducer } from "redux";
 import { Epic } from "redux-observable";
 import { Observable } from "rxjs";
 import { Diff } from "utility-types";
@@ -26,6 +26,8 @@ export type ConnectedComponentProps<
   ADDITIONAL_PROPS,
 > = {
   [key in MYTH_NAME]: (payload: MYTH_PROPS) => void;
+} & {
+  dispatch: Dispatch;
 } & ADDITIONAL_PROPS;
 
 export interface Myth<

--- a/yarn.lock
+++ b/yarn.lock
@@ -8035,6 +8035,15 @@ electron-updater@^4.3.1:
     lodash.isequal "^4.5.0"
     semver "^7.1.3"
 
+electron@7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.2.tgz#184b69fe9089693e179b3b34effa975dfc8e505d"
+  integrity sha512-5uSWVfCJogiPiU0G+RKi4ECnNs0gPNjAwYVE9KR7RXaOJYcpNIC5RFejaaUnuRoBssJ5B1n/5WU6wDUxvPajWQ==
+  dependencies:
+    "@electron/get" "^1.0.1"
+    "@types/node" "^12.0.12"
+    extract-zip "^1.0.3"
+
 electron@7.3.3:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.3.tgz#f61502a3d42d85adfecd8e37f98da449b591f8af"
@@ -9008,6 +9017,11 @@ file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
+file-url@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-3.0.0.tgz#247a586a746ce9f7a8ed05560290968afc262a77"
+  integrity sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==
 
 filelist@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Progress on #4799.

* Creates two myths in `mythic-windowing`:
  - `openExternalUrl`
  - `openExternalFile`
* Alters `desktop` and `mythic-notification` to use those.
* Also moves all the `blueprintjs`-specific notification stuff into the `blueprintjs` backend, where it should have been all along...
* Alters `myths` to inject `dispatch` into mythic connected components to allow them to use any mythic actions.
* Removes all references to electron's `shell` from `desktop`.

Note that `shell.openItem` is deprecated and removed in future versions of `electron`, so I changed the file opening to happen via `shell.openExternal` and a file url.