### PR TITLE
Fix mythic-configuration: do not import node packages by default

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -24,6 +24,8 @@ Provide a bulleted list of new features or improvements and a reference to the P
 
 Provide a bulleted list of bug fixes and a reference to the PR(s) containing the changes.
 
+- Fixed mythic-configuration, allowing it to be imported in a browser setting ([Issue #5445](https://github.com/nteract/nteract/issues/5445))
+
 ## Core SDK Packages
 
 ### @nteract/actions ([publish-version-here])

--- a/packages/mythic-configuration/__tests__/configuration.spec.ts
+++ b/packages/mythic-configuration/__tests__/configuration.spec.ts
@@ -120,7 +120,7 @@ describe("configuration", () => {
     });
 
     test("in non-node environment index.ts exports an implementation that throws exceptions [https://github.com/nteract/nteract/issues/5445]", () => {
-      jest.resetModules();  
+      jest.resetModules();
       jest.mock("../src/backends/filesystem", () => {
         throw new Error("Can't resolve 'fs' in '.../node_modules/mkdirp'");
       });

--- a/packages/mythic-configuration/__tests__/configuration.spec.ts
+++ b/packages/mythic-configuration/__tests__/configuration.spec.ts
@@ -111,4 +111,25 @@ describe("configuration", () => {
       })
     );
   });
+
+  describe('setConfigFile', () => {
+    test("in node environment index.ts exports the implementation from backends/filesystem", () => {
+      const indexVersion = require("../src").setConfigFile;
+      const fsBackendVersion = require("../src/backends/filesystem").setConfigFile;
+      expect(indexVersion).toBe(fsBackendVersion);
+    });
+
+    test("in non-node environment index.ts exports an implementation that throws exceptions [https://github.com/nteract/nteract/issues/5445]", () => {
+      jest.resetModules();  
+      jest.mock("../src/backends/filesystem", () => {
+        throw new Error("Can't resolve 'fs' in '.../node_modules/mkdirp'");
+      });
+      const indexVersion = require("../src").setConfigFile;
+      expect(() => indexVersion("/any/path/will/throw")).toThrow("Failed to load mythic-configuration");
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+  });
 });

--- a/packages/mythic-configuration/src/index.ts
+++ b/packages/mythic-configuration/src/index.ts
@@ -131,9 +131,13 @@ export const allDeprecations = () => {
 export const setConfigFile = (function () {
   // Try to return the actually requested function (works on node & electron)
   try {
-    // This line fails in the browser due to fs-observable dependencies
-    const fsBackend = require("./backends/filesystem");
-    
+    // This import fails in the browser due to fs-observable dependencies.
+    // Attempt the import using a non-literal string to gently dissuade webpack
+    // and similar creatures from pre-processing the `require` (which fails in a
+    // non-catchable way).
+    const fsBackendPath = "./backends/filesystem";
+    const fsBackend = require(fsBackendPath);
+
     // Some browsers define 'require', and maybe they will return something
     // falsy instead of throwing so let's make sure that's not happening.
     if (fsBackend === undefined || fsBackend.setConfigFile === undefined) {
@@ -142,7 +146,7 @@ export const setConfigFile = (function () {
 
     return fsBackend.setConfigFile;
   } catch (requireErr) {
-    // Ono the import failed. Not a showstopper for browser users. Return a
+    // Ono the import failed! Not a showstopper for browser users. Return a
     // version of the function that yells if you use it.
     return (filename: string) => {
       const err = Error("Failed to load mythic-configuration's filesystem backend. You're probably running in a browser, but this only works in a node runtime!");

--- a/packages/mythic-configuration/src/index.ts
+++ b/packages/mythic-configuration/src/index.ts
@@ -4,7 +4,6 @@ import { setConfigAtKey } from "./myths/set-config-at-key";
 import { configuration } from "./package";
 import { ConfigurationOption, ConfigurationOptionDefinition, ConfigurationOptionDeprecatedDefinition, HasPrivateConfigurationState } from "./types";
 
-export { setConfigFile } from "./backends/filesystem"
 export { configuration } from "./package";
 export { setConfigAtKey } from "./myths/set-config-at-key"
 export { toggleConfigAtKey } from "./myths/toggle-config-at-key"
@@ -125,3 +124,30 @@ export const allDeprecations = () => {
     changeTo,
   })));
 }
+
+// Export the filesystem backend's function for loading config. This export will
+// fail in the browser since it does not have the transitively depended 'fs'
+// package, so guard against that for our dear browser-bound friends.
+export const setConfigFile = (function () {
+  // Try to return the actually requested function (works on node & electron)
+  try {
+    // This line fails in the browser due to fs-observable dependencies
+    const fsBackend = require("./backends/filesystem");
+    
+    // Some browsers define 'require', and maybe they will return something
+    // falsy instead of throwing so let's make sure that's not happening.
+    if (fsBackend === undefined || fsBackend.setConfigFile === undefined) {
+      throw new Error(`Looked for 'setConfigFile' but couldn't find it on imported mythic-configuration/backends/filesystem: ${JSON.stringify(fsBackend)}`);
+    }
+
+    return fsBackend.setConfigFile;
+  } catch (requireErr) {
+    // Ono the import failed. Not a showstopper for browser users. Return a
+    // version of the function that yells if you use it.
+    return (filename: string) => {
+      const err = Error("Failed to load mythic-configuration's filesystem backend. You're probably running in a browser, but this only works in a node runtime!");
+      err.stack += "\nCaused by " + requireErr.stack;
+      throw err;
+    }
+  }
+})();


### PR DESCRIPTION
Fixes issue #5445
https://github.com/nteract/nteract/issues/5445

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.