### PR TITLE
fix: allow bumping version of @nteract/markdown

### DIFF
--- a/packages/stateful-components/package.json
+++ b/packages/stateful-components/package.json
@@ -25,7 +25,7 @@
     "@nteract/commutable": "^7.4.5",
     "@nteract/core": "^15.1.9",
     "@nteract/fixtures": "^2.3.19",
-    "@nteract/markdown": "4.6.1",
+    "@nteract/markdown": "^4.6.1",
     "@nteract/mythic-configuration": "^1.0.11",
     "@nteract/outputs": "^3.0.11",
     "@nteract/presentational-components": "^3.4.11",


### PR DESCRIPTION
The version of @nteract/markdown is locked to 4.6.1 which blocks 'npm audit fix' to fix vulnerability bugs when new version of markdown has addressed its vulnerability issues. 
This change updates the version requirement of @nteract/markdown to allow bumping minor version.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
