### PR TITLE
fix: capture both text and editor widget states on focus change

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -38,6 +38,7 @@ const mockEditor = {
   onDidFocusEditorText: jest.fn(),
   onDidBlurEditorText: jest.fn(),
   onDidChangeCursorSelection: jest.fn(),
+  onDidFocusEditorWidget: jest.fn(),
   onDidBlurEditorWidget: jest.fn(),
   onMouseMove: jest.fn(),
   updateOptions: jest.fn(),
@@ -49,6 +50,7 @@ const mockEditor = {
   getSelection: jest.fn(),
   focus: jest.fn(),
   hasTextFocus: jest.fn(),
+  hasWidgetFocus: jest.fn(),
   addCommand: jest.fn(),
   changeViewZones: jest.fn(),
 };
@@ -127,8 +129,11 @@ describe("MonacoEditor lifeCycle methods set up", () => {
     expect(MonacoEditor.prototype.calculateHeight).toHaveBeenCalledTimes(1);
   });
 
-  it("Should set editor's focus on render if editorFocused prop is set and editor does not have focus", () => {
-    mockEditor.hasTextFocus = jest.fn().mockReturnValue(false);
+  it("Should set editor's focus on render if editorFocused prop is set and editor text or widget does not have focus", () => {
+    mockEditor.hasWidgetFocus = jest.fn().mockReturnValue(false);
+    // hasWidgetFocus() would return false in the following case:
+    // 1. The editor text and editor widget(s) both do not have focus
+    // Since, neither an editor widget nor the editor text have focus, we explicitly set editor's focus.
     mount(
       <MonacoEditor
         {...monacoEditorCommonProps}
@@ -142,8 +147,12 @@ describe("MonacoEditor lifeCycle methods set up", () => {
     expect(mockEditor.focus).toHaveBeenCalledTimes(1);
   });
 
-  it("Should not set editor's focus on render if editorFocused prop is set but editor already has focus", () => {
-    mockEditor.hasTextFocus = jest.fn().mockReturnValue(true);
+  it("Should not set editor's focus on render if editorFocused prop is set but editor text or a widget already has focus", () => {
+    mockEditor.hasWidgetFocus = jest.fn().mockReturnValue(true);
+    // hasWidgetFocus() would return true in the following cases:
+    // 1. Editor text has focus i.e. cursor blink
+    // 2. An editor widget has focus i.e. context menu, command palette
+    // In both the scenarios we want to preserve the editor focus state and not steal the focus from a widget
     mount(
       <MonacoEditor
         {...monacoEditorCommonProps}

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -237,7 +237,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
       this.toggleEditorOptions(!!this.props.editorFocused);
 
       if (this.props.editorFocused) {
-        if (!this.editor.hasTextFocus()) {
+        if (!this.editor.hasWidgetFocus()) {
           // Bring browser focus to the editor if text not already in focus
           this.editor.focus();
         }
@@ -265,8 +265,8 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
         }
       });
       this.editor.onDidChangeModelContent(this.onDidChangeModelContent);
-      this.editor.onDidFocusEditorText(this.onFocus);
-      this.editor.onDidBlurEditorText(this.onBlur);
+      this.editor.onDidFocusEditorWidget(this.onFocus);
+      this.editor.onDidBlurEditorWidget(this.onBlur);
       this.calculateHeight();
 
       // Ensures that the source contents of the editor (value) is consistent with the state of the editor
@@ -274,11 +274,6 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
       if(this.props.cursorPositionHandler){
         this.props.cursorPositionHandler(this.editor, this.props);
       }
-
-      // When editor loses focus, hide parameter widgets (if any currently displayed).
-      this.blurEditorWidgetListener = this.editor.onDidBlurEditorWidget(() => {
-        this.hideParameterWidget();
-      });
 
       if (this.editor) {
         this.mouseMoveListener = this.editor.onMouseMove((e: any) => {
@@ -352,7 +347,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
             }
 
             // Set focus
-            if (editorFocused && !editor.hasTextFocus()) {
+            if (editorFocused && !editor.hasWidgetFocus()) {
               editor.focus();
             }
 
@@ -380,7 +375,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
 
     // Set focus
-    if (editorFocused && !this.editor.hasTextFocus()) {
+    if (editorFocused && !this.editor.hasWidgetFocus()) {
       this.editor.focus();
     }
 
@@ -445,6 +440,8 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
     this.toggleEditorOptions(false);
     this.unregisterCursorListener();
+    // When editor loses focus, hide parameter widgets (if any currently displayed).
+    this.hideParameterWidget();
   }
 
   private registerCursorListener() {

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -96,7 +96,6 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
   contentHeight?: number;
   private cursorPositionListener?: monaco.IDisposable;
 
-  private blurEditorWidgetListener?: monaco.IDisposable;
   private mouseMoveListener?: monaco.IDisposable;
 
   constructor(props: IMonacoProps) {
@@ -399,9 +398,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
         console.error(`Error occurs in disposing editor: ${JSON.stringify(err)}`);
       }
     }
-    if (this.blurEditorWidgetListener) {
-      this.blurEditorWidgetListener.dispose();
-    }
+
     if (this.mouseMoveListener) {
       this.mouseMoveListener.dispose();
     }


### PR DESCRIPTION
Monaco editor has specific APIs - [`onDidFocusEditorWidget`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html#onDidFocusEditorWidget), [`onDidBlurEditorWidget`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html#onDidBlurEditorWidget),  [`hasWidgetFocus`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html#hasWidgetFocus) which allow us to subscribe to and query focus states for both the editor text area i.e. the cursor as well as the variety of editor widgets that monaco editor supports.

We adopt these APIs for completeness. Otherwise, host applications providing focus change handlers would miss events when an editor widget eg: context menu or the command bar gain/lose focus.

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
