### PR TITLE
[add] detect and recover from kernel auto restarts

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -87,6 +87,8 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
 
+- Added support to detect and recover from Kernel auto-restarts for Jupyter. ([PR5558](https://github.com/nteract/nteract/pull/5558))
+
 #### Bug Fixes
 
 Provide a bulleted list of bug fixes and a reference to the PR(s) containing the changes.

--- a/packages/actions/src/actionTypes/kernel_lifecycle.ts
+++ b/packages/actions/src/actionTypes/kernel_lifecycle.ts
@@ -30,6 +30,7 @@ export const LAUNCH_KERNEL_FAILED         = "LAUNCH_KERNEL_FAILED";
 export const SHUTDOWN_REPLY_SUCCEEDED     = "SHUTDOWN_REPLY_SUCCEEDED";
 export const SHUTDOWN_REPLY_TIMED_OUT     = "SHUTDOWN_REPLY_TIMED_OUT";
 export const DISPOSE_KERNEL               = "DISPOSE_KERNEL";
+export const KERNEL_AUTO_RESTARTED        = "KERNEL_AUTO_RESTARTED";
 
 export type InterruptKernel               = Action     <typeof INTERRUPT_KERNEL,            MaybeHasContent & MaybeHasKernel>;
 export type InterruptKernelSuccessful     = Action     <typeof INTERRUPT_KERNEL_SUCCESSFUL, MaybeHasContent & MaybeHasKernel>;
@@ -48,6 +49,7 @@ export type LaunchKernelFailed            = ErrorAction<typeof LAUNCH_KERNEL_FAI
 export type ShutdownReplySucceeded        = Action     <typeof SHUTDOWN_REPLY_SUCCEEDED,    HasKernel & { content: { restart: boolean } }>;
 export type ShutdownReplyTimedOut         = Action     <typeof SHUTDOWN_REPLY_TIMED_OUT,    HasKernel>;
 export type DisposeKernel                 = Action     <typeof DISPOSE_KERNEL,              HasKernel>;
+export type KernelAutoRestarted           = Action     <typeof KERNEL_AUTO_RESTARTED,       HasKernel>;
 
 export const interruptKernel              = makeActionFunction      <InterruptKernel>           (INTERRUPT_KERNEL);
 export const interruptKernelSuccessful    = makeActionFunction      <InterruptKernelSuccessful> (INTERRUPT_KERNEL_SUCCESSFUL);
@@ -66,3 +68,4 @@ export const launchKernelFailed           = makeErrorActionFunction <LaunchKerne
 export const shutdownReplySucceeded       = makeActionFunction      <ShutdownReplySucceeded>    (SHUTDOWN_REPLY_SUCCEEDED);
 export const shutdownReplyTimedOut        = makeActionFunction      <ShutdownReplyTimedOut>     (SHUTDOWN_REPLY_TIMED_OUT);
 export const disposeKernel                = makeActionFunction      <DisposeKernel>             (DISPOSE_KERNEL);
+export const kernelAutoRestarted          = makeActionFunction      <KernelAutoRestarted>       (KERNEL_AUTO_RESTARTED);

--- a/packages/epics/src/index.ts
+++ b/packages/epics/src/index.ts
@@ -22,7 +22,8 @@ import {
   acquireKernelInfoEpic,
   launchKernelWhenNotebookSetEpic,
   restartKernelEpic,
-  watchExecutionStateEpic
+  watchExecutionStateEpic,
+  watchForKernelAutoRestartEpic
 } from "./kernel-lifecycle";
 import { fetchKernelspecsEpic } from "./kernelspecs";
 import {
@@ -51,6 +52,7 @@ const allEpics = [
   killKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
+  watchForKernelAutoRestartEpic,
   restartKernelEpic,
   fetchKernelspecsEpic,
   fetchContentEpic,
@@ -81,6 +83,7 @@ export {
   killKernelEpic,
   acquireKernelInfoEpic,
   watchExecutionStateEpic,
+  watchForKernelAutoRestartEpic,
   launchKernelWhenNotebookSetEpic,
   restartKernelEpic,
   fetchKernelspecsEpic,


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->
## Checklist
- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
## Context
This is PR for the issue mentioned at https://github.com/nteract/nteract/issues/5548
When the Jupyter option for kernel auto-restart is turned on (which it by default), then the kernel will be restarted on the server automatically. You get a "restarting" status followed by a "starting" message from the kernel. Server uses "restarting" only for auto-restart scenarios. 

This PR adds a new epic to detect the successful auto-restart and nudge the kernel back into the idle state. Also raises an action that applications can use to raise notifications since the Kernel state is lost. 

Only applicable to Jupyter host type. 

### Before
// Side note: The CSS for nteract_on_jupyter application seems to be broken in dev setup hence the weird cell layout.
After kernel auto-restart, status gets stuck in starting state and cell execution does not proceed. 
![kernelautorestart-before](https://user-images.githubusercontent.com/26466942/120710980-af85d980-c473-11eb-95b6-9b0435fb1538.gif)

### After
After kernel auto-restart, kernel is back to Idle and cell execution can continue. 
![kernelautorestart-after](https://user-images.githubusercontent.com/26466942/120711293-0db2bc80-c474-11eb-8826-998c34a212cb.gif)

