### PR TITLE
fix: `createCellAppend()` reducer shouldn't ignore passed in `cell` parameter

### DIFF
--- a/packages/reducers/src/core/entities/contents/notebook.ts
+++ b/packages/reducers/src/core/entities/contents/notebook.ts
@@ -543,11 +543,7 @@ function createCellAppend(
   const { cellType } = action.payload;
   const notebook: ImmutableNotebook = state.get("notebook");
   const cellOrder: List<CellId> = notebook.get("cellOrder", List());
-  let cell: ImmutableCell =
-    cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell;
-  if (action.payload.cell) {
-    cell = action.payload.cell;
-  }
+  const cell: ImmutableCell = action.payload.cell ?? (cellType === "markdown" ? emptyMarkdownCell : emptyCodeCell);
   const index = cellOrder.count();
   const cellId = uuid();
   return state.set("notebook", insertCellAt(notebook, cell, cellId, index));


### PR DESCRIPTION
#5708 didn't have the expected commit message format, so it wasn't being deployed automatically. This PR is just a no-op change to trigger an automatic release, now with the correct commit name

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [x] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [x] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [x] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.
  - The instructions in TEST_PLAN not working for me. `yarn dist` isn't working

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
