### PR TITLE
Update `react-syntax-highlighter` dependency to ^13.x.x

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -25,6 +25,7 @@ Provide a bulleted list of new features or improvements and a reference to the P
 Provide a bulleted list of bug fixes and a reference to the PR(s) containing the changes.
 
 - Fixed mythic-configuration, allowing it to be imported in a browser setting ([Issue #5445](https://github.com/nteract/nteract/issues/5445))
+- Upgraded react-syntax-highlighter v^12.0.0 -> v^13.0.0 ([PR#5523](https://github.com/nteract/nteract/pull/5523))
 
 ## Core SDK Packages
 

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -11,7 +11,7 @@
     "@blueprintjs/select": "^3.2.0",
     "classnames": "^2.2.6",
     "re-resizable": "^6.5.0",
-    "react-syntax-highlighter": "^12.0.0",
+    "react-syntax-highlighter": "^13.0.0",
     "react-toggle": "^4.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

The [VS Code Jupyter extension](https://github.com/microsoft/vscode-jupyter) indirectly depends on @nteract/presentational-components, which results in the following dependency chain:

```
@nteract/presentational-components
|__ react-syntax-highlighter ^12.0.0
      |__ refractor ^2.4.1
            |__ prismjs ~1.17.0
```

refractor@2.4.1 is the latest minor version available before a major version bump, and depends on prismjs~1.17.0, which has a known [high-severity vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2020-15138) that is fixed in 1.21.0. The intermediate dependencies between @nteract/presentational-components and prismjs, namely react-syntax-highlighter and refractor, have upgraded to remove their dependency on prismjs@~1.17.x. react-syntax-highlighter upgraded in https://github.com/react-syntax-highlighter/react-syntax-highlighter/commit/4a06144e2b9e82c2ce0436e3a042c8d2296d6a1e#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519 which was released in 13.0.0. Can we allow react-syntax-highlighter@^13.0.0 here as well?

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.
(I have not been able to build nteract to run through the test plan yet)


<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
