### PR TITLE
Fix monaco editor theme conflicts

### DIFF
--- a/packages/monaco-editor/src/theme.ts
+++ b/packages/monaco-editor/src/theme.ts
@@ -42,7 +42,7 @@ monaco.editor.defineTheme(DarkThemeName, customMonacoDarkTheme);
 /**
  * The custom high contrast light theme with customized background
  */
-export const HCLightThemeName = "nteract-hclight";
+export const HCLightThemeName = "nteract-hc-light";
 
 /**
  * Default monaco theme for light high contrast mode

--- a/packages/monaco-editor/src/theme.ts
+++ b/packages/monaco-editor/src/theme.ts
@@ -3,7 +3,7 @@ import * as monaco from "monaco-editor";
 /**
  * The default light theme with customized background
  */
-export const LightThemeName = "vs-light";
+export const LightThemeName = "nteract-light";
 
 /**
  * Default monaco theme for light theme
@@ -24,7 +24,7 @@ monaco.editor.defineTheme(LightThemeName, customMonacoLightTheme);
 /**
  * The default dark theme with customized background
  */
-export const DarkThemeName = "vs-dark";
+export const DarkThemeName = "nteract-dark";
 
 /**
  * Default monaco theme for dark theme
@@ -42,7 +42,7 @@ monaco.editor.defineTheme(DarkThemeName, customMonacoDarkTheme);
 /**
  * The custom high contrast light theme with customized background
  */
-export const HCLightThemeName = "hc-light";
+export const HCLightThemeName = "nteract-hclight";
 
 /**
  * Default monaco theme for light high contrast mode


### PR DESCRIPTION
Monaco editor by default comes with the following themes: `vs`, `vs-dark` and `hc_black`. While the package allows us to inherit and define custom themes, I noticed that we override the `vs-dark` theme in nteract. This can have unintended side effects on a consumer of this package. For instance, consider an app that has its own monaco editor package dependency and also for some reason relies on the nteract/moanco editor package. If the app already has an instance of monaco editor loaded with the default `vs-dark` theme (not from the `nteract/monaco-editor`) package,  loading the nteract/monaco-editor package would dynamically update the theme with our custom overrides. This happens because monaco editor has a global singleton for themes. This is already tracked as an [issue](https://github.com/microsoft/monaco-editor/issues/1713).

We update the theme definitions and prefix our strings with `nteract` to reduce the changes of theme name collisions and accidental overrides in scenarios I described above.

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
