### PR TITLE
fix: disable word based suggestions for monaco editor

### DIFF
--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -248,6 +248,8 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
         // Disable highlight current line, too much visual noise with it on.
         // VS Code also has it disabled for their notebook experience.
         renderLineHighlight: "none",
+        // Do not include words from the editor into the autocomplete suggestions list
+        wordBasedSuggestions: false,
         scrollbar: {
           useShadows: false,
           verticalHasArrows: false,


### PR DESCRIPTION
Disable word based suggestions for monaco editor.

- [x ] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [ ] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.
