### PR TITLE
fix: optimize resizing perf by using resize observer and batch the DOM reads and writes separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "@types/react-timeago": "^4.1.0",
     "@types/redux-immutable": "^4.0.0",
     "@types/redux-logger": "^3.0.6",
+    "@types/resize-observer-browser": "^0.1.7",
     "@types/semver": "^7.0.0",
     "@types/styled-components": "^5.0.1",
     "@types/webfontloader": "^1.6.29",

--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -49,6 +49,7 @@ const mockEditor = {
   getValue: jest.fn(),
   setValue: jest.fn(),
   getConfiguration: jest.fn(),
+  getContainerDomNode: jest.fn(() => ({ clientWidth: 100, clientHeight: 50 })),
   layout: jest.fn(),
   getModel: jest.fn(),
   getSelection: jest.fn(),
@@ -65,7 +66,7 @@ const mockEditorModel = {
 const mockCreateEditor = jest.fn().mockReturnValue(mockEditor);
 Monaco.editor.create = mockCreateEditor;
 Monaco.editor.createModel = jest.fn().mockReturnValue(mockEditorModel);
-MonacoEditor.prototype.calculateHeight = jest.fn();
+MonacoEditor.prototype.requestLayout = jest.fn();
 MonacoEditor.prototype.registerDefaultCompletionProvider = jest.fn();
 MonacoEditor.prototype.getLayoutDimension = jest.fn(() => ({ width: 300, height: 400 }));
 
@@ -116,7 +117,7 @@ describe("MonacoEditor lifeCycle methods set up", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it("Should call calculateHeight method before rendering editor", () => {
+  it("Should call requestLayout method before rendering editor", () => {
     mount(
       <MonacoEditor
         {...monacoEditorCommonProps}
@@ -127,7 +128,7 @@ describe("MonacoEditor lifeCycle methods set up", () => {
       />
     );
     expect(mockCreateEditor).toHaveBeenCalledTimes(1);
-    expect(MonacoEditor.prototype.calculateHeight).toHaveBeenCalledTimes(1);
+    expect(MonacoEditor.prototype.requestLayout).toHaveBeenCalledTimes(1);
   });
 
   it("Should set editor's focus on render if editorFocused prop is set and editor text or widget does not have focus", () => {
@@ -242,240 +243,5 @@ describe("MonacoEditor lineNumbers configuration", () => {
     const editorCreateArgs = mockCreateEditor.mock.calls[0][1];
     expect(editorCreateArgs).toHaveProperty("lineNumbers");
     expect(editorCreateArgs.lineNumbers).toEqual("off");
-  });
-});
-
-describe("MonacoEditor resize handler when window size changes", () => {
-  beforeAll(() => {
-    jest.clearAllMocks();
-  });
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-  it("Should not call resize handler at all when window is not resized", () => {
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={false}
-      />
-    );
-
-    expect(mockCreateEditor).toHaveBeenCalledTimes(1);
-    // Resize handler should be called
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(0);
-    // editor.layout should not be called
-    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
-  });
-
-  it("Resize handler should not trigger editor.layout when it is not focused", () => {
-    // This is a perf optimization to reduce layout calls for unfocussed editors
-
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={false}
-      />
-    );
-    (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event("resize"));
-
-    // Resize handler should be called
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
-    // editor.layout should not be called
-    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
-  });
-
-  it("Resize handler should trigger an editor.layout call for a focused editor", () => {
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={true}
-      />
-    );
-    (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event("resize"));
-
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
-    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
-  });
-
-  it("Resize handler should trigger an editor.layout call for a non-focused editor when shouldUpdateLayoutWhenNotFocused=true", () => {
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={false}
-        shouldUpdateLayoutWhenNotFocused={true}
-      />
-    );
-
-    (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event("resize"));
-
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
-    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
-  });
-
-  it("Resize handler should trigger an editor.layout call asynchronously when batchLayoutChanges=true", async () => {
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-    const originRAF = window.requestAnimationFrame;
-    const mockRAF = jest.fn((callback) => originRAF(callback));
-    window.requestAnimationFrame = mockRAF;
-
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={true}
-        batchLayoutChanges={true}
-      />
-    );
-
-    (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event("resize"));
-
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
-    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
-
-    expect(mockRAF).toHaveBeenCalledTimes(1);
-
-    // wait on the second RAF to returned, which should be called after the first RAF has been executed
-    await new Promise(originRAF);
-    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
-  });
-
-  it("Resize handler should trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is NOT hidden", async () => {
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    const wrapper = mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={true}
-        skipLayoutWhenHidden={true}
-      />
-    );
-
-    const componentInstance = wrapper.instance() as MonacoEditor;
-    componentInstance.isContainerHidden = jest.fn(() => false);
-
-    (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event("resize"));
-
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
-    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
-  });
-
-  it("Resize handler should NOT trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is hidden", async () => {
-    // Create a new editor instance with the mock layout
-    const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor };
-    newMockEditor.layout = mockEditorLayout;
-    mockCreateEditor.mockReturnValue(newMockEditor);
-
-    // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
-
-    const wrapper = mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={true}
-        skipLayoutWhenHidden={true}
-      />
-    );
-
-    const componentInstance = wrapper.instance() as MonacoEditor;
-    componentInstance.isContainerHidden = jest.fn(() => true);
-
-    (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event("resize"));
-
-    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
-    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
-
-    // Restore spy
-    resizeHandlerSpy.mockRestore();
   });
 });

