### PR TITLE
fix: address invalid keypath exception thrown in acceptpayloadmessage

### DIFF
--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -576,7 +576,7 @@ function acceptPayloadMessage(
         type: actionTypes.CREATE_CELL_BELOW,
         payload: {
           cellType: "code",
-          cell: emptyCodeCell.setIn("source", payload.text || ""),
+          cell: emptyCodeCell.setIn(["source"], payload.text || ""),
           id,
           contentRef: action.payload.contentRef,
         },


### PR DESCRIPTION
Fix invalid keypath exception thrown in acceptPayloadMessage method in the nteract/reducers package. The issue is that the setIn method used expects an ordered collection or array where as the previous code prior to the fix provided a string which is an invalid argument to the Immutable setIn method.

immutable.es.js:1875 Uncaught TypeError: Invalid keyPath: expected Ordered Collection or Array: source
    at coerceKeyPath (immutable.es.js:1875:1)
    at updateIn (immutable.es.js:1995:1)
    at setIn (immutable.es.js:2047:1)
    at Record.setIn$1 [as setIn] (immutable.es.js:2051:1)
    at acceptPayloadMessage (notebook.js:385:1)
    at Object.notebook (notebook.js:626:1)
    at Object.__webpack_modules__../node_modules/@nteract/reducers/lib/core/entities/contents/index.js.exports.byRef (index.js:257:1)
    at __webpack_modules__../node_modules/@nteract/reducers/lib/core/entities/contents/index.js.exports.contents (index.js:274:1)
    at combineReducers.js:39:1
    at Array.forEach (<anonymous>)

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [x] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

