### PR TITLE
fix: make skipLayoutWhenNotInViewport reactive when the prop is updated

### DIFF
--- a/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
+++ b/packages/monaco-editor/__tests__/MonacoEditor.test.tsx
@@ -189,7 +189,7 @@ describe("MonacoEditor lifeCycle methods set up", () => {
 
     // We expect setValue is called twice. First on componentDidMount and second on componentDidUpdate
     // when the props.value has new different value.
-    expect(mockEditor.setValue).toHaveBeenCalledTimes(2);
+    expect(mockEditor.setValue).toHaveBeenCalledTimes(1);
   });
 
   it("Should not call editor setValue when value prop has not changed on componentDidUpdate.", () => {
@@ -198,7 +198,7 @@ describe("MonacoEditor lifeCycle methods set up", () => {
     editorWrapper.setProps({ value: "initial_value" });
 
     // We expect setValue is called once on componentDidMount when the props.value does not have different value.
-    expect(mockEditor.setValue).toHaveBeenCalledTimes(1);
+    expect(mockEditor.setValue).toHaveBeenCalledTimes(0);
   });
 });
 


### PR DESCRIPTION
The `skipLayoutWhenNotInViewport` prop was only used when the editor component is mounted, and not respected if its value get updated later.
This PR fixed that by extracting the registration of intersectObserver into a `updateIntersectRegistration()` function and call it in both `componentDidMount()` and `componentDidUpdate()`.

<!-- If this is your first PR for nteract, please mark these boxes to confirm (otherwise you can exclude them) -->

<!-- Thank you for submitting a pull request to nteract. After all, open source is powered by contributors like you! -->

<!-- Before you submit your PR, make sure that you have gone through the following checklist to ensure that everything goes smoothly. -->

<!-- If you're PR is not fully polished yet or you'd like to park some work, you can open a draft PR. -->

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [ ] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [ ] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.

<!-- Questions? Feel free to ping us on https://nteract.slack.com/ -->
