### PR TITLE
Update package.json to include the repository 

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -3,6 +3,11 @@
   "version": "7.0.11",
   "description": "A collection of actions",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/actions"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/commutable/package.json
+++ b/packages/commutable/package.json
@@ -3,6 +3,11 @@
   "version": "7.4.6",
   "description": "library for immutable notebook operations",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/commutable"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/connected-components/package.json
+++ b/packages/connected-components/package.json
@@ -3,6 +3,11 @@
   "version": "6.8.12",
   "description": "Connected components exported from @nteract/core",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/connected-components"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "15.1.9",
   "description": "core modules and components for nteract apps",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/core"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,6 +3,11 @@
   "version": "10.1.12",
   "description": "The editor that lives inside cells in nteract",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/editor"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -3,6 +3,11 @@
   "version": "2.3.19",
   "description": "",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/fixtures"
+  },
   "types": "lib/index.d.ts",
   "scripts": {
     "release": "semantic-release -e semantic-release-monorepo --tag-format='@nteract/fixtures@${version}'"

--- a/packages/host-cache/package.json
+++ b/packages/host-cache/package.json
@@ -3,6 +3,11 @@
   "version": "2.1.36",
   "description": "Local Storage backed cache of binder hosts",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/host-cache"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.js",
   "scripts": {

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -3,6 +3,11 @@
   "version": "7.0.20",
   "description": "Messaging mechanics for nteract apps (jupyter spec)",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/messaging"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/monaco-editor/package.json
+++ b/packages/monaco-editor/package.json
@@ -3,6 +3,11 @@
   "version": "3.5.4",
   "description": "A React component for the monaco editor, tailored for nteract",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/monaco-editor"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/mythic-configuration/package.json
+++ b/packages/mythic-configuration/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.11",
   "description": "A configuration system based on the myths redux framework",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/mythic-configuration"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/mythic-multiselect/package.json
+++ b/packages/mythic-multiselect/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.12",
   "description": "For selecting multiple cells",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/mythic-multiselect"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/mythic-notifications/package.json
+++ b/packages/mythic-notifications/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.11",
   "description": "A notification system based on blueprintjs toasters and the myths redux framework",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/mythic-notifications"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/mythic-windowing/package.json
+++ b/packages/mythic-windowing/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.7",
   "description": "A windowing system based on electron and the myths redux framework",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/mythic-windowing"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/myths/package.json
+++ b/packages/myths/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.13",
   "description": "A redux-observable framework for better locality of dependencies",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/myths"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/notebook-app-component/package.json
+++ b/packages/notebook-app-component/package.json
@@ -3,6 +3,11 @@
   "version": "7.7.10",
   "description": "Editable notebook app component, backed by @nteract/core's store",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/notebook-app-component"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/presentational-components/package.json
+++ b/packages/presentational-components/package.json
@@ -3,6 +3,11 @@
   "version": "3.4.11",
   "description": "pure presentational components for nteract",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/presentational-components"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/reducers/package.json
+++ b/packages/reducers/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.10",
   "description": "A set of reducers for use in nteract applications",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/reducers"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/selectors/package.json
+++ b/packages/selectors/package.json
@@ -3,6 +3,11 @@
   "version": "3.1.9",
   "description": "A colletion of state selectors",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/selectors"
+  },
   "types": "lib/index.d.ts",
   "scripts": {
     "release": "semantic-release -e semantic-release-monorepo --tag-format='@nteract/selectors@${version}'"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.11",
   "description": "css for use in nteract apps",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/styles"
+  },
   "types": "index.d.ts",
   "nteractDesktop": "index.js",
   "files": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,6 +3,11 @@
   "version": "7.1.9",
   "description": "A collection of type definitions used within core nteract packages",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/types"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/webpack-configurator/package.json
+++ b/packages/webpack-configurator/package.json
@@ -3,6 +3,11 @@
   "version": "3.2.0",
   "main": "index.js",
   "description": "a common webpack configurator for nteract applications",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/nteract.git",
+    "directory": "packages/webpack-configurator"
+  },
   "files": [
     "*.js"
   ],


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @nteract/webpack-configurator
* @nteract/types
* @nteract/styles
* @nteract/selectors
* @nteract/reducers
* @nteract/presentational-components
* @nteract/notebook-app-component
* @nteract/myths
* @nteract/mythic-windowing
* @nteract/mythic-notifications
* @nteract/mythic-multiselect
* @nteract/mythic-configuration
* @nteract/monaco-editor
* @nteract/messaging
* @nteract/fixtures
* @nteract/editor
* @nteract/core
* @nteract/connected-components
* @nteract/commutable
* @nteract/actions
* @mybinder/host-cache