### PR TITLE
fix: import sub modules instead of the entire lodash to reduce build size

### DIFF
--- a/packages/mythic-configuration/src/index.ts
+++ b/packages/mythic-configuration/src/index.ts
@@ -1,5 +1,8 @@
 import { isImmutable, List } from "immutable";
-import { isEqual, result, set, unset } from "lodash";
+import isEqual from "lodash/isEqual";
+import result from "lodash/result";
+import set from "lodash/set";
+import unset from "lodash/unset";
 import { setConfigAtKey } from "./myths/set-config-at-key";
 import { configuration } from "./package";
 import { ConfigurationOption, ConfigurationOptionDefinition, ConfigurationOptionDeprecatedDefinition, HasPrivateConfigurationState } from "./types";

--- a/packages/mythic-configuration/src/myths/toggle-config-at-key.ts
+++ b/packages/mythic-configuration/src/myths/toggle-config-at-key.ts
@@ -1,4 +1,4 @@
-import { findIndex } from "lodash";
+import findIndex from "lodash/findIndex";
 import { of } from "rxjs";
 import { configOption } from "../index";
 import { configuration } from "../package";


### PR DESCRIPTION
Change importing the entire lodash package to just importing its sub modules to reduce the build size.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
