### PR TITLE
Use KernelStatus enum more in codebase

### DIFF
--- a/applications/desktop/src/notebook/epics/zeromq-kernels.ts
+++ b/applications/desktop/src/notebook/epics/zeromq-kernels.ts
@@ -469,7 +469,7 @@ export function watchSpawn(
             // We both set the state and make it easy for us to log the error
             observer.next(
               actions.setExecutionState({
-                kernelStatus: "process errored",
+                kernelStatus: KernelStatus.Error,
                 kernelRef: action.payload.kernelRef
               })
             );
@@ -479,7 +479,7 @@ export function watchSpawn(
           spawn.on("exit", () => {
             observer.next(
               actions.setExecutionState({
-                kernelStatus: "process exited",
+                kernelStatus: KernelStatus.NotConnected,
                 kernelRef: action.payload.kernelRef
               })
             );
@@ -488,7 +488,7 @@ export function watchSpawn(
           spawn.on("disconnect", () => {
             observer.next(
               actions.setExecutionState({
-                kernelStatus: "process disconnected",
+                kernelStatus: KernelStatus.NotConnected,
                 kernelRef: action.payload.kernelRef
               })
             );

--- a/packages/reducers/__tests__/core/entities/kernels.spec.ts
+++ b/packages/reducers/__tests__/core/entities/kernels.spec.ts
@@ -129,7 +129,7 @@ describe("kernels reducers", () => {
       error: new Error("test")
     });
     const state = kernels(originalState, action) as KernelsRecordProps;
-    expect(state.byRef.getIn([kernelRef, "status"])).toBe("failed to kill");
+    expect(state.byRef.getIn([kernelRef, "status"])).toBe(KernelStatus.Idle);
   });
   test("SET_EXECUTION_STATE sets kernel status", () => {
     const kernelRef = createKernelRef();
@@ -157,7 +157,7 @@ describe("kernels reducers", () => {
       kernelSpecName: "python2"
     });
     const state = kernels(originalState, action) as KernelsRecordProps;
-    expect(state.byRef.getIn([kernelRef, "status"])).toBe("launching");
+    expect(state.byRef.getIn([kernelRef, "status"])).toBe(KernelStatus.Starting);
   });
   test("LAUNCH_KERNEL_BY_NAME sets kernel status", () => {
     const kernelRef = createKernelRef();
@@ -171,6 +171,6 @@ describe("kernels reducers", () => {
       kernelSpecName: "python2"
     });
     const state = kernels(originalState, action) as KernelsRecordProps;
-    expect(state.byRef.getIn([kernelRef, "status"])).toBe("launching");
+    expect(state.byRef.getIn([kernelRef, "status"])).toBe(KernelStatus.Starting);
   });
 });

--- a/packages/reducers/src/core/entities/kernels.ts
+++ b/packages/reducers/src/core/entities/kernels.ts
@@ -31,7 +31,7 @@ const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
       typedAction = action as actionTypes.KillKernelFailed;
       return state.setIn(
         [typedAction.payload.kernelRef, "status"],
-        "failed to kill"
+        KernelStatus.Idle
       );
     case actionTypes.RESTART_KERNEL:
       typedAction = action as actionTypes.RestartKernel;
@@ -44,7 +44,7 @@ const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
       return state.set(
         typedAction.payload.kernelRef,
         makeKernelNotStartedRecord({
-          status: "launching",
+          status: KernelStatus.Starting,
           kernelSpecName: typedAction.payload.kernelSpec.name
         })
       );
@@ -53,7 +53,7 @@ const byRef = (state = Map(), action: Action): Map<unknown, unknown> => {
       return state.set(
         typedAction.payload.kernelRef,
         makeKernelNotStartedRecord({
-          status: "launching",
+          status: KernelStatus.Starting,
           kernelSpecName: typedAction.payload.kernelSpecName
         })
       );

--- a/packages/types/src/entities/kernels.ts
+++ b/packages/types/src/entities/kernels.ts
@@ -55,7 +55,9 @@ export enum KernelStatus {
   /** 0mq-based kernel is launched. */
   Launched = "launched",
   /** 0mq-based kernel is killed. */
-  Killed = "killed"
+  Killed = "killed",
+  /** Kernel is in an failed or error state. */
+  Error = "error"
 }
 
 export interface LocalKernelProps {


### PR DESCRIPTION
Closes https://github.com/nteract/nteract/issues/5349.

We weren't using the `KernelStatus` enum everywhere throughout the codebase. Comments inline for some of these changes.