### PR TITLE
fix: mark react-redux package as a peer dependency

### DIFF
--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -16,7 +16,6 @@
     "@nteract/commutable": "^7.4.5",
     "@nteract/core": "^15.1.9",
     "@nteract/types": "^7.1.9",
-    "react-redux": "7.2.5",
     "redux": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/myths/package.json
+++ b/packages/myths/package.json
@@ -15,7 +15,6 @@
     "access": "public"
   },
   "dependencies": {
-    "react-redux": "7.2.5",
     "redux": "^4.0.0",
     "redux-observable": "^2.0.0-alpha.0",
     "rxjs": "^6.3.3"

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -33,7 +33,6 @@
     "react-helmet": "^5.2.0",
     "react-hot-loader": "^4.1.2",
     "react-hotkeys": "^2.0.0",
-    "react-redux": "7.2.5",
     "redux": "^4.0.0",
     "scroll-into-view-if-needed": "2.2.28"
   },

--- a/packages/stateful-components/package.json
+++ b/packages/stateful-components/package.json
@@ -30,7 +30,6 @@
     "@nteract/outputs": "^3.0.11",
     "@nteract/presentational-components": "^3.4.11",
     "immutable": "^4.0.0-rc.12",
-    "react-redux": "7.2.5",
     "redux": "^4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

A recent [Pull request ](https://github.com/nteract/nteract/pull/5601) bumped up the mono repo to leverage `react-redux` v7 😃 . This is awesome as it sets us up to take several advantages of new apis. In that change, I noticed that `react-redux` was marked as a peer dependency as well as a regular dependency for some nested packages. Specifically:
- myths
- notebook-app-component
- connected-components
- stateful-components

While, it makes sense to manage `react-redux` as a regular dependency at the top level or for the individual applications, we'd want to ship nested nteract packages like myths etc to claim this package as a peer dependency only. This allows the users to manage a single copy of these core modules (like they already do for `react` right now). 