### PR TITLE
fix: add skipLayoutWhenHidden prop

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -419,4 +419,72 @@ describe("MonacoEditor resize handler when window size changes", () => {
     // Restore spy
     resizeHandlerSpy.mockRestore();
   });
+
+  it("Resize handler should trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is NOT hidden", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = {...mockEditor};
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+
+    const wrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        skipLayoutWhenHidden={true}
+      />
+    );
+
+    const componentInstance = wrapper.instance() as MonacoEditor;
+    componentInstance.isContainerHidden = jest.fn(()=>false);
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event('resize'));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should NOT trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is hidden", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = {...mockEditor};
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+
+    const wrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        skipLayoutWhenHidden={true}
+      />
+    );
+
+    const componentInstance = wrapper.instance() as MonacoEditor;
+    componentInstance.isContainerHidden = jest.fn(()=>true);
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event('resize'));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
 });

--- a/packages/monaco-editor/__tests__/calculateHeight.test.tsx
+++ b/packages/monaco-editor/__tests__/calculateHeight.test.tsx
@@ -12,7 +12,7 @@ const monacoEditorCommonProps = {
   value: "test_value",
   enableCompletion: true,
   language: "python",
-  onCursorPositionChange: () => {},
+  onCursorPositionChange: () => {}
 };
 
 // Setup items shared by all tests in this block
@@ -38,11 +38,11 @@ const mockEditor = {
   hasTextFocus: jest.fn(),
   hasWidgetFocus: jest.fn(),
   addCommand: jest.fn(),
-  changeViewZones: jest.fn(),
+  changeViewZones: jest.fn()
 };
 
 const mockEditorModel = {
-  updateOptions: jest.fn(),
+  updateOptions: jest.fn()
 };
 const mockCreateEditor = jest.fn().mockReturnValue(mockEditor);
 Monaco.editor.create = mockCreateEditor;
@@ -67,8 +67,8 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     const newMockEditor = {
       ...mockEditor,
       layout: mockEditorLayout,
-      getContentHeight: ()=>contentHeight,
-      getLayoutInfo: jest.fn(()=>({width, height})),
+      getContentHeight: () => contentHeight,
+      getLayoutInfo: jest.fn(() => ({ width, height }))
     };
 
     mockCreateEditor.mockReturnValue(newMockEditor);
@@ -87,13 +87,13 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     editorInstance.calculateHeight();
 
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
-    expect(mockEditorLayout.mock.calls[0][0]).toEqual({width, height: maxHeight});
+    expect(mockEditorLayout.mock.calls[0][0]).toEqual({ width, height: maxHeight });
   });
 
   it("should not trigger layout when autoFitContentHeight is false", () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor, layout: mockEditorLayout};
+    const newMockEditor = { ...mockEditor, layout: mockEditorLayout };
 
     mockCreateEditor.mockReturnValue(newMockEditor);
     const editorWrapper = mount(
@@ -108,7 +108,67 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     );
     const editorInstance = editorWrapper.instance() as MonacoEditor;
     editorInstance.calculateHeight();
-    
+
     expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+  });
+
+  it("should NOT trigger layout when skipLayoutWhenHidden is true and parent container is hidden", () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = {
+      ...mockEditor,
+      layout: mockEditorLayout,
+      getContentHeight: jest.fn(() => 100),
+      getLayoutInfo: jest.fn(() => ({ width: 100, height: 100 }))
+    };
+
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    const editorWrapper = mount(
+        <MonacoEditor
+          {...monacoEditorCommonProps}
+          channels={undefined}
+          onChange={jest.fn()}
+          onFocusChange={jest.fn()}
+          editorFocused={true}
+          skipLayoutWhenHidden={true}
+        />
+    );
+
+    const editorInstance = editorWrapper.instance() as MonacoEditor;
+    editorInstance.isContainerHidden = jest.fn(()=>true);
+
+    // set an arbitary height which is different from the current height return by editor.getContentHeight()
+    editorInstance.calculateHeight(200);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+  });
+
+  it("should trigger layout when skipLayoutWhenHidden is true and parent container is NOT hidden", () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = {
+      ...mockEditor,
+      layout: mockEditorLayout,
+      getContentHeight: jest.fn(() => 100),
+      getLayoutInfo: jest.fn(() => ({ width: 100, height: 100 }))
+    };
+
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    const editorWrapper = mount(
+        <MonacoEditor
+          {...monacoEditorCommonProps}
+          channels={undefined}
+          onChange={jest.fn()}
+          onFocusChange={jest.fn()}
+          editorFocused={true}
+          skipLayoutWhenHidden={true}
+        />
+    );
+
+    const editorInstance = editorWrapper.instance() as MonacoEditor;
+    editorInstance.isContainerHidden = jest.fn(()=>false);
+
+    // set an arbitary height which is different from the current height return by editor.getContentHeight()
+    editorInstance.calculateHeight(200);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -77,6 +77,11 @@ export interface IMonacoConfiguration {
    * This is better used together with batchLayoutChanges set to true so all editors layouts changes can be batched for better perf
    */
   shouldUpdateLayoutWhenNotFocused?: boolean;
+  /**
+   * whether we should call editor.layout() when the container or its parent is hidden by "display:none" or the height is set to 0
+   * default is false
+   */
+  skipLayoutWhenHidden?: boolean;
   /** automatically adjust size to fit content, default is true */
   autoFitContentHeight?: boolean;
   /** set a max content height in number of pixels, this only works when autoFitContentHeight is true*/
@@ -319,6 +324,12 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
    * Tells editor to check the surrounding container size and resize itself appropriately
    */
   resize() {
+    // when skipLayoutWhenHidden is true and the editor's parent or ancestor container is hidden, 
+    // we will not layout the editor. 
+    if(this.props.skipLayoutWhenHidden && !this.editorContainerRef.current?.offsetHeight) {
+      return;
+    }
+
     if (this.props.shouldUpdateLayoutWhenNotFocused) {
       this.updateEditorLayout();
     } else if (this.editor && this.props.editorFocused) {

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -134,8 +134,18 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
   }
 
+  isContainerHidden(){
+    return !this.editorContainerRef.current?.offsetHeight;
+  }
+
   updateEditorLayout(layout?: monaco.editor.IDimension) {
     if (!this.editor) {
+      return;
+    }
+
+    // when skipLayoutWhenHidden is true and the editor's parent or ancestor container is hidden, 
+    // we will not layout the editor. 
+    if(this.props.skipLayoutWhenHidden && this.isContainerHidden()) {
       return;
     }
 
@@ -172,7 +182,7 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     if (this.props.maxContentHeight) {
       height = Math.min(height, this.props.maxContentHeight);
     }
-
+    
     if (this.editorContainerRef && this.editorContainerRef.current && this.contentHeight !== height) {
       this.editorContainerRef.current.style.height = height + "px";
       /**
@@ -324,12 +334,6 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
    * Tells editor to check the surrounding container size and resize itself appropriately
    */
   resize() {
-    // when skipLayoutWhenHidden is true and the editor's parent or ancestor container is hidden, 
-    // we will not layout the editor. 
-    if(this.props.skipLayoutWhenHidden && !this.editorContainerRef.current?.offsetHeight) {
-      return;
-    }
-
     if (this.props.shouldUpdateLayoutWhenNotFocused) {
       this.updateEditorLayout();
     } else if (this.editor && this.props.editorFocused) {


### PR DESCRIPTION
Added a skipLayoutWhenHidden prop in monaco-editor to skip calling editor.layout() in cases when the monaco-editor is hidden by its parent or ancestor container.

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
