### PR TITLE
fix: fix pagers

### DIFF
--- a/packages/stateful-components/src/outputs/pagers.tsx
+++ b/packages/stateful-components/src/outputs/pagers.tsx
@@ -21,7 +21,7 @@ export class Pagers extends React.PureComponent<ComponentProps & StateProps> {
     return (
       <div className="nteract-cell-pagers">
         {pagers.map(pager => (
-          <RichMedia data={pager.data} metadata={pager.metadata}>
+          <RichMedia data={pager} metadata={{}}>
             {React.Children.map(this.props.children, child => {
               if (
                 typeof child === "string" ||


### PR DESCRIPTION
The format of a pager message is as follows, [per the Jupyter spec](https://jupyter-protocol.readthedocs.io/en/latest/messaging.html#payloads-deprecated):

```python
{
  "source": "page",
  # mime-bundle of data to display in the pager.
  # Must include text/plain.
  "data": mimebundle,
  # line offset to start from
  "start": int,
}
```

The `data` mime bundle gets saved into the notebook state and then fetched in the `Pagers` stateful component. However, the component (currently) tries to extract `.data` and `.metadata` objects from the mime bundle, which fails.

This PR fixes the issue by using the mimebundle directly for the data, and no metadata (as there is no metadata support for pages in the spec).