### PR TITLE
Upgrade myths version pin

### DIFF
--- a/packages/mythic-multiselect/package.json
+++ b/packages/mythic-multiselect/package.json
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@nteract/myths": "^0.1.9"
+    "@nteract/myths": "^0.2.10"
   },
   "peerDependencies": {
     "immutable": "^4.0.0-rc.12"


### PR DESCRIPTION
Since `@nteract/myths` is at `0.x.y`, pinning it at "^0.1.9" keeps it at `0.1.y` (instead of allowing `0.2.y`) because the `y` is a minor version flag with a leading `0` in semver (the `x` here is the major version).

Right now when installing `@nteract/myths@latest` and `@nteract/mythic-multiselect@latest`, you are forced to have two versions of `@nteract/myths` (and possibly multiple versions of rxjs too). Updating this to match the repo versions allows a temporary fix (until `@nteract/myths` is no longer semver `0`-leading).