### PR TITLE
fix: normalize cell source line endings to LF on language change

### DIFF
--- a/packages/monaco-editor/src/MonacoEditor.tsx
+++ b/packages/monaco-editor/src/MonacoEditor.tsx
@@ -478,7 +478,11 @@ export default class MonacoEditor
           const position = editor.getPosition();
 
           // Set new model targeting the changed language.
-          editor.setModel(monaco.editor.createModel(value, language, newUri));
+          // Set line endings to \n line feed to be consistent across OS platforms. This will auto-normalize the line 
+          // endings of the current value to use \n and any future values produced by the Monaco editor will use \n.
+          const newModel = monaco.editor.createModel(value, language, newUri);
+          newModel.setEOL(monaco.editor.EndOfLineSequence.LF);
+          editor.setModel(newModel);
 
           // Restore cursor position to new model.
           if (position) {


### PR DESCRIPTION
Updated to normalized line endings to LF when the Monaco Editor language changes. In this case, a new Monaco model is created so it should be configured to use LF as default like when we newly create a model on componentDidMount.

- [X] I have read the [Contributor Guide](https://github.com/nteract/nteract/blob/master/CONTRIBUTING.md)
- [X] I have updated the changelogs/current_changelog.md file with some information about the change that I am making the appropriate file.
- [X] I have validated or unit-tested the changes that I have made.
- [X] I have run through the TEST_PLAN.md to ensure that my change does not break anything else.
