### PR TITLE
Move to the new updateOptions API to dynamically update editor options

### DIFF
--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -381,9 +381,12 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
         }, 0);
     }
     
+    const monacoUpdateOptions: monaco.editor.IEditorOptions & monaco.editor.IGlobalEditorOptions = { readOnly: this.props.readOnly };
     if (theme) {
-      monaco.editor.setTheme(theme);
+      monacoUpdateOptions.theme = theme;
     }
+
+    this.editor.updateOptions(monacoUpdateOptions);
 
     // In the multi-tabs scenario, when the notebook is hidden by setting "display:none",
     // Any state update propagated here would cause a UI re-layout, monaco-editor will then recalculate


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->
As we bumped up monaco editor to the latest version, we transition to the new [`updateOptions`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonecodeeditor.html#updateoptions) API to dynamically update some editor constructor options.


- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
