### PR TITLE
fix: minor fixes to monaco-editor interface

### DIFF
--- a/packages/monaco-editor/src/layoutSchedule.ts
+++ b/packages/monaco-editor/src/layoutSchedule.ts
@@ -1,7 +1,7 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 
 export interface IEditor {
-  layout(dimension?: monaco.editor.IDimension): void;
+  layout(dimension: monaco.editor.IDimension): void;
   shouldLayout(): boolean;
   getLayoutDimension: () => monaco.editor.IDimension | undefined;
 }

--- a/packages/monaco-editor/src/polyfill/intersectionObserver.ts
+++ b/packages/monaco-editor/src/polyfill/intersectionObserver.ts
@@ -1,4 +1,11 @@
 /**
+ * Polyfill for DOMRect
+ */
+class DOMRectPolyfill {
+  constructor(public x: number, public y: number, public width: number, public height: number) {}
+}
+
+/**
  * Polyfill for IntersectionObserver
  * Always reports the element as intersecting when it is observed.
  */
@@ -6,8 +13,9 @@ export default class AlwaysIntersectingObserver {
   constructor(private callback: IntersectionObserverCallback) {}
 
   observe(element: Element): void {
+    const DOMRectImpl = window.DOMRect || DOMRectPolyfill;
     // we don't want to cause a reflow if we read the DOM, so we use a dummy rect
-    const dummyRect = new DOMRect(0, 0, 0, 0);
+    const dummyRect = new DOMRectImpl(0, 0, 0, 0);
 
     this.callback(
       [


### PR DESCRIPTION
Updated the signature of layout() method in monaco editor to disallow optional dimension parameter.

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
