### PR TITLE
Fix issues with handling of kernel completions

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -181,6 +181,7 @@ Provide a bulleted list of new features or improvements and a reference to the P
 #### Bug Fixes
 
 - Hide Monaco parameter widget when mouse moves into another editor cell ([#5301](https://github.com/nteract/nteract/pull/5301)).
+- Fix issues with handling of kernel completions ([#5407](https://github.com/nteract/nteract/pull/5407)).
 
 ### @nteract/mythic-configuration ([publish-version-here])
 

--- a/packages/monaco-editor/src/completions/completionItemProvider.ts
+++ b/packages/monaco-editor/src/completions/completionItemProvider.ts
@@ -272,7 +272,9 @@ class CompletionItemProvider
       // This is then used to figure out what we should actually insert.
       // example: context = "a/path/to/some." and text = "some.folder.name" should produce "folder.name"
       const completionContext = context.substr(context.lastIndexOf("/") + 1);
-      text = text.substr(completionContext.length);
+      if (text.startsWith(completionContext)) {
+        text = text.substr(completionContext.length);
+      }
     }
 
     for (let i = 0; i < percentCount; i++) {

--- a/packages/monaco-editor/src/completions/completionItemProvider.ts
+++ b/packages/monaco-editor/src/completions/completionItemProvider.ts
@@ -228,7 +228,8 @@ class CompletionItemProvider
    * @param text Text of Jupyter completion item
    */
   private sanitizeText(text: string, context?: string) {
-    if (!context) {
+    // make sure that we only do this when the context is considered complete (ie. there is a "." or "/")
+    if (!context || (!context.endsWith(".") && !context.endsWith("/"))) {
       return text;
     }
     // if we have whitespace within a path, we should just return quotes around that


### PR DESCRIPTION
## Checklist

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

## Context
There were two issues with the previous approach of sanitization:
1. Anything that had a "." in the completion was being rewritten to be only the part trailing the "." when this wasn't always what we wanted. E.g. folders generally support "." and file names with extensions do too!

### [OLD] File path with "."
![intellisense3](https://user-images.githubusercontent.com/8560030/102826706-0f8d3580-4396-11eb-99a7-85175597c508.gif)

2. We also want to apply a similar logic to paths, e.g. for a path `some/path` we want to only be suggested `path` instead of `some/path` because otherwise we end up with `some/some/path` after accepting the completion

### [OLD] Full file paths were being offered
![intellisense5](https://user-images.githubusercontent.com/8560030/102826631-ecfb1c80-4395-11eb-98fd-1df0e46f001d.gif)

### [OLD] File path with whitespace
![intellisense4](https://user-images.githubusercontent.com/8560030/102826724-1a47ca80-4396-11eb-9f75-efa70be56141.gif)

## Solution
We should make use of the context available for the completion. In other words, in the example above we should check that we are currently receiving suggestions off of `some/` and use this to our advantage by removing it from the suggestion.

### [FIXED] Paths with "."
![intellisense1](https://user-images.githubusercontent.com/8560030/102825023-d4d5ce00-4392-11eb-9dc1-1126ada8fa51.gif)

### [FIXED] Paths with whitespace
![intellisense2](https://user-images.githubusercontent.com/8560030/102825028-d8695500-4392-11eb-8d20-a16fa5436f0a.gif)

## Known issues
See https://github.com/ipython/ipython/issues/2463 - we just make sure that the completion up to that point works