### PR TITLE
Only show the last input prompt

### DIFF
--- a/packages/stateful-components/__tests__/outputs/input-prompts.spec.tsx
+++ b/packages/stateful-components/__tests__/outputs/input-prompts.spec.tsx
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
-import Immutable from "immutable";
-import React from "react";
+import * as Immutable from "immutable";
+import * as React from "react";
 
 import { PromptRequest } from "../../src/outputs/input-prompts";
 
@@ -9,7 +9,7 @@ describe("PromptRequest", () => {
     const component = mount(<PromptRequest prompts={Immutable.List([])} />);
     expect(component.find("form")).toHaveLength(0);
   });
-  it("renders a form for each prompt", () => {
+  it("renders one form when given multiple prompts", () => {
     const component = mount(
       <PromptRequest
         prompts={Immutable.List([
@@ -24,6 +24,6 @@ describe("PromptRequest", () => {
         ])}
       />
     );
-    expect(component.find("form")).toHaveLength(2);
+    expect(component.find("form")).toHaveLength(1);
   });
 });

--- a/packages/stateful-components/src/cells/code-cell.tsx
+++ b/packages/stateful-components/src/cells/code-cell.tsx
@@ -99,9 +99,9 @@ export default class CodeCell extends React.Component<ComponentProps> {
      * Users can continue to add the editorSlots as children
      */
     const editor = children?.editor;
-    const pagers = children?.pagers || defaults.pagers;
-    const inputPrompts = children?.pagers || defaults.inputPrompts;
-    const outputs = children?.outputs || defaults.outputs;
+    const pagers = children?.pagers ?? defaults.pagers;
+    const inputPrompts = children?.inputPrompts ?? defaults.inputPrompts;
+    const outputs = children?.outputs ?? defaults.outputs;
     const toolbar = children?.toolbar;
 
     return (

--- a/packages/stateful-components/src/outputs/input-prompts.tsx
+++ b/packages/stateful-components/src/outputs/input-prompts.tsx
@@ -49,19 +49,26 @@ export class PromptRequest extends React.PureComponent<Props, State> {
 
   render() {
     const { prompts } = this.props;
+    // Only the last prompt should be visible, beucase the rest have already been handled
+    // and we only store a single value in our state anyway. See #5592.
+    const prompt = prompts.last(undefined);
     return (
       <div className="nteract-cell-input-prompts">
-        {prompts.map(prompt => (
-          <form onSubmit={this.handleSubmitPromptReply}>
-            <label>{prompt.prompt}</label>
-            <input
-              type={prompt.password ? "password" : "text"}
-              value={this.state.value}
-              onChange={this.handleChange}
-            />
-            <input type="submit" />
-          </form>
-        ))}
+        {
+          prompt === undefined
+            ? null
+            : (
+              <form onSubmit={this.handleSubmitPromptReply}>
+                <label>{prompt.prompt}</label>
+                <input
+                  type={prompt.password ? "password" : "text"}
+                  value={this.state.value}
+                  onChange={this.handleChange}
+                />
+                <input type="submit"/>
+              </form>
+            )
+        }
       </div>
     );
   }


### PR DESCRIPTION
Fixes #5592.

Changed the input prompts to only show the last one.

NB: I'm not sure this is the correct way to fix this. Maybe we should store the value of each and turn them read-only once they have been submitted?
