### PR TITLE
fix: batch dom writings to avoid layout thrashing

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Monaco from "monaco-editor";
-import { default as MonacoEditor } from "../src/MonacoEditor";
+import { default as MonacoEditor, waitForLayoutsDone } from "../src/MonacoEditor";
 import { mount } from "enzyme";
 
 // Common Props required to instantiate MonacoEditor View, shared by all tests.
@@ -313,7 +313,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
     resizeHandlerSpy.mockRestore();
   });
 
-  it("Resize handler should trigger an editor.layout call for a focused editor", () => {
+  it("Resize handler should trigger an editor.layout call for a focused editor", async () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
     const newMockEditor = {...mockEditor};
@@ -333,7 +333,8 @@ describe("MonacoEditor resize handler when window size changes", () => {
     );
     (window as any).innerWidth = 500;
     window.dispatchEvent(new Event('resize'));
-
+    
+    await waitForLayoutsDone();
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

Monaco editor's layout() is a major source that cause reflows, which causes UI responsiveness issue. By isolate DOM operations and batch the readings in one group and writings in another group can significantly reduce the times of reflows and improve the performance.



<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
