### PR TITLE
Add new configuration prop to register custom commands

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -176,7 +176,7 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 #### New Features
 
-Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
+- Add support to register custom commands using the command handler ([#5418](https://github.com/nteract/nteract/pull/5418))
 
 #### Bug Fixes
 

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -317,6 +317,11 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
       this.props.cursorPositionHandler(this.editor, this.props);
     }
 
+    // Handle custom commands
+    if (this.editor && this.props.commandHandler) {
+      this.props.commandHandler(this.editor);
+    }
+
     // Ensures that the source contents of the editor (value) is consistent with the state of the editor
     if (this.editor.getValue() !== this.props.value) {
       this.editor.setValue(this.props.value);

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -75,6 +75,7 @@ export interface IMonacoConfiguration {
   shortcutsOptions?: IMonacoShortCutProps;
   shortcutsHandler?: (editor: monaco.editor.IStandaloneCodeEditor, settings?: IMonacoShortCutProps) => void;
   cursorPositionHandler?: (editor: monaco.editor.IStandaloneCodeEditor, settings?: IMonacoProps) => void;
+  commandHandler?: (editor: monaco.editor.IStandaloneCodeEditor) => void;
 }
 
 /**
@@ -222,6 +223,11 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
       // Handle custom keyboard shortcuts
       if (this.editor && this.props.shortcutsHandler && this.props.shortcutsOptions) {
         this.props.shortcutsHandler(this.editor, this.props.shortcutsOptions);
+      }
+
+      // Handle custom commands
+      if (this.editor && this.props.commandHandler) {
+        this.props.commandHandler(this.editor);
       }
 
       this.toggleEditorOptions(!!this.props.editorFocused);


### PR DESCRIPTION
### Checklist
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

### Context
In a monaco editor instance, a command can be used upon the acceptance of a [completion item](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.languages.completionitem.html). This is helpful to trigger specific actions and log events, so it would be nice to add support to register custom commands in the monaco editor.

### Solution
A way to achieve this, is by adding a command handler to the monaco configuration props (similar to the shortcuts handler). In this way, a user can call the [addCommand](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonecodeeditor.html#addcommand) method and add some logic on what type of action will be triggered.

```
<MonacoEditor
    ...
    commandHandler={myCommandHandler}
/>

myCommandHandler(editor) {
    // Add some logic on what type of action will be triggered
    const commandHandler = () => {
        alert('My command is executing');
    };

    const myCommand = editor.addCommand(0, commandHandler);
    
    // The alert will be triggered upon the acceptance of this completion item
    const myCompletionItem = {
        ...
        command: myCommand
    }
}
```

This PR adds an optional prop to the `IMonacoConfiguration`, so that a user can register and handle custom commands in the editor.

### Side notes
While running the `TEST_PLAN.md` I opened the **Explore Your World with GeoJSON** example and the maps look like this (not sure if it's a bug or not):
![image](https://user-images.githubusercontent.com/72623351/104382959-e880da00-54e3-11eb-87d1-9525041f02aa.png)