### PR TITLE
Fix processing of kernelspecs request

### DIFF
--- a/applications/desktop/src/main/index.ts
+++ b/applications/desktop/src/main/index.ts
@@ -69,9 +69,11 @@ ipc.on("show-message-box", async (event: IpcMainEvent, arg: any) => {
   event.sender.send("show-message-box-response", response);
 });
 
-ipc.on("kernel_specs_request", event => {
-  event.reply("kernel_specs_reply", kernelSpecs$.pipe(last()));
-});
+ipc.on("kernel_specs_request", event =>
+  kernelSpecs$
+    .pipe(last())
+    .subscribe(specs => event.reply("kernel_specs_reply", specs))
+);
 
 app.on("ready", initAutoUpdater);
 


### PR DESCRIPTION
Resolves an issue that I noticed was introduced in https://github.com/nteract/nteract/pull/5353.

In the code below:

https://github.com/nteract/nteract/blob/0626e0a48cfc1355fce385ed92de3539f67ceacc/applications/desktop/src/main/index.ts#L72-L74

`last()` returns an `Observable` which is then processed as a `Kernelspecs` object in the code below when it is not.

https://github.com/nteract/nteract/blob/0626e0a48cfc1355fce385ed92de3539f67ceacc/applications/desktop/src/notebook/epics/zeromq-kernels.ts#L168-L171

To resolve this, we subscribe to the Observable and pass the `Kernelspecs` object from there.