### PR TITLE
Remove electron dependency from mythic-notifications

### DIFF
--- a/applications/desktop/src/common/commands/by-menu/file.tsx
+++ b/applications/desktop/src/common/commands/by-menu/file.tsx
@@ -1,5 +1,6 @@
 import { actions, createKernelRef, selectors } from "@nteract/core";
 import { sendNotification } from "@nteract/mythic-notifications";
+import { openExternalFile } from "@nteract/mythic-windowing";
 import { app, dialog, remote } from "electron";
 import * as fs from "fs";
 import * as path from "path";
@@ -178,7 +179,7 @@ export const ExportPDF: DesktopCommand<ReqContent> = {
         level: "success",
         action: {
           label: "Open",
-          file: pdfPath,
+          callback: () => store.dispatch(openExternalFile.create(pdfPath)),
         },
       });
     } catch (error) {

--- a/applications/desktop/src/notebook/epics/github-publish.ts
+++ b/applications/desktop/src/notebook/epics/github-publish.ts
@@ -1,5 +1,6 @@
 import { actions, selectors } from "@nteract/core";
 import { sendNotification } from "@nteract/mythic-notifications";
+import { openExternalUrl } from "@nteract/mythic-windowing";
 
 import * as path from "path";
 import { ofType, StateObservable } from "redux-observable";
@@ -140,7 +141,7 @@ export const publishEpic = (
                 level: "success",
                 action: {
                   label: "Open",
-                  url: `https://nbviewer.jupyter.org/${xhr.response.id}`,
+                  callback: () => window.store.dispatch(openExternalUrl.create(`https://nbviewer.jupyter.org/${xhr.response.id}`)),
                 },
               }),
             )

--- a/packages/mythic-notifications/package.json
+++ b/packages/mythic-notifications/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.7.0",
-    "@nteract/mythic-windowing": "^0.1.1",
     "@nteract/myths": "^0.2.5"
   },
   "peerDependencies": {

--- a/packages/mythic-notifications/src/backends/blueprintjs.tsx
+++ b/packages/mythic-notifications/src/backends/blueprintjs.tsx
@@ -1,5 +1,4 @@
 import { Callout, Classes, Intent, Spinner, Toaster } from "@blueprintjs/core";
-import { openExternalFile, openExternalUrl } from "@nteract/mythic-windowing";
 import { MythicComponent } from "@nteract/myths";
 import React, { RefObject } from "react";
 import { Dispatch } from "redux";
@@ -23,14 +22,6 @@ const callbackOf = (action: NotificationAction, dispatch: Dispatch) => {
 
   if ("dispatch" in action) {
     return () => dispatch(action.dispatch);
-  }
-
-  if ("url" in action) {
-    return () => dispatch(openExternalUrl.create(action.url));
-  }
-
-  if ("file" in action) {
-    return () => dispatch(openExternalFile.create(action.file));
   }
 }
 

--- a/packages/mythic-windowing/package.json
+++ b/packages/mythic-windowing/package.json
@@ -15,8 +15,10 @@
   },
   "dependencies": {
     "@nteract/myths": "^0.2.5",
-    "electron": "7.3.2",
     "file-url": "^3.0.0"
+  },
+  "peerDependencies": {
+    "electron": "7.3.2"
   },
   "author": "nteract contributers",
   "license": "BSD-3-Clause"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8005,15 +8005,6 @@ electron-updater@^4.3.1:
     lodash.isequal "^4.5.0"
     semver "^7.1.3"
 
-electron@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.2.tgz#184b69fe9089693e179b3b34effa975dfc8e505d"
-  integrity sha512-5uSWVfCJogiPiU0G+RKi4ECnNs0gPNjAwYVE9KR7RXaOJYcpNIC5RFejaaUnuRoBssJ5B1n/5WU6wDUxvPajWQ==
-  dependencies:
-    "@electron/get" "^1.0.1"
-    "@types/node" "^12.0.12"
-    extract-zip "^1.0.3"
-
 electron@7.3.3:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/electron/-/electron-7.3.3.tgz#f61502a3d42d85adfecd8e37f98da449b591f8af"


### PR DESCRIPTION
Closes #5389.

@CrystallineCat mythic-notifications is used in nteract web but the mythic-window dependency brings in Electron which uses Node APIs that are not in the browser.

Temporarily removing the APIs that use mythic-windowing to resolve this issue to unblock using the packages in web environments.