### PR TITLE
Fix nteract monaco editor's completion provider issue #5545

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -57,6 +57,8 @@ Provide a bulleted list of new features or improvements and a reference to the P
 
 #### Bug Fixes
 
+- Monaco autocompletion should return suggestion content after the last dot ([#5545](https://github.com/nteract/nteract/pull/5545))
+
 Provide a bulleted list of bug fixes and a reference to the PR(s) containing the changes.
 
 ### @nteract/connected-components ([publish-version-here])

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -57,7 +57,7 @@ Provide a bulleted list of new features or improvements and a reference to the P
 
 #### Bug Fixes
 
-- Monaco autocompletion should return suggestion content after the last dot ([#5545](https://github.com/nteract/nteract/pull/5545))
+- Monaco autocompletion should return suggestion content after the last dot - issue #5545 ([#5546](https://github.com/nteract/nteract/pull/5546))
 
 Provide a bulleted list of bug fixes and a reference to the PR(s) containing the changes.
 

--- a/packages/monaco-editor/__tests__/completionItemProvider.test.ts
+++ b/packages/monaco-editor/__tests__/completionItemProvider.test.ts
@@ -211,4 +211,34 @@ describe("Appropriate completions should be provided", () => {
     channels.next(mockCompleteReply);
     channels.complete();
   });
+
+  it("Should return suggestions with content after any last dots", (done) => {
+    const mockCompleteReply = createMessage("complete_reply", {
+      content: {
+        status: "some_status",
+        cursor_start: 3,
+        cursor_end: 5,
+        matches: ["completion1.itemA.itemB", "completion2.itemC"]
+      },
+      parent_header: mockCompletionRequest.header
+    });
+
+    const channels = new Subject<JupyterMessage>();
+    completionProvider.setChannels(channels);
+    completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
+      expect(result).toHaveProperty("suggestions");
+      const returnedSuggestions = result.suggestions;
+      expect(returnedSuggestions.length).toEqual(2);
+      expect(returnedSuggestions[0].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
+      expect(returnedSuggestions[0].label).toEqual("itemB");
+      expect(returnedSuggestions[0].insertText).toEqual("itemB");
+      expect(returnedSuggestions[1].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
+      expect(returnedSuggestions[1].label).toEqual("itemC");
+      expect(returnedSuggestions[1].insertText).toEqual("itemC");
+      done();
+    });
+    // Set the reply message on channels and complete the stream
+    channels.next(mockCompleteReply);
+    channels.complete();
+  });
 });

--- a/packages/monaco-editor/src/completions/completionItemProvider.ts
+++ b/packages/monaco-editor/src/completions/completionItemProvider.ts
@@ -255,7 +255,8 @@ class CompletionItemProvider
     // Handle taking only the suggestion content after the last dot. There are cases that a kernel when given 
     // "suggestion1.itemA" text and typing "." that it will suggest the full path of "suggestion.itemA.itemB" instead of 
     // just "itemB". The logic below handles these cases. This also handles the case where given "suggestion1.itemA.it" 
-    // text and typing "e" will suggest the full path of "suggestion.itemA.itemB". This logic also covers that scenario.
+    // text and typing "e" will suggest the full path of "suggestion.itemA.itemB" instead of "itemB". 
+    // This logic also covers that scenario.
     const index = text.lastIndexOf(".");
     if (index > -1 && index < text.length - 1) {
       return text.substring(index + 1);

--- a/packages/monaco-editor/src/completions/completionItemProvider.ts
+++ b/packages/monaco-editor/src/completions/completionItemProvider.ts
@@ -252,6 +252,15 @@ class CompletionItemProvider
       return text.substr(toRemove.length);
     }
 
+    // Handle taking only the suggestion content after the last dot. There are cases that a kernel when given 
+    // "suggestion1.itemA" text and typing "." that it will suggest the full path of "suggestion.itemA.itemB" instead of 
+    // just "itemB". The logic below handles these cases. This also handles the case where given "suggestion1.itemA.it" 
+    // text and typing "e" will suggest the full path of "suggestion.itemA.itemB". This logic also covers that scenario.
+    const index = text.lastIndexOf(".");
+    if (index > -1 && index < text.length - 1) {
+      return text.substring(index + 1);
+    }
+
     return text;
   }
 


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x ] I have validated or unit-tested the changes that I have made.
- [x ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

Fixes nteract monaco editor's completion provider issue #5545 which is a regression caused by #5407

Handle taking only the suggestion content after the last dot. There are cases that a kernel when given "suggestion1.itemA" text and typing "." that it will suggest the full path of "suggestion.itemA.itemB" instead of just "itemB". The logic below handles these cases. This also handles the case where given "suggestion1.itemA.it" text and typing "e" will suggest the full path of "suggestion.itemA.itemB". This logic also covers that scenario.
