### PR TITLE
[Change] add support for multiclients in remote connection

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -114,6 +114,7 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 #### New Features
 
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
+- Add support for multiple clients to be able to connect the same remote kernel. ([PR#5557](https://github.com/nteract/nteract/pull/5557))
 
 #### Bug Fixes
 

--- a/packages/epics/__tests__/websocket-kernel.spec.ts
+++ b/packages/epics/__tests__/websocket-kernel.spec.ts
@@ -112,7 +112,8 @@ describe("launchWebSocketKernelEpic", () => {
           selectNextKernel: true,
           kernel: {
             info: null,
-            sessionId: "test",
+            sessionId: "fake",
+            remoteSessionId: "test",
             hostRef,
             type: "websocket",
             channels: expect.any(Subject),
@@ -681,7 +682,8 @@ describe("killKernelEpic", () => {
             byRef: Immutable.Map({
               aKernel: stateModule.makeRemoteKernelRecord({
                 id: "test",
-                sessionId: "test"
+                sessionId: "aKernel", 
+                remoteSessionId: "test"
               })
             })
           }),

--- a/packages/fixtures/src/index.ts
+++ b/packages/fixtures/src/index.ts
@@ -106,6 +106,7 @@ export const mockAppState = (config: JSONObject): AppState => {
           byRef: Immutable.Map({
             [kernelRef]: makeRemoteKernelRecord({
               sessionId: "aSessionId",
+              remoteSessionId: "aSessionId",
               channels,
               status: KernelStatus.NotConnected
             })

--- a/packages/types/src/entities/kernels.ts
+++ b/packages/types/src/entities/kernels.ts
@@ -107,7 +107,10 @@ export interface RemoteKernelProps {
   //   shutting down, not connected.
   status?: string | null;
   type: "websocket";
-  sessionId?: SessionId | null;
+  // Xref: https://jupyter-client.readthedocs.io/en/stable/messaging.html#message-header
+  // Each client has it's own unique session ID that is used to connect to the remote kernel. 
+  sessionId?: SessionId | null; // unique client session ID
+  remoteSessionId?: SessionId | null; // unique sessionID on the server
   id?: KernelId | null;
 }
 
@@ -121,6 +124,7 @@ export const makeRemoteKernelRecord = Immutable.Record<RemoteKernelProps>({
   lastActivity: null,
   channels: new Subject(),
   sessionId: null,
+  remoteSessionId: null,
   status: null
 });
 


### PR DESCRIPTION

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->
## Checklist
- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
## Change
Adding support for multiple web clients to connect to same remote kernel

This addresses the issue as described here: https://github.com/nteract/nteract/issues/5547 

Tested the repro using the nteract_on_jupyter app which seems to be using the remote kernel props. The desktop app doesn't look like it's using websockets. 

| Before: | After: |
|--------------|-------------|
| When the second client's cell execution starts, the first client's websocket closes and the output stream errors out but the kernel is still busy so the second client does not execute until the kernel becomes idle again. |First client's cell execution completes to the end while second client's request queues up and starts processing when kernel becomes idle.|
|![multiclient-before](https://user-images.githubusercontent.com/26466942/120413484-3c625300-c30d-11eb-826f-c441c3840c34.gif)|    ![multiclient-after](https://user-images.githubusercontent.com/26466942/120413629-80edee80-c30d-11eb-9c71-40d13ad31af4.gif) |