### PR TITLE
Fix cursor position issue when invoking language cell magics in Monaco editor

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -181,7 +181,7 @@ Provide a bulleted list of new features or improvements and a reference to the P
 #### Bug Fixes
 
 - Hide Monaco parameter widget when mouse moves into another editor cell ([#5301](https://github.com/nteract/nteract/pull/5301)).
-- Fix cursor position issue when invoking language cell magics in Monaco editor ([#5301](https://github.com/nteract/nteract/pull/5405))
+- Fix cursor position issue when invoking language cell magics in Monaco editor ([#5405](https://github.com/nteract/nteract/pull/5405))
 
 ### @nteract/mythic-configuration ([publish-version-here])
 

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -181,6 +181,7 @@ Provide a bulleted list of new features or improvements and a reference to the P
 #### Bug Fixes
 
 - Hide Monaco parameter widget when mouse moves into another editor cell ([#5301](https://github.com/nteract/nteract/pull/5301)).
+- Fix cursor position issue when invoking language cell magics in Monaco editor ([#5301](https://github.com/nteract/nteract/pull/5405))
 
 ### @nteract/mythic-configuration ([publish-version-here])
 

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -324,25 +324,39 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     // Apply new model to the editor when the language is changed.
     const model = this.editor.getModel();
     if (model && language && model.getModeId() !== language) {
-      const newUri = DocumentUri.createCellUri(contentRef, id, language);
-      if (!monaco.editor.getModel(newUri)) {
-        // Save the cursor position before we set new model.
-        const position = this.editor.getPosition();
 
-        // Set new model targeting the changed language.
-        this.editor.setModel(monaco.editor.createModel(value, language, newUri));
-        this.addEditorTopMargin();
+        // Get a reference to the current editor
+        const editor = this.editor;
 
-        // Restore cursor position to new model.
-        if (position) {
-          this.editor.setPosition(position);
-        }
-
-        // Dispose of the old model in a seperate event. We cannot dispose of the model within the
+        // We need to set the model in a separate event because the `language` prop update happens before the
+        // internal editor receives an update to the cursor position when invoking language magics. Additionally,
+        // we need to dispose of the old model in a separate event. We cannot dispose of the model within the
         // componentDidUpdate method or else the editor will throw an exception. Zero in the timeout field
         // means execute immediately but in a seperate next event.
-        setTimeout(() => model.dispose(), 0);
-      }
+        setTimeout(() => {
+          const newUri = DocumentUri.createCellUri(contentRef, id, language);
+          if (!monaco.editor.getModel(newUri)) {
+            // Save the cursor position before we set new model.
+            const position = editor.getPosition();
+
+            // Set new model targeting the changed language.
+            editor.setModel(monaco.editor.createModel(value, language, newUri));
+            this.addEditorTopMargin();
+
+            // Restore cursor position to new model.
+            if (position) {
+              editor.setPosition(position);
+            }
+
+            // Set focus
+            if (editorFocused && !editor.hasTextFocus()) {
+              editor.focus();
+            }
+
+            // Dispose the old model
+            model.dispose()
+          }
+        }, 0);
     }
     
     if (theme) {


### PR DESCRIPTION
## Checklist

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

## Context
When invoking cell magics to change the monaco editor language the cursor position will always be erroneously set to the position prior to completing the magic. This is because the prop update for `language` happens before the internal update of the editor cursor position occurs.

![cellmagic1](https://user-images.githubusercontent.com/8560030/102654784-0302a600-4126-11eb-9dbe-5bfb4455b529.gif)

## Solution
Move entire `setModel` logic onto the event queue to ensure that we have the latest cursorPosition.

![cellmagic2](https://user-images.githubusercontent.com/8560030/102654934-44935100-4126-11eb-8e87-83893847b95c.gif)
