### PR TITLE
fix: consider value prop changed before calling setvalue on monaco editor

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -169,6 +169,35 @@ describe("MonacoEditor lifeCycle methods set up", () => {
     expect(mockCreateEditor).toHaveBeenCalledTimes(1);
     expect(mockEditor.focus).toHaveBeenCalledTimes(0);
   });
+
+  it("Should call editor setValue when value prop has changed on componentDidUpdate.", () => {
+    mockEditor.setValue = jest.fn();
+    const editorWrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        value="initial_value"
+      />
+    );
+    editorWrapper.setProps({ value: "different_value" });
+
+    // We expect setValue is called twice. First on componentDidMount and second on componentDidUpdate 
+    // when the props.value has new different value.
+    expect(mockEditor.setValue).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should not call editor setValue when value prop has not changed on componentDidUpdate.", () => {
+    mockEditor.setValue = jest.fn();
+    const editorWrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        value="initial_value"
+      />
+    );
+    editorWrapper.setProps({ value: "initial_value" });
+    
+    // We expect setValue is called once on componentDidMount when the props.value does not have different value.
+    expect(mockEditor.setValue).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("MonacoEditor lineNumbers configuration", () => {

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -24,7 +24,7 @@
     "styled-components": "^4.4.1"
   },
   "dependencies": {
-    "@nteract/core": "^15.0.0",
+    "@nteract/core": "^14.0.0",
     "@nteract/messaging": "^7.0.19",
     "lodash.debounce": "^4.0.6",
     "monaco-editor": "0.22.3",

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -24,7 +24,7 @@
     "styled-components": "^4.4.1"
   },
   "dependencies": {
-    "@nteract/core": "^14.0.0",
+    "@nteract/core": "^15.0.0",
     "@nteract/messaging": "^7.0.19",
     "lodash.debounce": "^4.0.6",
     "monaco-editor": "0.22.3",

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -317,7 +317,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: IMonacoProps) {
     if (!this.editor) {
       return;
     }
@@ -334,7 +334,8 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
 
     // Ensures that the source contents of the editor (value) is consistent with the state of the editor
-    if (this.editor.getValue() !== this.props.value) {
+    // and the value has actually changed.
+    if (this.editor.getValue() !== this.props.value && prevProps.value !== this.props.value) {
       this.editor.setValue(this.props.value);
     }
 

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -316,7 +316,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
 
     // Ensures that the source contents of the editor (value) is consistent with the state of the editor
     // and the value has actually changed.
-    if (this.editor.getValue() !== this.props.value && prevProps.value !== this.props.value) {
+    if (prevProps.value !== this.props.value && this.editor.getValue() !== this.props.value) {
       this.editor.setValue(this.props.value);
     }
 

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -318,7 +318,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     // and the value has actually changed.
     if (prevProps.value !== this.props.value && this.editor.getValue() !== this.props.value) {
       this.editor.setValue(this.props.value);
-    }
+    } 
 
     completionProvider.setChannels(this.props.channels);
 

--- a/packages/monaco-editor/src/converter.ts
+++ b/packages/monaco-editor/src/converter.ts
@@ -30,7 +30,7 @@ export function mapCodeMirrorModeToMonaco(mode: any): string {
   }
   // Immutable Map
   else if (Immutable.Map.isMap(mode) && mode.has("name")) {
-    language = mode.get("name");
+    language = mode.get("name") as string;
   }
 
   // Need to handle "ipython" as a special case since it is not a registered language


### PR DESCRIPTION
Updated Monaco editor to take into consideration that the value prop has changed before calling setValue with a new value. 

Fixes issue: #5590 

Old code in componentDidUpdate:

```js
// Ensures that the source contents of the editor (value) is consistent with the state of the editor
if (this.editor.getValue() !== this.props.value) {
  this.editor.setValue(this.props.value);
}
```

The use case for taking in consideration of "the value prop has changed" is to allow folks who may want to do some performance/scalability optimizations for large notebook scenarios is to cache the typing text externally outside of the editor and later committing the cached text to the redux store versus committing each typed character immediately to the redux store. Each redux store change per character typed could be expensive to re-render. The issue without taking "the value prop has changed" into consideration is that the current code above would cause the Monaco editor to re-render the using the old value prop that we know is not updated in the redux store to reflect what has been typed into the Monaco editor. So based on the current condition statement above, it will see that the Monaco editor text (up-to-date text value) is different from value prop (original text value), so it will call setValue with the old text value reverting what the user has typed. In the new proposal, we will detect that the value has actually changed and the value is different between the prop versus the text shown in the Monaco editor before calling setValue.

New code in componentDidUpdate:

```js
// Ensures that the source contents of the editor (value) is consistent with the state of the editor
// and the value has actually changed.
if (this.editor.getValue() !== this.props.value && prevProps.value !== this.props.value) {
  this.editor.setValue(this.props.value);
}
```


- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

