### PR TITLE
feat: add support for Markdown cell attachments

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -55,8 +55,6 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 #### New Features
 
-- Add support for Markdown cell attachments ([PR#5694])(https://github.com/nteract/nteract/pull/5694)
-
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
 
 #### Bug Fixes
@@ -118,7 +116,6 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 #### New Features
 
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
-
 - Add support for multiple clients to be able to connect the same remote kernel. ([PR#5557](https://github.com/nteract/nteract/pull/5557))
 
 #### Bug Fixes
@@ -203,99 +200,98 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 - New mythic package, will setup a transient in-memory configuration store, but different backends (such as using a configuration file) can be setup (see below). ([PR#5137](https://github.com/nteract/nteract/pull/5137))
 - To use the package, either:
-
-  - use the `makeConfigureStore` function from `@nteract/myths`:
-
-    ```typescript
-    import { configuration } from "@nteract/mythic-configuration";
-    import { makeConfigureStore } from "@nteract/myths";
-
-    type NonPrivateState = { foo: string };
-    const configureStore = makeConfigureStore<NonPrivateState>()({
-      packages: [configuration]
-      // reducers, epics, etc.
-    });
-    export const store = configureStore({ foo: "bar" });
-    ```
-
-  - or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.
-
+    * use the `makeConfigureStore` function from `@nteract/myths`:
+        ```typescript
+        import {configuration} from "@nteract/mythic-configuration";
+        import {makeConfigureStore} from "@nteract/myths";
+      
+        type NonPrivateState = { foo: string };
+        const configureStore = makeConfigureStore<NonPrivateState>()({
+          packages: [
+            configuration,
+          ],
+          // reducers, epics, etc.
+        });
+        export const store = configureStore({ foo: "bar" });
+        ```
+    * or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.     
 - Dispatch the return value of `setConfigFile(<path>)` to make it load/write/watch a config file instead.
 - To define configuration options, use `defineConfigOption(...)`:
-
-  ```typescript
-  import { defineConfigOption } from "@nteract/mythic-configuration";
-
-  export const { selector: tabSize, action: setTabSize } = defineConfigOption({
-    label: "Tab Size",
-    key: "codeMirror.tabSize",
-    values: [
-      { label: "2 Spaces", value: 2 },
-      { label: "3 Spaces", value: 3 },
-      { label: "4 Spaces", value: 4 }
-    ],
-    defaultValue: 4
-  });
-  ```
-
+    ```typescript
+    import {defineConfigOption} from "@nteract/mythic-configuration";
+    
+    export const {
+      selector: tabSize,
+      action: setTabSize,
+    } = defineConfigOption({
+      label: "Tab Size",
+      key: "codeMirror.tabSize",
+      values: [
+        {label: "2 Spaces", value: 2},
+        {label: "3 Spaces", value: 3},
+        {label: "4 Spaces", value: 4},
+      ],
+      defaultValue: 4,
+    });
+    ```
 - You can then use the selector (e.g. `tabSize` above) to get the value from a store (e.g. `tabSize(store.getState())`).
 - You can then alter the state by dispatching the result of the action function (e.g. `setTabSize` above, `store.dispatch(setTabSize(4))`).
 - If you have a group of config options with a common prefix (e.g. `codemirror.<...>`), you can get a selector for the whole group with `createConfigCollection(...)`:
-
-  ```typescript
-  import { createConfigCollection } from "@nteract/mythic-configuration";
-
-  const codeMirrorConfig = createConfigCollection({
-    key: "codeMirror"
-  });
-  ```
-
-  You can then do something like `codeMirrorConfig(store.getState())` to get something like
-
-  ```javascript
-  {
-    tabSize: 4,
-    // ... other options starting with `codemirror.`, potentially nested if more than one dot
-  }
-  ```
-
+    ```typescript
+    import {createConfigCollection} from "@nteract/mythic-configuration";
+    
+    const codeMirrorConfig = createConfigCollection({
+      key: "codeMirror",
+    });
+    ```
+    You can then do something like `codeMirrorConfig(store.getState())` to get something like
+    ```javascript
+    {
+      tabSize: 4,
+      // ... other options starting with `codemirror.`, potentially nested if more than one dot 
+    }
+    ```
 - The state is stored under `__private__.configuration` in the store, but it shouldn't be neccessary to directly access it.
 - To type the state/store you can use `HasPrivateConfigurationState`.
 - If you need a different way of persisting the config, you can set your own backend, e.g.:
-
-  ```typescript
-  // Since the cats are typically lazing about the computer, let's utilize them to store our
-  // config...
-  const catConfigurationBackend = (whichCats: Cat[]) =>
-    ({
+    ```typescript
+    // Since the cats are typically lazing about the computer, let's utilize them to store our
+    // config...
+    const catConfigurationBackend = (whichCats: Cat[]) => ({
       setup: () =>
         // Is called when the config system initialises, should return an Observable<Action>,
         // generally using the loadConfig myth to specify when the config should be loaded.
-        concat(of("immediately"), interval(10 * 60 * 1000)).pipe(
-          tap((_) => wakeUpCats(whichCats)),
-          mapTo(loadConfig.create())
+        concat(
+          of("immediately"),
+          interval(10 * 60 * 1000),
+        ).pipe(
+          tap(_ => wakeUpCats(whichCats)),
+          mapTo(loadConfig.create()),
         ),
-
+        
       load: () =>
         // Is called to load config, should return an Observable<Action>, generally using
         // the setConfig and/or setConfigAtKey myths to determine the config.
         askTheCatsAboutTheirConfigOptions(whichCats).pipe(
-          mapErrorTo(undefined, (error) => error?.complaint === "HUNGRY"),
-          skipWhile((data) => data === undefined),
-          map(setConfig.create)
+          mapErrorTo(undefined, error => error?.complaint === "HUNGRY"),
+          skipWhile(data => data === undefined),
+          map(setConfig.create),
         ),
-
+    
       save: (current: Map<string, any>) =>
         // Is called with the current config object to save it after it changed, should return an
         // Observable<Action>, which should be empty unless you need to dispatch actions on save.
-        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(ignoreElements())
+        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(
+          ignoreElements(),
+        ),
     } as ConfigurationBackend);
-
-  export const setConfigCats = (whichCats: Cat[]) => setConfigBackend.create(catConfigurationBackend(whichCats));
-
-  // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
-  // memory and feel like cooperating...
-  ```
+    
+    export const setConfigCats = (whichCats: Cat[]) =>
+      setConfigBackend.create(catConfigurationBackend(whichCats));
+    
+    // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
+    // memory and feel like cooperating...
+    ```
 
 ### @nteract/mythic-notifications ([publish-version-here])
 

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -55,6 +55,8 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 #### New Features
 
+- Add support for Markdown cell attachments ([PR#5694])(https://github.com/nteract/nteract/pull/5694)
+
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
 
 #### Bug Fixes
@@ -116,6 +118,7 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 #### New Features
 
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
+
 - Add support for multiple clients to be able to connect the same remote kernel. ([PR#5557](https://github.com/nteract/nteract/pull/5557))
 
 #### Bug Fixes
@@ -200,98 +203,99 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 - New mythic package, will setup a transient in-memory configuration store, but different backends (such as using a configuration file) can be setup (see below). ([PR#5137](https://github.com/nteract/nteract/pull/5137))
 - To use the package, either:
-    * use the `makeConfigureStore` function from `@nteract/myths`:
-        ```typescript
-        import {configuration} from "@nteract/mythic-configuration";
-        import {makeConfigureStore} from "@nteract/myths";
-      
-        type NonPrivateState = { foo: string };
-        const configureStore = makeConfigureStore<NonPrivateState>()({
-          packages: [
-            configuration,
-          ],
-          // reducers, epics, etc.
-        });
-        export const store = configureStore({ foo: "bar" });
-        ```
-    * or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.     
+
+  - use the `makeConfigureStore` function from `@nteract/myths`:
+
+    ```typescript
+    import { configuration } from "@nteract/mythic-configuration";
+    import { makeConfigureStore } from "@nteract/myths";
+
+    type NonPrivateState = { foo: string };
+    const configureStore = makeConfigureStore<NonPrivateState>()({
+      packages: [configuration]
+      // reducers, epics, etc.
+    });
+    export const store = configureStore({ foo: "bar" });
+    ```
+
+  - or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.
+
 - Dispatch the return value of `setConfigFile(<path>)` to make it load/write/watch a config file instead.
 - To define configuration options, use `defineConfigOption(...)`:
-    ```typescript
-    import {defineConfigOption} from "@nteract/mythic-configuration";
-    
-    export const {
-      selector: tabSize,
-      action: setTabSize,
-    } = defineConfigOption({
-      label: "Tab Size",
-      key: "codeMirror.tabSize",
-      values: [
-        {label: "2 Spaces", value: 2},
-        {label: "3 Spaces", value: 3},
-        {label: "4 Spaces", value: 4},
-      ],
-      defaultValue: 4,
-    });
-    ```
+
+  ```typescript
+  import { defineConfigOption } from "@nteract/mythic-configuration";
+
+  export const { selector: tabSize, action: setTabSize } = defineConfigOption({
+    label: "Tab Size",
+    key: "codeMirror.tabSize",
+    values: [
+      { label: "2 Spaces", value: 2 },
+      { label: "3 Spaces", value: 3 },
+      { label: "4 Spaces", value: 4 }
+    ],
+    defaultValue: 4
+  });
+  ```
+
 - You can then use the selector (e.g. `tabSize` above) to get the value from a store (e.g. `tabSize(store.getState())`).
 - You can then alter the state by dispatching the result of the action function (e.g. `setTabSize` above, `store.dispatch(setTabSize(4))`).
 - If you have a group of config options with a common prefix (e.g. `codemirror.<...>`), you can get a selector for the whole group with `createConfigCollection(...)`:
-    ```typescript
-    import {createConfigCollection} from "@nteract/mythic-configuration";
-    
-    const codeMirrorConfig = createConfigCollection({
-      key: "codeMirror",
-    });
-    ```
-    You can then do something like `codeMirrorConfig(store.getState())` to get something like
-    ```javascript
-    {
-      tabSize: 4,
-      // ... other options starting with `codemirror.`, potentially nested if more than one dot 
-    }
-    ```
+
+  ```typescript
+  import { createConfigCollection } from "@nteract/mythic-configuration";
+
+  const codeMirrorConfig = createConfigCollection({
+    key: "codeMirror"
+  });
+  ```
+
+  You can then do something like `codeMirrorConfig(store.getState())` to get something like
+
+  ```javascript
+  {
+    tabSize: 4,
+    // ... other options starting with `codemirror.`, potentially nested if more than one dot
+  }
+  ```
+
 - The state is stored under `__private__.configuration` in the store, but it shouldn't be neccessary to directly access it.
 - To type the state/store you can use `HasPrivateConfigurationState`.
 - If you need a different way of persisting the config, you can set your own backend, e.g.:
-    ```typescript
-    // Since the cats are typically lazing about the computer, let's utilize them to store our
-    // config...
-    const catConfigurationBackend = (whichCats: Cat[]) => ({
+
+  ```typescript
+  // Since the cats are typically lazing about the computer, let's utilize them to store our
+  // config...
+  const catConfigurationBackend = (whichCats: Cat[]) =>
+    ({
       setup: () =>
         // Is called when the config system initialises, should return an Observable<Action>,
         // generally using the loadConfig myth to specify when the config should be loaded.
-        concat(
-          of("immediately"),
-          interval(10 * 60 * 1000),
-        ).pipe(
-          tap(_ => wakeUpCats(whichCats)),
-          mapTo(loadConfig.create()),
+        concat(of("immediately"), interval(10 * 60 * 1000)).pipe(
+          tap((_) => wakeUpCats(whichCats)),
+          mapTo(loadConfig.create())
         ),
-        
+
       load: () =>
         // Is called to load config, should return an Observable<Action>, generally using
         // the setConfig and/or setConfigAtKey myths to determine the config.
         askTheCatsAboutTheirConfigOptions(whichCats).pipe(
-          mapErrorTo(undefined, error => error?.complaint === "HUNGRY"),
-          skipWhile(data => data === undefined),
-          map(setConfig.create),
+          mapErrorTo(undefined, (error) => error?.complaint === "HUNGRY"),
+          skipWhile((data) => data === undefined),
+          map(setConfig.create)
         ),
-    
+
       save: (current: Map<string, any>) =>
         // Is called with the current config object to save it after it changed, should return an
         // Observable<Action>, which should be empty unless you need to dispatch actions on save.
-        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(
-          ignoreElements(),
-        ),
+        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(ignoreElements())
     } as ConfigurationBackend);
-    
-    export const setConfigCats = (whichCats: Cat[]) =>
-      setConfigBackend.create(catConfigurationBackend(whichCats));
-    
-    // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
-    // memory and feel like cooperating...
-    ```
+
+  export const setConfigCats = (whichCats: Cat[]) => setConfigBackend.create(catConfigurationBackend(whichCats));
+
+  // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
+  // memory and feel like cooperating...
+  ```
 
 ### @nteract/mythic-notifications ([publish-version-here])
 

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -118,7 +118,6 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 #### New Features
 
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
-
 - Add support for multiple clients to be able to connect the same remote kernel. ([PR#5557](https://github.com/nteract/nteract/pull/5557))
 
 #### Bug Fixes
@@ -203,99 +202,98 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 - New mythic package, will setup a transient in-memory configuration store, but different backends (such as using a configuration file) can be setup (see below). ([PR#5137](https://github.com/nteract/nteract/pull/5137))
 - To use the package, either:
-
-  - use the `makeConfigureStore` function from `@nteract/myths`:
-
-    ```typescript
-    import { configuration } from "@nteract/mythic-configuration";
-    import { makeConfigureStore } from "@nteract/myths";
-
-    type NonPrivateState = { foo: string };
-    const configureStore = makeConfigureStore<NonPrivateState>()({
-      packages: [configuration]
-      // reducers, epics, etc.
-    });
-    export const store = configureStore({ foo: "bar" });
-    ```
-
-  - or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.
-
+    * use the `makeConfigureStore` function from `@nteract/myths`:
+        ```typescript
+        import {configuration} from "@nteract/mythic-configuration";
+        import {makeConfigureStore} from "@nteract/myths";
+      
+        type NonPrivateState = { foo: string };
+        const configureStore = makeConfigureStore<NonPrivateState>()({
+          packages: [
+            configuration,
+          ],
+          // reducers, epics, etc.
+        });
+        export const store = configureStore({ foo: "bar" });
+        ```
+    * or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.     
 - Dispatch the return value of `setConfigFile(<path>)` to make it load/write/watch a config file instead.
 - To define configuration options, use `defineConfigOption(...)`:
-
-  ```typescript
-  import { defineConfigOption } from "@nteract/mythic-configuration";
-
-  export const { selector: tabSize, action: setTabSize } = defineConfigOption({
-    label: "Tab Size",
-    key: "codeMirror.tabSize",
-    values: [
-      { label: "2 Spaces", value: 2 },
-      { label: "3 Spaces", value: 3 },
-      { label: "4 Spaces", value: 4 }
-    ],
-    defaultValue: 4
-  });
-  ```
-
+    ```typescript
+    import {defineConfigOption} from "@nteract/mythic-configuration";
+    
+    export const {
+      selector: tabSize,
+      action: setTabSize,
+    } = defineConfigOption({
+      label: "Tab Size",
+      key: "codeMirror.tabSize",
+      values: [
+        {label: "2 Spaces", value: 2},
+        {label: "3 Spaces", value: 3},
+        {label: "4 Spaces", value: 4},
+      ],
+      defaultValue: 4,
+    });
+    ```
 - You can then use the selector (e.g. `tabSize` above) to get the value from a store (e.g. `tabSize(store.getState())`).
 - You can then alter the state by dispatching the result of the action function (e.g. `setTabSize` above, `store.dispatch(setTabSize(4))`).
 - If you have a group of config options with a common prefix (e.g. `codemirror.<...>`), you can get a selector for the whole group with `createConfigCollection(...)`:
-
-  ```typescript
-  import { createConfigCollection } from "@nteract/mythic-configuration";
-
-  const codeMirrorConfig = createConfigCollection({
-    key: "codeMirror"
-  });
-  ```
-
-  You can then do something like `codeMirrorConfig(store.getState())` to get something like
-
-  ```javascript
-  {
-    tabSize: 4,
-    // ... other options starting with `codemirror.`, potentially nested if more than one dot
-  }
-  ```
-
+    ```typescript
+    import {createConfigCollection} from "@nteract/mythic-configuration";
+    
+    const codeMirrorConfig = createConfigCollection({
+      key: "codeMirror",
+    });
+    ```
+    You can then do something like `codeMirrorConfig(store.getState())` to get something like
+    ```javascript
+    {
+      tabSize: 4,
+      // ... other options starting with `codemirror.`, potentially nested if more than one dot 
+    }
+    ```
 - The state is stored under `__private__.configuration` in the store, but it shouldn't be neccessary to directly access it.
 - To type the state/store you can use `HasPrivateConfigurationState`.
 - If you need a different way of persisting the config, you can set your own backend, e.g.:
-
-  ```typescript
-  // Since the cats are typically lazing about the computer, let's utilize them to store our
-  // config...
-  const catConfigurationBackend = (whichCats: Cat[]) =>
-    ({
+    ```typescript
+    // Since the cats are typically lazing about the computer, let's utilize them to store our
+    // config...
+    const catConfigurationBackend = (whichCats: Cat[]) => ({
       setup: () =>
         // Is called when the config system initialises, should return an Observable<Action>,
         // generally using the loadConfig myth to specify when the config should be loaded.
-        concat(of("immediately"), interval(10 * 60 * 1000)).pipe(
-          tap((_) => wakeUpCats(whichCats)),
-          mapTo(loadConfig.create())
+        concat(
+          of("immediately"),
+          interval(10 * 60 * 1000),
+        ).pipe(
+          tap(_ => wakeUpCats(whichCats)),
+          mapTo(loadConfig.create()),
         ),
-
+        
       load: () =>
         // Is called to load config, should return an Observable<Action>, generally using
         // the setConfig and/or setConfigAtKey myths to determine the config.
         askTheCatsAboutTheirConfigOptions(whichCats).pipe(
-          mapErrorTo(undefined, (error) => error?.complaint === "HUNGRY"),
-          skipWhile((data) => data === undefined),
-          map(setConfig.create)
+          mapErrorTo(undefined, error => error?.complaint === "HUNGRY"),
+          skipWhile(data => data === undefined),
+          map(setConfig.create),
         ),
-
+    
       save: (current: Map<string, any>) =>
         // Is called with the current config object to save it after it changed, should return an
         // Observable<Action>, which should be empty unless you need to dispatch actions on save.
-        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(ignoreElements())
+        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(
+          ignoreElements(),
+        ),
     } as ConfigurationBackend);
-
-  export const setConfigCats = (whichCats: Cat[]) => setConfigBackend.create(catConfigurationBackend(whichCats));
-
-  // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
-  // memory and feel like cooperating...
-  ```
+    
+    export const setConfigCats = (whichCats: Cat[]) =>
+      setConfigBackend.create(catConfigurationBackend(whichCats));
+    
+    // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
+    // memory and feel like cooperating...
+    ```
 
 ### @nteract/mythic-notifications ([publish-version-here])
 

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -55,9 +55,9 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 #### New Features
 
-- Add support for Markdown cell attachments ([PR#5694])(https://github.com/nteract/nteract/pull/5694)
-
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
+
+- Add support for Markdown cell attachments ([PR#5694])(https://github.com/nteract/nteract/pull/5694)
 
 #### Bug Fixes
 
@@ -203,6 +203,7 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 - New mythic package, will setup a transient in-memory configuration store, but different backends (such as using a configuration file) can be setup (see below). ([PR#5137](https://github.com/nteract/nteract/pull/5137))
 - To use the package, either:
+
   - use the `makeConfigureStore` function from `@nteract/myths`:
 
     ```typescript
@@ -218,8 +219,10 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
     ```
 
   - or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.
+
 - Dispatch the return value of `setConfigFile(<path>)` to make it load/write/watch a config file instead.
 - To define configuration options, use `defineConfigOption(...)`:
+
   ```typescript
   import { defineConfigOption } from "@nteract/mythic-configuration";
 
@@ -234,9 +237,11 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
     defaultValue: 4
   });
   ```
+
 - You can then use the selector (e.g. `tabSize` above) to get the value from a store (e.g. `tabSize(store.getState())`).
 - You can then alter the state by dispatching the result of the action function (e.g. `setTabSize` above, `store.dispatch(setTabSize(4))`).
 - If you have a group of config options with a common prefix (e.g. `codemirror.<...>`), you can get a selector for the whole group with `createConfigCollection(...)`:
+
   ```typescript
   import { createConfigCollection } from "@nteract/mythic-configuration";
 
@@ -244,16 +249,20 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
     key: "codeMirror"
   });
   ```
+
   You can then do something like `codeMirrorConfig(store.getState())` to get something like
+
   ```javascript
   {
     tabSize: 4,
     // ... other options starting with `codemirror.`, potentially nested if more than one dot
   }
   ```
+
 - The state is stored under `__private__.configuration` in the store, but it shouldn't be neccessary to directly access it.
 - To type the state/store you can use `HasPrivateConfigurationState`.
 - If you need a different way of persisting the config, you can set your own backend, e.g.:
+
   ```typescript
   // Since the cats are typically lazing about the computer, let's utilize them to store our
   // config...

--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -55,6 +55,8 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 #### New Features
 
+- Add support for Markdown cell attachments ([PR#5694])(https://github.com/nteract/nteract/pull/5694)
+
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
 
 #### Bug Fixes
@@ -116,6 +118,7 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 #### New Features
 
 Provide a bulleted list of new features or improvements and a reference to the PR(s) containing these changes.
+
 - Add support for multiple clients to be able to connect the same remote kernel. ([PR#5557](https://github.com/nteract/nteract/pull/5557))
 
 #### Bug Fixes
@@ -200,98 +203,90 @@ Provide a bulleted list of breaking changes and a reference to the PR(s) contain
 
 - New mythic package, will setup a transient in-memory configuration store, but different backends (such as using a configuration file) can be setup (see below). ([PR#5137](https://github.com/nteract/nteract/pull/5137))
 - To use the package, either:
-    * use the `makeConfigureStore` function from `@nteract/myths`:
-        ```typescript
-        import {configuration} from "@nteract/mythic-configuration";
-        import {makeConfigureStore} from "@nteract/myths";
-      
-        type NonPrivateState = { foo: string };
-        const configureStore = makeConfigureStore<NonPrivateState>()({
-          packages: [
-            configuration,
-          ],
-          // reducers, epics, etc.
-        });
-        export const store = configureStore({ foo: "bar" });
-        ```
-    * or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.     
+  - use the `makeConfigureStore` function from `@nteract/myths`:
+
+    ```typescript
+    import { configuration } from "@nteract/mythic-configuration";
+    import { makeConfigureStore } from "@nteract/myths";
+
+    type NonPrivateState = { foo: string };
+    const configureStore = makeConfigureStore<NonPrivateState>()({
+      packages: [configuration]
+      // reducers, epics, etc.
+    });
+    export const store = configureStore({ foo: "bar" });
+    ```
+
+  - or call `configuration.rootReducer(state, action)` in your reducer and add the return value of `configuration.makeRootEpic()` to your epics.
 - Dispatch the return value of `setConfigFile(<path>)` to make it load/write/watch a config file instead.
 - To define configuration options, use `defineConfigOption(...)`:
-    ```typescript
-    import {defineConfigOption} from "@nteract/mythic-configuration";
-    
-    export const {
-      selector: tabSize,
-      action: setTabSize,
-    } = defineConfigOption({
-      label: "Tab Size",
-      key: "codeMirror.tabSize",
-      values: [
-        {label: "2 Spaces", value: 2},
-        {label: "3 Spaces", value: 3},
-        {label: "4 Spaces", value: 4},
-      ],
-      defaultValue: 4,
-    });
-    ```
+  ```typescript
+  import { defineConfigOption } from "@nteract/mythic-configuration";
+
+  export const { selector: tabSize, action: setTabSize } = defineConfigOption({
+    label: "Tab Size",
+    key: "codeMirror.tabSize",
+    values: [
+      { label: "2 Spaces", value: 2 },
+      { label: "3 Spaces", value: 3 },
+      { label: "4 Spaces", value: 4 }
+    ],
+    defaultValue: 4
+  });
+  ```
 - You can then use the selector (e.g. `tabSize` above) to get the value from a store (e.g. `tabSize(store.getState())`).
 - You can then alter the state by dispatching the result of the action function (e.g. `setTabSize` above, `store.dispatch(setTabSize(4))`).
 - If you have a group of config options with a common prefix (e.g. `codemirror.<...>`), you can get a selector for the whole group with `createConfigCollection(...)`:
-    ```typescript
-    import {createConfigCollection} from "@nteract/mythic-configuration";
-    
-    const codeMirrorConfig = createConfigCollection({
-      key: "codeMirror",
-    });
-    ```
-    You can then do something like `codeMirrorConfig(store.getState())` to get something like
-    ```javascript
-    {
-      tabSize: 4,
-      // ... other options starting with `codemirror.`, potentially nested if more than one dot 
-    }
-    ```
+  ```typescript
+  import { createConfigCollection } from "@nteract/mythic-configuration";
+
+  const codeMirrorConfig = createConfigCollection({
+    key: "codeMirror"
+  });
+  ```
+  You can then do something like `codeMirrorConfig(store.getState())` to get something like
+  ```javascript
+  {
+    tabSize: 4,
+    // ... other options starting with `codemirror.`, potentially nested if more than one dot
+  }
+  ```
 - The state is stored under `__private__.configuration` in the store, but it shouldn't be neccessary to directly access it.
 - To type the state/store you can use `HasPrivateConfigurationState`.
 - If you need a different way of persisting the config, you can set your own backend, e.g.:
-    ```typescript
-    // Since the cats are typically lazing about the computer, let's utilize them to store our
-    // config...
-    const catConfigurationBackend = (whichCats: Cat[]) => ({
+  ```typescript
+  // Since the cats are typically lazing about the computer, let's utilize them to store our
+  // config...
+  const catConfigurationBackend = (whichCats: Cat[]) =>
+    ({
       setup: () =>
         // Is called when the config system initialises, should return an Observable<Action>,
         // generally using the loadConfig myth to specify when the config should be loaded.
-        concat(
-          of("immediately"),
-          interval(10 * 60 * 1000),
-        ).pipe(
-          tap(_ => wakeUpCats(whichCats)),
-          mapTo(loadConfig.create()),
+        concat(of("immediately"), interval(10 * 60 * 1000)).pipe(
+          tap((_) => wakeUpCats(whichCats)),
+          mapTo(loadConfig.create())
         ),
-        
+
       load: () =>
         // Is called to load config, should return an Observable<Action>, generally using
         // the setConfig and/or setConfigAtKey myths to determine the config.
         askTheCatsAboutTheirConfigOptions(whichCats).pipe(
-          mapErrorTo(undefined, error => error?.complaint === "HUNGRY"),
-          skipWhile(data => data === undefined),
-          map(setConfig.create),
+          mapErrorTo(undefined, (error) => error?.complaint === "HUNGRY"),
+          skipWhile((data) => data === undefined),
+          map(setConfig.create)
         ),
-    
+
       save: (current: Map<string, any>) =>
         // Is called with the current config object to save it after it changed, should return an
         // Observable<Action>, which should be empty unless you need to dispatch actions on save.
-        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(
-          ignoreElements(),
-        ),
+        tellTheCatsToRememberConfigOptions(current.toJSON(), whichCats).pipe(ignoreElements())
     } as ConfigurationBackend);
-    
-    export const setConfigCats = (whichCats: Cat[]) =>
-      setConfigBackend.create(catConfigurationBackend(whichCats));
-    
-    // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
-    // memory and feel like cooperating...
-    ```
+
+  export const setConfigCats = (whichCats: Cat[]) => setConfigBackend.create(catConfigurationBackend(whichCats));
+
+  // Now just do store.dispatch(setConfigCats(...)) to start using it and hope the cats have good
+  // memory and feel like cooperating...
+  ```
 
 ### @nteract/mythic-notifications ([publish-version-here])
 

--- a/packages/commutable/__tests__/v4.spec.ts
+++ b/packages/commutable/__tests__/v4.spec.ts
@@ -165,6 +165,27 @@ describe("cell ids", () => {
         initial
       );
     });
+    it("can read notebook containing a markdown cell with attachments", () => {
+      const sampleMarkdownCell = createMarkdownCell({
+        attachments: Immutable.Map({
+          "foo.gif": {
+            "image/gif": ["<mulitline-base64", "-string>"]
+          }
+        })
+      }).toJS();
+      const notebook = getNotebook({
+        cells: [
+          {
+            ...sampleMarkdownCell,
+            id: "markdown-test-cell"
+          }
+        ]
+      });
+      const immNotebook = fromJS(notebook);
+      const markdownCell = immNotebook.getIn(["cellMap", "markdown-test-cell"]).toJS();
+
+      expect(markdownCell).toHaveProperty(["attachments", "foo.gif", "image/gif"], "<mulitline-base64-string>");
+    });
   });
 
   describe("toJS", () => {

--- a/packages/commutable/__tests__/v4.spec.ts
+++ b/packages/commutable/__tests__/v4.spec.ts
@@ -41,6 +41,19 @@ describe("cellToJS", () => {
     expect(cellToJS(codeCell).cell_type).toBe("code");
     expect(cellToJS(markdownCell).cell_type).toBe("markdown");
   });
+  it("can create and convert a markdown cell with attachments", () => {
+    const markdownCell = createMarkdownCell({
+      attachments: Immutable.Map({
+        "4e9a85bc-16ff-4d09-a23d-b3f731a5cc16.jpg": {
+          "image/jpeg": 
+          "<base64-string>"
+        }
+      })
+    });
+    const markdownCellAsJs = cellToJS(markdownCell);
+    expect(markdownCellAsJs.attachments).toBeDefined();
+    expect(markdownCellAsJs.attachments).toHaveProperty(["4e9a85bc-16ff-4d09-a23d-b3f731a5cc16.jpg", "image/jpeg"], "<base64-string>");
+  })
 });
 
 describe("outputToJS", () => {

--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -1,6 +1,6 @@
 import { ImmutableOutput } from "./outputs";
 
-import { ExecutionCount } from "./primitives";
+import { ExecutionCount, MimeBundle } from "./primitives";
 
 import {
   List as ImmutableList,
@@ -44,6 +44,7 @@ export type ImmutableCodeCell = RecordOf<CodeCellParams>;
 /* MarkdownCell Record Boilerplate */
 
 export interface MarkdownCellParams {
+  attachments?: ImmutableMap<string, MimeBundle>;
   cell_type: "markdown";
   id?: string;
   source: string;
@@ -51,6 +52,7 @@ export interface MarkdownCellParams {
 }
 
 export const makeMarkdownCell = Record<MarkdownCellParams>({
+  attachments: undefined,
   cell_type: "markdown",
   metadata: ImmutableMap({
     nteract: ImmutableMap({

--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -1,6 +1,6 @@
 import { ImmutableOutput } from "./outputs";
 
-import { ExecutionCount, MimeBundle } from "./primitives";
+import { ExecutionCount, MimeBundle, MultiLineString } from "./primitives";
 
 import {
   List as ImmutableList,
@@ -44,7 +44,7 @@ export type ImmutableCodeCell = RecordOf<CodeCellParams>;
 /* MarkdownCell Record Boilerplate */
 
 export interface MarkdownCellParams {
-  attachments?: ImmutableMap<string, MimeBundle>;
+  attachments?: ImmutableMap<string, MimeBundle<MultiLineString>>;
   cell_type: "markdown";
   id?: string;
   source: string;

--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -44,7 +44,7 @@ export type ImmutableCodeCell = RecordOf<CodeCellParams>;
 /* MarkdownCell Record Boilerplate */
 
 export interface MarkdownCellParams {
-  attachments?: ImmutableMap<string, MimeBundle<MultiLineString>>;
+  attachments?: ImmutableMap<string, MimeBundle<string>>;
   cell_type: "markdown";
   id?: string;
   source: string;

--- a/packages/commutable/src/cells.ts
+++ b/packages/commutable/src/cells.ts
@@ -1,6 +1,6 @@
 import { ImmutableOutput } from "./outputs";
 
-import { ExecutionCount, MimeBundle, MultiLineString } from "./primitives";
+import { ExecutionCount, MimeBundle } from "./primitives";
 
 import {
   List as ImmutableList,

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -11,6 +11,16 @@ export interface JSONObject {
 }
 export type JSONArray = Array<JSONType>
 
+/**
+ * A mime-type keyed dictionary of data.
+ * See https://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments for docs 
+ * and https://github.com/jupyter/nbformat/blob/b23aad6e29d8c3909a1b04a7edc9ae541096dc7b/nbformat/v4/nbformat.v4.schema.json#L442 
+ * for the schema
+ */
+export interface MimeBundle {
+  [mime_type: string]: string;
+}
+
 export type CellId = string;
 export function createCellId(): CellId {
   return uuid();

--- a/packages/commutable/src/primitives.ts
+++ b/packages/commutable/src/primitives.ts
@@ -11,16 +11,6 @@ export interface JSONObject {
 }
 export type JSONArray = Array<JSONType>
 
-/**
- * A mime-type keyed dictionary of data.
- * See https://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments for docs 
- * and https://github.com/jupyter/nbformat/blob/b23aad6e29d8c3909a1b04a7edc9ae541096dc7b/nbformat/v4/nbformat.v4.schema.json#L442 
- * for the schema
- */
-export interface MimeBundle {
-  [mime_type: string]: string;
-}
-
 export type CellId = string;
 export function createCellId(): CellId {
   return uuid();
@@ -29,6 +19,17 @@ export function createCellId(): CellId {
 // On disk multi-line strings are used to accomodate line-by-line diffs in tools
 // like git and GitHub. They get converted to strings for the in-memory format.
 export type MultiLineString = string | string[];
+
+/**
+ * A mime-type keyed dictionary of data.
+ * See https://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments for docs 
+ * and https://github.com/jupyter/nbformat/blob/b23aad6e29d8c3909a1b04a7edc9ae541096dc7b/nbformat/v4/nbformat.v4.schema.json#L442 
+ * for the schema
+ */
+ export interface MimeBundle<TPayload = string> {
+  [mime_type: string]: TPayload;
+}
+
 
 export type ImmutableJSONType =
   | PrimitiveImmutable

--- a/packages/commutable/src/v4.ts
+++ b/packages/commutable/src/v4.ts
@@ -45,6 +45,7 @@ import {
   demultiline,
   ExecutionCount,
   JSONObject,
+  MimeBundle,
   MultiLineString,
   remultiline
 } from "./primitives";
@@ -70,6 +71,7 @@ export interface CodeCell {
 }
 
 export interface MarkdownCell {
+  attachments?: { [mime_type: string]: MultiLineString }
   cell_type: "markdown";
   id?: string;
   metadata: JSONObject;
@@ -126,6 +128,7 @@ function createImmutableMarkdownCell(
   cell: MarkdownCell
 ): ImmutableMarkdownCell {
   return makeMarkdownCell({
+    attachments: cell.attachments ? ImmutableMap(cell.attachments).map((data: MultiLineString) => demultiline(data)) : undefined,
     cell_type: cell.cell_type,
     source: demultiline(cell.source),
     metadata: createImmutableMetadata(cell.metadata)
@@ -213,6 +216,11 @@ function metadataToJS(immMetadata: ImmutableMap<string, any>): JSONObject {
   return immMetadata.toJS() as JSONObject;
 }
 
+function attachmentsToJS(immAttachments: ImmutableMap<string, string> | undefined): MimeBundle | undefined
+{
+  return immAttachments?.toJS() as MimeBundle | undefined
+}
+
 export function outputToJS(output: ImmutableOutput): OnDiskOutput {
   switch (output.output_type) {
     case "execute_result":
@@ -251,6 +259,7 @@ export function outputToJS(output: ImmutableOutput): OnDiskOutput {
 
 function markdownCellToJS(immCell: ImmutableMarkdownCell): MarkdownCell {
   return {
+    attachments: attachmentsToJS(immCell.attachments),
     cell_type: "markdown",
     source: remultiline(immCell.source),
     metadata: metadataToJS(immCell.metadata)


### PR DESCRIPTION
<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

The Jupyter notebook file specification states that Markdown and raw cells have an optional field for [cell attachments](https://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments), but this field is not supported by `@nteract/commutable`. By supporting attachments for markdown cells, it will be possible to embed images within the notebook that can then be referenced by Markdown cells. An added bonus is better compatibility with JupyterLab notebook files as any images that are pasted or dropped onto a markdown cell are stored as cell attachments (see [here](https://github.com/jupyterlab/jupyterlab/blob/cb117e3c0767f3fcfd734f3cc84b058b22b414c9/packages/cells/src/widget.ts#L1420) for the JupyterLab implementation)

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
