### PR TITLE
[Fix] `createCellAppend()` reducer shouldn't ignore passed in `cell` parameter

### DIFF
--- a/changelogs/current_changelog.md
+++ b/changelogs/current_changelog.md
@@ -30,6 +30,7 @@ Provide a bulleted list of bug fixes and a reference to the PR(s) containing the
 - Fixed mythic-configuration, allowing it to be imported in a browser setting ([Issue #5445](https://github.com/nteract/nteract/issues/5445))
 - Upgraded react-syntax-highlighter v^12.0.0 -> v^13.0.0 ([PR#5523](https://github.com/nteract/nteract/pull/5523))
 - Fixed outputToJS, no reformatting text in serializing stream output ([#5596](https://github.com/nteract/nteract/pull/5596))
+- Added logic inside `createCellAppend()` to handle passed-in `cell` parameter, which was previously being ignored. ([#5708](https://github.com/nteract/nteract/pull/5708))
 
 ## Core SDK Packages
 

--- a/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
+++ b/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
@@ -516,11 +516,11 @@ describe("newCellAppend", () => {
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
   });
-  test("appends a new code cell at the end given cell contents", () => {
+  test("appends a new cell at the end given cell contents", () => {
     const originalState = initialDocument.set("notebook", fixtureCommutable);
     const state = reducers(
       originalState,
-      actions.createCellAppend({ cellType: "code", cell: emptyMarkdownCell.set("source", "test contents") })
+      actions.createCellAppend({ cellType: "markdown", cell: emptyMarkdownCell.set("source", "test contents") })
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
     const insertedCellId = state.getIn(["notebook", "cellOrder"]).last();

--- a/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
+++ b/packages/reducers/__tests__/core/entities/contents/notebook.spec.ts
@@ -516,6 +516,16 @@ describe("newCellAppend", () => {
     );
     expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
   });
+  test("appends a new code cell at the end given cell contents", () => {
+    const originalState = initialDocument.set("notebook", fixtureCommutable);
+    const state = reducers(
+      originalState,
+      actions.createCellAppend({ cellType: "code", cell: emptyMarkdownCell.set("source", "test contents") })
+    );
+    expect(state.getIn(["notebook", "cellOrder"]).size).toBe(3);
+    const insertedCellId = state.getIn(["notebook", "cellOrder"]).last();
+    expect(state.getIn(["notebook", "cellMap", insertedCellId, "source"])).toEqual("test contents")
+  });
 });
 
 describe("updateSource", () => {

--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -543,8 +543,11 @@ function createCellAppend(
   const { cellType } = action.payload;
   const notebook: ImmutableNotebook = state.get("notebook");
   const cellOrder: List<CellId> = notebook.get("cellOrder", List());
-  const cell: ImmutableCell =
+  let cell: ImmutableCell =
     cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
+  if (action.payload.cell) {
+    cell = action.payload.cell;
+  }
   const index = cellOrder.count();
   const cellId = uuid();
   return state.set("notebook", insertCellAt(notebook, cell, cellId, index));


### PR DESCRIPTION
Added logic inside `createCellAppend()` to handle passed-in `cell` parameter, which was previously being ignored

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.
  - The instructions in TEST_PLAN not working for me. `yarn dist` isn't working

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
