### PR TITLE
Added Project Resources nav, Binder group name

### DIFF
--- a/docs/groups/binder-group.md
+++ b/docs/groups/binder-group.md
@@ -1,4 +1,4 @@
-# Group 4 (name tentative)
+# Binder
 
 **Table of contents**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,13 @@ nav:
       - "Mythic": "./groups/mythic-group.md"
       - "Editors": "./groups/editors-group.md"
       - "Jupyter": "./groups/jupyter-group.md"
-      - "group4": "./groups/group4-group.md"
+      - "Binder": "./groups/binder-group.md"
+  - Project Resources:
+      - "Data Explorer": "https://data-explorer.nteract.io"
+      - "Semiotic": "https://semiotic.nteract.io"
+      - "papermill": "https://papermill.readthedocs.io/en/latest/#"
+      - "testbook": "https://testbook.readthedocs.io/en/latest/"
+      - "Scrapbook": "https://scrapbook.readthedocs.io/en/latest/"
 
 markdown_extensions:
   - toc:


### PR DESCRIPTION
# Navigation changes
- Project Resources section
    - Data Explorer, Semiotic, Papermill, testbook, Scrapbook
- Renamed group4 to Binder

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
