### PR TITLE
Use 'scrolled' instead of 'collapsed' metadata property for output scrolling

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -10,6 +10,8 @@
 
 Provide a bulleted list of breaking changes and a reference to the PR(s) containing those changes.
 
+- Now using "scrolled" metadata property instead of "collapsed" to denote whether a cell output is within a scrolled div or not, in order to align with standard [ipynb format](https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json). "collapsed" metadata property is no longer being set for new cells (used to be set to true). ([#5538](https://github.com/nteract/nteract/pull/5538))
+
 #### New Features
 
 - Upgraded electron v5.0.13 → v7.3.2 ([Changelog](https://github.com/electron/electron/releases)) ([PR#5115](https://github.com/nteract/nteract/pull/5115))

--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -25,7 +25,6 @@ export const makeCodeCell = Record<CodeCellParams>({
   cell_type: "code",
   execution_count: null,
   metadata: ImmutableMap({
-    collapsed: true,
     jupyter: ImmutableMap({
       source_hidden: false,
       outputs_hidden: false,

--- a/packages/commutable/src/v3.ts
+++ b/packages/commutable/src/v3.ts
@@ -86,6 +86,8 @@ export interface HeadingCell {
 
 export interface CodeCell {
   cell_type: "code";
+  language: string;
+  collapsed: boolean;
   metadata: JSONObject;
   input: MultiLineString;
   prompt_number: number;

--- a/packages/commutable/src/v3.ts
+++ b/packages/commutable/src/v3.ts
@@ -86,8 +86,6 @@ export interface HeadingCell {
 
 export interface CodeCell {
   cell_type: "code";
-  language: string;
-  collapsed: boolean;
   metadata: JSONObject;
   input: MultiLineString;
   prompt_number: number;

--- a/packages/presentational-components/src/components/outputs.tsx
+++ b/packages/presentational-components/src/components/outputs.tsx
@@ -28,7 +28,6 @@ const OutputWrapper = styled.div.attrs<OutputWrapperProps>((props) => ({
   word-wrap: break-word;
   overflow-y: hidden;
   outline: none;
-  /* When expanded, this is overtaken to 100% */
   text-overflow: ellipsis;
 
   &:empty {

--- a/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
+++ b/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
@@ -792,20 +792,27 @@ describe("changeCellType", () => {
 });
 
 describe("toggleOutputExpansion", () => {
-  test("toggles value of collapsed property", () => {
+  test("toggles value of scrolled property", () => {
     const originalState = monocellDocument.updateIn(
       ["notebook", "cellMap"],
       (cells) =>
-        cells.map((value) => value.setIn(["metadata", "collapsed"], true))
+        cells.map((value) => value.setIn(["metadata", "scrolled"], true))
     );
     const id = originalState.getIn(["notebook", "cellOrder"]).first();
-    const state = reducers(
+    const state2 = reducers(
       originalState,
       actions.toggleOutputExpansion({ id })
     );
+    const state3 = reducers(
+      state2,
+      actions.toggleOutputExpansion({ id })
+    );
     expect(
-      state.getIn(["notebook", "cellMap", id, "metadata", "collapsed"])
+      state2.getIn(["notebook", "cellMap", id, "metadata", "scrolled"])
     ).toBe(false);
+    expect(
+      state3.getIn(["notebook", "cellMap", id, "metadata", "scrolled"])
+    ).toBe(true);
   });
 });
 describe("appendOutput", () => {

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -861,11 +861,15 @@ function toggleOutputExpansion(
 
   return state.updateIn(
     ["notebook", "cellMap"],
-    (cells: Map<CellId, ImmutableCell>) =>
-      cells.setIn(
-        [id, "metadata", "collapsed"],
-        !cells.getIn([id, "metadata", "collapsed"])
+    (cells: Map<CellId, ImmutableCell>) => {
+      const scrolled = cells.getIn([id, "metadata", "scrolled"]);
+      // TODO: Revisit when implementing "auto" scrolled mode. We should update this to reflect whether the output is actually currently scrolled or not, which can depend on current output height.
+      const isCurrentlyScrolled = scrolled !== false;
+      return cells.setIn(
+        [id, "metadata", "scrolled"],
+        !isCurrentlyScrolled
       )
+    }
   );
 }
 

--- a/packages/stateful-components/src/outputs/index.tsx
+++ b/packages/stateful-components/src/outputs/index.tsx
@@ -56,8 +56,9 @@ export const makeMapStateToProps = (
           cell.cell_type === "code" &&
           cell.getIn(["metadata", "jupyter", "outputs_hidden"]);
         expanded =
+          // TODO: Revisit when implementing "auto" scrolled mode.
           cell.cell_type === "code" &&
-          cell.getIn(["metadata", "collapsed"]) === false;
+          cell.getIn(["metadata", "scrolled"]) === false;
       }
     }
 

--- a/packages/styles/themes/base.css
+++ b/packages/styles/themes/base.css
@@ -17,8 +17,8 @@
   word-wrap: break-word;
   overflow-y: auto;
   outline: none;
-  /* When expanded, this is overtaken to 100% */
   text-overflow: ellipsis;
+  /* When expanded, this is overtaken to 100% */
   max-height: 336px;
 }
 
@@ -29,6 +29,7 @@
 .nteract-cell-outputs.hidden {
   display: none;
 }
+
 .nteract-cell-outputs.expanded {
   height: 100%;
   max-height: 100%;


### PR DESCRIPTION
Using "scrolled" instead of "collapsed" for representing outputs with a scrolled div, to better align with [official ipynb format](https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json).

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
