### PR TITLE
fix: import statements of monaco-editor for configurable build options

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Monaco from "monaco-editor";
+import * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { default as MonacoEditor } from "../src/MonacoEditor";
 import { mount } from "enzyme";
 

--- a/packages/monaco-editor/__tests__/completionItemProvider.test.ts
+++ b/packages/monaco-editor/__tests__/completionItemProvider.test.ts
@@ -1,6 +1,6 @@
 import { createMessage, JupyterMessage } from "@nteract/messaging";
 import { Subject } from "rxjs";
-import * as Monaco from "monaco-editor";
+import * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { completionProvider } from "../src/completions/completionItemProvider";
 import * as editorBase from "../src/editor-base";
 
@@ -32,7 +32,7 @@ describe("Completions should not get trigerred when channels/messages are missin
 
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
-      expect(result.suggestions.length).toEqual(0);
+      expect(result.suggestions).toHaveLength(0);
       done();
     });
   });
@@ -44,7 +44,7 @@ describe("Completions should not get trigerred when channels/messages are missin
 
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
-      expect(result.suggestions.length).toEqual(0);
+      expect(result.suggestions).toHaveLength(0);
       done();
     });
     channels.complete();
@@ -58,7 +58,7 @@ describe("Completions should not get trigerred when channels/messages are missin
 
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
-      expect(result.suggestions.length).toEqual(0);
+      expect(result.suggestions).toHaveLength(0);
       done();
     });
     // No suggestions should be provided for incompatible message type
@@ -81,7 +81,7 @@ describe("Completions should not get trigerred when channels/messages are missin
 
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
-      expect(result.suggestions.length).toEqual(0);
+      expect(result.suggestions).toHaveLength(0);
       done();
     });
     // Although we have a complete reply message, it is not the child of the appropriate complete_request message
@@ -113,7 +113,7 @@ describe("Appropriate completions should be provided", () => {
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
       const returnedSuggestions = result.suggestions;
-      expect(returnedSuggestions.length).toEqual(1);
+      expect(returnedSuggestions).toHaveLength(1);
       expect(returnedSuggestions[0].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
       expect(returnedSuggestions[0].insertText).toEqual("some_completion");
       done();
@@ -139,7 +139,7 @@ describe("Appropriate completions should be provided", () => {
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
       const returnedSuggestions = result.suggestions;
-      expect(returnedSuggestions.length).toEqual(2);
+      expect(returnedSuggestions).toHaveLength(2);
       expect(returnedSuggestions[0].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
       expect(returnedSuggestions[0].insertText).toEqual("completion1");
       expect(returnedSuggestions[1].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
@@ -174,7 +174,7 @@ describe("Appropriate completions should be provided", () => {
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
       const returnedSuggestions = result.suggestions;
-      expect(returnedSuggestions.length).toEqual(1);
+      expect(returnedSuggestions).toHaveLength(1);
       expect(returnedSuggestions[0].kind).toEqual(Monaco.languages.CompletionItemKind.Keyword);
       expect(returnedSuggestions[0].insertText).toEqual("some_completion");
       done();
@@ -202,7 +202,7 @@ describe("Appropriate completions should be provided", () => {
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
       const returnedSuggestions = result.suggestions;
-      expect(returnedSuggestions.length).toEqual(1);
+      expect(returnedSuggestions).toHaveLength(1);
       expect(returnedSuggestions[0].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
       expect(returnedSuggestions[0].insertText).toEqual("some_completion");
       done();
@@ -228,7 +228,7 @@ describe("Appropriate completions should be provided", () => {
     completionProvider.provideCompletionItems(testModel, testPos).then((result) => {
       expect(result).toHaveProperty("suggestions");
       const returnedSuggestions = result.suggestions;
-      expect(returnedSuggestions.length).toEqual(2);
+      expect(returnedSuggestions).toHaveLength(2);
       expect(returnedSuggestions[0].kind).toEqual(Monaco.languages.CompletionItemKind.Field);
       expect(returnedSuggestions[0].label).toEqual("itemB");
       expect(returnedSuggestions[0].insertText).toEqual("itemB");

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -1,6 +1,6 @@
 import { Channels } from "@nteract/messaging";
 import { CellType, CellId } from "@nteract/commutable";
-import * as monaco from "monaco-editor";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
 import { completionProvider } from "./completions/completionItemProvider";
 import { ContentRef } from "@nteract/core";

--- a/packages/monaco-editor/src/completions/completionItemProvider.ts
+++ b/packages/monaco-editor/src/completions/completionItemProvider.ts
@@ -1,4 +1,4 @@
-import * as monaco from "monaco-editor";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import { Observable, Observer } from "rxjs";
 import { first, map } from "rxjs/operators";
 import {

--- a/packages/monaco-editor/src/converter.ts
+++ b/packages/monaco-editor/src/converter.ts
@@ -1,5 +1,5 @@
 import Immutable from "immutable";
-import * as monaco from "monaco-editor";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 /**
  * Code Mirror to Monaco constants.

--- a/packages/monaco-editor/src/documentUri.ts
+++ b/packages/monaco-editor/src/documentUri.ts
@@ -1,5 +1,5 @@
-import { Uri } from "monaco-editor";
-import * as monaco from "monaco-editor";
+import { Uri } from "monaco-editor/esm/vs/editor/editor.api";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 /**
  * Common Uri identifiers

--- a/packages/monaco-editor/src/theme.ts
+++ b/packages/monaco-editor/src/theme.ts
@@ -1,4 +1,4 @@
-import * as monaco from "monaco-editor";
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 /**
  * The default light theme with customized background


### PR DESCRIPTION
The options in MonacoWebpackPlugin, like `languages`, `features` won't work if we are importing the entire monaco-editor, as per https://github.com/microsoft/monaco-editor/tree/main/webpack-plugin :
> import * as monaco from 'monaco-editor';
> // or import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
> // if shipping only a subset of the features & languages is desired

To make that configurable, this PR replaces all imports with the one mentioned above.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
