### PR TITLE
fix: skip remultiline in serializing stream output

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -29,6 +29,7 @@ Provide a bulleted list of bug fixes and a reference to the PR(s) containing the
 
 - Fixed mythic-configuration, allowing it to be imported in a browser setting ([Issue #5445](https://github.com/nteract/nteract/issues/5445))
 - Upgraded react-syntax-highlighter v^12.0.0 -> v^13.0.0 ([PR#5523](https://github.com/nteract/nteract/pull/5523))
+- Fixed outputToJS, no reformatting text in serializing stream output ([#5596](https://github.com/nteract/nteract/pull/5596))
 
 ## Core SDK Packages
 

--- a/packages/commutable/__tests__/v4.spec.ts
+++ b/packages/commutable/__tests__/v4.spec.ts
@@ -4,7 +4,8 @@ import {
   makeDisplayData,
   makeErrorOutput,
   makeExecuteResult,
-  makeStreamOutput
+  makeStreamOutput,
+  OnDiskStreamOutput
 } from "../src/outputs";
 import {
   createCodeCell,
@@ -55,6 +56,13 @@ describe("outputToJS", () => {
     expect(outputToJS(displayDataOutput).output_type).toEqual("display_data");
     expect(outputToJS(streamOutput).output_type).toEqual("stream");
     expect(outputToJS(errorOutput).output_type).toEqual("error");
+  });
+
+  it("stream output does not reformat multiline string", () => {
+    const text = "line1\r\nline2\rline3\nline4\n\n\r\n\r\r\n";
+    const streamOutput = makeStreamOutput().set("text", text)
+    const outputJS = outputToJS(streamOutput) as OnDiskStreamOutput;
+    expect(outputJS.text).toEqual(text);
   });
 });
 

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -232,7 +232,10 @@ export function outputToJS(output: ImmutableOutput): OnDiskOutput {
       return {
         output_type: output.output_type,
         name: output.name,
-        text: remultiline(output.text)
+        // Note: similar to createOnDiskMediaBundle, steam output could be very big e.g. stdout dumps a large chunk of text
+        //       calling remultiline on that will cause performance issue.
+        // TODO: figure out a configurable way to reformat the string when needed.
+        text: output.text
       };
     case "error":
       return {


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->

Remove using remultiline to reformat the text in serializing stream output to avoid the performance issue when the text is huge to process in time.  
See issue #5595 for details.
