### PR TITLE
fix: add maxHeight and autoFitContentHeight options

### DIFF
--- a/packages/monaco-editor/__tests__/calculateHeight.test.tsx
+++ b/packages/monaco-editor/__tests__/calculateHeight.test.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
+import { default as MonacoEditor } from "../src/MonacoEditor";
+import { mount } from "enzyme";
+
+// Common Props required to instantiate MonacoEditor View, shared by all tests.
+const monacoEditorCommonProps = {
+  id: "foo",
+  contentRef: "bar",
+  editorType: "monaco",
+  theme: "vs",
+  value: "test_value",
+  enableCompletion: true,
+  language: "python",
+  onCursorPositionChange: () => {},
+};
+
+// Setup items shared by all tests in this block
+// Mock out the common API methods so that private function calls don't fail
+const mockEditor = {
+  onDidContentSizeChange: jest.fn(),
+  onDidChangeModelContent: jest.fn(),
+  onDidFocusEditorText: jest.fn(),
+  onDidBlurEditorText: jest.fn(),
+  onDidChangeCursorSelection: jest.fn(),
+  onDidFocusEditorWidget: jest.fn(),
+  onDidBlurEditorWidget: jest.fn(),
+  onMouseMove: jest.fn(),
+  updateOptions: jest.fn(),
+  getValue: jest.fn(),
+  setValue: jest.fn(),
+  getConfiguration: jest.fn(),
+  layout: jest.fn(),
+  getModel: jest.fn(),
+  getSelection: jest.fn(),
+  getContentHeight: jest.fn(),
+  focus: jest.fn(),
+  hasTextFocus: jest.fn(),
+  hasWidgetFocus: jest.fn(),
+  addCommand: jest.fn(),
+  changeViewZones: jest.fn(),
+};
+
+const mockEditorModel = {
+  updateOptions: jest.fn(),
+};
+const mockCreateEditor = jest.fn().mockReturnValue(mockEditor);
+Monaco.editor.create = mockCreateEditor;
+Monaco.editor.createModel = jest.fn().mockReturnValue(mockEditorModel);
+MonacoEditor.prototype.registerDefaultCompletionProvider = jest.fn();
+
+describe("MonacoEditor process calculateHeight correctly", () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maxHeight is honored when content height exceeds it", () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const width = 500;
+    const height = 100;
+    const maxHeight = 200;
+    const contentHeight = 300;
+    const newMockEditor = {
+      ...mockEditor,
+      layout: mockEditorLayout,
+      getContentHeight: ()=>contentHeight,
+      getLayoutInfo: jest.fn(()=>({width, height})),
+    };
+
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    const editorWrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        maxContentHeight={maxHeight}
+      />
+    );
+
+    const editorInstance = editorWrapper.instance() as MonacoEditor;
+    editorInstance.calculateHeight();
+
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout.mock.calls[0][0]).toEqual({width, height: maxHeight});
+  });
+
+  it("should not trigger layout when autoFitContentHeight is false", () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = {...mockEditor, layout: mockEditorLayout};
+
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    const editorWrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        autoFitContentHeight={false}
+      />
+    );
+    const editorInstance = editorWrapper.instance() as MonacoEditor;
+    editorInstance.calculateHeight();
+    
+    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -71,8 +71,8 @@ export interface IMonacoConfiguration {
   lineNumbers?: boolean;
   /** automatically adjust size to fit content, default is true */
   autoFitContentHeight?: boolean;
-  /** set a max height in number of pixels */
-  maxHeight?: number;
+  /** set a max content height in number of pixels, this only works when autoFitContentHeight is true*/
+  maxContentHeight?: number;
   /** set height of editor to fit the specified number of lines in display */
   numberOfLines?: number;
   indentSize?: number;
@@ -143,10 +143,10 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     if (typeof height === "undefined") {
       // Retrieve content height directly from the editor if no height provided as param
       height = this.editor.getContentHeight();
+    }
 
-      if(this.props.maxHeight) {
-        height = Math.min(height, this.props.maxHeight);
-      }
+    if(this.props.maxContentHeight) {
+      height = Math.min(height, this.props.maxContentHeight);
     }
 
     if (this.editorContainerRef && this.editorContainerRef.current && (this.contentHeight !== height)) {

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -69,6 +69,10 @@ export interface IMonacoConfiguration {
   onRegisterCompletionProvider?: (languageId: string) => void;
   language: string;
   lineNumbers?: boolean;
+  /** automatically adjust size to fit content, default is true */
+  autoFitContentHeight?: boolean;
+  /** set a max height in number of pixels */
+  maxHeight?: number;
   /** set height of editor to fit the specified number of lines in display */
   numberOfLines?: number;
   indentSize?: number;
@@ -131,10 +135,20 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
       return;
     }
 
+    const shouldProceed = this.props.autoFitContentHeight ?? true;
+    if(!shouldProceed) {
+      return;
+    }
+
     if (typeof height === "undefined") {
       // Retrieve content height directly from the editor if no height provided as param
       height = this.editor.getContentHeight();
+
+      if(this.props.maxHeight) {
+        height = Math.min(height, this.props.maxHeight);
+      }
     }
+
     if (this.editorContainerRef && this.editorContainerRef.current && (this.contentHeight !== height)) {
       this.editorContainerRef.current.style.height = height + "px";
       /**


### PR DESCRIPTION
Add two options in monaco-editor component
* autoFixContentHeight - this is already on by default, adding this option to allow users to disable it by setting it to false
* maxHeight - allow users to set a max height of the editor


<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