--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -12,7 +12,7 @@ const monacoEditorCommonProps = {
   value: "test_value",
   enableCompletion: true,
   language: "python",
-  onCursorPositionChange: () => {},
+  onCursorPositionChange: () => {}
 };
 
 describe("MonacoEditor component is rendering correctly", () => {
@@ -52,11 +52,11 @@ const mockEditor = {
   hasTextFocus: jest.fn(),
   hasWidgetFocus: jest.fn(),
   addCommand: jest.fn(),
-  changeViewZones: jest.fn(),
+  changeViewZones: jest.fn()
 };
 
 const mockEditorModel = {
-  updateOptions: jest.fn(),
+  updateOptions: jest.fn()
 };
 const mockCreateEditor = jest.fn().mockReturnValue(mockEditor);
 Monaco.editor.create = mockCreateEditor;
@@ -84,9 +84,7 @@ describe("MonacoEditor default completion provider", () => {
       />
     );
     expect(mockCreateEditor).toHaveBeenCalledTimes(1);
-    expect(
-      MonacoEditor.prototype.registerDefaultCompletionProvider
-    ).toHaveBeenCalledTimes(1);
+    expect(MonacoEditor.prototype.registerDefaultCompletionProvider).toHaveBeenCalledTimes(1);
   });
 
   it("Should not call registerDefaultCompletionProvider method when registerCompletionUsingDefault is set to false", () => {
@@ -102,9 +100,7 @@ describe("MonacoEditor default completion provider", () => {
       />
     );
     expect(mockCreateEditor).toHaveBeenCalledTimes(1);
-    expect(
-      MonacoEditor.prototype.registerDefaultCompletionProvider
-    ).toHaveBeenCalledTimes(0);
+    expect(MonacoEditor.prototype.registerDefaultCompletionProvider).toHaveBeenCalledTimes(0);
   });
 });
 
@@ -182,29 +178,19 @@ describe("MonacoEditor lifeCycle methods set up", () => {
 
   it("Should call editor setValue when value prop has changed on componentDidUpdate.", () => {
     mockEditor.setValue = jest.fn();
-    const editorWrapper = mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        value="initial_value"
-      />
-    );
+    const editorWrapper = mount(<MonacoEditor {...monacoEditorCommonProps} value="initial_value" />);
     editorWrapper.setProps({ value: "different_value" });
 
-    // We expect setValue is called twice. First on componentDidMount and second on componentDidUpdate 
+    // We expect setValue is called twice. First on componentDidMount and second on componentDidUpdate
     // when the props.value has new different value.
     expect(mockEditor.setValue).toHaveBeenCalledTimes(2);
   });
 
   it("Should not call editor setValue when value prop has not changed on componentDidUpdate.", () => {
     mockEditor.setValue = jest.fn();
-    const editorWrapper = mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        value="initial_value"
-      />
-    );
+    const editorWrapper = mount(<MonacoEditor {...monacoEditorCommonProps} value="initial_value" />);
     editorWrapper.setProps({ value: "initial_value" });
-    
+
     // We expect setValue is called once on componentDidMount when the props.value does not have different value.
     expect(mockEditor.setValue).toHaveBeenCalledTimes(1);
   });
