### PR TITLE
fix: update editor resize handler to incorporate the new contentsizechange event and adopt padding option

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -33,6 +33,7 @@ describe("MonacoEditor component is rendering correctly", () => {
 // Setup items shared by all tests in this block
 // Mock out the common API methods so that private function calls don't fail
 const mockEditor = {
+  onDidContentSizeChange: jest.fn(),
   onDidChangeModelContent: jest.fn(),
   onDidFocusEditorText: jest.fn(),
   onDidBlurEditorText: jest.fn(),

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -138,7 +138,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
     if (this.editorContainerRef && this.editorContainerRef.current && (this.contentHeight !== height)) {
       this.editorContainerRef.current.style.height = height + "px";
-      this.editor.layout();
+      this.editor.layout({ width: this.editor.getLayoutInfo().width, height });
       this.contentHeight = height;
     }
   }
@@ -188,6 +188,10 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
         },
         model,
         overviewRulerLanes: 0,
+        padding: {
+          top: 12,
+          bottom: 5
+        },
         readOnly: this.props.readOnly,
         // Disable highlight current line, too much visual noise with it on.
         // VS Code also has it disabled for their notebook experience.

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -114,10 +114,8 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
   }
 
   onDidChangeModelContent(e: monaco.editor.IModelContentChangedEvent) {
-    if (this.editor) {
-      if (this.props.onChange) {
+    if (this.editor && this.props.onChange) {
         this.props.onChange(this.editor.getValue(), e);
-      }
     }
   }
 
@@ -138,12 +136,10 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
       // Retrieve content height directly from the editor if no height provided as param
       height = this.editor.getContentHeight();
     }
-    if (this.editorContainerRef && this.editorContainerRef.current) {
-      if (this.contentHeight !== height) {
-        this.editorContainerRef.current.style.height = height + "px";
-        this.editor.layout();
-        this.contentHeight = height;
-      }
+    if (this.editorContainerRef && this.editorContainerRef.current && (this.contentHeight !== height)) {
+      this.editorContainerRef.current.style.height = height + "px";
+      this.editor.layout();
+      this.contentHeight = height;
     }
   }
 

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -138,6 +138,11 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
     if (this.editorContainerRef && this.editorContainerRef.current && (this.contentHeight !== height)) {
       this.editorContainerRef.current.style.height = height + "px";
+      /**
+       * With no params, the layout method queries the DOM to get the parent container dimensions
+       * This causes a forced layout by the browser
+       * We pass in the expected width and height to as an optimization to avoid the forced layout
+       */
       this.editor.layout({ width: this.editor.getLayoutInfo().width, height });
       this.contentHeight = height;
     }
@@ -206,11 +211,12 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
           horizontalScrollbarSize: 0,
           arrowSize: 30
         },
-        scrollBeyondLastLine: false,
         theme: this.props.theme,
         value: this.props.value,
         // Apply custom settings from configuration
         ...this.props.options,
+        // this is required, otherwise the editor will continue to change its size on layout if set to true in options overrides
+        scrollBeyondLastLine: false
       });
 
       // Handle on create events

--- a/packages/stateful-components/src/inputs/connected-editors/monacoEditor.tsx
+++ b/packages/stateful-components/src/inputs/connected-editors/monacoEditor.tsx
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 
 import { selectors, AppState, ContentRef } from "@nteract/core";
-import MonacoEditor, {LightThemeName, DarkThemeName, Mode, mapCodeMirrorModeToMonaco} from "@nteract/monaco-editor";
+import * as monaco from "@nteract/monaco-editor";
 
 import { userTheme } from "../../config-options";
 import { Channels } from "@nteract/messaging";
@@ -25,12 +25,12 @@ function getMonacoTheme(theme?: string) : string {
   if (typeof theme === "string") {
     switch (theme) {
       case "dark":
-        return DarkThemeName;
+        return monaco.DarkThemeName;
       default:
-        return LightThemeName;
+        return monaco.LightThemeName;
     }
   } else {
-    return LightThemeName;
+    return monaco.LightThemeName;
   }
 }
 
@@ -39,15 +39,15 @@ const makeMapStateToProps = (initialState: AppState, ownProps: ComponentProps) =
   function mapStateToProps(state: any) {
     const model = selectors.model(state, { contentRef });
     const theme = userTheme(state) || "vs";
-    let wordWrap = "on";
-    let editorMode: any = Mode.raw;
+    let wordWrap:monaco.editor.IEditorOptions["wordWrap"] = "on";
+    let editorMode: string = monaco.Mode.raw;
     if (model && model.type === "notebook") {
       const cell = selectors.notebook.cellById(model, { id });
       if (cell) {
         // Bring all changes to the options based on cell type 
         switch (cell.cell_type) {
           case "markdown":
-            editorMode = Mode.markdown;
+            editorMode = monaco.Mode.markdown;
             break;
           case "code": {
             wordWrap = "off";
@@ -59,18 +59,22 @@ const makeMapStateToProps = (initialState: AppState, ownProps: ComponentProps) =
                 kernel && kernel.info
                 ? kernel.info.codemirrorMode
                 : selectors.notebook.codeMirrorMode(model);
-            editorMode = mapCodeMirrorModeToMonaco(mode);
+            editorMode = monaco.mapCodeMirrorModeToMonaco(mode);
             break;
           }
           default:
-            editorMode = Mode.raw;
+            editorMode = monaco.Mode.raw;
             break;
           }
         }
       }
-    const defaultEditorOptions = {
+    const defaultEditorOptions: monaco.editor.IEditorOptions = {
       wordWrap,
-      autoClosingBrackets: "never"
+      autoClosingBrackets: "never",
+      padding: {
+        top: 12,
+        bottom: 5
+      }
     }
     const options = {
       ...defaultEditorOptions,
@@ -91,4 +95,4 @@ const makeMapStateToProps = (initialState: AppState, ownProps: ComponentProps) =
   return mapStateToProps;
 };
 
-export default connect(makeMapStateToProps)(MonacoEditor);
+export default connect(makeMapStateToProps)(monaco.default);

--- a/packages/stateful-components/src/inputs/connected-editors/monacoEditor.tsx
+++ b/packages/stateful-components/src/inputs/connected-editors/monacoEditor.tsx
@@ -70,11 +70,7 @@ const makeMapStateToProps = (initialState: AppState, ownProps: ComponentProps) =
       }
     const defaultEditorOptions: monaco.editor.IEditorOptions = {
       wordWrap,
-      autoClosingBrackets: "never",
-      padding: {
-        top: 12,
-        bottom: 5
-      }
+      autoClosingBrackets: "never"
     }
     const options = {
       ...defaultEditorOptions,


### PR DESCRIPTION
Monaco 0.20 introduced a [`getContentHeight`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.icodeeditor.html#getcontentheight) API that enables us to get
the current editor height without resorting to hacks around line counts.
This also handles cases such as code folding. See this issue for
details: https://github.com/microsoft/monaco-editor/issues/794

Also added more type checking in the editor instantiation, leveraged the
new [padding](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorpaddingoptions.html) option to do away with the TopMargin work around.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

**Screenshots**:

Before:
![monacoResizeNteractBefore](https://user-images.githubusercontent.com/1658576/126851931-a969baf8-44c3-4038-9924-154d2eb27edd.gif)

After:

![monacoResizeNteractAfter](https://user-images.githubusercontent.com/1658576/126851934-88b34c27-2c94-4c40-82c5-3dada471bc7c.gif)