@@ -264,11 +250,11 @@ describe("MonacoEditor resize handler when window size changes", () => {
   it("Should not call resize handler at all when window is not resized", () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     mount(
       <MonacoEditor
@@ -295,11 +281,11 @@ describe("MonacoEditor resize handler when window size changes", () => {
 
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     mount(
       <MonacoEditor
@@ -311,7 +297,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
       />
     );
     (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event("resize"));
 
     // Resize handler should be called
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
@@ -325,11 +311,11 @@ describe("MonacoEditor resize handler when window size changes", () => {
   it("Resize handler should trigger an editor.layout call for a focused editor", () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     mount(
       <MonacoEditor
@@ -341,7 +327,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
       />
     );
     (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event("resize"));
 
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
@@ -353,11 +339,11 @@ describe("MonacoEditor resize handler when window size changes", () => {
   it("Resize handler should trigger an editor.layout call for a non-focused editor when shouldUpdateLayoutWhenNotFocused=true", () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     mount(
       <MonacoEditor
@@ -371,7 +357,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
     );
 
     (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event("resize"));
 
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
@@ -383,7 +369,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
   it("Resize handler should trigger an editor.layout call asynchronously when batchLayoutChanges=true", async () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
     const originRAF = window.requestAnimationFrame;
@@ -391,7 +377,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
     window.requestAnimationFrame = mockRAF;
 
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     mount(
       <MonacoEditor
@@ -405,7 +391,7 @@ describe("MonacoEditor resize handler when window size changes", () => {
     );
 
     (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event("resize"));
 
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
     expect(mockEditorLayout).toHaveBeenCalledTimes(0);
@@ -423,12 +409,12 @@ describe("MonacoEditor resize handler when window size changes", () => {
   it("Resize handler should trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is NOT hidden", async () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
 
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     const wrapper = mount(
       <MonacoEditor
@@ -442,10 +428,10 @@ describe("MonacoEditor resize handler when window size changes", () => {
     );
 
     const componentInstance = wrapper.instance() as MonacoEditor;
-    componentInstance.isContainerHidden = jest.fn(()=>false);
+    componentInstance.isContainerHidden = jest.fn(() => false);
 
     (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event("resize"));
 
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
@@ -457,12 +443,12 @@ describe("MonacoEditor resize handler when window size changes", () => {
   it("Resize handler should NOT trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is hidden", async () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = {...mockEditor};
+    const newMockEditor = { ...mockEditor };
     newMockEditor.layout = mockEditorLayout;
     mockCreateEditor.mockReturnValue(newMockEditor);
 
     // We spy on the resize handler calls without changing the implementation
-    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "resize");;
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
 
     const wrapper = mount(
       <MonacoEditor
@@ -476,10 +462,10 @@ describe("MonacoEditor resize handler when window size changes", () => {
     );
 
     const componentInstance = wrapper.instance() as MonacoEditor;
-    componentInstance.isContainerHidden = jest.fn(()=>true);
+    componentInstance.isContainerHidden = jest.fn(() => true);
 
     (window as any).innerWidth = 500;
-    window.dispatchEvent(new Event('resize'));
+    window.dispatchEvent(new Event("resize"));
 
     expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
     expect(mockEditorLayout).toHaveBeenCalledTimes(0);

--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
 import * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+import ResizeObserver from "../src/polyfill/windowResizeEventObserver";
+global.ResizeObserver = ResizeObserver;
+
 import { default as MonacoEditor } from "../src/MonacoEditor";
 import { mount } from "enzyme";
 

--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -67,7 +67,7 @@ Monaco.editor.create = mockCreateEditor;
 Monaco.editor.createModel = jest.fn().mockReturnValue(mockEditorModel);
 MonacoEditor.prototype.calculateHeight = jest.fn();
 MonacoEditor.prototype.registerDefaultCompletionProvider = jest.fn();
-MonacoEditor.prototype.getContainerDimension = jest.fn(() => ({ width: 300, height: 400 }));
+MonacoEditor.prototype.getLayoutDimension = jest.fn(() => ({ width: 300, height: 400 }));
 
 describe("MonacoEditor default completion provider", () => {
   beforeAll(() => {

--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -67,6 +67,7 @@ Monaco.editor.create = mockCreateEditor;
 Monaco.editor.createModel = jest.fn().mockReturnValue(mockEditorModel);
 MonacoEditor.prototype.calculateHeight = jest.fn();
 MonacoEditor.prototype.registerDefaultCompletionProvider = jest.fn();
+MonacoEditor.prototype.getContainerDimension = jest.fn(() => ({ width: 300, height: 400 }));
 
 describe("MonacoEditor default completion provider", () => {
   beforeAll(() => {

--- a/packages/monaco-editor/__tests__/calculateHeight.test.tsx
+++ b/packages/monaco-editor/__tests__/calculateHeight.test.tsx
@@ -61,7 +61,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     jest.clearAllMocks();
   });
 
-  it("maxHeight is honored when content height exceeds it", () => {
+  it("maxContentHeight is honored when content height exceeds it", () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
     const width = 500;
@@ -142,7 +142,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     editorInstance.isContainerHidden = jest.fn(() => true);
 
     // set an arbitary height which is different from the current height return by editor.getContentHeight()
-    editorInstance.calculateHeight(200);
+    editorInstance.updateContainerHeight(200);
     expect(mockEditorLayout).toHaveBeenCalledTimes(0);
   });
 
@@ -172,7 +172,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     editorInstance.isContainerHidden = jest.fn(() => false);
 
     // set an arbitary height which is different from the current height return by editor.getContentHeight()
-    editorInstance.calculateHeight(200);
+    editorInstance.updateContainerHeight(200);
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/monaco-editor/__tests__/calculateHeight.test.tsx
+++ b/packages/monaco-editor/__tests__/calculateHeight.test.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
 import * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+import ResizeObserver from "../src/polyfill/windowResizeEventObserver";
+global.ResizeObserver = ResizeObserver;
+
 import { default as MonacoEditor } from "../src/MonacoEditor";
 import { mount } from "enzyme";
 
@@ -124,18 +128,18 @@ describe("MonacoEditor process calculateHeight correctly", () => {
 
     mockCreateEditor.mockReturnValue(newMockEditor);
     const editorWrapper = mount(
-        <MonacoEditor
-          {...monacoEditorCommonProps}
-          channels={undefined}
-          onChange={jest.fn()}
-          onFocusChange={jest.fn()}
-          editorFocused={true}
-          skipLayoutWhenHidden={true}
-        />
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        skipLayoutWhenHidden={true}
+      />
     );
 
     const editorInstance = editorWrapper.instance() as MonacoEditor;
-    editorInstance.isContainerHidden = jest.fn(()=>true);
+    editorInstance.isContainerHidden = jest.fn(() => true);
 
     // set an arbitary height which is different from the current height return by editor.getContentHeight()
     editorInstance.calculateHeight(200);
@@ -154,18 +158,18 @@ describe("MonacoEditor process calculateHeight correctly", () => {
 
     mockCreateEditor.mockReturnValue(newMockEditor);
     const editorWrapper = mount(
-        <MonacoEditor
-          {...monacoEditorCommonProps}
-          channels={undefined}
-          onChange={jest.fn()}
-          onFocusChange={jest.fn()}
-          editorFocused={true}
-          skipLayoutWhenHidden={true}
-        />
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        skipLayoutWhenHidden={true}
+      />
     );
 
     const editorInstance = editorWrapper.instance() as MonacoEditor;
-    editorInstance.isContainerHidden = jest.fn(()=>false);
+    editorInstance.isContainerHidden = jest.fn(() => false);
 
     // set an arbitary height which is different from the current height return by editor.getContentHeight()
     editorInstance.calculateHeight(200);

--- a/packages/monaco-editor/__tests__/layout.test.tsx
+++ b/packages/monaco-editor/__tests__/layout.test.tsx
@@ -38,6 +38,7 @@ const mockEditor = {
   getModel: jest.fn(),
   getSelection: jest.fn(),
   getContentHeight: jest.fn(),
+  getContainerDomNode: jest.fn(),
   focus: jest.fn(),
   hasTextFocus: jest.fn(),
   hasWidgetFocus: jest.fn(),
@@ -53,7 +54,7 @@ Monaco.editor.create = mockCreateEditor;
 Monaco.editor.createModel = jest.fn().mockReturnValue(mockEditorModel);
 MonacoEditor.prototype.registerDefaultCompletionProvider = jest.fn();
 
-describe("MonacoEditor process calculateHeight correctly", () => {
+describe("MonacoEditor process layout correctly", () => {
   beforeAll(() => {
     jest.clearAllMocks();
   });
@@ -61,7 +62,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     jest.clearAllMocks();
   });
 
-  it("maxContentHeight is honored when content height exceeds it", () => {
+  it("maxContentHeight is honored when content height exceeds it", async () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
     const width = 500;
@@ -72,6 +73,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
       ...mockEditor,
       layout: mockEditorLayout,
       getContentHeight: () => contentHeight,
+      getContainerDomNode: () => ({ clientWidth: width, clientHeight: height }),
       getLayoutInfo: jest.fn(() => ({ width, height }))
     };
 
@@ -87,33 +89,48 @@ describe("MonacoEditor process calculateHeight correctly", () => {
       />
     );
 
-    const editorInstance = editorWrapper.instance() as MonacoEditor;
-    editorInstance.calculateHeight();
-
+    await new Promise(window.requestAnimationFrame);
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    const editorInstance = editorWrapper.instance() as MonacoEditor;
+    editorInstance.requestLayout();
+
+    expect(mockEditorLayout).toHaveBeenCalledTimes(2);
     expect(mockEditorLayout.mock.calls[0][0]).toEqual({ width, height: maxHeight });
   });
 
-  it("should not trigger layout when autoFitContentHeight is false", () => {
+  it("should use the previous clientHeight when autoFitContentHeight is false", () => {
     // Create a new editor instance with the mock layout
     const mockEditorLayout = jest.fn();
-    const newMockEditor = { ...mockEditor, layout: mockEditorLayout };
+    const getContentHeight = jest.fn();
+    getContentHeight.mockReturnValue(100);
+
+    const newMockEditor = {
+      ...mockEditor,
+      layout: mockEditorLayout,
+      getContentHeight,
+      getContainerDomNode: jest.fn(() => ({ clientHeight: 50, clientWidth: 100 }))
+    };
 
     mockCreateEditor.mockReturnValue(newMockEditor);
-    const editorWrapper = mount(
-      <MonacoEditor
-        {...monacoEditorCommonProps}
-        channels={undefined}
-        onChange={jest.fn()}
-        onFocusChange={jest.fn()}
-        editorFocused={true}
-        autoFitContentHeight={false}
-      />
-    );
-    const editorInstance = editorWrapper.instance() as MonacoEditor;
-    editorInstance.calculateHeight();
+    const props = {
+      ...monacoEditorCommonProps,
+      channels: undefined,
+      onChange: jest.fn(),
+      onFocusChange: jest.fn(),
+      editorFocused: true,
+      autoFitContentHeight: false
+    };
 
-    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+    const editorWrapper = mount(<MonacoEditor {...props} />);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledWith({ height: 50, width: 100 });
+
+    getContentHeight.mockReturnValue(200);
+    editorWrapper.setProps({ value: "test\nsecond line" });
+
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledWith({ height: 50, width: 100 });
   });
 
   it("should NOT trigger layout when skipLayoutWhenHidden is true and parent container is hidden", () => {
@@ -142,7 +159,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     editorInstance.isContainerHidden = jest.fn(() => true);
 
     // set an arbitary height which is different from the current height return by editor.getContentHeight()
-    editorInstance.updateContainerHeight(200);
+    editorInstance.requestLayout();
     expect(mockEditorLayout).toHaveBeenCalledTimes(0);
   });
 
@@ -153,6 +170,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
       ...mockEditor,
       layout: mockEditorLayout,
       getContentHeight: jest.fn(() => 100),
+      getContainerDomNode: jest.fn(() => ({ clientHeight: 50, clientWidth: 100 })),
       getLayoutInfo: jest.fn(() => ({ width: 100, height: 100 }))
     };
 
@@ -172,7 +190,7 @@ describe("MonacoEditor process calculateHeight correctly", () => {
     editorInstance.isContainerHidden = jest.fn(() => false);
 
     // set an arbitary height which is different from the current height return by editor.getContentHeight()
-    editorInstance.updateContainerHeight(200);
+    editorInstance.requestLayout();
     expect(mockEditorLayout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/monaco-editor/__tests__/resize.test.tsx
+++ b/packages/monaco-editor/__tests__/resize.test.tsx
@@ -1,0 +1,309 @@
+import * as React from "react";
+import * as Monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+import ResizeObserver from "../src/polyfill/windowResizeEventObserver";
+global.ResizeObserver = ResizeObserver;
+
+import { default as MonacoEditor } from "../src/MonacoEditor";
+import { mount } from "enzyme";
+
+// Common Props required to instantiate MonacoEditor View, shared by all tests.
+const monacoEditorCommonProps = {
+  id: "foo",
+  contentRef: "bar",
+  editorType: "monaco",
+  theme: "vs",
+  value: "test_value",
+  enableCompletion: true,
+  language: "python",
+  onCursorPositionChange: () => {}
+};
+
+// Setup items shared by all tests in this block
+// Mock out the common API methods so that private function calls don't fail
+const mockEditor = {
+  onDidContentSizeChange: jest.fn(),
+  onDidChangeModelContent: jest.fn(),
+  onDidFocusEditorText: jest.fn(),
+  onDidBlurEditorText: jest.fn(),
+  onDidChangeCursorSelection: jest.fn(),
+  onDidFocusEditorWidget: jest.fn(),
+  onDidBlurEditorWidget: jest.fn(),
+  onMouseMove: jest.fn(),
+  updateOptions: jest.fn(),
+  getValue: jest.fn(),
+  setValue: jest.fn(),
+  getConfiguration: jest.fn(),
+  getContainerDomNode: jest.fn(() => ({ clientWidth: 100, clientHeight: 50 })),
+  layout: jest.fn(),
+  getModel: jest.fn(),
+  getSelection: jest.fn(),
+  focus: jest.fn(),
+  hasTextFocus: jest.fn(),
+  hasWidgetFocus: jest.fn(),
+  addCommand: jest.fn(),
+  changeViewZones: jest.fn()
+};
+
+const mockEditorModel = {
+  updateOptions: jest.fn()
+};
+const mockCreateEditor = jest.fn().mockReturnValue(mockEditor);
+Monaco.editor.create = mockCreateEditor;
+Monaco.editor.createModel = jest.fn().mockReturnValue(mockEditorModel);
+MonacoEditor.prototype.registerDefaultCompletionProvider = jest.fn();
+MonacoEditor.prototype.getLayoutDimension = jest.fn(() => ({ width: 300, height: 400 }));
+
+describe("MonacoEditor resize handler when window size changes", () => {
+  beforeAll(() => {
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Should not call resize handler at all when window is not resized", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
+
+    mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={false}
+      />
+    );
+
+    await new Promise(window.requestAnimationFrame);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    expect(mockCreateEditor).toHaveBeenCalledTimes(1);
+    // Resize handler should be called
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(0);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should not trigger editor.layout when it is not focused", async () => {
+    // This is a perf optimization to reduce layout calls for unfocussed editors
+
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
+
+    mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={false}
+      />
+    );
+
+    await new Promise(window.requestAnimationFrame);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event("resize"));
+
+    // Resize handler should be called
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    // editor.layout should not be called
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should trigger an editor.layout call for a focused editor", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(MonacoEditor.prototype, "onResize");
+
+    mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+      />
+    );
+
+    await new Promise(window.requestAnimationFrame);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event("resize"));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(2);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should trigger an editor.layout call for a non-focused editor when shouldUpdateLayoutWhenNotFocused=true", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+
+    const wrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={false}
+        shouldUpdateLayoutWhenNotFocused={true}
+      />
+    );
+
+    await new Promise(window.requestAnimationFrame);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    const componentInstance = wrapper.instance() as MonacoEditor;
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(componentInstance, "onResize");
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event("resize"));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(2);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should trigger an editor.layout call asynchronously when batchLayoutChanges=true", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+    const originRAF = window.requestAnimationFrame;
+    const mockRAF = jest.fn((callback) => originRAF(callback));
+    window.requestAnimationFrame = mockRAF;
+
+    const wrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        batchLayoutChanges={true}
+      />
+    );
+
+    const componentInstance = wrapper.instance() as MonacoEditor;
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(componentInstance, "onResize");
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event("resize"));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+
+    expect(mockRAF).toHaveBeenCalledTimes(1);
+
+    // wait on the second RAF to returned, which should be called after the first RAF has been executed
+    await new Promise(originRAF);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is NOT hidden", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+
+    const wrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        skipLayoutWhenHidden={true}
+      />
+    );
+
+    await new Promise(window.requestAnimationFrame);
+    const componentInstance = wrapper.instance() as MonacoEditor;
+
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(componentInstance, "onResize");
+    componentInstance.isContainerHidden = jest.fn(() => false);
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event("resize"));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(1);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+
+  it("Resize handler should NOT trigger an editor.layout call when skipLayoutWhenHidden=true and parent container is hidden", async () => {
+    // Create a new editor instance with the mock layout
+    const mockEditorLayout = jest.fn();
+    const newMockEditor = { ...mockEditor };
+    newMockEditor.layout = mockEditorLayout;
+    mockCreateEditor.mockReturnValue(newMockEditor);
+
+    const wrapper = mount(
+      <MonacoEditor
+        {...monacoEditorCommonProps}
+        channels={undefined}
+        onChange={jest.fn()}
+        onFocusChange={jest.fn()}
+        editorFocused={true}
+        skipLayoutWhenHidden={true}
+      />
+    );
+
+    await new Promise(window.requestAnimationFrame);
+
+    const componentInstance = wrapper.instance() as MonacoEditor;
+
+    // We spy on the resize handler calls without changing the implementation
+    const resizeHandlerSpy = jest.spyOn(componentInstance, "onResize");
+    componentInstance.isContainerHidden = jest.fn(() => true);
+
+    (window as any).innerWidth = 500;
+    window.dispatchEvent(new Event("resize"));
+
+    expect(resizeHandlerSpy).toHaveBeenCalledTimes(1);
+    expect(mockEditorLayout).toHaveBeenCalledTimes(0);
+
+    // Restore spy
+    resizeHandlerSpy.mockRestore();
+  });
+});

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -135,13 +135,14 @@ export default class MonacoEditor extends React.Component<IMonacoProps> implemen
     }
   }
 
-  getContainerDimension() {
-    const container = this.editorContainerRef.current;
-    if (!container || !container.offsetHeight || !container.offsetWidth) {
+  getLayoutDimension() {
+    const container = this.editor?.getContainerDomNode();
+    if (!container) {
       return undefined;
     }
 
-    return { width: container.offsetWidth, height: container.offsetHeight };
+    // use clientHeight and clientWidth to align with what monaco editor does for getting the dimension when it is undefined.
+    return { width: container.clientWidth, height: container.clientHeight };
   }
 
   isContainerHidden() {

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -217,13 +217,14 @@ export default class MonacoEditor
     return this.props.skipLayoutWhenHidden ? !this.isContainerHidden() : true;
   }
 
-  requestLayout(layout?: monaco.editor.IDimension): void {
+  requestLayout(dimension?: monaco.editor.IDimension): void {
     if (!this.editor) {
       return;
     }
 
+    // check if the editor is in the viewport first since it doesn't touch the DOM
     if (!this.isInViewport) {
-      this.deferredLayoutDimension = layout;
+      this.deferredLayoutDimension = dimension;
       this.deferredLayoutRequest = true;
       return;
     }
@@ -235,11 +236,14 @@ export default class MonacoEditor
     }
 
     if (this.props.batchLayoutChanges === true) {
-      scheduleEditorForLayout(this, layout);
+      scheduleEditorForLayout(this, dimension);
     } else {
-      const layout = this.getLayoutDimension();
-      if (layout) {
-        this.layout(layout);
+      if (!dimension) {
+        dimension = this.getLayoutDimension();
+      }
+
+      if (dimension) {
+        this.layout(dimension);
       }
     }
   }

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -6,7 +6,7 @@ import { completionProvider } from "./completions/completionItemProvider";
 import { ContentRef } from "@nteract/core";
 import { DocumentUri } from "./documentUri";
 import debounce from "lodash.debounce";
-import { scheduleEditorForLayout } from "./layoutSchedule";
+import { scheduleEditorForLayout, IEditor } from "./layoutSchedule";
 import * as resizeObserver from "./resizeObserver";
 
 export type IModelContentChangedEvent = monaco.editor.IModelContentChangedEvent;
@@ -107,7 +107,7 @@ export type IMonacoProps = IMonacoComponentProps & IMonacoConfiguration;
 /**
  * Creates a MonacoEditor instance
  */
-export default class MonacoEditor extends React.Component<IMonacoProps> {
+export default class MonacoEditor extends React.Component<IMonacoProps> implements IEditor {
   editor?: monaco.editor.IStandaloneCodeEditor;
   editorContainerRef = React.createRef<HTMLDivElement>();
   contentHeight?: number;
@@ -137,7 +137,11 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
 
   getContainerDimension() {
     const container = this.editorContainerRef.current;
-    return container ? { width: container.offsetWidth, height: container.offsetHeight } : undefined;
+    if (!container || !container.offsetHeight || !container.offsetWidth) {
+      return undefined;
+    }
+
+    return { width: container.offsetWidth, height: container.offsetHeight };
   }
 
   isContainerHidden() {

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -201,7 +201,7 @@ export default class MonacoEditor
     return this.props.skipLayoutWhenHidden ? !this.isContainerHidden() : true;
   }
 
-  requestLayout(layout?: monaco.editor.IDimension) {
+  requestLayout(layout?: monaco.editor.IDimension): void {
     if (!this.editor) {
       return;
     }
@@ -214,7 +214,7 @@ export default class MonacoEditor
 
     // when skipLayoutWhenHidden is true and the editor's parent or ancestor container is hidden,
     // we will not layout the editor.
-    if (this.props.skipLayoutWhenHidden && this.isContainerHidden()) {
+    if (!this.shouldLayout()) {
       return;
     }
 

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -147,6 +147,13 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     this.editor?.layout(layout);
   }
 
+  /**
+   * Implementation for IEditor from layoutSchedule
+   */
+  shouldLayout() {
+    return this.props.skipLayoutWhenHidden ? !this.isContainerHidden() : true;
+  }
+
   requestLayout(layout?: monaco.editor.IDimension) {
     if (!this.editor) {
       return;

--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -135,6 +135,11 @@ export default class MonacoEditor extends React.Component<IMonacoProps> {
     }
   }
 
+  getContainerDimension() {
+    const container = this.editorContainerRef.current;
+    return container ? { width: container.offsetWidth, height: container.offsetHeight } : undefined;
+  }
+
   isContainerHidden() {
     const container = this.editorContainerRef.current;
     return !container?.offsetParent || !container?.offsetHeight;

--- a/packages/monaco-editor/src/intersectionObserver.ts
+++ b/packages/monaco-editor/src/intersectionObserver.ts
@@ -1,0 +1,51 @@
+import ObserverPolyfill from "./polyfill/intersectionObserver";
+
+/**
+ * Interface for objects that is handling the intersection events.
+ */
+export interface IIntersectable {
+  onIntersecting(isIntersecting: boolean): void;
+}
+
+const monitoredIntersectables = new Map<Element, IIntersectable>();
+
+let viewPortObserver: IntersectionObserver;
+function getObserverSingleton() {
+  if (!viewPortObserver) {
+    const IntersectionObserverImpl = window.IntersectionObserver || ObserverPolyfill;
+
+    viewPortObserver = new IntersectionObserverImpl((entries) => {
+      for (const entry of entries) {
+        const element = entry.target;
+        const editor = monitoredIntersectables.get(element);
+        if (editor) {
+          editor.onIntersecting(entry.isIntersecting);
+        }
+      }
+    });
+  }
+
+  return viewPortObserver;
+}
+
+/**
+ * Observe the element for viewport intersection events.
+ * @param editor
+ * @param element
+ * @returns callback to unobserve the element
+ */
+export function observe(intersectable: IIntersectable, element: Element): () => void {
+  monitoredIntersectables.set(element, intersectable);
+  getObserverSingleton().observe(element);
+
+  return () => unobserve(element);
+}
+
+/**
+ * unobserve the element for viewport intersection events.
+ * @param element the monitored html element
+ */
+export function unobserve(element: Element): void {
+  getObserverSingleton().unobserve(element);
+  monitoredIntersectables.delete(element);
+}

--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -1,24 +1,38 @@
-
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
-const editorsToLayout: Map<monaco.editor.IEditor, monaco.editor.IDimension | undefined> = new Map();
+export interface IEditor {
+  layout(dimension?: monaco.editor.IDimension): void;
+  isContainerHidden(): boolean;
+}
+
+const editorsInSchedule: Map<IEditor, monaco.editor.IDimension | undefined> = new Map();
 let layoutTimer: ReturnType<typeof requestAnimationFrame> | null = null;
+
+function executeLayout() {
+  layoutTimer = null;
+  const editorsToLayout = [];
+  for (const [editor, layout] of editorsInSchedule) {
+    if (!editor.isContainerHidden()) {
+      editorsToLayout.push([editor, layout]);
+    }
+  }
+
+  for (const [editor, layout] of editorsToLayout) {
+    (editor as IEditor).layout(layout as monaco.editor.IDimension | undefined);
+  }
+
+  editorsInSchedule.clear();
+}
 
 /**
  * For monaco editors, we need to call layout() on any editors that might have changed size otherwise the view will look off.
  * These updates often happen together with other editors, such as when the window resizes.
  * In order to avoid layout thrashing, we batch these layout calls together and perform them all at once in a RAF timeout.
  */
-export function scheduleEditorForLayout(editor: monaco.editor.IEditor, layout: monaco.editor.IDimension | undefined) {
-  editorsToLayout.set(editor, layout);
+export function scheduleEditorForLayout(editor: IEditor, layout: monaco.editor.IDimension | undefined) {
+  editorsInSchedule.set(editor, layout);
   if (!layoutTimer) {
     // Using RAF here ensures that the layout will happen on the next frame.
-    layoutTimer = requestAnimationFrame(() => {
-      layoutTimer = null;
-      editorsToLayout.forEach((layout, ed) => {
-        ed.layout(layout);
-      });
-      editorsToLayout.clear();
-    });
+    layoutTimer = requestAnimationFrame(executeLayout);
   }
 }

--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -3,7 +3,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 export interface IEditor {
   layout(dimension?: monaco.editor.IDimension): void;
   shouldLayout(): boolean;
-  getContainerDimension: () => monaco.editor.IDimension | undefined;
+  getLayoutDimension: () => monaco.editor.IDimension | undefined;
 }
 
 const editorsInSchedule: Map<IEditor, monaco.editor.IDimension | undefined> = new Map();
@@ -18,7 +18,7 @@ function executeLayout() {
     if (editor.shouldLayout()) {
       let dim = scheduledDimention;
       if (!dim) {
-        dim = editor.getContainerDimension();
+        dim = editor.getLayoutDimension();
       }
 
       // skip layout if dimension is not available

--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -41,7 +41,7 @@ function executeLayout() {
  * These updates often happen together with other editors, such as when the window resizes.
  * In order to avoid layout thrashing, we batch these layout calls together and perform them all at once in a RAF timeout.
  */
-export function scheduleEditorForLayout(editor: IEditor, layout?: monaco.editor.IDimension) {
+export function scheduleEditorForLayout(editor: IEditor, layout?: monaco.editor.IDimension): void {
   editorsInSchedule.set(editor, layout);
   if (!layoutTimer) {
     // Using RAF here ensures that the layout will happen on the next frame.

--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -3,6 +3,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 export interface IEditor {
   layout(dimension?: monaco.editor.IDimension): void;
   shouldLayout(): boolean;
+  getContainerDimension: () => monaco.editor.IDimension;
 }
 
 const editorsInSchedule: Map<IEditor, monaco.editor.IDimension | undefined> = new Map();
@@ -13,12 +14,16 @@ function executeLayout() {
   const editorsToLayout = [];
   for (const [editor, layout] of editorsInSchedule) {
     if (editor.shouldLayout()) {
-      editorsToLayout.push([editor, layout]);
+      if (layout) {
+        editorsToLayout.push([editor, layout]);
+      } else {
+        editorsToLayout.push([editor, editor.getContainerDimension()]);
+      }
     }
   }
 
   for (const [editor, layout] of editorsToLayout) {
-    (editor as IEditor).layout(layout as monaco.editor.IDimension | undefined);
+    (editor as IEditor).layout(layout as monaco.editor.IDimension);
   }
 
   editorsInSchedule.clear();

--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -29,7 +29,7 @@ function executeLayout() {
  * These updates often happen together with other editors, such as when the window resizes.
  * In order to avoid layout thrashing, we batch these layout calls together and perform them all at once in a RAF timeout.
  */
-export function scheduleEditorForLayout(editor: IEditor, layout: monaco.editor.IDimension | undefined) {
+export function scheduleEditorForLayout(editor: IEditor, layout?: monaco.editor.IDimension) {
   editorsInSchedule.set(editor, layout);
   if (!layoutTimer) {
     // Using RAF here ensures that the layout will happen on the next frame.

--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -2,7 +2,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 export interface IEditor {
   layout(dimension?: monaco.editor.IDimension): void;
-  isContainerHidden(): boolean;
+  shouldLayout(): boolean;
 }
 
 const editorsInSchedule: Map<IEditor, monaco.editor.IDimension | undefined> = new Map();
@@ -12,7 +12,7 @@ function executeLayout() {
   layoutTimer = null;
   const editorsToLayout = [];
   for (const [editor, layout] of editorsInSchedule) {
-    if (!editor.isContainerHidden()) {
+    if (editor.shouldLayout()) {
       editorsToLayout.push([editor, layout]);
     }
   }

--- a/packages/monaco-editor/src/polyfill/intersectionObserver.ts
+++ b/packages/monaco-editor/src/polyfill/intersectionObserver.ts
@@ -1,0 +1,42 @@
+/**
+ * Polyfill for IntersectionObserver
+ * Always reports the element as intersecting when it is observed.
+ */
+export default class AlwaysIntersectingObserver {
+  constructor(private callback: IntersectionObserverCallback) {}
+
+  observe(element: Element): void {
+    // we don't want to cause a reflow if we read the DOM, so we use a dummy rect
+    const dummyRect = new DOMRect(0, 0, 0, 0);
+
+    this.callback(
+      [
+        {
+          target: element,
+          isIntersecting: true,
+          intersectionRatio: 1,
+          boundingClientRect: dummyRect, // should not be used by the callback
+          rootBounds: null,
+          intersectionRect: dummyRect, // should not be used by the callback
+          time: performance.now()
+        }
+      ],
+      this
+    );
+  }
+
+  unobserve(element: Element): void {
+    element;
+  }
+
+  /**
+   * The following methods are not implemented, but are required by the interface.
+   */
+  root: Element | null = null;
+  rootMargin: string = "";
+  thresholds: number[] = [];
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}

--- a/packages/monaco-editor/src/polyfill/windowResizeEventObserver.ts
+++ b/packages/monaco-editor/src/polyfill/windowResizeEventObserver.ts
@@ -4,7 +4,8 @@
 class ResizeObserver {
   elements: Set<Element> = new Set();
   constructor(private callback: ResizeObserverCallback) {
-    window.addEventListener("resize", this.onWindowResize.bind(this));
+    this.onWindowResize = this.onWindowResize.bind(this);
+    window.addEventListener("resize", this.onWindowResize);
   }
 
   onWindowResize() {
@@ -30,7 +31,9 @@ class ResizeObserver {
     this.elements.delete(element);
   }
 
-  disconnect() {}
+  disconnect() {
+    window.removeEventListener("resize", this.onWindowResize);
+  }
 }
 
 export default ResizeObserver;

--- a/packages/monaco-editor/src/polyfill/windowResizeEventObserver.ts
+++ b/packages/monaco-editor/src/polyfill/windowResizeEventObserver.ts
@@ -1,0 +1,36 @@
+/**
+ * Simple polifill of ResizeObserver for testing
+ */
+class ResizeObserver {
+  elements: Set<Element> = new Set();
+  constructor(private callback: ResizeObserverCallback) {
+    window.addEventListener("resize", this.onWindowResize.bind(this));
+  }
+
+  onWindowResize() {
+    const entries: ResizeObserverEntry[] = [];
+    for (const element of this.elements) {
+      entries.push({
+        target: element,
+        contentRect: element.getBoundingClientRect(),
+        borderBoxSize: [],
+        contentBoxSize: [],
+        devicePixelContentBoxSize: []
+      });
+    }
+
+    this.callback(entries, this);
+  }
+
+  observe(element: Element) {
+    this.elements.add(element);
+  }
+
+  unobserve(element: Element) {
+    this.elements.delete(element);
+  }
+
+  disconnect() {}
+}
+
+export default ResizeObserver;

--- a/packages/monaco-editor/src/resizeObserver.ts
+++ b/packages/monaco-editor/src/resizeObserver.ts
@@ -1,0 +1,43 @@
+/**
+ * This module is responsible for monitoring elements and call the resizable components.
+ */
+
+/**
+ * Interface for resizable components.
+ */
+export interface IResizable {
+  resize(): void;
+}
+
+/**
+ * ResizeObserver that monitors the size of the element and calls the resizable component.
+ */
+const monitoredResizables = new Map<Element, IResizable>();
+
+/**
+ * ResizeObserver that monitors the size of the element and calls the resizable component.
+ */
+const resizeObserver = new ResizeObserver((entries) => {
+  for (const entry of entries) {
+    if (monitoredResizables.has(entry.target)) {
+      const editor = monitoredResizables.get(entry.target);
+      editor?.resize();
+    }
+  }
+});
+
+/**
+ * Observe the element for resize events.
+ */
+export function observe(resizable: IResizable, element: HTMLDivElement) {
+  monitoredResizables.set(element, resizable);
+  resizeObserver.observe(element);
+}
+
+/**
+ * Unobserve the element for resize events.
+ */
+export function unobserve(element: HTMLDivElement) {
+  resizeObserver.unobserve(element);
+  monitoredResizables.delete(element);
+}

--- a/packages/monaco-editor/src/resizeObserver.ts
+++ b/packages/monaco-editor/src/resizeObserver.ts
@@ -15,32 +15,40 @@ export interface IResizable {
  * ResizeObserver that monitors the size of the element and calls the resizable component.
  */
 const monitoredResizables = new Map<Element, IResizable>();
-const ResizeObserverImpl = window.ResizeObserver || ResizeObserverPolyfill;
 
 /**
  * ResizeObserver that monitors the size of the element and calls the resizable component.
  */
-const resizeObserver = new ResizeObserverImpl((entries) => {
-  for (const entry of entries) {
-    if (monitoredResizables.has(entry.target)) {
-      const editor = monitoredResizables.get(entry.target);
-      editor?.onResize();
-    }
+let resizeObserver: ResizeObserver;
+function getResizeObserverSingleton() {
+  if (!resizeObserver) {
+    const ResizeObserverImpl = window.ResizeObserver || ResizeObserverPolyfill;
+
+    resizeObserver = new ResizeObserverImpl((entries) => {
+      for (const entry of entries) {
+        if (monitoredResizables.has(entry.target)) {
+          const editor = monitoredResizables.get(entry.target);
+          editor?.onResize();
+        }
+      }
+    });
   }
-});
+
+  return resizeObserver;
+}
 
 /**
  * Observe the element for resize events.
  */
 export function observe(resizable: IResizable, element: HTMLDivElement) {
   monitoredResizables.set(element, resizable);
-  resizeObserver.observe(element);
+  getResizeObserverSingleton().observe(element);
 }
 
 /**
  * Unobserve the element for resize events.
  */
 export function unobserve(element: HTMLDivElement) {
-  resizeObserver.unobserve(element);
+  getResizeObserverSingleton().unobserve(element);
   monitoredResizables.delete(element);
 }

--- a/packages/monaco-editor/src/resizeObserver.ts
+++ b/packages/monaco-editor/src/resizeObserver.ts
@@ -6,7 +6,7 @@
  * Interface for resizable components.
  */
 export interface IResizable {
-  resize(): void;
+  onResize(): void;
 }
 
 /**
@@ -21,7 +21,7 @@ const resizeObserver = new ResizeObserver((entries) => {
   for (const entry of entries) {
     if (monitoredResizables.has(entry.target)) {
       const editor = monitoredResizables.get(entry.target);
-      editor?.resize();
+      editor?.onResize();
     }
   }
 });

--- a/packages/monaco-editor/src/resizeObserver.ts
+++ b/packages/monaco-editor/src/resizeObserver.ts
@@ -2,6 +2,8 @@
  * This module is responsible for monitoring elements and call the resizable components.
  */
 
+import ResizeObserverPolyfill from "./polyfill/windowResizeEventObserver";
+
 /**
  * Interface for resizable components.
  */
@@ -13,11 +15,12 @@ export interface IResizable {
  * ResizeObserver that monitors the size of the element and calls the resizable component.
  */
 const monitoredResizables = new Map<Element, IResizable>();
+const ResizeObserverImpl = window.ResizeObserver || ResizeObserverPolyfill;
 
 /**
  * ResizeObserver that monitors the size of the element and calls the resizable component.
  */
-const resizeObserver = new ResizeObserver((entries) => {
+const resizeObserver = new ResizeObserverImpl((entries) => {
   for (const entry of entries) {
     if (monitoredResizables.has(entry.target)) {
       const editor = monitoredResizables.get(entry.target);

--- a/packages/monaco-editor/src/resizeObserver.ts
+++ b/packages/monaco-editor/src/resizeObserver.ts
@@ -14,7 +14,7 @@ export interface IResizable {
 /**
  * ResizeObserver that monitors the size of the element and calls the resizable component.
  */
-const monitoredResizables = new Map<Element, IResizable>();
+const monitoredResizables = new WeakMap<Element, IResizable>();
 
 /**
  * ResizeObserver that monitors the size of the element and calls the resizable component.

--- a/packages/monaco-editor/src/resizeObserver.ts
+++ b/packages/monaco-editor/src/resizeObserver.ts
@@ -40,15 +40,16 @@ function getResizeObserverSingleton() {
 /**
  * Observe the element for resize events.
  */
-export function observe(resizable: IResizable, element: HTMLDivElement) {
+export function observe(resizable: IResizable, element: HTMLDivElement): () => void {
   monitoredResizables.set(element, resizable);
   getResizeObserverSingleton().observe(element);
+  return () => unobserve(element);
 }
 
 /**
  * Unobserve the element for resize events.
  */
-export function unobserve(element: HTMLDivElement) {
+export function unobserve(element: HTMLDivElement): void {
   getResizeObserverSingleton().unobserve(element);
   monitoredResizables.delete(element);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4404,6 +4404,11 @@
   dependencies:
     redux "^4.0.0"
 
+"@types/resize-observer-browser@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz#294aaadf24ac6580b8fbd1fe3ab7b59fe85f9ef3"
+  integrity sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg==
+
 "@types/retry@^0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"


### PR DESCRIPTION
This PR fixed several issues with resizing perf
* Use ResizeObserver to detect resize changes. Previously it was using window resize event which is not enough to trigger the layout of monaco editors, there are other cases like container div gets resized, or changed from hidden to visible. 
* Use editor.layout to control the height instead of setting height on the container, which simplify the write operations on DOM.
* Add skipLayoutWhenNotInViewport property, when set to true, we only do the layout when the editor is in viewport.


- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
